### PR TITLE
Fix invalidateUpdateList not to use both cycle and recursion traverse

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Node.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Node.java
@@ -199,15 +199,15 @@ public class Node extends Spatial implements Savable {
     }
 
     /**
-     *  Called to invalide the root node's update list.  This is
+     *  Called to invalidate the root node's update list.  This is
      *  called whenever a spatial is attached/detached as well as
      *  when a control is added/removed from a Spatial in a way
      *  that would change state.
      */
     void invalidateUpdateList() {
         updateListValid = false;
-        for( Node n = parent; n != null; n = n.getParent() ) {
-            n.invalidateUpdateList();
+        if ( parent != null ) {
+          parent.invalidateUpdateList();
         }
     }
 


### PR DESCRIPTION
This is only fix of trivial: Last significant change of updateLogicalState in 05c6986492166c549d928cc2b23dc4c5de289b54 has used both cycle and recursion inside `Node.invalidateUpdateList()`. So it has had quadratic complexity O(depth^2).
