### PR TITLE
Fix Node.getUpdateList() to add the root Node itself when necessary

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Node.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Node.java
@@ -222,6 +222,9 @@ public class Node extends Spatial implements Savable {
         }
 
         // Build the list
+        if( requiresUpdates() ) {
+            updateList.add(this);
+        }
         addUpdateChildren(updateList);
         updateListValid = true;       
         return updateList;   


### PR DESCRIPTION
In the Last significant change of updateLogicalState in 05c6986492166c549d928cc2b23dc4c5de289b54 the `Node.getUpdateList()` rebuilds the `updateList`, but only children are added, the rootNode never.
The fix is trivial.
