### PR TITLE
Fixed constantly mipmap generation

### DIFF
--- a/jme3-core/src/main/java/com/jme3/texture/Texture.java
+++ b/jme3-core/src/main/java/com/jme3/texture/Texture.java
@@ -339,7 +339,7 @@ public abstract class Texture implements CloneableSmartAsset, Savable, Cloneable
                     "minificationFilter can not be null.");
         }
         this.minificationFilter = minificationFilter;
-        if (minificationFilter.usesMipMapLevels() && image != null && !image.isGeneratedMipmapsRequired()) {
+        if (minificationFilter.usesMipMapLevels() && image != null && !image.isGeneratedMipmapsRequired() && !image.hasMipmaps()) {
             image.setNeedGeneratedMipmaps();
         }
     }


### PR DESCRIPTION
Fixed bug when setting MinFilter with mipmapping after generating mipmaps causes jME to update image data every frame.
