### PR TITLE
SDK: fix #152 SceneComposer/SceneViewer bug in open/close Scene

### DIFF
--- a/sdk/jme3-scenecomposer/src/com/jme3/gde/scenecomposer/SceneComposerTopComponent.java
+++ b/sdk/jme3-scenecomposer/src/com/jme3/gde/scenecomposer/SceneComposerTopComponent.java
@@ -864,6 +864,7 @@ private void jToggleSelectGeomActionPerformed(java.awt.event.ActionEvent evt) {/
             sceneInfoLabel2.setToolTipText("");
             close();
         } else {
+            result.addLookupListener(this);
             showSelectionToggleButton.setSelected(true);
             showGridToggleButton.setSelected(false);
             //TODO: threading
@@ -881,7 +882,6 @@ private void jToggleSelectGeomActionPerformed(java.awt.event.ActionEvent evt) {/
     public void openScene(Spatial spat, AssetDataObject file, ProjectAssetManager manager) {
         cleanupControllers();
         SceneApplication.getApplication().addSceneListener(this);
-        result.addLookupListener(this);
         Node node;
         if (spat instanceof Node) {
             node = (Node) spat;


### PR DESCRIPTION
The less intrusive fix, it introduce a better symmetrie between open/close scene . A better fix require a "refactor" in the way to chain actions between job/AWT/jME thread => discussion before.
