### PR TITLE
Obsolete shadowRecv and sceneReceivers code cleanup

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/queue/RenderQueue.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/queue/RenderQueue.java
@@ -50,7 +50,6 @@ public class RenderQueue {
     private GeometryList transparentList;
     private GeometryList translucentList;
     private GeometryList skyList;
-    private GeometryList shadowRecv;
 
     /**
      * Creates a new RenderQueue, the default {@link GeometryComparator comparators}
@@ -62,7 +61,6 @@ public class RenderQueue {
         this.transparentList = new GeometryList(new TransparentComparator());
         this.translucentList = new GeometryList(new TransparentComparator());
         this.skyList = new GeometryList(new NullComparator());
-        this.shadowRecv = new GeometryList(new OpaqueComparator());
     }
 
     /**
@@ -259,21 +257,6 @@ public class RenderQueue {
         }
     }
 
-    /**
-     * 
-     * @param shadBucket The shadow mode to retrieve the {@link GeometryList
-     * queue content} for.  Only {@link ShadowMode#Receive Receive} is valid.
-     * @return The cast or receive {@link GeometryList}
-     */
-    public GeometryList getShadowQueueContent(ShadowMode shadBucket) {
-        switch (shadBucket) {
-            case Receive:
-                return shadowRecv;
-            default:
-                throw new IllegalArgumentException("Only Cast or Receive are allowed");
-        }
-    }
-
     private void renderGeometryList(GeometryList list, RenderManager rm, Camera cam, boolean clear) {
         list.setCamera(cam); // select camera for sorting
         list.sort();
@@ -342,6 +325,5 @@ public class RenderQueue {
         transparentList.clear();
         translucentList.clear();
         skyList.clear();
-        shadowRecv.clear();
     }
 }

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
@@ -206,24 +206,18 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
     }
 
     /**
-     * returns true if the PssmRenderer flushed the shadow queues
-     *
-     * @return flushQueues
+     * isFlushQueues does nothing and is kept only for backward compatibility
      */
+    @Deprecated
     public boolean isFlushQueues() {
         return shadowRenderer.isFlushQueues();
     }
 
     /**
-     * Set this to false if you want to use several PssmRederers to have
-     * multiple shadows cast by multiple light sources. Make sure the last
-     * PssmRenderer in the stack DO flush the queues, but not the others
-     *
-     * @param flushQueues
+     * setFlushQueues does nothing now and is kept only for backward compatibility
      */
-    public void setFlushQueues(boolean flushQueues) {
-        shadowRenderer.setFlushQueues(flushQueues);
-    }
+    @Deprecated
+    public void setFlushQueues(boolean flushQueues) {}
 
     /**
      * sets the shadow compare mode see {@link CompareMode} for more info

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
@@ -92,7 +92,6 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
     protected EdgeFilteringMode edgeFilteringMode = EdgeFilteringMode.Bilinear;
     protected CompareMode shadowCompareMode = CompareMode.Hardware;
     protected Picture[] dispPic;
-    protected boolean flushQueues = true;
     /**
      * true if the fallback material should be used, otherwise false
      */
@@ -105,7 +104,6 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
      * list of materials for post shadow queue geometries
      */
     protected List<Material> matCache = new ArrayList<Material>();
-    protected GeometryList sceneReceivers;
     protected GeometryList lightReceivers = new GeometryList(new OpaqueComparator());
     protected GeometryList shadowMapOccluders = new GeometryList(new OpaqueComparator());
     private String[] shadowMapStringCache;
@@ -385,7 +383,6 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
 
     @SuppressWarnings("fallthrough")
     public void postQueue(RenderQueue rq) {
-        sceneReceivers = rq.getShadowQueueContent(ShadowMode.Receive);
         lightReceivers.clear();
         skipPostPass = false;
         if ( !checkCulling(viewPort.getCamera()) ) {
@@ -462,7 +459,7 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
         debug = true;
     }
 
-    abstract GeometryList getReceivers(GeometryList sceneReceivers, GeometryList lightReceivers);
+    abstract void getReceivers(GeometryList lightReceivers);
 
     public void postFrame(FrameBuffer out) {
         if (skipPostPass) {
@@ -472,7 +469,7 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
             displayShadowMap(renderManager.getRenderer());
         }
         
-        lightReceivers = getReceivers(sceneReceivers, lightReceivers);
+        getReceivers(lightReceivers);
 
         if (lightReceivers.size() != 0) {
             //setting params to recieving geometry list
@@ -497,10 +494,6 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
             
             //clearing the params in case there are some other shadow renderers
             clearMatParams();
-        }
-
-        if (flushQueues) {
-            sceneReceivers.clear();
         }
     }
     
@@ -726,24 +719,16 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
     }
 
     /**
-     * Returns true if this shadow renderer flushes the shadow queues.
-     *
-     * @return flushQueues
+     *  isFlushQueues does nothing now and is kept only for backward compatibility
      */
-    public boolean isFlushQueues() {
-        return flushQueues;
-    }
+    @Deprecated
+    public boolean isFlushQueues() { return false; }
 
     /**
-     * Set flushQueues to false if you have multiple shadow renderers, in order
-     * for multiple light sources to cast shadows. Make sure the last shadow
-     * renderer in the stack DOES flush the queues, but not the others.
-     *
-     * @param flushQueues
+     * setFlushQueues does nothing now and is kept only for backward compatibility
      */
