### PR TITLE
Spatial remove "null" from controls on read(...).

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Spatial.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Spatial.java
@@ -35,11 +35,19 @@ import com.jme3.asset.AssetKey;
 import com.jme3.asset.CloneableSmartAsset;
 import com.jme3.bounding.BoundingVolume;
 import com.jme3.collision.Collidable;
-import com.jme3.export.*;
+import com.jme3.export.InputCapsule;
+import com.jme3.export.JmeExporter;
+import com.jme3.export.JmeImporter;
+import com.jme3.export.OutputCapsule;
+import com.jme3.export.Savable;
 import com.jme3.light.Light;
 import com.jme3.light.LightList;
 import com.jme3.material.Material;
-import com.jme3.math.*;
+import com.jme3.math.Matrix3f;
+import com.jme3.math.Matrix4f;
+import com.jme3.math.Quaternion;
+import com.jme3.math.Transform;
+import com.jme3.math.Vector3f;
 import com.jme3.renderer.Camera;
 import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.ViewPort;
@@ -50,7 +58,12 @@ import com.jme3.scene.control.Control;
 import com.jme3.util.SafeArrayList;
 import com.jme3.util.TempVars;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Queue;
 import java.util.logging.Logger;
 
 /**
@@ -1328,6 +1341,9 @@ public abstract class Spatial implements Savable, Cloneable, Collidable, Cloneab
         //When backward compatibility won't be needed anymore this can be replaced by : 
         //controls = ic.readSavableArrayList("controlsList", null));
         controls.addAll(0, ic.readSavableArrayList("controlsList", null));
+        for(int i = controls.size() -1 ; i > -1; i--) {
+            if (controls.get(i) == null) controls.remove(i);
+        }
 
         userData = (HashMap<String, Savable>) ic.readStringSavableMap("user_data", null);
     }


### PR DESCRIPTION
It's possible if the class of the control is not found (may be deleted).

In SDK with this modification, the exception about ClassNotFound is "notify"
but it no longer raise a NPE (on clone()) and the j3o can be open and edited
without the missing Control.

```
SEVERE [com.jme3.export.binary.BinaryImporter]: Exception
java.lang.ClassNotFoundException: vdrones.NewControl
	at java.net.URLClassLoader$1.run(URLClassLoader.java:372)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:360)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at com.jme3.export.SavableClassUtil.fromName(SavableClassUtil.java:195)
[catch] at com.jme3.export.binary.BinaryImporter.readObject(BinaryImporter.java:333)
	at com.jme3.export.binary.BinaryInputCapsule.resolveIDs(BinaryInputCapsule.java:483)
	at com.jme3.export.binary.BinaryInputCapsule.readSavableArray(BinaryInputCapsule.java:471)
	at com.jme3.export.binary.BinaryInputCapsule.readSavableArrayList(BinaryInputCapsule.java:587)
	at com.jme3.scene.Spatial.read(Spatial.java:1333)
	at com.jme3.scene.Node.read(Node.java:608)
	at com.jme3.export.binary.BinaryImporter.readObject(BinaryImporter.java:344)
	at com.jme3.export.binary.BinaryInputCapsule.resolveIDs(BinaryInputCapsule.java:483)
	at com.jme3.export.binary.BinaryInputCapsule.readSavableArray(BinaryInputCapsule.java:471)
	at com.jme3.export.binary.BinaryInputCapsule.readSavableArrayList(BinaryInputCapsule.java:587)
	at com.jme3.scene.Node.read(Node.java:598)
	at com.jme3.export.binary.BinaryImporter.readObject(BinaryImporter.java:344)
	at com.jme3.export.binary.BinaryImporter.load(BinaryImporter.java:242)
	at com.jme3.export.binary.BinaryImporter.load(BinaryImporter.java:125)
	at com.jme3.export.binary.BinaryImporter.load(BinaryImporter.java:109)
	at com.jme3.asset.DesktopAssetManager.loadAsset(DesktopAssetManager.java:288)
	at com.jme3.asset.DesktopAssetManager.loadModel(DesktopAssetManager.java:374)
	at com.jme3.gde.core.assets.SpatialAssetDataObject.loadAsset(SpatialAssetDataObject.java:94)
	at com.jme3.gde.scenecomposer.OpenSceneComposer$1.run(OpenSceneComposer.java:38)
	at java.lang.Thread.run(Thread.java:745)
SEVERE [org.openide.util.Exceptions]
java.lang.NullPointerException
	at com.jme3.scene.Spatial.clone(Spatial.java:1188)
	at com.jme3.scene.Node.clone(Node.java:564)
	at com.jme3.scene.Node.clone(Node.java:60)
	at com.jme3.scene.Spatial.clone(Spatial.java:1173)
	at com.jme3.scene.Node.clone(Node.java:564)
	at com.jme3.scene.Node.clone(Node.java:60)
	at com.jme3.scene.Spatial.clone(Spatial.java:1218)
	at com.jme3.scene.Spatial.clone(Spatial.java:66)
	at com.jme3.asset.CloneableAssetProcessor.createClone(CloneableAssetProcessor.java:48)
	at com.jme3.asset.DesktopAssetManager.loadAsset(DesktopAssetManager.java:327)
	at com.jme3.asset.DesktopAssetManager.loadModel(DesktopAssetManager.java:374)
[catch] at com.jme3.gde.core.assets.SpatialAssetDataObject.loadAsset(SpatialAssetDataObject.java:94)
	at com.jme3.gde.scenecomposer.OpenSceneComposer$1.run(OpenSceneComposer.java:38)
	at java.lang.Thread.run(Thread.java:745)
```