### PR TITLE
feature: Update Nifty GUI to version 1.4.1

### DIFF
--- a/jme3-examples/src/main/java/jme3test/niftygui/TestNiftyGui.java
+++ b/jme3-examples/src/main/java/jme3test/niftygui/TestNiftyGui.java
@@ -52,6 +52,7 @@ public class TestNiftyGui extends SimpleApplication implements ScreenController 
         app.start();
     }
 
+    @Override
     public void simpleInitApp() {
         Box b = new Box(Vector3f.ZERO, 1, 1, 1);
         Geometry geom = new Geometry("Box", b);
@@ -60,10 +61,11 @@ public class TestNiftyGui extends SimpleApplication implements ScreenController 
         geom.setMaterial(mat);
         rootNode.attachChild(geom);
 
-        NiftyJmeDisplay niftyDisplay = new NiftyJmeDisplay(assetManager,
-                                                          inputManager,
-                                                          audioRenderer,
-                                                          guiViewPort);
+        NiftyJmeDisplay niftyDisplay = NiftyJmeDisplay.newNiftyJmeDisplay(
+                assetManager,
+                inputManager,
+                audioRenderer,
+                guiViewPort);
         nifty = niftyDisplay.getNifty();
         nifty.fromXml("Interface/Nifty/HelloJme.xml", "start", this);
 
@@ -76,14 +78,17 @@ public class TestNiftyGui extends SimpleApplication implements ScreenController 
         inputManager.setCursorVisible(true);
     }
 
+    @Override
     public void bind(Nifty nifty, Screen screen) {
         System.out.println("bind( " + screen.getScreenId() + ")");
     }
 
+    @Override
     public void onStartScreen() {
         System.out.println("onStartScreen");
     }
 
+    @Override
     public void onEndScreen() {
         System.out.println("onEndScreen");
     }

