### PR TITLE
Fix some FBX loader problems

### DIFF
--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneLoader.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneLoader.java
@@ -780,8 +780,8 @@ public class SceneLoader implements AssetLoader {
 				int index = unIndexMap[i];
 				if(index > srcCount)
 					throw new AssetLoadException("Invalid texcoord mapping. Unexpected lookup texcoord " + index + " from " + srcCount);
-				float u = (float) data.uv[2 * index + 0];
-				float v = (float) data.uv[2 * index + 1];
+				float u = index >= 0 ? (float) data.uv[2 * index + 0] : 0;
+				float v = index >= 0 ? (float) data.uv[2 * index + 1] : 0;
 				tcBuf.put(u).put(v);
 			}
 		}
@@ -959,10 +959,8 @@ public class SceneLoader implements AssetLoader {
 		// Build mesh nodes
 		for(long nodeId : modelDataMap.keySet()) {
 			ModelData data = modelDataMap.get(nodeId);
-			if(data.type.equals("Mesh")) {
-				Node node = createNode(data);
-				modelMap.put(nodeId, node);
-			}
+			Node node = createNode(data);
+			modelMap.put(nodeId, node);
 		}
 		// Link model nodes into scene
 		for(long modelId : modelMap.keySet()) {


### PR DESCRIPTION
Fix exception when loading geometry with some polygons without uv, fix loading nodes
without models (nested nodes).

(I'm doing it because @tort32 is too lazy to commit changes :))

Original forum topic: http://hub.jmonkeyengine.org/forum/topic/fbx-importer/
