### PR TITLE
Optimize RenderShadow to use scene hierarchy for culling

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
@@ -658,8 +658,6 @@ public class RenderManager {
     public void renderScene(Spatial scene, ViewPort vp) {
         //reset of the camera plane state for proper culling (must be 0 for the first note of the scene to be rendered)
         vp.getCamera().setPlaneState(0);
-        //remember the scene for possible later use
-        vp.getQueue().setRootScene(scene);
         //rendering the scene
         renderSubScene(scene, vp);
     }

--- a/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
@@ -591,6 +591,7 @@ public class RenderManager {
      * is still rendered in the shadow frustum (shadow casting queue)
      * through this recursive method.
      */
+    @Deprecated
     private void renderShadow(Spatial s, RenderQueue rq) {
         if (s instanceof Node) {
             Node n = (Node) s;
@@ -681,6 +682,8 @@ public class RenderManager {
     public void renderScene(Spatial scene, ViewPort vp) {
         //reset of the camera plane state for proper culling (must be 0 for the first note of the scene to be rendered)
         vp.getCamera().setPlaneState(0);
+        //remember the scene for possible later use
+        vp.getQueue().setRootScene(scene);
         //rendering the scene
         renderSubScene(scene, vp);
     }
@@ -690,10 +693,6 @@ public class RenderManager {
 
         // check culling first.
         if (!scene.checkCulling(vp.getCamera())) {
-            // move on to shadow-only render
-            if ((scene.getShadowMode() != RenderQueue.ShadowMode.Off || scene instanceof Node) && scene.getCullHint() != Spatial.CullHint.Always) {
-                renderShadow(scene, vp.getQueue());
-            }
             return;
         }
 
@@ -717,12 +716,6 @@ public class RenderManager {
             }
 
             vp.getQueue().addToQueue(gm, scene.getQueueBucket());
-
-            // add to shadow queue if needed
-            RenderQueue.ShadowMode shadowMode = scene.getShadowMode();
-            if (shadowMode != RenderQueue.ShadowMode.Off) {
-                vp.getQueue().addToShadowQueue(gm, shadowMode);
-            }
         }
     }
 

--- a/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
@@ -587,30 +587,6 @@ public class RenderManager {
     }
 
     /**
-     * If a spatial is not inside the eye frustum, it
-     * is still rendered in the shadow frustum (shadow casting queue)
-     * through this recursive method.
-     */
-    @Deprecated
-    private void renderShadow(Spatial s, RenderQueue rq) {
-        if (s instanceof Node) {
-            Node n = (Node) s;
-            List<Spatial> children = n.getChildren();
-            for (int i = 0; i < children.size(); i++) {
-                renderShadow(children.get(i), rq);
-            }
-        } else if (s instanceof Geometry) {
-            Geometry gm = (Geometry) s;
-
-            RenderQueue.ShadowMode shadowMode = s.getShadowMode();
-            if (shadowMode != RenderQueue.ShadowMode.Off && shadowMode != RenderQueue.ShadowMode.Receive && !gm.isGrouped()) {
-                //forcing adding to shadow cast mode, culled objects doesn't have to be in the receiver queue
-                rq.addToShadowQueue(gm, RenderQueue.ShadowMode.Cast);
-            }
-        }
-    }
-
-    /**
      * Preloads a scene for rendering.
      * <p>
      * After invocation of this method, the underlying

--- a/jme3-core/src/main/java/com/jme3/renderer/queue/RenderQueue.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/queue/RenderQueue.java
@@ -51,7 +51,6 @@ public class RenderQueue {
     private GeometryList translucentList;
     private GeometryList skyList;
     private GeometryList shadowRecv;
-    private Spatial rootScene = null;
 
     /**
      * Creates a new RenderQueue, the default {@link GeometryComparator comparators}
@@ -337,14 +336,6 @@ public class RenderQueue {
         }
     }
 
-    public void setRootScene(Spatial rs) {
-        rootScene = rs;
-    }
-    
-    public Spatial getRootScene() {
-        return rootScene;
-    }
-    
     public void clear() {
         opaqueList.clear();
         guiList.clear();

--- a/jme3-core/src/main/java/com/jme3/renderer/queue/RenderQueue.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/queue/RenderQueue.java
@@ -50,8 +50,9 @@ public class RenderQueue {
     private GeometryList transparentList;
     private GeometryList translucentList;
     private GeometryList skyList;
-    private GeometryList shadowRecv;
-    private GeometryList shadowCast;
+    @Deprecated private GeometryList shadowRecv;
+    @Deprecated private GeometryList shadowCast;
+    private Spatial rootScene = null;
 
     /**
      * Creates a new RenderQueue, the default {@link GeometryComparator comparators}
@@ -242,21 +243,14 @@ public class RenderQueue {
      * {@link ShadowMode#CastAndReceive}, it is added to both the cast
      * and the receive buckets.
      */
+    @Deprecated
     public void addToShadowQueue(Geometry g, ShadowMode shadBucket) {
         switch (shadBucket) {
             case Inherit:
-                break;
             case Off:
-                break;
             case Cast:
-                shadowCast.add(g);
-                break;
             case Receive:
-                shadowRecv.add(g);
-                break;
             case CastAndReceive:
-                shadowCast.add(g);
-                shadowRecv.add(g);
                 break;
             default:
                 throw new UnsupportedOperationException("Unrecognized shadow bucket type: " + shadBucket);
@@ -331,6 +325,7 @@ public class RenderQueue {
         renderGeometryList(list, rm, cam, clear);
     }
 
+    @Deprecated
     public void renderShadowQueue(ShadowMode shadBucket, RenderManager rm, Camera cam, boolean clear) {
         switch (shadBucket) {
             case Cast:
@@ -388,6 +383,14 @@ public class RenderQueue {
         }
     }
 
+    public void setRootScene(Spatial rs) {
+        rootScene = rs;
+    }
+    
+    public Spatial getRootScene() {
+        return rootScene;
+    }
+    
     public void clear() {
         opaqueList.clear();
         guiList.clear();

--- a/jme3-core/src/main/java/com/jme3/renderer/queue/RenderQueue.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/queue/RenderQueue.java
@@ -50,8 +50,7 @@ public class RenderQueue {
     private GeometryList transparentList;
     private GeometryList translucentList;
     private GeometryList skyList;
-    @Deprecated private GeometryList shadowRecv;
-    @Deprecated private GeometryList shadowCast;
+    private GeometryList shadowRecv;
     private Spatial rootScene = null;
 
     /**
@@ -65,7 +64,6 @@ public class RenderQueue {
         this.translucentList = new GeometryList(new TransparentComparator());
         this.skyList = new GeometryList(new NullComparator());
         this.shadowRecv = new GeometryList(new OpaqueComparator());
-        this.shadowCast = new GeometryList(new OpaqueComparator());
     }
 
     /**
@@ -231,33 +229,6 @@ public class RenderQueue {
     }
 
     /**
-     * Adds a geometry to a shadow bucket.
-     * Note that this operation is done automatically by the
-     * {@link RenderManager}. {@link SceneProcessor}s that handle
-     * shadow rendering should fetch the queue by using
-     * {@link #getShadowQueueContent(com.jme3.renderer.queue.RenderQueue.ShadowMode) },
-     * by default no action is taken on the shadow queues.
-     * 
-     * @param g The geometry to add
-     * @param shadBucket The shadow bucket type, if it is
-     * {@link ShadowMode#CastAndReceive}, it is added to both the cast
-     * and the receive buckets.
-     */
-    @Deprecated
-    public void addToShadowQueue(Geometry g, ShadowMode shadBucket) {
-        switch (shadBucket) {
-            case Inherit:
-            case Off:
-            case Cast:
-            case Receive:
-            case CastAndReceive:
-                break;
-            default:
-                throw new UnsupportedOperationException("Unrecognized shadow bucket type: " + shadBucket);
-        }
-    }
-
-    /**
      * Adds a geometry to the given bucket.
      * The {@link RenderManager} automatically handles this task
      * when flattening the scene graph. The bucket to add
@@ -292,14 +263,11 @@ public class RenderQueue {
     /**
      * 
      * @param shadBucket The shadow mode to retrieve the {@link GeometryList
-     * queue content} for.  Only {@link ShadowMode#Cast Cast} and
-     * {@link ShadowMode#Receive Receive} are valid.
+     * queue content} for.  Only {@link ShadowMode#Receive Receive} is valid.
      * @return The cast or receive {@link GeometryList}
      */
     public GeometryList getShadowQueueContent(ShadowMode shadBucket) {
         switch (shadBucket) {
-            case Cast:
-                return shadowCast;
             case Receive:
                 return shadowRecv;
             default:
@@ -323,20 +291,6 @@ public class RenderQueue {
 
     public void renderShadowQueue(GeometryList list, RenderManager rm, Camera cam, boolean clear) {
         renderGeometryList(list, rm, cam, clear);
-    }
-
-    @Deprecated
-    public void renderShadowQueue(ShadowMode shadBucket, RenderManager rm, Camera cam, boolean clear) {
-        switch (shadBucket) {
-            case Cast:
-                renderGeometryList(shadowCast, rm, cam, clear);
-                break;
-            case Receive:
-                renderGeometryList(shadowRecv, rm, cam, clear);
-                break;
-            default:
-                throw new IllegalArgumentException("Unexpected shadow bucket: " + shadBucket);
-        }
     }
 
     public boolean isQueueEmpty(Bucket bucket) {
@@ -397,7 +351,6 @@ public class RenderQueue {
         transparentList.clear();
         translucentList.clear();
         skyList.clear();
-        shadowCast.clear();
         shadowRecv.clear();
     }
 }

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
@@ -489,9 +489,6 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
 
             //rendering the post shadow pass
             viewPort.getQueue().renderShadowQueue(lightReceivers, renderManager, cam, false);
-            if (flushQueues) {
-                sceneReceivers.clear();
-            }
 
             //resetting renderManager settings
             renderManager.setForcedTechnique(null);
@@ -502,6 +499,9 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
             clearMatParams();
         }
 
+        if (flushQueues) {
+            sceneReceivers.clear();
+        }
     }
     
     /**

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
@@ -387,8 +387,9 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
     public void postQueue(RenderQueue rq) {
         GeometryList occluders = rq.getShadowQueueContent(ShadowMode.Cast);
         sceneReceivers = rq.getShadowQueueContent(ShadowMode.Receive);
+        lightReceivers.clear();
         skipPostPass = false;
-        if (sceneReceivers.size() == 0 || occluders.size() == 0 || !checkCulling(viewPort.getCamera())) {
+        if ( !checkCulling(viewPort.getCamera()) ) {
             skipPostPass = true;
             return;
         }
@@ -473,12 +474,12 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
         if (debug) {
             displayShadowMap(renderManager.getRenderer());
         }
-
+        
         lightReceivers = getReceivers(sceneReceivers, lightReceivers);
 
         if (lightReceivers.size() != 0) {
             //setting params to recieving geometry list
-            setMatParams();
+            setMatParams(lightReceivers);
 
             Camera cam = viewPort.getCamera();
             //some materials in the scene does not have a post shadow technique so we're using the fall back material
@@ -541,10 +542,7 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
      */
     protected abstract void setMaterialParameters(Material material);
 
-    private void setMatParams() {
-
-        GeometryList l = viewPort.getQueue().getShadowQueueContent(ShadowMode.Receive);
-
+    private void setMatParams(GeometryList l) {
         //iteration throught all the geometries of the list to gather the materials
 
         matCache.clear();

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
@@ -363,7 +363,7 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
      * @param shadowMapOcculders
      * @return
      */
-    protected abstract GeometryList getOccludersToRender(int shadowMapIndex, GeometryList sceneOccluders, GeometryList sceneReceivers, GeometryList shadowMapOccluders);
+    protected abstract GeometryList getOccludersToRender(int shadowMapIndex, GeometryList shadowMapOccluders);
 
     /**
      * return the shadow camera to use for rendering the shadow map according
@@ -385,7 +385,6 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
 
     @SuppressWarnings("fallthrough")
     public void postQueue(RenderQueue rq) {
-        GeometryList occluders = rq.getShadowQueueContent(ShadowMode.Cast);
         sceneReceivers = rq.getShadowQueueContent(ShadowMode.Receive);
         lightReceivers.clear();
         skipPostPass = false;
@@ -405,14 +404,12 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
                 if (debugfrustums) {
                     doDisplayFrustumDebug(shadowMapIndex);
                 }
-                renderShadowMap(shadowMapIndex, occluders, sceneReceivers);
+                renderShadowMap(shadowMapIndex);
 
             }
 
         debugfrustums = false;
-        if (flushQueues) {
-            occluders.clear();
-        }
+
         //restore setting for future rendering
         r.setFrameBuffer(viewPort.getOutputFrameBuffer());
         renderManager.setForcedMaterial(null);
@@ -421,8 +418,8 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
         
     }
 
-    protected void renderShadowMap(int shadowMapIndex, GeometryList occluders, GeometryList receivers) {
-        shadowMapOccluders = getOccludersToRender(shadowMapIndex, occluders, receivers, shadowMapOccluders);
+    protected void renderShadowMap(int shadowMapIndex) {
+        shadowMapOccluders = getOccludersToRender(shadowMapIndex, shadowMapOccluders);
         Camera shadowCam = getShadowCam(shadowMapIndex);
 
         //saving light view projection matrix for this split            

--- a/jme3-core/src/main/java/com/jme3/shadow/BasicShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/BasicShadowRenderer.java
@@ -43,6 +43,7 @@ import com.jme3.renderer.queue.GeometryList;
 import com.jme3.renderer.queue.OpaqueComparator;
 import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.renderer.queue.RenderQueue.ShadowMode;
+import com.jme3.scene.Spatial;
 import com.jme3.texture.FrameBuffer;
 import com.jme3.texture.Image.Format;
 import com.jme3.texture.Texture2D;
@@ -146,7 +147,9 @@ public class BasicShadowRenderer implements SceneProcessor {
     }
 
     public void postQueue(RenderQueue rq) {
-        ShadowUtil.getGeometriesInCamFrustum(rq.getRootScene(), viewPort.getCamera(), ShadowMode.Receive, lightReceivers);
+        for (Spatial scene : viewPort.getScenes()) {
+            ShadowUtil.getGeometriesInCamFrustum(scene, viewPort.getCamera(), ShadowMode.Receive, lightReceivers);
+        }
 
         // update frustum points based on current camera
         Camera viewCam = viewPort.getCamera();
@@ -174,7 +177,7 @@ public class BasicShadowRenderer implements SceneProcessor {
         shadowCam.updateViewProjection();
 
         // render shadow casters to shadow map
-        ShadowUtil.updateShadowCamera(rq.getRootScene(), lightReceivers, shadowCam, points, shadowOccluders, shadowMapSize);
+        ShadowUtil.updateShadowCamera(viewPort, lightReceivers, shadowCam, points, shadowOccluders, shadowMapSize);
         if (shadowOccluders.size() == 0) {
             noOccluders = true;
             return;

--- a/jme3-core/src/main/java/com/jme3/shadow/BasicShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/BasicShadowRenderer.java
@@ -174,9 +174,7 @@ public class BasicShadowRenderer implements SceneProcessor {
         shadowCam.updateViewProjection();
 
         // render shadow casters to shadow map
-        ShadowUtil.rootScene = rq.getRootScene();
-        ShadowUtil.updateShadowCamera(null, lightReceivers, shadowCam, points, shadowOccluders, shadowMapSize);
-        ShadowUtil.rootScene = null;
+        ShadowUtil.updateShadowCamera(rq.getRootScene(), lightReceivers, shadowCam, points, shadowOccluders, shadowMapSize);
         if (shadowOccluders.size() == 0) {
             noOccluders = true;
             return;
@@ -209,7 +207,7 @@ public class BasicShadowRenderer implements SceneProcessor {
         if (!noOccluders) {
             postshadowMat.setMatrix4("LightViewProjectionMatrix", shadowCam.getViewProjectionMatrix());
             renderManager.setForcedMaterial(postshadowMat);
-            viewPort.getQueue().renderShadowQueue(lightReceivers, renderManager, shadowCam, true);
+            viewPort.getQueue().renderShadowQueue(lightReceivers, renderManager, viewPort.getCamera(), true);
             renderManager.setForcedMaterial(null);
         }
     }

--- a/jme3-core/src/main/java/com/jme3/shadow/DirectionalLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/DirectionalLightShadowRenderer.java
@@ -42,7 +42,9 @@ import com.jme3.math.ColorRGBA;
 import com.jme3.math.Vector2f;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.Camera;
+import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.queue.GeometryList;
+import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.Node;
 import java.io.IOException;
 
@@ -178,14 +180,21 @@ public class DirectionalLightShadowRenderer extends AbstractShadowRenderer {
         // update frustum points based on current camera and split
         ShadowUtil.updateFrustumPoints(viewPort.getCamera(), splitsArray[shadowMapIndex], splitsArray[shadowMapIndex + 1], 1.0f, points);
 
-        //Updating shadow cam with curent split frustra        
-        ShadowUtil.updateShadowCamera(sceneOccluders, sceneReceivers, shadowCam, points, shadowMapOccluders, stabilize?shadowMapSize:0);
+        //Updating shadow cam with curent split frustra
+        if (sceneReceivers.size()==0) {
+            ShadowUtil.getGeometriesInCamFrustum(viewPort.getQueue().getRootScene(), viewPort.getCamera(), RenderQueue.ShadowMode.Receive, sceneReceivers);
+        }
+        ShadowUtil.updateShadowCameraFromRoot(viewPort.getQueue().getRootScene(), sceneReceivers, shadowCam, points, shadowMapOccluders, stabilize?shadowMapSize:0);
 
         return shadowMapOccluders;
     }
 
     @Override
     GeometryList getReceivers(GeometryList sceneReceivers, GeometryList lightReceivers) {
+        if (sceneReceivers.size()==0) {
+            ShadowUtil.getGeometriesInCamFrustum(viewPort.getQueue().getRootScene(), viewPort.getCamera(), RenderQueue.ShadowMode.Receive, sceneReceivers);
+        }
+        lightReceivers = sceneReceivers;
         return sceneReceivers;
     }
 

--- a/jme3-core/src/main/java/com/jme3/shadow/DirectionalLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/DirectionalLightShadowRenderer.java
@@ -42,7 +42,6 @@ import com.jme3.math.ColorRGBA;
 import com.jme3.math.Vector2f;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.Camera;
-import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.queue.GeometryList;
 import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.Node;
@@ -175,7 +174,7 @@ public class DirectionalLightShadowRenderer extends AbstractShadowRenderer {
     }
     
     @Override
-    protected GeometryList getOccludersToRender(int shadowMapIndex, GeometryList sceneOccluders, GeometryList sceneReceivers, GeometryList shadowMapOccluders) {
+    protected GeometryList getOccludersToRender(int shadowMapIndex, GeometryList shadowMapOccluders) {
 
         // update frustum points based on current camera and split
         ShadowUtil.updateFrustumPoints(viewPort.getCamera(), splitsArray[shadowMapIndex], splitsArray[shadowMapIndex + 1], 1.0f, points);
@@ -184,7 +183,7 @@ public class DirectionalLightShadowRenderer extends AbstractShadowRenderer {
         if (sceneReceivers.size()==0) {
             ShadowUtil.getGeometriesInCamFrustum(viewPort.getQueue().getRootScene(), viewPort.getCamera(), RenderQueue.ShadowMode.Receive, sceneReceivers);
         }
-        ShadowUtil.updateShadowCameraFromRoot(viewPort.getQueue().getRootScene(), sceneReceivers, shadowCam, points, shadowMapOccluders, stabilize?shadowMapSize:0);
+        ShadowUtil.updateShadowCamera(viewPort.getQueue().getRootScene(), sceneReceivers, shadowCam, points, shadowMapOccluders, stabilize?shadowMapSize:0);
 
         return shadowMapOccluders;
     }

--- a/jme3-core/src/main/java/com/jme3/shadow/DirectionalLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/DirectionalLightShadowRenderer.java
@@ -45,6 +45,7 @@ import com.jme3.renderer.Camera;
 import com.jme3.renderer.queue.GeometryList;
 import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.Node;
+import com.jme3.scene.Spatial;
 import java.io.IOException;
 
 /**
@@ -181,9 +182,11 @@ public class DirectionalLightShadowRenderer extends AbstractShadowRenderer {
 
         //Updating shadow cam with curent split frustra
         if (sceneReceivers.size()==0) {
-            ShadowUtil.getGeometriesInCamFrustum(viewPort.getQueue().getRootScene(), viewPort.getCamera(), RenderQueue.ShadowMode.Receive, sceneReceivers);
+            for (Spatial scene : viewPort.getScenes()) {
+              ShadowUtil.getGeometriesInCamFrustum(scene, viewPort.getCamera(), RenderQueue.ShadowMode.Receive, sceneReceivers);
+            }
         }
-        ShadowUtil.updateShadowCamera(viewPort.getQueue().getRootScene(), sceneReceivers, shadowCam, points, shadowMapOccluders, stabilize?shadowMapSize:0);
+        ShadowUtil.updateShadowCamera(viewPort, sceneReceivers, shadowCam, points, shadowMapOccluders, stabilize?shadowMapSize:0);
 
         return shadowMapOccluders;
     }
@@ -191,7 +194,9 @@ public class DirectionalLightShadowRenderer extends AbstractShadowRenderer {
     @Override
     GeometryList getReceivers(GeometryList sceneReceivers, GeometryList lightReceivers) {
         if (sceneReceivers.size()==0) {
-            ShadowUtil.getGeometriesInCamFrustum(viewPort.getQueue().getRootScene(), viewPort.getCamera(), RenderQueue.ShadowMode.Receive, sceneReceivers);
+            for (Spatial scene : viewPort.getScenes()) {
+                ShadowUtil.getGeometriesInCamFrustum(scene, viewPort.getCamera(), RenderQueue.ShadowMode.Receive, sceneReceivers);
+            }
         }
         lightReceivers = sceneReceivers;
         return sceneReceivers;

--- a/jme3-core/src/main/java/com/jme3/shadow/PointLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/PointLightShadowRenderer.java
@@ -44,6 +44,7 @@ import com.jme3.renderer.queue.GeometryList;
 import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.Geometry;
 import com.jme3.scene.Node;
+import com.jme3.scene.Spatial;
 import com.jme3.util.TempVars;
 import java.io.IOException;
 
@@ -131,14 +132,18 @@ public class PointLightShadowRenderer extends AbstractShadowRenderer {
 
     @Override
     protected GeometryList getOccludersToRender(int shadowMapIndex, GeometryList shadowMapOccluders) {
-        ShadowUtil.getGeometriesInCamFrustum(viewPort.getQueue().getRootScene(), shadowCams[shadowMapIndex], RenderQueue.ShadowMode.Cast, shadowMapOccluders);
+        for (Spatial scene : viewPort.getScenes()) {
+            ShadowUtil.getGeometriesInCamFrustum(scene, shadowCams[shadowMapIndex], RenderQueue.ShadowMode.Cast, shadowMapOccluders);
+        }
         return shadowMapOccluders;
     }
 
     @Override
     GeometryList getReceivers(GeometryList sceneReceivers, GeometryList lightReceivers) {
         lightReceivers.clear();
-        ShadowUtil.getLitGeometriesInViewPort(viewPort.getQueue().getRootScene(), viewPort.getCamera(), shadowCams, RenderQueue.ShadowMode.Receive, lightReceivers);
+        for (Spatial scene : viewPort.getScenes()) {
+            ShadowUtil.getLitGeometriesInViewPort(scene, viewPort.getCamera(), shadowCams, RenderQueue.ShadowMode.Receive, lightReceivers);
+        }
         return lightReceivers;
     }
 

--- a/jme3-core/src/main/java/com/jme3/shadow/PointLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/PointLightShadowRenderer.java
@@ -40,7 +40,10 @@ import com.jme3.light.PointLight;
 import com.jme3.material.Material;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.Camera;
+import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.queue.GeometryList;
+import com.jme3.renderer.queue.OpaqueComparator;
+import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.Geometry;
 import com.jme3.scene.Node;
 import com.jme3.util.TempVars;
@@ -130,14 +133,14 @@ public class PointLightShadowRenderer extends AbstractShadowRenderer {
 
     @Override
     protected GeometryList getOccludersToRender(int shadowMapIndex, GeometryList sceneOccluders, GeometryList sceneReceivers, GeometryList shadowMapOccluders) {
-        ShadowUtil.getGeometriesInCamFrustum(sceneOccluders, shadowCams[shadowMapIndex], shadowMapOccluders);
+        ShadowUtil.getGeometriesInCamFrustum(viewPort.getQueue().getRootScene(), shadowCams[shadowMapIndex], RenderQueue.ShadowMode.Cast, shadowMapOccluders);
         return shadowMapOccluders;
     }
 
     @Override
     GeometryList getReceivers(GeometryList sceneReceivers, GeometryList lightReceivers) {
         lightReceivers.clear();
-        ShadowUtil.getGeometriesInLightRadius(sceneReceivers, shadowCams, lightReceivers);
+        ShadowUtil.getLitGeometriesInViewPort(viewPort.getQueue().getRootScene(), viewPort.getCamera(), shadowCams, RenderQueue.ShadowMode.Receive, lightReceivers);
         return lightReceivers;
     }
 
@@ -207,7 +210,7 @@ public class PointLightShadowRenderer extends AbstractShadowRenderer {
         oc.write(light, "light", null);
     }
     
-   /**
+    /**
      *
      * @param viewCam
      * @return 
@@ -224,6 +227,5 @@ public class PointLightShadowRenderer extends AbstractShadowRenderer {
         boolean intersects = light.intersectsFrustum(cam,vars);
         vars.release();
         return intersects;
-        
     }
 }

--- a/jme3-core/src/main/java/com/jme3/shadow/PointLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/PointLightShadowRenderer.java
@@ -40,9 +40,7 @@ import com.jme3.light.PointLight;
 import com.jme3.material.Material;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.Camera;
-import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.queue.GeometryList;
-import com.jme3.renderer.queue.OpaqueComparator;
 import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.Geometry;
 import com.jme3.scene.Node;
@@ -132,7 +130,7 @@ public class PointLightShadowRenderer extends AbstractShadowRenderer {
     }
 
     @Override
-    protected GeometryList getOccludersToRender(int shadowMapIndex, GeometryList sceneOccluders, GeometryList sceneReceivers, GeometryList shadowMapOccluders) {
+    protected GeometryList getOccludersToRender(int shadowMapIndex, GeometryList shadowMapOccluders) {
         ShadowUtil.getGeometriesInCamFrustum(viewPort.getQueue().getRootScene(), shadowCams[shadowMapIndex], RenderQueue.ShadowMode.Cast, shadowMapOccluders);
         return shadowMapOccluders;
     }

--- a/jme3-core/src/main/java/com/jme3/shadow/PssmShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/PssmShadowRenderer.java
@@ -387,7 +387,9 @@ public class PssmShadowRenderer implements SceneProcessor {
 
     @SuppressWarnings("fallthrough")
     public void postQueue(RenderQueue rq) {
-        ShadowUtil.getGeometriesInCamFrustum(rq.getRootScene(), viewPort.getCamera(), ShadowMode.Receive, lightReceivers);
+        for (Spatial scene : viewPort.getScenes()) {
+            ShadowUtil.getGeometriesInCamFrustum(scene, viewPort.getCamera(), ShadowMode.Receive, lightReceivers);
+        }
 
         Camera viewCam = viewPort.getCamera();
 
@@ -431,7 +433,7 @@ public class PssmShadowRenderer implements SceneProcessor {
             ShadowUtil.updateFrustumPoints(viewCam, splitsArray[i], splitsArray[i + 1], 1.0f, points);
 
             //Updating shadow cam with curent split frustra
-            ShadowUtil.updateShadowCamera(rq.getRootScene(), lightReceivers, shadowCam, points, splitOccluders, shadowMapSize);
+            ShadowUtil.updateShadowCamera(viewPort, lightReceivers, shadowCam, points, splitOccluders, shadowMapSize);
 
             //saving light view projection matrix for this split            
             lightViewProjectionsMatrices[i].set(shadowCam.getViewProjectionMatrix());

--- a/jme3-core/src/main/java/com/jme3/shadow/PssmShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/PssmShadowRenderer.java
@@ -431,9 +431,7 @@ public class PssmShadowRenderer implements SceneProcessor {
             ShadowUtil.updateFrustumPoints(viewCam, splitsArray[i], splitsArray[i + 1], 1.0f, points);
 
             //Updating shadow cam with curent split frustra
-            ShadowUtil.rootScene = rq.getRootScene();
-            ShadowUtil.updateShadowCamera(null, lightReceivers, shadowCam, points, splitOccluders, shadowMapSize);
-            ShadowUtil.rootScene = null;
+            ShadowUtil.updateShadowCamera(rq.getRootScene(), lightReceivers, shadowCam, points, splitOccluders, shadowMapSize);
 
             //saving light view projection matrix for this split            
             lightViewProjectionsMatrices[i].set(shadowCam.getViewProjectionMatrix());

--- a/jme3-core/src/main/java/com/jme3/shadow/ShadowUtil.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/ShadowUtil.java
@@ -39,6 +39,7 @@ import com.jme3.math.Transform;
 import com.jme3.math.Vector2f;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.Camera;
+import com.jme3.renderer.ViewPort;
 import com.jme3.renderer.queue.GeometryList;
 import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.Geometry;
@@ -452,7 +453,7 @@ public class ShadowUtil {
      * contain the eye camera frustum corners) and the shadow occluder objects
      * collected through the traverse of the scene hierarchy
      */
-    public static void updateShadowCamera(Spatial rootScene,
+    public static void updateShadowCamera(ViewPort viewPort,
             GeometryList receivers,
             Camera shadowCam,
             Vector3f[] points,
@@ -496,7 +497,10 @@ public class ShadowUtil {
 
         // collect splitOccluders through scene recursive traverse
         OccludersExtractor occExt = new OccludersExtractor(viewProjMatrix, casterCount, splitBB, casterBB, splitOccluders, vars);
-        casterCount = occExt.addOccluders(rootScene);
+        for (Spatial scene : viewPort.getScenes()) {
+            occExt.addOccluders(scene);
+        }
+        casterCount = occExt.casterCount;
   
         //Nehon 08/18/2010 this is to avoid shadow bleeding when the ground is set to only receive shadows
         if (casterCount != receiverCount) {

--- a/jme3-core/src/main/java/com/jme3/shadow/ShadowUtil.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/ShadowUtil.java
@@ -39,8 +39,12 @@ import com.jme3.math.Transform;
 import com.jme3.math.Vector2f;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.Camera;
+import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.queue.GeometryList;
+import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.Geometry;
+import com.jme3.scene.Node;
+import com.jme3.scene.Spatial;
 import com.jme3.util.TempVars;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -343,7 +347,126 @@ public class ShadowUtil {
             float shadowMapSize) {
         updateShadowCamera(occluders, receivers, shadowCam, points, null, shadowMapSize);
     }
+    
+    /**
+     * OccludersExtractor is a helper class to collect splitOccluders from scene recursively.
+     * It utilizes the scene hierarchy, instead of making the huge flat geometries list first.
+     * Instead of adding all geometries from scene to the RenderQueue.shadowCast and checking
+     * all of them one by one against camera frustum the whole Node is checked first
+     * to hopefully avoid the check on its children.
+     */
+    static public Spatial rootScene = null; // static global used for OccludersExtractor in order not to change public ShadoUtil.updateShadowCamera interface
+    public static class OccludersExtractor
+    {
+        // global variables set in order not to have recursive addOccluders method with too many parameters
+        Matrix4f viewProjMatrix;
+        public Integer casterCount;
+        BoundingBox splitBB, casterBB;
+        GeometryList splitOccluders;
+        TempVars vars;
+        
+        public OccludersExtractor() {}
+        
+        // initialize the global OccludersExtractor variables
+        public OccludersExtractor(Matrix4f vpm, int cc, BoundingBox sBB, BoundingBox cBB, GeometryList sOCC, TempVars v) {
+            viewProjMatrix = vpm; 
+            casterCount = cc;
+            splitBB = sBB;
+            casterBB = cBB;
+            splitOccluders = sOCC;
+            vars = v;
+        }
 
+        /**
+         * Check the rootScene against camera frustum and if intersects process it recursively.
+         * The global OccludersExtractor variables need to be initialized first.
+         * The {@link OccludersExtractor#rootScene} need to be set before the call to {@link ShadowUtil#updateShadowCamera}
+         * Variables are updated and used in {@link ShadowUtil#updateShadowCamera} at last.
+         */
+        public int addOccluders() {
+            if ( rootScene != null ) addOccluders(rootScene);
+            return casterCount;
+        }
+        
+        private void addOccluders(Spatial scene) {
+            if (scene.getCullHint() == Spatial.CullHint.Always) return;
+
+            RenderQueue.ShadowMode shadowMode = scene.getShadowMode();
+            if ( scene instanceof Geometry )
+            {
+                // convert bounding box to light's viewproj space
+                Geometry occluder = (Geometry)scene;
+                if (shadowMode != RenderQueue.ShadowMode.Off && shadowMode != RenderQueue.ShadowMode.Receive
+                        && !occluder.isGrouped() && occluder.getWorldBound()!=null) {
+                    BoundingVolume bv = occluder.getWorldBound();
+                    BoundingVolume occBox = bv.transform(viewProjMatrix, vars.bbox);
+          
+                    boolean intersects = splitBB.intersects(occBox);
+                    if (!intersects && occBox instanceof BoundingBox) {
+                        BoundingBox occBB = (BoundingBox) occBox;
+                        //Kirill 01/10/2011
+                        // Extend the occluder further into the frustum
+                        // This fixes shadow dissapearing issues when
+                        // the caster itself is not in the view camera
+                        // but its shadow is in the camera
+                        //      The number is in world units
+                        occBB.setZExtent(occBB.getZExtent() + 50);
+                        occBB.setCenter(occBB.getCenter().addLocal(0, 0, 25));
+                        if (splitBB.intersects(occBB)) {
+                            //Nehon : prevent NaN and infinity values to screw the final bounding box
+                            if (!Float.isNaN(occBox.getCenter().x) && !Float.isInfinite(occBox.getCenter().x)) {
+                                // To prevent extending the depth range too much
+                                // We return the bound to its former shape
+                                // Before adding it
+                                occBB.setZExtent(occBB.getZExtent() - 50);
+                                occBB.setCenter(occBB.getCenter().subtractLocal(0, 0, 25));                    
+                                casterBB.mergeLocal(occBox);
+                                casterCount++;
+                            }
+                            if (splitOccluders != null) {
+                                splitOccluders.add(occluder);
+                            }
+                        }
+                    } else if (intersects) {
+                        casterBB.mergeLocal(occBox);
+                        casterCount++;
+                        if (splitOccluders != null) {
+                            splitOccluders.add(occluder);
+                        }
+                    }
+                }
+            }
+            else if ( scene instanceof Node && ((Node)scene).getWorldBound()!=null )
+            {
+                Node nodeOcc = (Node)scene;
+                boolean intersects = false;
+                // some 
+                BoundingVolume bv = nodeOcc.getWorldBound();
+                BoundingVolume occBox = bv.transform(viewProjMatrix, vars.bbox);
+      
+                intersects = splitBB.intersects(occBox);
+                if (!intersects && occBox instanceof BoundingBox) {
+                    BoundingBox occBB = (BoundingBox) occBox;
+                    //Kirill 01/10/2011
+                    // Extend the occluder further into the frustum
+                    // This fixes shadow dissapearing issues when
+                    // the caster itself is not in the view camera
+                    // but its shadow is in the camera
+                    //      The number is in world units
+                    occBB.setZExtent(occBB.getZExtent() + 50);
+                    occBB.setCenter(occBB.getCenter().addLocal(0, 0, 25));
+                    intersects = splitBB.intersects(occBB);
+                }
+ 
+                if ( intersects ) {
+                    for (Spatial child : ((Node)scene).getChildren()) {
+                        addOccluders(child);
+                    }
+                }
+            }
+        }
+    }
+    
     /**
      * Updates the shadow camera to properly contain the given points (which
      * contain the eye camera frustum corners) and the shadow occluder objects.
@@ -394,47 +517,9 @@ public class ShadowUtil {
             }
         }
 
-        for (int i = 0; i < occluders.size(); i++) {
-            // convert bounding box to light's viewproj space
-            Geometry occluder = occluders.get(i);
-            BoundingVolume bv = occluder.getWorldBound();
-            BoundingVolume occBox = bv.transform(viewProjMatrix, vars.bbox);
-
-            boolean intersects = splitBB.intersects(occBox);
-            if (!intersects && occBox instanceof BoundingBox) {
-                BoundingBox occBB = (BoundingBox) occBox;
-                //Kirill 01/10/2011
-                // Extend the occluder further into the frustum
-                // This fixes shadow dissapearing issues when
-                // the caster itself is not in the view camera
-                // but its shadow is in the camera
-                //      The number is in world units
-                occBB.setZExtent(occBB.getZExtent() + 50);
-                occBB.setCenter(occBB.getCenter().addLocal(0, 0, 25));
-                if (splitBB.intersects(occBB)) {
-                    //Nehon : prevent NaN and infinity values to screw the final bounding box
-                    if (!Float.isNaN(occBox.getCenter().x) && !Float.isInfinite(occBox.getCenter().x)) {
-                        // To prevent extending the depth range too much
-                        // We return the bound to its former shape
-                        // Before adding it
-                        occBB.setZExtent(occBB.getZExtent() - 50);
-                        occBB.setCenter(occBB.getCenter().subtractLocal(0, 0, 25));                    
-                        casterBB.mergeLocal(occBox);
-                        casterCount++;
-                    }
-                    if (splitOccluders != null) {
-                        splitOccluders.add(occluder);
-                    }
-                    
-                }
-            } else if (intersects) {
-                casterBB.mergeLocal(occBox);
-                casterCount++;
-                if (splitOccluders != null) {
-                    splitOccluders.add(occluder);
-                }
-            }
-        }
+        // collect splitOccluders through scene recursive traverse
+        OccludersExtractor occExt = new OccludersExtractor(viewProjMatrix, casterCount, splitBB, casterBB, splitOccluders, vars);
+        casterCount = occExt.addOccluders(); // the rootScene inside
 
         //Nehon 08/18/2010 this is to avoid shadow bleeding when the ground is set to only receive shadows
         if (casterCount != receiverCount) {
@@ -527,6 +612,23 @@ public class ShadowUtil {
     }
 
     /**
+     * Updates the shadow camera to properly contain the given points (which
+     * contain the eye camera frustum corners) and the shadow occluder objects.
+     *
+     * Render Shadow optimization to traverse the scene hierarchy instead of using the whole, but flattened, scene
+     */
+    public static void updateShadowCameraFromRoot(Spatial rootScene,
+            GeometryList receivers,
+            Camera shadowCam,
+            Vector3f[] points,
+            GeometryList splitOccluders,
+            float shadowMapSize) {
+        ShadowUtil.rootScene = rootScene;
+        ShadowUtil.updateShadowCamera(null, receivers, shadowCam, points, splitOccluders, shadowMapSize);
+        ShadowUtil.rootScene = null;
+    }
+    
+    /**
      * Populates the outputGeometryList with the geometry of the
      * inputGeomtryList that are in the frustum of the given camera
      *
@@ -552,9 +654,74 @@ public class ShadowUtil {
     }
 
     /**
+     * Populates the outputGeometryList with the geometries of the children 
+     * of OccludersExtractor.rootScene node that are in the frustum of the given camera
+     *
+     * @param camera the camera to check geometries against
+     * @param outputGeometryList the list of all geometries that are in the
+     * camera frustum
+     */    
+    public static void getGeometriesInCamFrustum(Spatial rootScene, Camera camera, RenderQueue.ShadowMode mode, GeometryList outputGeometryList) {
+        if (rootScene != null && rootScene instanceof Node) {
+            int planeState = camera.getPlaneState();
+            addGeometriesInCamFrustumFromNode(camera, (Node)rootScene, mode, outputGeometryList);
+            camera.setPlaneState(planeState);
+        }
+    }
+    
+    /**
+     * Helper function to distinguish between Occluders and Receivers
+     * 
+     * @param shadowMode the ShadowMode tested
+     * @param desired the desired ShadowMode 
+     * @return true if tested ShadowMode matches the desired one
+     */
+    static private boolean checkShadowMode(RenderQueue.ShadowMode shadowMode, RenderQueue.ShadowMode desired)
+    {
+        if (shadowMode != RenderQueue.ShadowMode.Off)
+        {
+            switch (desired) {
+                case Cast : 
+                    return shadowMode==RenderQueue.ShadowMode.Cast || shadowMode==RenderQueue.ShadowMode.CastAndReceive;
+                case Receive: 
+                    return shadowMode==RenderQueue.ShadowMode.Receive || shadowMode==RenderQueue.ShadowMode.CastAndReceive;
+                case CastAndReceive:
+                    return true;
+            }
+        }
+        return false;
+    }
+    
+    /**
+     * Helper function used to recursively populate the outputGeometryList 
+     * with geometry children of scene node
+     * 
+     * @param camera
+     * @param scene
+     * @param outputGeometryList 
+     */
+    private static void addGeometriesInCamFrustumFromNode(Camera camera, Node scene, RenderQueue.ShadowMode mode, GeometryList outputGeometryList) {
+        if (scene.getCullHint() == Spatial.CullHint.Always) return;
+        camera.setPlaneState(0);
+        if (camera.contains(scene.getWorldBound()) != Camera.FrustumIntersect.Outside) {
+            for (Spatial child: scene.getChildren()) {
+                if (child instanceof Node) addGeometriesInCamFrustumFromNode(camera, (Node)child, mode, outputGeometryList);
+                else if (child instanceof Geometry && child.getCullHint() != Spatial.CullHint.Always) {
+                    camera.setPlaneState(0);
+                    if (checkShadowMode(child.getShadowMode(), mode) &&
+                            !((Geometry)child).isGrouped() &&
+                            camera.contains(child.getWorldBound()) != Camera.FrustumIntersect.Outside) {
+                      outputGeometryList.add((Geometry)child);
+                    }
+                }
+            }
+        }
+    }
+    
+    /**
      * Populates the outputGeometryList with the geometry of the
      * inputGeomtryList that are in the radius of a light.
-     * The array of camera must be an array of 6 cameara initialized so they represent the light viewspace of a pointlight
+     * The array of camera must be an array of 6 cameras initialized so they represent the light viewspace of a pointlight
      *
      * @param inputGeometryList The list containing all geometry to check
      * against the camera frustum
@@ -581,4 +748,54 @@ public class ShadowUtil {
         }
 
     }
+
+    /**
+     * Populates the outputGeometryList with the geometries of the children 
+     * of OccludersExtractor.rootScene node that are both in the frustum of the given vpCamera and some camera inside cameras array.
+     * The array of cameras must be initialized to represent the light viewspace of some light like pointLight or spotLight
+     *
+     * @param camera the viewPort camera 
+     * @param cameras the camera array to check geometries against, representing the light viewspace
+     * @param outputGeometryList the output list of all geometries that are in the camera frustum
+     */
+    public static void getLitGeometriesInViewPort(Spatial rootScene, Camera vpCamera, Camera[] cameras, RenderQueue.ShadowMode mode, GeometryList outputGeometryList) {
+        if (rootScene != null && rootScene instanceof Node) {
+            addGeometriesInCamFrustumAndViewPortFromNode(vpCamera, cameras, (Node)rootScene, mode, outputGeometryList);
+        }
+    }
+    /**
+     * Helper function to recursively collect the geometries for getLitGeometriesInViewPort function.
+     * 
+     * @param vpCamera the viewPort camera 
+     * @param cameras the camera array to check geometries against, representing the light viewspace
+     * @param scene the Node to traverse or geometry to possibly add
+     * @param outputGeometryList the output list of all geometries that are in the camera frustum
+     */
+    private static void addGeometriesInCamFrustumAndViewPortFromNode(Camera vpCamera, Camera[] cameras, Spatial scene, RenderQueue.ShadowMode mode, GeometryList outputGeometryList) {
+        if (scene.getCullHint() == Spatial.CullHint.Always) return;
+
+        boolean inFrustum = false;
+        for (int j = 0; j < cameras.length && inFrustum == false; j++) {
+            Camera camera = cameras[j];
+            int planeState = camera.getPlaneState();
+            camera.setPlaneState(0);
+            inFrustum = camera.contains(scene.getWorldBound()) != Camera.FrustumIntersect.Outside && scene.checkCulling(vpCamera);
+            camera.setPlaneState(planeState);
+        }
+        if (inFrustum) {
+            if (scene instanceof Node)
+            {
+                Node node = (Node)scene;
+                for (Spatial child: node.getChildren()) {
+                    addGeometriesInCamFrustumAndViewPortFromNode(vpCamera, cameras, child, mode, outputGeometryList);
+                }
+            }
+            else if (scene instanceof Geometry) {
+                if (checkShadowMode(scene.getShadowMode(), mode) && !((Geometry)scene).isGrouped() ) {
+                    outputGeometryList.add((Geometry)scene);
+                }
+            }
+        }
+    }
+
 }

--- a/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowRenderer.java
@@ -42,7 +42,9 @@ import com.jme3.math.FastMath;
 import com.jme3.math.Vector2f;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.Camera;
+import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.queue.GeometryList;
+import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.Node;
 import com.jme3.util.TempVars;
 import java.io.IOException;
@@ -142,14 +144,16 @@ public class SpotLightShadowRenderer extends AbstractShadowRenderer {
 
     @Override
     protected GeometryList getOccludersToRender(int shadowMapIndex, GeometryList sceneOccluders, GeometryList sceneReceivers, GeometryList shadowMapOccluders) {
-        ShadowUtil.getGeometriesInCamFrustum(sceneOccluders, shadowCam, shadowMapOccluders);
+        ShadowUtil.getGeometriesInCamFrustum(viewPort.getQueue().getRootScene(), shadowCam, RenderQueue.ShadowMode.Cast, shadowMapOccluders);
         return shadowMapOccluders;
     }
 
     @Override
     GeometryList getReceivers(GeometryList sceneReceivers, GeometryList lightReceivers) {
         lightReceivers.clear();
-        ShadowUtil.getGeometriesInCamFrustum(sceneReceivers, shadowCam, lightReceivers);
+        Camera[] cameras = new Camera[1];
+        cameras[0] = shadowCam;
+        ShadowUtil.getLitGeometriesInViewPort(viewPort.getQueue().getRootScene(), viewPort.getCamera(), cameras, RenderQueue.ShadowMode.Receive, lightReceivers);
         return lightReceivers;
     }
     

--- a/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowRenderer.java
@@ -42,7 +42,6 @@ import com.jme3.math.FastMath;
 import com.jme3.math.Vector2f;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.Camera;
-import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.queue.GeometryList;
 import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.Node;
@@ -143,7 +142,7 @@ public class SpotLightShadowRenderer extends AbstractShadowRenderer {
     }
 
     @Override
-    protected GeometryList getOccludersToRender(int shadowMapIndex, GeometryList sceneOccluders, GeometryList sceneReceivers, GeometryList shadowMapOccluders) {
+    protected GeometryList getOccludersToRender(int shadowMapIndex, GeometryList shadowMapOccluders) {
         ShadowUtil.getGeometriesInCamFrustum(viewPort.getQueue().getRootScene(), shadowCam, RenderQueue.ShadowMode.Cast, shadowMapOccluders);
         return shadowMapOccluders;
     }

--- a/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowRenderer.java
@@ -45,6 +45,7 @@ import com.jme3.renderer.Camera;
 import com.jme3.renderer.queue.GeometryList;
 import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.Node;
+import com.jme3.scene.Spatial;
 import com.jme3.util.TempVars;
 import java.io.IOException;
 
@@ -143,7 +144,9 @@ public class SpotLightShadowRenderer extends AbstractShadowRenderer {
 
     @Override
     protected GeometryList getOccludersToRender(int shadowMapIndex, GeometryList shadowMapOccluders) {
-        ShadowUtil.getGeometriesInCamFrustum(viewPort.getQueue().getRootScene(), shadowCam, RenderQueue.ShadowMode.Cast, shadowMapOccluders);
+        for (Spatial scene : viewPort.getScenes()) {
+            ShadowUtil.getGeometriesInCamFrustum(scene, shadowCam, RenderQueue.ShadowMode.Cast, shadowMapOccluders);
+        }
         return shadowMapOccluders;
     }
 
@@ -152,7 +155,9 @@ public class SpotLightShadowRenderer extends AbstractShadowRenderer {
         lightReceivers.clear();
         Camera[] cameras = new Camera[1];
         cameras[0] = shadowCam;
-        ShadowUtil.getLitGeometriesInViewPort(viewPort.getQueue().getRootScene(), viewPort.getCamera(), cameras, RenderQueue.ShadowMode.Receive, lightReceivers);
+        for (Spatial scene : viewPort.getScenes()) {
+            ShadowUtil.getLitGeometriesInViewPort(scene, viewPort.getCamera(), cameras, RenderQueue.ShadowMode.Receive, lightReceivers);
+        }
         return lightReceivers;
     }
     


### PR DESCRIPTION
Shadow rendering was using the flattened list of all scene geometries to check culling. This optimization traverses the scene hierarchy recursively from `rootNode` and tries to cull the whole `Node` whenever possible.
When the scene is constructed carefully to take advantage of hierarchical culling the optimization is significant.

The optimization tries to maintain the jME `public interface`. Some shadow related `RenderManager` or `RenderQueue` members were marked `@Deprecated`, mainly the flattened lists of shadow occluders and receivers, which are no longer used.

Two deprecated renderers, `BasicShadowRenderer` and `PssmShadowRenderer` were updated too, as these would not work with flattened occluders and receivers missing.

We are not aware of any other dependencies to be addressed.