-    public void setFlushQueues(boolean flushQueues) {
-        this.flushQueues = flushQueues;
-    }
+    @Deprecated
+    public void setFlushQueues(boolean flushQueues) {}
 
     /**
      * De-serialize this instance, for example when loading from a J3O file.
@@ -758,7 +743,6 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
         shadowIntensity = ic.readFloat("shadowIntensity", 0.7f);
         edgeFilteringMode = ic.readEnum("edgeFilteringMode", EdgeFilteringMode.class, EdgeFilteringMode.Bilinear);
         shadowCompareMode = ic.readEnum("shadowCompareMode", CompareMode.class, CompareMode.Hardware);
-        flushQueues = ic.readBoolean("flushQueues", false);
         init(assetManager, nbShadowMaps, (int) shadowMapSize);
         edgesThickness = ic.readFloat("edgesThickness", 1.0f);
         postshadowMat.setFloat("PCFEdge", edgesThickness);
@@ -777,7 +761,6 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable 
         oc.write(shadowIntensity, "shadowIntensity", 0.7f);
         oc.write(edgeFilteringMode, "edgeFilteringMode", EdgeFilteringMode.Bilinear);
         oc.write(shadowCompareMode, "shadowCompareMode", CompareMode.Hardware);
-        oc.write(flushQueues, "flushQueues", false);
         oc.write(edgesThickness, "edgesThickness", 1.0f);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/shadow/DirectionalLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/DirectionalLightShadowRenderer.java
@@ -181,25 +181,23 @@ public class DirectionalLightShadowRenderer extends AbstractShadowRenderer {
         ShadowUtil.updateFrustumPoints(viewPort.getCamera(), splitsArray[shadowMapIndex], splitsArray[shadowMapIndex + 1], 1.0f, points);
 
         //Updating shadow cam with curent split frustra
-        if (sceneReceivers.size()==0) {
+        if (lightReceivers.size()==0) {
             for (Spatial scene : viewPort.getScenes()) {
-              ShadowUtil.getGeometriesInCamFrustum(scene, viewPort.getCamera(), RenderQueue.ShadowMode.Receive, sceneReceivers);
+              ShadowUtil.getGeometriesInCamFrustum(scene, viewPort.getCamera(), RenderQueue.ShadowMode.Receive, lightReceivers);
             }
         }
-        ShadowUtil.updateShadowCamera(viewPort, sceneReceivers, shadowCam, points, shadowMapOccluders, stabilize?shadowMapSize:0);
+        ShadowUtil.updateShadowCamera(viewPort, lightReceivers, shadowCam, points, shadowMapOccluders, stabilize?shadowMapSize:0);
 
         return shadowMapOccluders;
     }
 
     @Override
-    GeometryList getReceivers(GeometryList sceneReceivers, GeometryList lightReceivers) {
-        if (sceneReceivers.size()==0) {
+    void getReceivers(GeometryList lightReceivers) {
+        if (lightReceivers.size()==0) {
             for (Spatial scene : viewPort.getScenes()) {
-                ShadowUtil.getGeometriesInCamFrustum(scene, viewPort.getCamera(), RenderQueue.ShadowMode.Receive, sceneReceivers);
+                ShadowUtil.getGeometriesInCamFrustum(scene, viewPort.getCamera(), RenderQueue.ShadowMode.Receive, lightReceivers);
             }
         }
-        lightReceivers = sceneReceivers;
-        return sceneReceivers;
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/shadow/PointLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/PointLightShadowRenderer.java
@@ -139,12 +139,11 @@ public class PointLightShadowRenderer extends AbstractShadowRenderer {
     }
 
     @Override
-    GeometryList getReceivers(GeometryList sceneReceivers, GeometryList lightReceivers) {
+    void getReceivers(GeometryList lightReceivers) {
         lightReceivers.clear();
         for (Spatial scene : viewPort.getScenes()) {
             ShadowUtil.getLitGeometriesInViewPort(scene, viewPort.getCamera(), shadowCams, RenderQueue.ShadowMode.Receive, lightReceivers);
         }
-        return lightReceivers;
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowRenderer.java
@@ -151,14 +151,13 @@ public class SpotLightShadowRenderer extends AbstractShadowRenderer {
     }
 
     @Override
-    GeometryList getReceivers(GeometryList sceneReceivers, GeometryList lightReceivers) {
+    void  getReceivers(GeometryList lightReceivers) {
         lightReceivers.clear();
         Camera[] cameras = new Camera[1];
         cameras[0] = shadowCam;
         for (Spatial scene : viewPort.getScenes()) {
             ShadowUtil.getLitGeometriesInViewPort(scene, viewPort.getCamera(), cameras, RenderQueue.ShadowMode.Receive, lightReceivers);
         }
-        return lightReceivers;
     }
     
     @Override


### PR DESCRIPTION
During tweaking [Optimize RenderShadow to use scene hierarchy for culling](https://github.com/jMonkeyEngine/jmonkeyengine/pull/211) there was the statement:
> Bebul: The reason why there is still `RenderQueue.shadowRecv` left is to possibly reuse the collected receivers, as having the list of receivers in the camera frustum can become handy. So it is not necessarily empty! It is also used in our next to come push request...

The PR mentioned is [Fix shadow disappearing for Spot and Point Lights](https://github.com/jMonkeyEngine/jmonkeyengine/pull/218) which @shadowislord  and @Nehon has recognized to be more hack / workaround for an issue that shouldn't be there in the first place.
If so, the reason to keep recv shadow bucket in `RenderQueue` has vanished and there is no need to have both `lightReceivers` and `sceneReceivers` in the code.
I think it deserves this simple code cleanup.

Except for code cleanup, the `setFlushQueues(boolean flushQueues)` was marked `@Deprecated` as there are no shadow buckets left now, so there is no need to take care about shadow queues flushing anymore.