### PR TITLE
Added steps for proper Eclipse setup and steps to build project with Gradle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,13 @@ When you're ready to submit your code, just make a [pull request](https://help.g
 - When committing, always be sure to run an update before you commit. If there is a conflict between the latest revision and your patch after the update, then it is your responsibility to track down the update that caused the conflict and determine the issue (and fix it). In the case where the breaking commit has no thread linked (and one cannot be found in the forum), then the contributor should contact an administrator and wait for feedback before committing.
 - If your code is committed and it introduces new functionality, please edit the wiki accordingly. We can easily roll back to previous revisions, so just do your best; point us to it and we’ll see if it sticks!
 
-**Note to Eclipse users:** The Eclipse [git client does not support https](http://hub.jmonkeyengine.org/forum/topic/problem-cloning-the-new-git-repository/#post-265594). The current workaround is to use the command line to clone the repository and then add local repository in Eclipse.
+**Note to Eclipse users:** The Eclipse [git client does not support https](http://hub.jmonkeyengine.org/forum/topic/problem-cloning-the-new-git-repository/#post-265594). The current workaround is to use the command line to clone the repository.
+To import the local repository as a project follow these steps:
+1. Add a line 'apply plugin: eclipse' to your common.gradle file in the main project directory.
+2. Navigate to the project directory in command line and execute command 'gradle eclipse'. This will load all the dependancies for eclipse.
+3. In Eclipse, add the repository as an existing Java Project.
+
+
 
 #### Core Contributors
 
@@ -24,7 +30,8 @@ Developers in the Contributors team can push directly to Main instead of submitt
 
 ## Building the engine
 
-NEEDS ATTENTION: Gradle and whatnot.
+1. Install [Gradle](http://www.gradle.org/)
+2. Navigate to the project directory and run 'gradle build' from command line to build the engine.
 
 ## Best Practices
 


### PR DESCRIPTION
Updated the wiki to include steps to import the project in Eclipse as an existing Java Project.
Also added steps to install Gradle to build the project from the command line.
