### PR TITLE
add GL3 support for Unshaded and MRT (v2)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -401,7 +401,7 @@ public class GLRenderer implements Renderer {
                 }
             }
 
-            if (hasExtension("GL_ARB_draw_buffers")) {
+            if (hasExtension("GL_ARB_draw_buffers") || gl3 != null) {
                 limits.put(Limits.FrameBufferMrtAttachments, getInteger(GLExt.GL_MAX_DRAW_BUFFERS_ARB));
                 if (limits.get(Limits.FrameBufferMrtAttachments) > 1) {
                     caps.add(Caps.FrameBufferMRT);

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -1080,6 +1080,7 @@ public class GLRenderer implements Renderer {
         if (linearizeSrgbImages) {
             stringBuf.append("#define SRGB 1\n");
         }
+        stringBuf.append("#define ").append(source.getType().name().toUpperCase()).append("_SHADER 1\n");
 
         stringBuf.append(source.getDefines());
         stringBuf.append(source.getSource());

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.frag
@@ -1,3 +1,5 @@
+#import "Common/ShaderLib/GLSL150Compat.glsllib"
+
 #if defined(HAS_GLOWMAP) || defined(HAS_COLORMAP) || (defined(HAS_LIGHTMAP) && !defined(SEPARATE_TEXCOORD))
     #define NEED_TEXCOORD1
 #endif

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.j3md
@@ -13,7 +13,7 @@ MaterialDef Unshaded {
         Color GlowColor
 
         // For instancing
-	Boolean UseInstancing
+        Boolean UseInstancing
 
         // For hardware skinning
         Int NumberOfBones
@@ -54,8 +54,8 @@ MaterialDef Unshaded {
     }
 
     Technique {
-        VertexShader GLSL100:   Common/MatDefs/Misc/Unshaded.vert
-        FragmentShader GLSL100: Common/MatDefs/Misc/Unshaded.frag
+        VertexShader GLSL150:   Common/MatDefs/Misc/Unshaded.vert
+        FragmentShader GLSL150: Common/MatDefs/Misc/Unshaded.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -76,6 +76,25 @@ MaterialDef Unshaded {
     }
 
     Technique {
+        VertexShader GLSL100:   Common/MatDefs/Misc/Unshaded.vert
+        FragmentShader GLSL100: Common/MatDefs/Misc/Unshaded.frag
+
+        WorldParameters {
+            WorldViewProjectionMatrix
+            ViewProjectionMatrix
+            ViewMatrix
+        }
+
+        Defines {
+            INSTANCING : UseInstancing
+            SEPARATE_TEXCOORD : SeparateTexCoord
+            HAS_COLORMAP : ColorMap
+            HAS_LIGHTMAP : LightMap
+            HAS_VERTEXCOLOR : VertexColor
+            HAS_COLOR : Color
+            NUM_BONES : NumberOfBones
+            DISCARD_ALPHA : AlphaDiscardThreshold
+        }
     }
 
     Technique PreNormalPass {

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.vert
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.vert
@@ -1,3 +1,4 @@
+#import "Common/ShaderLib/GLSL150Compat.glsllib"
 #import "Common/ShaderLib/Skinning.glsllib"
 #import "Common/ShaderLib/Instancing.glsllib"
 

--- a/jme3-core/src/main/resources/Common/ShaderLib/GLSL150Compat.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/GLSL150Compat.glsllib
@@ -1,4 +1,4 @@
-#if _VERSION_ >= 150
+#if __VERSION__ >= 130
 out vec4 outFragColor;
 #  define texture1D texture
 #  define texture2D texture


### PR DESCRIPTION
I remade the PR #288 to have a cleaner diff and history (commit log).

The PR include a fix for  GLSL150Compat  (the version + auto-injection of the define XXXX_SHADER).