### PR TITLE
Allow stats to be displayed without counting stats themselves

### DIFF
--- a/jme3-core/src/main/java/com/jme3/app/StatsAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/StatsAppState.java
@@ -57,6 +57,7 @@ public class StatsAppState extends AbstractAppState {
     protected boolean showSettings = true;
     private boolean showFps = true;
     private boolean showStats = true;
+    private boolean includePostStats = true;
     private boolean darkenBehind = true;
     
     protected Node guiNode;
@@ -99,8 +100,15 @@ public class StatsAppState extends AbstractAppState {
     }
 
     public void toggleStats() {
-        setDisplayFps( !showFps );
-        setDisplayStatView( !showStats );
+        if (!showStats) {
+            setDisplayFps(true);
+            setDisplayStatView(true); // also sets includePostStats = true
+        } else if (isIncludePostStats()) {
+            setIncludePostStats(false);
+        } else {
+            setDisplayFps(false);
+            setDisplayStatView(false);
+        }
     }
 
     public void setDisplayFps(boolean show) {
@@ -116,12 +124,24 @@ public class StatsAppState extends AbstractAppState {
 
     public void setDisplayStatView(boolean show) {
         showStats = show;
+        includePostStats = show;
         if (statsView != null ) {
             statsView.setEnabled(show);
             statsView.setCullHint(show ? CullHint.Never : CullHint.Always);
             if (darkenStats != null) {
                 darkenStats.setCullHint(showStats && darkenBehind ? CullHint.Never : CullHint.Always);
             }
+        }
+    }
+
+    public boolean isIncludePostStats() {
+        return includePostStats;
+    }
+
+    public void setIncludePostStats(boolean includePostStats) {
+        this.includePostStats = includePostStats;
+        if (statsView != null ) {
+            statsView.setIncludePostStats(includePostStats);
         }
     }
 

--- a/jme3-core/src/main/java/com/jme3/app/StatsView.java
+++ b/jme3-core/src/main/java/com/jme3/app/StatsView.java
@@ -65,8 +65,10 @@ public class StatsView extends Node implements Control {
 
     private String[] statLabels;
     private int[] statData;
+    private int[] statDataNoPost;
 
     private boolean enabled = true;
+    private boolean includePostStats = true;
     
     private final StringBuilder stringBuilder = new StringBuilder();
 
@@ -81,6 +83,7 @@ public class StatsView extends Node implements Control {
 
         statLabels = statistics.getLabels();
         statData = new int[statLabels.length];
+        statDataNoPost = new int[statLabels.length];
         labels = new BitmapText[statLabels.length];
 
         BitmapFont font = manager.loadFont("Interface/Fonts/Console.fnt");
@@ -103,9 +106,12 @@ public class StatsView extends Node implements Control {
             return;
             
         statistics.getData(statData);
+
+        int[] showData = isIncludePostStats() ? statData : statDataNoPost;
+
         for (int i = 0; i < labels.length; i++) {
             stringBuilder.setLength(0);
-            stringBuilder.append(statLabels[i]).append(" = ").append(statData[i]);
+            stringBuilder.append(statLabels[i]).append(" = ").append(showData[i]);
             labels[i].setText(stringBuilder);
         }
         
@@ -126,12 +132,19 @@ public class StatsView extends Node implements Control {
         this.enabled = enabled;
         statistics.setEnabled(enabled);
     }
+    public void setIncludePostStats(boolean includePostStats) {
+        this.includePostStats = includePostStats;
+    }
 
     public boolean isEnabled() {
         return enabled;
     }
 
     public void render(RenderManager rm, ViewPort vp) {
+        statistics.getData(statDataNoPost);
     }
 
+    public boolean isIncludePostStats() {
+        return includePostStats;
+    }
 }


### PR DESCRIPTION
Currently the stats shown on pressing F5 include even the primitives used to render the stats themselves. While this is not incorrect, sometimes it can be confusing.

F5 now cycles between three states: off, full, post not included.

In the last mode the stats shown are captured when the stats object starts rendering, which means the stats do not include the stats object itself.

Depending on what are other viewports present in postFrame it may also skip some other primitives.

If you think changing the F5 for all applications is too drastic, I may adjust it so that it is done only when the application opts for it explicitely.