--- a/jme3-niftygui/build.gradle
+++ b/jme3-niftygui/build.gradle
@@ -10,7 +10,7 @@ repositories {
 
 dependencies {
     compile project(':jme3-core')
-    compile 'lessvoid:nifty:1.3.3'
-    compile 'lessvoid:nifty-default-controls:1.3.3'
-    compile 'lessvoid:nifty-style-black:1.3.3'
+    compile 'lessvoid:nifty:1.4.1'
+    compile 'lessvoid:nifty-default-controls:1.4.1'
+    compile 'lessvoid:nifty-style-black:1.4.1'
 }

--- a/jme3-niftygui/src/main/java/com/jme3/cinematic/events/GuiEvent.java
+++ b/jme3-niftygui/src/main/java/com/jme3/cinematic/events/GuiEvent.java
@@ -37,7 +37,6 @@ import com.jme3.export.JmeExporter;
 import com.jme3.export.JmeImporter;
 import com.jme3.export.OutputCapsule;
 import de.lessvoid.nifty.Nifty;
-import de.lessvoid.nifty.screen.NullScreen;
 import java.io.IOException;
 
 /**
@@ -82,7 +81,8 @@ public class GuiEvent extends AbstractCinematicEvent {
     }
 
     @Override
-    public void onStop() {        if (!(nifty.getCurrentScreen() instanceof NullScreen)) {
+    public void onStop() {
+        if (nifty.getCurrentScreen() != null) {
             nifty.getCurrentScreen().endScreen(null);
         }
     }

--- a/jme3-niftygui/src/main/java/com/jme3/cinematic/events/GuiTrack.java
+++ b/jme3-niftygui/src/main/java/com/jme3/cinematic/events/GuiTrack.java
@@ -37,7 +37,6 @@ import com.jme3.export.JmeExporter;
 import com.jme3.export.JmeImporter;
 import com.jme3.export.OutputCapsule;
 import de.lessvoid.nifty.Nifty;
-import de.lessvoid.nifty.screen.NullScreen;
 import java.io.IOException;
 
 /**
@@ -84,7 +83,8 @@ public class GuiTrack extends AbstractCinematicEvent {
     }
 
     @Override
-    public void onStop() {        if (!(nifty.getCurrentScreen() instanceof NullScreen)) {
+    public void onStop() {
+        if (nifty.getCurrentScreen() != null) {
             nifty.getCurrentScreen().endScreen(null);
         }
     }

--- a/jme3-niftygui/src/main/java/com/jme3/niftygui/InputSystemJme.java
+++ b/jme3-niftygui/src/main/java/com/jme3/niftygui/InputSystemJme.java
@@ -41,7 +41,6 @@ import com.jme3.system.JmeSystem;
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.NiftyInputConsumer;
 import de.lessvoid.nifty.controls.TextField;
-import de.lessvoid.nifty.controls.nullobjects.TextFieldNull;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.input.keyboard.KeyboardInputEvent;
 import de.lessvoid.nifty.spi.input.InputSystem;
@@ -310,7 +309,7 @@ public class InputSystemJme implements InputSystem, RawInputListener {
             Element element = nifty.getCurrentScreen().getFocusHandler().getKeyboardFocusElement();
             if (element != null) {
                 final TextField textField = element.getNiftyControl(TextField.class);
-                if (textField != null && !(textField instanceof TextFieldNull)) {
+                if (textField != null) {
                     Logger.getLogger(InputSystemJme.class.getName()).log(Level.FINE, "Current TextField: {0}", textField.getId());
                     String initialValue = textField.getText();
                     if (initialValue == null) {

--- a/jme3-niftygui/src/main/java/com/jme3/niftygui/RenderDeviceJme.java
+++ b/jme3-niftygui/src/main/java/com/jme3/niftygui/RenderDeviceJme.java
@@ -47,7 +47,6 @@ import com.jme3.scene.VertexBuffer.Usage;
 import com.jme3.scene.shape.Quad;
 import com.jme3.texture.Texture2D;
 import com.jme3.util.BufferUtils;
-import de.lessvoid.nifty.elements.render.TextRenderer.RenderFontNull;
 import de.lessvoid.nifty.render.BlendMode;
 import de.lessvoid.nifty.spi.render.MouseCursor;
 import de.lessvoid.nifty.spi.render.RenderDevice;
@@ -152,6 +151,14 @@ public class RenderDeviceJme implements RenderDevice {
         return new MouseCursor() {
             public void dispose() {
             }
+
+            @Override
+            public void enable() {
+            }
+
+            @Override
+            public void disable() {
+            }
         };
     }
     
@@ -223,7 +230,7 @@ public class RenderDeviceJme implements RenderDevice {
 
     @Override
     public void renderFont(RenderFont font, String str, int x, int y, Color color, float sizeX, float sizeY) {        
-        if (str.length() == 0 || font instanceof RenderFontNull) {
+        if (str.length() == 0) {
             return;
         }
         


### PR DESCRIPTION
This commit updates Nifty to version 1.4.1 and makes all
the necessary changes to the JME-Nifty integration to be
compatible with this version of Nifty (manily support of multiple
texture atlases in the batch renderer and some minor changes
like the removal of some *Null classes).

Most User code should still be able to compile with this change.

However, the NiftyJmeDisplay constructor that requires the
width and height of the texture atlas has been deprecated in
favour of the newly added static factory methods:
NiftyJmeDisplay.newNiftyJmeDisplay(). The new methods
add support for the Nifty BatchRenderConfiguration class that
allow further configuration of some rendering details.

The testcase jme3test.niftygui.TestNiftyGui has been modified
to use the new methods and seems to render fine for me.

Most of Nifty 1.4.1 should be compatible with old versions of
Nifty. However some compile-time incompatibilities might
exists to old 1.3.x code. Additionally some internal mechanism
have been modified with 1.4 so there might be additional runtime
incompatibilities as well.