### PR TITLE
Fix shadow disappearing for Spot and Point Lights

### DIFF
--- a/jme3-core/src/main/java/com/jme3/light/PointLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/PointLight.java
@@ -62,6 +62,8 @@ public class PointLight extends Light {
     protected float radius = 0;
     protected float invRadius = 0;
 
+    protected boolean showCulledLightsShadows = false;    
+    
     @Override
     public void computeLastDistance(Spatial owner) {
         if (owner.getWorldBound() != null) {
@@ -185,5 +187,13 @@ public class PointLight extends Light {
         }else{
             this.invRadius = 0;
         }
+    }
+    
+    /// if showCulledLightsShadows is set, the PointLightShadowRenderer.checkCulling would not cull anything to make possible shadow rendered
+    public boolean showCulledLightsShadows() {
+        return showCulledLightsShadows;
+    }
+    public void setShowCulledLightsShadows(boolean val) {
+        showCulledLightsShadows = val;
     }
 }


### PR DESCRIPTION
After **Light culling** implementation there is a problem with shadow disappearing for `SpotLight` and `PointLight`. As documented in worthy @Nehon article: [3.1 Sneak peek : Light culling and Single pass lighting](http://jmonkeyengine.org/298849/3-1-sneak-peek-light-culling-and-single-pass-lighting/)
> **Noteworthy**
> Shadows now also use light culling. This means that shadow maps won’t be calculated for lights that are outside of the frustum. This can give a huge performance boost.

The shadow disappears when shadow caster geometry is inside light cone which does not reach the camera view frustum but its shadow is casted into the view. It happens very easy. Just make the shadow long enough and move the camera.
It is because the light radius (or range) is short enough not to reach the view frustum but the caster is close enough, so the shadow is casted.

Proposed fix in this pull request is conservative. It allows to cull shadows less aggressively through new `PointLight` or `SpotLight` setting public method `setShowCulledLightssShadows(boolean)` while default is the old behaviour.