### PR TITLE
Fix for incorrect viewport sizes

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
@@ -865,8 +865,8 @@ public class RenderManager {
         if (cam != prevCam || cam.isViewportChanged()) {
             viewX = (int) (cam.getViewPortLeft() * cam.getWidth());
             viewY = (int) (cam.getViewPortBottom() * cam.getHeight());
-            viewWidth = (int) ((cam.getViewPortRight() - cam.getViewPortLeft()) * cam.getWidth());
-            viewHeight = (int) ((cam.getViewPortTop() - cam.getViewPortBottom()) * cam.getHeight());
+            viewWidth = ((int)(cam.getViewPortRight() * cam.getWidth())) - ((int)(cam.getViewPortLeft() * cam.getWidth()));
+            viewHeight = ((int)(cam.getViewPortTop() * cam.getHeight())) - ((int)(cam.getViewPortBottom() * cam.getHeight()));
             uniformBindingManager.setViewPort(viewX, viewY, viewWidth, viewHeight);
             renderer.setViewPort(viewX, viewY, viewWidth, viewHeight);
             renderer.setClipRect(viewX, viewY, viewWidth, viewHeight);


### PR DESCRIPTION
Fixed an issue where viewport sizes could be a pixel smaller in either
dimension in certain situations.  This caused gaps to appear between
adjacent viewports at certain resolutions.
Forum Reference:

http://hub.jmonkeyengine.org/t/fix-for-rounding-errors-in-viewport-dimensions/31751