### PR TITLE
Fix for ZipLocator and path with the root slash

### DIFF
--- a/jme3-core/src/plugins/java/com/jme3/asset/plugins/ZipLocator.java
+++ b/jme3-core/src/plugins/java/com/jme3/asset/plugins/ZipLocator.java
@@ -82,6 +82,7 @@ public class ZipLocator implements AssetLocator {
 
     public AssetInfo locate(AssetManager manager, AssetKey key) {
         String name = key.getName();
+        if(name.startsWith("/"))name=name.substring(1);
         ZipEntry entry = zipfile.getEntry(name);
         if (entry == null)
             return null;


### PR DESCRIPTION
While for the FileLocator "/path/x.png" and "path/x.png" are the same location, the ZipLocator (since they are passed directly to ZipFile.getEntry) treats them as two different location, as it should be on a zip archive, but since there is no need of this for the asset manager I think it's reasonable to make both FileLocator and ZipLocator work in the same way.

I noticed this problem after I load a blend model from a zip file and its textures were missed because all path were starting with a slash. I'm not sure if the HttpZipLoader is affected too.