### PR TITLE
A very small change that creates two getters in VehicleWheel,,

### DIFF
--- a/jme3-bullet/src/main/java/com/jme3/bullet/objects/VehicleWheel.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/objects/VehicleWheel.java
@@ -420,4 +420,22 @@ public class VehicleWheel implements Savable {
         this.applyLocal = applyLocal;
     }
 
+    /**
+    * write the content of the wheelWorldRotation into the store
+    * 
+    * @param store
+    */
+    public void getWheelWorldRotation(final Quaternion store) {
+        store.set(this.wheelWorldRotation);
+    }
+
+    /**
+    * write the content of the wheelWorldLocation into the store
+    * 
+    * @param store
+    */
+    public void getWheelWorldLocation(final Vector3f store) {
+        store.set(this.wheelWorldLocation);
+    }
+
 }

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/objects/VehicleWheel.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/objects/VehicleWheel.java
@@ -399,4 +399,23 @@ public class VehicleWheel implements Savable {
     public void setApplyLocal(boolean applyLocal) {
         this.applyLocal = applyLocal;
     }
+
+    /**
+    * write the content of the wheelWorldRotation into the store
+    * 
+    * @param store
+    */
+    public void getWheelWorldRotation(final Quaternion store) {
+        store.set(this.wheelWorldRotation);
+    }
+
+    /**
+    * write the content of the wheelWorldLocation into the store
+    * 
+    * @param store
+    */
+    public void getWheelWorldLocation(final Vector3f store) {
+        store.set(this.wheelWorldLocation);
+    }
+
 }


### PR DESCRIPTION
These are necessary if jme's bullet wrapper is used in a non Scenegraph enviroment,
for example a ES based server. As without this there is no clean way to get the values of these two variables.
-> wheelspat being null in this case, normally the rotation and position is set to the Wheel Spatial.

In the case of a Scenegraphless Server it makes no sense to have a dummy spatial just for this, especially if all logic necessary already exist, and only the getters are missing.

Signed-off-by: Kai Börnert <kai-boernert@visiongamestudios.de>