### PR TITLE
Fix badly specified RGB10_A2 format

### DIFF
--- a/jme3-lwjgl/src/main/java/com/jme3/renderer/lwjgl/TextureUtil.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/renderer/lwjgl/TextureUtil.java
@@ -118,7 +118,7 @@ class TextureUtil {
         setFormat(Format.RGB9E5,               GL30.GL_RGB9_E5,         GL11.GL_RGB, GL30.GL_UNSIGNED_INT_5_9_9_9_REV, false);
         setFormat(Format.RGB16F_to_RGB111110F, GL30.GL_R11F_G11F_B10F, GL11.GL_RGB, GL30.GL_HALF_FLOAT, false);
         setFormat(Format.RGB16F_to_RGB9E5,     GL30.GL_RGB9_E5,         GL11.GL_RGB, GL30.GL_HALF_FLOAT, false);
-        setFormat(Format.RGB10_A2,             GL11.GL_RGB10_A2,        GL11.GL_RGB, GL12.GL_UNSIGNED_INT_10_10_10_2, false);
+        setFormat(Format.RGB10_A2,             GL11.GL_RGB10_A2,        GL11.GL_RGBA, GL12.GL_UNSIGNED_INT_10_10_10_2, false);
         
         // RGBA formats
         setFormat(Format.ABGR8,   GL11.GL_RGBA8,  GL11.GL_RGBA, GL12.GL_UNSIGNED_INT_8_8_8_8, false);


### PR DESCRIPTION
There is a bug in RGB10_A2 format for lwjgl implementation - it was specified as RBG instead of RGBA texture. It was causing GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT_EXT when trying to use it with MRT.

There might be same problem in other renderers (? jogl, android, ios), I do not compile these projects, so cannot check/fix there - please take a look.
