### PR TITLE
A better error dialog.

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/system/ErrorDialog.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/ErrorDialog.java
@@ -1,0 +1,65 @@
+package com.jme3.system;
+
+import java.awt.BorderLayout;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
+/**
+ * Simple dialog for diplaying error messages,
+ * 
+ * @author kwando
+ */
+public class ErrorDialog extends JDialog {
+    public static String DEFAULT_TITLE = "Error in application";
+    public static int PADDING = 8;
+    
+    /**
+     * Create a new Dialog with a title and a message.
+     * @param message
+     * @param title 
+     */
+    public ErrorDialog(String message, String title) {
+        setTitle(title);
+        setSize(new Dimension(600, 400));
+        setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+        setLocationRelativeTo(null);   
+        
+        Container container = getContentPane();
+        container.setLayout(new BorderLayout());
+        
+        JTextArea textArea = new JTextArea();
+        textArea.setText(message);
+        textArea.setEditable(false);
+        textArea.setMargin(new Insets(PADDING, PADDING, PADDING, PADDING));
+        add(new JScrollPane(textArea), BorderLayout.CENTER);
+        
+        final JDialog dialog = this;
+        JButton button = new JButton(new AbstractAction("OK"){
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                dialog.dispose();
+            }
+        });
+        add(button, BorderLayout.SOUTH);
+    }
+    
+    public ErrorDialog(String message){
+        this(message, DEFAULT_TITLE);
+    }
+    
+    /**
+     * Show a dialog with the proved message.
+     * @param message 
+     */
+    public static void showDialog(String message){
+        ErrorDialog dialog = new ErrorDialog("Opps, this was bad =S");
+        dialog.setVisible(true);
+    }
+}

--- a/jme3-desktop/src/main/java/com/jme3/system/JmeDesktopSystem.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/JmeDesktopSystem.java
@@ -52,7 +52,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import javax.imageio.ImageIO;
-import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
 /**
@@ -87,10 +86,9 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
     @Override
     public void showErrorDialog(String message) {
         final String msg = message;
-        final String title = "Error in application";
         EventQueue.invokeLater(new Runnable() {
             public void run() {
-                JOptionPane.showMessageDialog(null, msg, title, JOptionPane.ERROR_MESSAGE);
+                ErrorDialog.showDialog(msg);
             }
         });
     }


### PR DESCRIPTION
This is a simple replacement for the JOptionPane showing error messages right now.. on OSX you cannot copy text from a JOptionPane which makes it cumbersome to file error reports.

![skarmavbild 2014-04-01 kl 17 26 35](https://cloud.githubusercontent.com/assets/891566/2580867/4cc31c46-b9b2-11e3-8286-bf5c7248368a.png)
