### PR TITLE
Error dialog being displayed in a headless context

### DIFF
--- a/jme3-core/src/main/java/com/jme3/app/Application.java
+++ b/jme3-core/src/main/java/com/jme3/app/Application.java
@@ -518,12 +518,14 @@ public class Application implements SystemListener {
     public void handleError(String errMsg, Throwable t){
         // Print error to log.
         logger.log(Level.SEVERE, errMsg, t);
-        // Display error message on screen
-        if (t != null) {
-            JmeSystem.showErrorDialog(errMsg + "\n" + t.getClass().getSimpleName() +
-                    (t.getMessage() != null ? ": " +  t.getMessage() : ""));
-        } else {
-            JmeSystem.showErrorDialog(errMsg);
+        // Display error message on screen if not in headless mode
+        if (context.getType() != JmeContext.Type.Headless) {
+            if (t != null) {
+                JmeSystem.showErrorDialog(errMsg + "\n" + t.getClass().getSimpleName() +
+                        (t.getMessage() != null ? ": " +  t.getMessage() : ""));
+            } else {
+                JmeSystem.showErrorDialog(errMsg);
+            }
         }
 
         stop(); // stop the application


### PR DESCRIPTION
This was causing an infinite cycle of java.awt.HeadlessException in case handleError was called in an environment without display.

In applications with a headless context, the error dialog will now be skipped.
