### PR TITLE
Refactor screenshots

### DIFF
--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
@@ -106,7 +106,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
         }
     }
 
-    public ScreenshotAppState(DefaultNamingScheme scheme){
+    private ScreenshotAppState(DefaultNamingScheme scheme){
         super();
         this.namingScheme = scheme;
         processor = new ScreenshotProcessor(new WriteToFileStrategy(namingScheme));

--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
@@ -222,35 +222,43 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
         if (capture){
             capture = false;
 
-            Camera curCamera = rm.getCurrentCamera();
-            int viewX = (int) (curCamera.getViewPortLeft() * curCamera.getWidth());
-            int viewY = (int) (curCamera.getViewPortBottom() * curCamera.getHeight());
-            int viewWidth = (int) ((curCamera.getViewPortRight() - curCamera.getViewPortLeft()) * curCamera.getWidth());
-            int viewHeight = (int) ((curCamera.getViewPortTop() - curCamera.getViewPortBottom()) * curCamera.getHeight());
-
-            renderer.setViewPort(0, 0, width, height);
-            renderer.readFrameBuffer(out, outBuf);
-            renderer.setViewPort(viewX, viewY, viewWidth, viewHeight);
+            captureScreenshot(out);
 
             File file = determineFilename();
             logger.log(Level.FINE, "Saving ScreenShot to: {0}", file.getAbsolutePath());
 
-            OutputStream outStream = null;
-            try {
-                outStream = new FileOutputStream(file);
-                JmeSystem.writeImageFile(outStream, "png", outBuf, width, height);
-            } catch (IOException ex) {
-                logger.log(Level.SEVERE, "Error while saving screenshot", ex);
-            } finally {
-                if (outStream != null){
-                    try {
-                        outStream.close();
-                    } catch (IOException ex) {
-                        logger.log(Level.SEVERE, "Error while saving screenshot", ex);
-                    }
+            writeFile(file, outBuf, width, height);
+        }
+    }
+
+    private void writeFile(File file, ByteBuffer outBuf, int width, int height) {
+        OutputStream outStream = null;
+        try {
+            outStream = new FileOutputStream(file);
+            JmeSystem.writeImageFile(outStream, "png", outBuf, width, height);
+        } catch (IOException ex) {
+            logger.log(Level.SEVERE, "Error while saving screenshot", ex);
+        } finally {
+            if (outStream != null){
+                try {
+                    outStream.close();
+                } catch (IOException ex) {
+                    logger.log(Level.SEVERE, "Error while saving screenshot", ex);
                 }
             }
         }
+    }
+
+    private void captureScreenshot(FrameBuffer out) {
+        Camera curCamera = rm.getCurrentCamera();
+        int viewX = (int) (curCamera.getViewPortLeft() * curCamera.getWidth());
+        int viewY = (int) (curCamera.getViewPortBottom() * curCamera.getHeight());
+        int viewWidth = (int) ((curCamera.getViewPortRight() - curCamera.getViewPortLeft()) * curCamera.getWidth());
+        int viewHeight = (int) ((curCamera.getViewPortTop() - curCamera.getViewPortBottom()) * curCamera.getHeight());
+        
+        renderer.setViewPort(0, 0, width, height);
+        renderer.readFrameBuffer(out, outBuf);
+        renderer.setViewPort(viewX, viewY, viewWidth, viewHeight);
     }
 
     private File determineFilename() {

--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
@@ -64,7 +64,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
     private ByteBuffer outBuf;
     
     private int width, height;
-    private NamingScheme namingScheme = new NamingScheme();
+    private NamingScheme namingScheme;
     
     private static class Screenshot{
         private static int nextSequenceNumber = 1;
@@ -99,6 +99,69 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
         private boolean numbered = true;
         private String filePath = null;
         
+        /**
+        * Using this constructor, the screenshot files will be written sequentially to the system
+        * default storage folder.
+        */
+        private NamingScheme(){
+        }
+        
+        /**
+        * This constructor allows you to specify the output file path of the screenshot.
+        * Include the seperator at the end of the path.
+        * Use an emptry string to use the application folder. Use NULL to use the system
+        * default storage folder.
+        * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
+        */
+        private NamingScheme(String filePath){
+            this.filePath = filePath;
+        }
+        
+        /**
+        * This constructor allows you to specify the output file path of the screenshot.
+        * Include the seperator at the end of the path.
+        * Use an emptry string to use the application folder. Use NULL to use the system
+        * default storage folder.
+        * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
+        * @param shotName The name of the file to save the screeshot as.
+        */
+        private NamingScheme(String filePath, String shotName){
+            this.filePath = filePath;
+            this.shotName = shotName;
+        }
+        
+        /**
+        * This constructor allows you to specify the output file path of the screenshot and
+        * a base index for the shot index.
+        * Include the seperator at the end of the path.
+        * Use an emptry string to use the application folder. Use NULL to use the system
+        * default storage folder.
+        * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
+        * @param shotIndex The base index for screen shots.  The first screen shot will have
+        *                  shotIndex + 1 appended, the next shotIndex + 2, and so on.
+        */
+        private NamingScheme(String filePath, long shotIndex){
+            this.filePath = filePath;
+            this.shotIndex = shotIndex;
+        }
+        
+        /**
+        * This constructor allows you to specify the output file path of the screenshot and
+        * a base index for the shot index.
+        * Include the seperator at the end of the path.
+        * Use an emptry string to use the application folder. Use NULL to use the system
+        * default storage folder.
+        * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
+        * @param fileName The name of the file to save the screeshot as.
+        * @param shotIndex The base index for screen shots.  The first screen shot will have
+        *                  shotIndex + 1 appended, the next shotIndex + 2, and so on.
+        */
+        private NamingScheme(String filePath, String shotName, long shotIndex){
+            this.filePath = filePath;
+            this.shotName = shotName;
+            this.shotIndex = shotIndex;
+        }
+        
         private File filenameForScreenshot(Screenshot screenshot) {
             File file;
             String filename;
@@ -123,6 +186,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
      */
     public ScreenshotAppState() {
         this(null);
+        namingScheme = new NamingScheme();
     }
 
     /**
@@ -133,7 +197,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
      * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
      */
     public ScreenshotAppState(String filePath) {
-        namingScheme.filePath = filePath;
+        namingScheme = new NamingScheme(filePath);
     }
 
     /**
@@ -145,8 +209,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
      * @param fileName The name of the file to save the screeshot as.
      */
     public ScreenshotAppState(String filePath, String fileName) {
-        namingScheme.filePath = filePath;
-        namingScheme.shotName = fileName;
+        namingScheme = new NamingScheme(filePath, fileName);
     }
 
     /**
@@ -160,8 +223,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
      *                  shotIndex + 1 appended, the next shotIndex + 2, and so on.
      */
     public ScreenshotAppState(String filePath, long shotIndex) {
-        namingScheme.filePath = filePath;
-        namingScheme.shotIndex = shotIndex;
+        namingScheme = new NamingScheme(filePath, shotIndex);
     }
 
     /**
@@ -176,9 +238,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
      *                  shotIndex + 1 appended, the next shotIndex + 2, and so on.
      */
     public ScreenshotAppState(String filePath, String fileName, long shotIndex) {
-        namingScheme.filePath = filePath;
-        namingScheme.shotName = fileName;
-        namingScheme.shotIndex = shotIndex;
+        namingScheme = new NamingScheme(filePath, fileName, shotIndex);
     }
     
     /**

--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
@@ -232,20 +232,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
             renderer.readFrameBuffer(out, outBuf);
             renderer.setViewPort(viewX, viewY, viewWidth, viewHeight);
 
-            File file;
-            String filename;
-            if (numbered) {
-                shotIndex++;
-                filename = shotName + shotIndex;
-            } else {
-                filename = shotName;
-            }
-
-            if (filePath == null) {
-                file = new File(JmeSystem.getStorageFolder() + File.separator + filename + ".png").getAbsoluteFile();
-            } else {
-                file = new File(filePath + filename + ".png").getAbsoluteFile();
-            }
+            File file = determineFilename();
             logger.log(Level.FINE, "Saving ScreenShot to: {0}", file.getAbsolutePath());
 
             OutputStream outStream = null;
@@ -264,5 +251,22 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
                 }
             }
         }
+    }
+
+    private File determineFilename() {
+        File file;
+        String filename;
+        if (numbered) {
+            shotIndex++;
+            filename = shotName + shotIndex;
+        } else {
+            filename = shotName;
+        }
+        if (filePath == null) {
+            file = new File(JmeSystem.getStorageFolder() + File.separator + filename + ".png").getAbsoluteFile();
+        } else {
+            file = new File(filePath + filename + ".png").getAbsoluteFile();
+        }
+        return file;
     }
 }

--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
@@ -67,17 +67,32 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
     private NamingScheme namingScheme = new NamingScheme();
     
     private static class Screenshot{
+        private static int nextSequenceNumber = 1;
         private ByteBuffer buffer;
-        private int width;
-        private int height;
+        private final int width;
+        private final int height;
+        private final int sequenceNumber;
 
         private Screenshot(ByteBuffer buffer, int width, int height) {
             this.buffer = buffer;
             this.width = width;
             this.height = height;
+            sequenceNumber = nextSequenceNumber++;
+        }
+        
+        public int getSequenceNumber(){
+            return this.sequenceNumber;
+        }
+        
+        public int getWidth(){
+            return width;
+        }
+        
+        public int getHeight(){
+            return height;
         }
     }
-    
+
     private class NamingScheme{
         private String shotName;
         private long shotIndex = 0;
@@ -264,7 +279,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
     }
 
     private void writeScreenshotToFile(Screenshot screenshot, File file) {
-        writeFile(file, screenshot.buffer, screenshot.width, screenshot.height);
+        writeFile(file, screenshot.buffer, screenshot.getWidth(), screenshot.getHeight());
     }
     
     private void writeFile(File file, ByteBuffer outBuf, int width, int height) {

--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
@@ -95,7 +95,6 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
 
     private static class NamingScheme{
         private String shotName;
-        private long shotIndex = 0;
         private boolean numbered = true;
         private String filePath = null;
         
@@ -113,7 +112,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
         * default storage folder.
         * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
         */
-        private NamingScheme(String filePath){
+        public NamingScheme(String filePath){
             this.filePath = filePath;
         }
         
@@ -125,49 +124,16 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
         * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
         * @param shotName The name of the file to save the screeshot as.
         */
-        private NamingScheme(String filePath, String shotName){
+        public NamingScheme(String filePath, String shotName){
             this.filePath = filePath;
             this.shotName = shotName;
         }
         
-        /**
-        * This constructor allows you to specify the output file path of the screenshot and
-        * a base index for the shot index.
-        * Include the seperator at the end of the path.
-        * Use an emptry string to use the application folder. Use NULL to use the system
-        * default storage folder.
-        * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
-        * @param shotIndex The base index for screen shots.  The first screen shot will have
-        *                  shotIndex + 1 appended, the next shotIndex + 2, and so on.
-        */
-        private NamingScheme(String filePath, long shotIndex){
-            this.filePath = filePath;
-            this.shotIndex = shotIndex;
-        }
-        
-        /**
-        * This constructor allows you to specify the output file path of the screenshot and
-        * a base index for the shot index.
-        * Include the seperator at the end of the path.
-        * Use an emptry string to use the application folder. Use NULL to use the system
-        * default storage folder.
-        * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
-        * @param fileName The name of the file to save the screeshot as.
-        * @param shotIndex The base index for screen shots.  The first screen shot will have
-        *                  shotIndex + 1 appended, the next shotIndex + 2, and so on.
-        */
-        private NamingScheme(String filePath, String shotName, long shotIndex){
-            this.filePath = filePath;
-            this.shotName = shotName;
-            this.shotIndex = shotIndex;
-        }
-        
-        private File filenameForScreenshot(Screenshot screenshot) {
+        public File filenameForScreenshot(Screenshot screenshot) {
             File file;
             String filename;
             if (numbered) {
-                shotIndex++;
-                filename = shotName + shotIndex;
+                filename = shotName + screenshot.getSequenceNumber();
             } else {
                 filename = shotName;
             }
@@ -180,7 +146,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
         }
     }
     
-    private ScreenshotAppState(NamingScheme scheme){
+    public ScreenshotAppState(NamingScheme scheme){
         super();
         this.namingScheme = scheme;
     }
@@ -203,47 +169,6 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
     public ScreenshotAppState(String filePath) {
         this(new NamingScheme(filePath));
     }
-
-    /**
-     * This constructor allows you to specify the output file path of the screenshot.
-     * Include the seperator at the end of the path.
-     * Use an emptry string to use the application folder. Use NULL to use the system
-     * default storage folder.
-     * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
-     * @param fileName The name of the file to save the screeshot as.
-     */
-    public ScreenshotAppState(String filePath, String fileName) {
-        this(new NamingScheme(filePath, fileName));
-    }
-
-    /**
-     * This constructor allows you to specify the output file path of the screenshot and
-     * a base index for the shot index.
-     * Include the seperator at the end of the path.
-     * Use an emptry string to use the application folder. Use NULL to use the system
-     * default storage folder.
-     * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
-     * @param shotIndex The base index for screen shots.  The first screen shot will have
-     *                  shotIndex + 1 appended, the next shotIndex + 2, and so on.
-     */
-    public ScreenshotAppState(String filePath, long shotIndex) {
-        this(new NamingScheme(filePath, shotIndex));
-    }
-
-    /**
-     * This constructor allows you to specify the output file path of the screenshot and
-     * a base index for the shot index.
-     * Include the seperator at the end of the path.
-     * Use an emptry string to use the application folder. Use NULL to use the system
-     * default storage folder.
-     * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
-     * @param fileName The name of the file to save the screeshot as.
-     * @param shotIndex The base index for screen shots.  The first screen shot will have
-     *                  shotIndex + 1 appended, the next shotIndex + 2, and so on.
-     */
-    public ScreenshotAppState(String filePath, String fileName, long shotIndex) {
-        this(new NamingScheme(filePath, fileName, shotIndex));
-    }
     
     /**
      * Set the file path to store the screenshot.
@@ -254,30 +179,6 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
      */
     public void setFilePath(String filePath) {
         namingScheme.filePath = filePath;
-    }
-
-    /**
-     * Set the file name of the screenshot.
-     * @param fileName File name to save the screenshot as.
-     */
-    public void setFileName(String fileName) {
-        namingScheme.shotName = fileName;
-    }
-
-    /**
-     * Sets the base index that will used for subsequent screen shots. 
-     */
-    public void setShotIndex(long index) {
-        namingScheme.shotIndex = index;
-    }
-
-    /**
-     * Sets if the filename should be appended with a number representing the 
-     * current sequence.
-     * @param numberedWanted If numbering is wanted.
-     */
-    public void setIsNumbered(boolean numberedWanted) {
-        namingScheme.numbered = numberedWanted;
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
@@ -93,7 +93,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
         }
     }
 
-    private class NamingScheme{
+    private static class NamingScheme{
         private String shotName;
         private long shotIndex = 0;
         private boolean numbered = true;
@@ -179,14 +179,18 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
             return file;
         }
     }
+    
+    private ScreenshotAppState(NamingScheme scheme){
+        super();
+        this.namingScheme = scheme;
+    }
 
     /**
      * Using this constructor, the screenshot files will be written sequentially to the system
      * default storage folder.
      */
     public ScreenshotAppState() {
-        this(null);
-        namingScheme = new NamingScheme();
+        this(new NamingScheme());
     }
 
     /**
@@ -197,7 +201,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
      * @param filePath The screenshot file path to use. Include the seperator at the end of the path.
      */
     public ScreenshotAppState(String filePath) {
-        namingScheme = new NamingScheme(filePath);
+        this(new NamingScheme(filePath));
     }
 
     /**
@@ -209,7 +213,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
      * @param fileName The name of the file to save the screeshot as.
      */
     public ScreenshotAppState(String filePath, String fileName) {
-        namingScheme = new NamingScheme(filePath, fileName);
+        this(new NamingScheme(filePath, fileName));
     }
 
     /**
@@ -223,7 +227,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
      *                  shotIndex + 1 appended, the next shotIndex + 2, and so on.
      */
     public ScreenshotAppState(String filePath, long shotIndex) {
-        namingScheme = new NamingScheme(filePath, shotIndex);
+        this(new NamingScheme(filePath, shotIndex));
     }
 
     /**
@@ -238,7 +242,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
      *                  shotIndex + 1 appended, the next shotIndex + 2, and so on.
      */
     public ScreenshotAppState(String filePath, String fileName, long shotIndex) {
-        namingScheme = new NamingScheme(filePath, fileName, shotIndex);
+        this(new NamingScheme(filePath, fileName, shotIndex));
     }
     
     /**

--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
@@ -32,6 +32,8 @@
 package com.jme3.app.state;
 
 import com.jme3.app.Application;
+import com.jme3.app.state.ScreenshotProcessor.Screenshot;
+import com.jme3.app.state.ScreenshotProcessor.ScreenshotHandler;
 import com.jme3.input.InputManager;
 import com.jme3.input.KeyInput;
 import com.jme3.input.controls.ActionListener;
@@ -63,40 +65,6 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
     private DefaultNamingScheme namingScheme;
     private ScreenshotHandler handler;
     
-    public static class Screenshot{
-        private static int nextSequenceNumber = 1;
-        private ByteBuffer buffer;
-        private final int width;
-        private final int height;
-        private final int sequenceNumber;
-
-        private Screenshot(ByteBuffer buffer, int width, int height) {
-            this.buffer = buffer;
-            this.width = width;
-            this.height = height;
-            sequenceNumber = nextSequenceNumber++;
-        }
-        
-        protected ByteBuffer getBuffer(){
-            return buffer;
-        }
-        
-        public int getSequenceNumber(){
-            return this.sequenceNumber;
-        }
-        
-        public int getWidth(){
-            return width;
-        }
-        
-        public int getHeight(){
-            return height;
-        }
-    }
-    
-    public interface ScreenshotHandler{
-        public void screenshotCaptured(Screenshot screenshot);
-    }
 
     private static class DefaultNamingScheme implements WriteToFileStrategy.NamingScheme{
         private String shotName;

--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotProcessor.java
@@ -1,0 +1,128 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.jme3.app.state;
+
+import com.jme3.post.SceneProcessor;
+import com.jme3.renderer.Camera;
+import com.jme3.renderer.RenderManager;
+import com.jme3.renderer.Renderer;
+import com.jme3.renderer.ViewPort;
+import com.jme3.renderer.queue.RenderQueue;
+import com.jme3.texture.FrameBuffer;
+import com.jme3.util.BufferUtils;
+import java.nio.ByteBuffer;
+
+/**
+ *
+ * @author kwando
+ */
+public class ScreenshotProcessor implements SceneProcessor {
+
+    public interface ScreenshotHandler {
+
+        public void screenshotCaptured(Screenshot screenshot);
+    }
+
+    public static class Screenshot {
+
+        private static int nextSequenceNumber = 1;
+        private ByteBuffer buffer;
+        private final int width;
+        private final int height;
+        private final int sequenceNumber;
+
+        Screenshot(ByteBuffer buffer, int width, int height) {
+            this.buffer = buffer;
+            this.width = width;
+            this.height = height;
+            sequenceNumber = nextSequenceNumber++;
+        }
+
+        protected ByteBuffer getBuffer() {
+            return buffer;
+        }
+
+        public int getSequenceNumber() {
+            return this.sequenceNumber;
+        }
+
+        public int getWidth() {
+            return width;
+        }
+
+        public int getHeight() {
+            return height;
+        }
+    }
+
+    private boolean doCapture;
+    private Renderer renderer;
+    private RenderManager rm;
+    private ByteBuffer outBuf;
+    private int width, height;
+
+    private ScreenshotHandler handler;
+
+    private ScreenshotProcessor(ScreenshotHandler handler) {
+        if (handler == null) {
+            throw new IllegalArgumentException("ScreenshotHandler cannot be null");
+        }
+        this.handler = handler;
+    }
+
+    public void initialize(RenderManager renderManager, ViewPort vp) {
+        renderer = rm.getRenderer();
+        rm = renderManager;
+        reshape(vp, vp.getCamera().getWidth(), vp.getCamera().getHeight());
+    }
+
+    public void reshape(ViewPort vp, int w, int h) {
+        outBuf = BufferUtils.createByteBuffer(w * h * 4);
+        width = w;
+        height = h;
+    }
+
+    public boolean isInitialized() {
+        return renderer != null;
+    }
+
+    public void preFrame(float tpf) {
+        // Noop
+    }
+
+    public void postQueue(RenderQueue rq) {
+        // Noop
+    }
+
+    public void postFrame(FrameBuffer out) {
+        if (doCapture) {
+            Screenshot screenshot = captureScreenshot(out);
+            handler.screenshotCaptured(screenshot);
+            doCapture = false;
+        }
+    }
+
+    public void takeScreenshot() {
+        this.doCapture = true;
+    }
+
+    public void cleanup() {
+        // Noop
+    }
+
+    private Screenshot captureScreenshot(FrameBuffer out) {
+        Camera curCamera = rm.getCurrentCamera();
+        int viewX = (int) (curCamera.getViewPortLeft() * curCamera.getWidth());
+        int viewY = (int) (curCamera.getViewPortBottom() * curCamera.getHeight());
+        int viewWidth = (int) ((curCamera.getViewPortRight() - curCamera.getViewPortLeft()) * curCamera.getWidth());
+        int viewHeight = (int) ((curCamera.getViewPortTop() - curCamera.getViewPortBottom()) * curCamera.getHeight());
+
+        renderer.setViewPort(0, 0, width, height);
+        renderer.readFrameBuffer(out, outBuf);
+        renderer.setViewPort(viewX, viewY, viewWidth, viewHeight);
+        return new Screenshot(outBuf, width, height);
+    }
+}

--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotProcessor.java
@@ -33,12 +33,14 @@ public class ScreenshotProcessor implements SceneProcessor {
         private final int width;
         private final int height;
         private final long sequenceNumber;
+        private final long timestamp;
 
         private Screenshot(ByteBuffer buffer, int width, int height) {
             this.buffer = buffer;
             this.width = width;
             this.height = height;
             sequenceNumber = nextSequenceNumber++;
+            timestamp = System.currentTimeMillis();
         }
 
         protected ByteBuffer getBuffer() {
@@ -47,6 +49,10 @@ public class ScreenshotProcessor implements SceneProcessor {
 
         public long getSequenceNumber() {
             return this.sequenceNumber;
+        }
+        
+        public long getTimestamp(){
+            return this.timestamp;
         }
 
         public int getWidth() {

--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotProcessor.java
@@ -32,7 +32,7 @@ public class ScreenshotProcessor implements SceneProcessor {
         private ByteBuffer buffer;
         private final int width;
         private final int height;
-        private final int sequenceNumber;
+        private final long sequenceNumber;
 
         private Screenshot(ByteBuffer buffer, int width, int height) {
             this.buffer = buffer;
@@ -45,7 +45,7 @@ public class ScreenshotProcessor implements SceneProcessor {
             return buffer;
         }
 
-        public int getSequenceNumber() {
+        public long getSequenceNumber() {
             return this.sequenceNumber;
         }
 

--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotProcessor.java
@@ -34,7 +34,7 @@ public class ScreenshotProcessor implements SceneProcessor {
         private final int height;
         private final int sequenceNumber;
 
-        Screenshot(ByteBuffer buffer, int width, int height) {
+        private Screenshot(ByteBuffer buffer, int width, int height) {
             this.buffer = buffer;
             this.width = width;
             this.height = height;
@@ -66,7 +66,7 @@ public class ScreenshotProcessor implements SceneProcessor {
 
     private ScreenshotHandler handler;
 
-    private ScreenshotProcessor(ScreenshotHandler handler) {
+    public ScreenshotProcessor(ScreenshotHandler handler) {
         if (handler == null) {
             throw new IllegalArgumentException("ScreenshotHandler cannot be null");
         }

--- a/jme3-core/src/main/java/com/jme3/app/state/WriteToFileStrategy.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/WriteToFileStrategy.java
@@ -1,7 +1,8 @@
 package com.jme3.app.state;
 
 import java.io.File;
-import com.jme3.app.state.ScreenshotAppState.Screenshot;
+import com.jme3.app.state.ScreenshotProcessor.ScreenshotHandler;
+import com.jme3.app.state.ScreenshotProcessor.Screenshot;
 import com.jme3.system.JmeSystem;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -14,7 +15,7 @@ import java.util.logging.Logger;
  *
  * @author kwando
  */
-public class WriteToFileStrategy implements ScreenshotAppState.ScreenshotHandler {
+public class WriteToFileStrategy implements ScreenshotHandler {
 
     public interface NamingScheme {
 

--- a/jme3-core/src/main/java/com/jme3/app/state/WriteToFileStrategy.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/WriteToFileStrategy.java
@@ -1,0 +1,59 @@
+package com.jme3.app.state;
+
+import java.io.File;
+import com.jme3.app.state.ScreenshotAppState.Screenshot;
+import com.jme3.system.JmeSystem;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ *
+ * @author kwando
+ */
+public class WriteToFileStrategy implements ScreenshotAppState.ScreenshotHandler {
+
+    public interface NamingScheme {
+
+        public File filenameForScreenshot(Screenshot screenshot);
+    }
+
+    private static final Logger logger = Logger.getLogger(ScreenshotAppState.class.getName());
+    private NamingScheme namingScheme;
+
+    public WriteToFileStrategy(NamingScheme namingScheme) {
+        if (namingScheme == null) {
+            throw new IllegalArgumentException("Namingscheme cannot be nulll");
+        }
+        this.namingScheme = namingScheme;
+    }
+
+    public void screenshotCaptured(Screenshot screenshot) {
+        writeScreenshotToFile(screenshot, namingScheme.filenameForScreenshot(screenshot));
+    }
+
+    private void writeScreenshotToFile(Screenshot screenshot, File file) {
+        writeFile(file, screenshot.getBuffer(), screenshot.getWidth(), screenshot.getHeight());
+    }
+
+    private void writeFile(File file, ByteBuffer outBuf, int width, int height) {
+        OutputStream outStream = null;
+        try {
+            outStream = new FileOutputStream(file);
+            JmeSystem.writeImageFile(outStream, "png", outBuf, width, height);
+        } catch (IOException ex) {
+            logger.log(Level.SEVERE, "Error while saving screenshot", ex);
+        } finally {
+            if (outStream != null) {
+                try {
+                    outStream.close();
+                } catch (IOException ex) {
+                    logger.log(Level.SEVERE, "Error while saving screenshot", ex);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I have taken the time to refactor the ScreenshotAppState and made the system more extendable.

Key changes:
- Split out the SceneProcessor from the AppState.
- Separate the writeToFile aspect from the SceneProcessor, what happens to the screenshot after it is taken is now pluggable.
- The file writing has support for custom naming schemes.

This is still a bit WIP, but please give me your thoughts.

 I will squash this when it is cooked =)