### PR TITLE
Mipmapped texture arrays

### DIFF
--- a/jme3-lwjgl/src/main/java/com/jme3/renderer/lwjgl/TextureUtil.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/renderer/lwjgl/TextureUtil.java
@@ -307,7 +307,7 @@ class TextureUtil {
                     // or upload slice
                     if (index == -1){
                         GL12.glTexImage3D(target,
-                                          0,
+                                          i,
                                           glFmt.internalFormat,
                                           mipWidth,
                                           mipHeight,


### PR DESCRIPTION
Fixed TextureUtil to properly handle mipmapped texture 2d arrays and 3d textures
