### PR TITLE
Bullet RigidBody : added support to vector3f based AngularFactor & LinearFactor

### DIFF
--- a/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.cpp
+++ b/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.cpp
@@ -829,20 +829,20 @@ extern "C" {
      * Method:    setAngularFactor
      * Signature: (JF)V
      */
-    JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_setAngularFactor
-    (JNIEnv *env, jobject object, jlong bodyId, jfloat value) {
-        btRigidBody* body = reinterpret_cast<btRigidBody*>(bodyId);
-        if (body == NULL) {
-            jclass newExc = env->FindClass("java/lang/NullPointerException");
-            env->ThrowNew(newExc, "The native object does not exist.");
-            return;
-        }
-        btVector3 vec1 = btVector3();
-        vec1.setX(value);
-        vec1.setY(value);
-        vec1.setZ(value);
-        body->setAngularFactor(vec1);
-    }
+//    JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_setAngularFactor
+//    (JNIEnv *env, jobject object, jlong bodyId, jfloat value) {
+//        btRigidBody* body = reinterpret_cast<btRigidBody*>(bodyId);
+//        if (body == NULL) {
+//            jclass newExc = env->FindClass("java/lang/NullPointerException");
+//            env->ThrowNew(newExc, "The native object does not exist.");
+//            return;
+//        }
+//        btVector3 vec1 = btVector3();
+//        vec1.setX(value);
+//        vec1.setY(value);
+//        vec1.setZ(value);
+//        body->setAngularFactor(vec1);
+//    }
 
     /*
      * Class:     com_jme3_bullet_objects_PhysicsRigidBody

--- a/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.cpp
+++ b/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.cpp
@@ -811,17 +811,17 @@ extern "C" {
     /*
      * Class:     com_jme3_bullet_objects_PhysicsRigidBody
      * Method:    getAngularFactor
-     * Signature: (J)F
+     * Signature: (JLcom/jme3/math/Vector3f;)V
      */
-    JNIEXPORT jfloat JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_getAngularFactor
-    (JNIEnv *env, jobject object, jlong bodyId) {
+    JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_getAngularFactor
+    (JNIEnv *env, jobject object, jlong bodyId, jobject factor) {
         btRigidBody* body = reinterpret_cast<btRigidBody*>(bodyId);
         if (body == NULL) {
             jclass newExc = env->FindClass("java/lang/NullPointerException");
             env->ThrowNew(newExc, "The native object does not exist.");
-            return 0;
+            return;
         }
-        return body->getAngularFactor().getX();
+        jmeBulletUtil::convert(env, &body->getAngularFactor(), factor);
     }
 
     /*
@@ -844,6 +844,58 @@ extern "C" {
         body->setAngularFactor(vec1);
     }
 
+    /*
+     * Class:     com_jme3_bullet_objects_PhysicsRigidBody
+     * Method:    setAngularFactor
+     * Signature: (JLcom/jme3/math/Vector3f;)V
+     */
+    JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_setAngularFactor
+    (JNIEnv *env, jobject object, jlong bodyId, jobject factor) {
+        btRigidBody* body = reinterpret_cast<btRigidBody*>(bodyId);
+        if (body == NULL) {
+            jclass newExc = env->FindClass("java/lang/NullPointerException");
+            env->ThrowNew(newExc, "The native object does not exist.");
+            return;
+        }
+        btVector3 vec = btVector3();
+        jmeBulletUtil::convert(env, factor, &vec);
+        body->setAngularFactor(vec);
+    }
+
+    /*
+     * Class:     com_jme3_bullet_objects_PhysicsRigidBody
+     * Method:    getLinearFactor
+     * Signature: (JLcom/jme3/math/Vector3f;)V
+     */
+    JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_getLinearFactor
+    (JNIEnv *env, jobject object, jlong bodyId, jobject factor) {
+        btRigidBody* body = reinterpret_cast<btRigidBody*>(bodyId);
+        if (body == NULL) {
+            jclass newExc = env->FindClass("java/lang/NullPointerException");
+            env->ThrowNew(newExc, "The native object does not exist.");
+            return;
+        }
+        jmeBulletUtil::convert(env, &body->getLinearFactor(), factor);
+    }
+
+    /*
+     * Class:     com_jme3_bullet_objects_PhysicsRigidBody
+     * Method:    setLinearFactor
+     * Signature: (JLcom/jme3/math/Vector3f;)V
+     */
+    JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_setLinearFactor
+    (JNIEnv *env, jobject object, jlong bodyId, jobject factor) {
+        btRigidBody* body = reinterpret_cast<btRigidBody*>(bodyId);
+        if (body == NULL) {
+            jclass newExc = env->FindClass("java/lang/NullPointerException");
+            env->ThrowNew(newExc, "The native object does not exist.");
+            return;
+        }
+        btVector3 vec = btVector3();
+        jmeBulletUtil::convert(env, factor, &vec);
+        body->setLinearFactor(vec);
+    }
+    
 #ifdef __cplusplus
 }
 #endif

--- a/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.cpp
+++ b/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.cpp
@@ -824,25 +824,6 @@ extern "C" {
         jmeBulletUtil::convert(env, &body->getAngularFactor(), factor);
     }
 
-    /*
-     * Class:     com_jme3_bullet_objects_PhysicsRigidBody
-     * Method:    setAngularFactor
-     * Signature: (JF)V
-     */
-//    JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_setAngularFactor
-//    (JNIEnv *env, jobject object, jlong bodyId, jfloat value) {
-//        btRigidBody* body = reinterpret_cast<btRigidBody*>(bodyId);
-//        if (body == NULL) {
-//            jclass newExc = env->FindClass("java/lang/NullPointerException");
-//            env->ThrowNew(newExc, "The native object does not exist.");
-//            return;
-//        }
-//        btVector3 vec1 = btVector3();
-//        vec1.setX(value);
-//        vec1.setY(value);
-//        vec1.setZ(value);
-//        body->setAngularFactor(vec1);
-//    }
 
     /*
      * Class:     com_jme3_bullet_objects_PhysicsRigidBody

--- a/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.h
+++ b/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.h
@@ -401,13 +401,6 @@ JNIEXPORT jfloat JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_getAngula
 JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_getAngularFactor
   (JNIEnv *, jobject, jlong, jobject);
 
-/*
- * Class:     com_jme3_bullet_objects_PhysicsRigidBody
- * Method:    setAngularFactor
- * Signature: (JF)V
- */
-//JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_setAngularFactor
-//  (JNIEnv *, jobject, jlong, jfloat);
 
 /*
  * Class:     com_jme3_bullet_objects_PhysicsRigidBody

--- a/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.h
+++ b/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.h
@@ -396,10 +396,10 @@ JNIEXPORT jfloat JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_getAngula
 /*
  * Class:     com_jme3_bullet_objects_PhysicsRigidBody
  * Method:    getAngularFactor
- * Signature: (J)F
+ * Signature: (JLcom/jme3/math/Vector3f;)V
  */
-JNIEXPORT jfloat JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_getAngularFactor
-  (JNIEnv *, jobject, jlong);
+JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_getAngularFactor
+  (JNIEnv *, jobject, jlong, jobject);
 
 /*
  * Class:     com_jme3_bullet_objects_PhysicsRigidBody
@@ -408,6 +408,30 @@ JNIEXPORT jfloat JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_getAngula
  */
 JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_setAngularFactor
   (JNIEnv *, jobject, jlong, jfloat);
+
+/*
+ * Class:     com_jme3_bullet_objects_PhysicsRigidBody
+ * Method:    setAngularFactor
+ * Signature: (JLcom/jme3/math/Vector3f;)V
+ */
+JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_setAngularFactor
+  (JNIEnv *, jobject, jlong, jobject);
+
+/*
+ * Class:     com_jme3_bullet_objects_PhysicsRigidBody
+ * Method:    getLinearFactor
+ * Signature: (JLcom/jme3/math/Vector3f;)V
+ */
+JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_getLinearFactor
+  (JNIEnv *, jobject, jlong, jobject);
+
+/*
+ * Class:     com_jme3_bullet_objects_PhysicsRigidBody
+ * Method:    setLinearFactor
+ * Signature: (JLcom/jme3/math/Vector3f;)V
+ */
+JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_setLinearFactor
+  (JNIEnv *, jobject, jlong, jobject);
 
 #ifdef __cplusplus
 }

--- a/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.h
+++ b/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.h
@@ -406,8 +406,8 @@ JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_getAngularF
  * Method:    setAngularFactor
  * Signature: (JF)V
  */
-JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_setAngularFactor
-  (JNIEnv *, jobject, jlong, jfloat);
+//JNIEXPORT void JNICALL Java_com_jme3_bullet_objects_PhysicsRigidBody_setAngularFactor
+//  (JNIEnv *, jobject, jlong, jfloat);
 
 /*
  * Class:     com_jme3_bullet_objects_PhysicsRigidBody

--- a/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
@@ -635,10 +635,8 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void getAngularFactor(long objectId, Vector3f vec);
 
     public void setAngularFactor(float factor) {
-        setAngularFactor(objectId, factor);
+        setAngularFactor(objectId, new Vector3f(factor, factor, factor));
     }
-
-    private native void setAngularFactor(long objectId, float factor);
 
     public void setAngularFactor(Vector3f factor) {
 	setAngularFactor(objectId, factor);

--- a/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
@@ -626,17 +626,40 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     private native float getAngularSleepingThreshold(long objectId);
 
-    public float getAngularFactor() {
-        return getAngularFactor(objectId);
+    public Vector3f getAngularFactor() {
+        Vector3f vec = new Vector3f();
+        getAngularFactor(objectId, vec);
+	return vec;
     }
 
-    private native float getAngularFactor(long objectId);
+    private native void getAngularFactor(long objectId, Vector3f vec);
 
     public void setAngularFactor(float factor) {
         setAngularFactor(objectId, factor);
     }
 
     private native void setAngularFactor(long objectId, float factor);
+
+    public void setAngularFactor(Vector3f factor) {
+	setAngularFactor(objectId, factor);
+    }
+
+    private native void setAngularFactor(long objectId, Vector3f factor);
+
+    public Vector3f getLinearFactor() {
+        Vector3f vec = new Vector3f();
+	getLinearFactor(objectId, vec);
+        return vec;
+    }
+
+    private native void getLinearFactor(long objectId, Vector3f vec);
+
+    public void setLinearFactor(Vector3f factor) {
+	setLinearFactor(objectId, factor);
+    }
+
+    private native void setLinearFactor(long objectId, Vector3f factor);
+
 
     /**
      * do not use manually, joints are added automatically
@@ -673,7 +696,8 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
         capsule.write(getGravity(), "gravity", Vector3f.ZERO);
         capsule.write(getFriction(), "friction", 0.5f);
         capsule.write(getRestitution(), "restitution", 0);
-        capsule.write(getAngularFactor(), "angularFactor", 1);
+        capsule.write(getAngularFactor(), "angularFactor", Vector3f.UNIT_XYZ);
+        capsule.write(getLinearFactor(), "linearFactor", Vector3f.UNIT_XYZ);
         capsule.write(kinematic, "kinematic", false);
 
         capsule.write(getLinearDamping(), "linearDamping", 0);
@@ -703,7 +727,8 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
         setKinematic(capsule.readBoolean("kinematic", false));
 
         setRestitution(capsule.readFloat("restitution", 0));
-        setAngularFactor(capsule.readFloat("angularFactor", 1));
+        setAngularFactor((Vector3f) capsule.readSavable("angularFactor", Vector3f.UNIT_XYZ.clone()));
+        setLinearFactor((Vector3f) capsule.readSavable("linearFactor", Vector3f.UNIT_XYZ.clone()));
         setDamping(capsule.readFloat("linearDamping", 0), capsule.readFloat("angularDamping", 0));
         setSleepingThresholds(capsule.readFloat("linearSleepingThreshold", 0.8f), capsule.readFloat("angularSleepingThreshold", 1.0f));
         setCcdMotionThreshold(capsule.readFloat("ccdMotionThreshold", 0));

--- a/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
@@ -626,10 +626,16 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     private native float getAngularSleepingThreshold(long objectId);
 
-    public Vector3f getAngularFactor() {
-        Vector3f vec = new Vector3f();
-        getAngularFactor(objectId, vec);
-	return vec;
+    public float getAngularFactor() {
+        return getAngularFactor(null).getX();
+    }
+	
+    public Vector3f getAngularFactor(Vector3f store) {
+    	// doing like this prevent from breaking the API
+        if(store == null) 
+            store = new Vector3f();
+        getAngularFactor(objectId, store);
+        return store;
     }
 
     private native void getAngularFactor(long objectId, Vector3f vec);
@@ -694,8 +700,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
         capsule.write(getGravity(), "gravity", Vector3f.ZERO);
         capsule.write(getFriction(), "friction", 0.5f);
         capsule.write(getRestitution(), "restitution", 0);
-        capsule.write(getAngularFactor(), "angularFactor", Vector3f.UNIT_XYZ);
-        capsule.write(getLinearFactor(), "linearFactor", Vector3f.UNIT_XYZ);
+        capsule.write(getAngularFactor(), "angularFactor", 1);
         capsule.write(kinematic, "kinematic", false);
 
         capsule.write(getLinearDamping(), "linearDamping", 0);
@@ -725,8 +730,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
         setKinematic(capsule.readBoolean("kinematic", false));
 
         setRestitution(capsule.readFloat("restitution", 0));
-        setAngularFactor((Vector3f) capsule.readSavable("angularFactor", Vector3f.UNIT_XYZ.clone()));
-        setLinearFactor((Vector3f) capsule.readSavable("linearFactor", Vector3f.UNIT_XYZ.clone()));
+        setAngularFactor(capsule.readFloat("angularFactor", 1));
         setDamping(capsule.readFloat("linearDamping", 0), capsule.readFloat("angularDamping", 0));
         setSleepingThresholds(capsule.readFloat("linearSleepingThreshold", 0.8f), capsule.readFloat("angularSleepingThreshold", 1.0f));
         setCcdMotionThreshold(capsule.readFloat("ccdMotionThreshold", 0));

--- a/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
@@ -51,7 +51,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * <p>PhysicsRigidBody - Basic physics object</p>
+ * <p>
+ * PhysicsRigidBody - Basic physics object</p>
+ *
  * @author normenhansen
  */
 public class PhysicsRigidBody extends PhysicsCollisionObject {
@@ -66,6 +68,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Creates a new PhysicsRigidBody with the supplied collision shape
+     *
      * @param child
      * @param shape
      */
@@ -134,6 +137,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the physics object location
+     *
      * @param location the location of the actual physics object
      */
     public void setPhysicsLocation(Vector3f location) {
@@ -144,6 +148,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the physics object rotation
+     *
      * @param rotation the rotation of the actual physics object
      */
     public void setPhysicsRotation(Matrix3f rotation) {
@@ -154,6 +159,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the physics object rotation
+     *
      * @param rotation the rotation of the actual physics object
      */
     public void setPhysicsRotation(Quaternion rotation) {
@@ -249,9 +255,10 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 //        return Converter.convert(tempTrans.basis, rotation);
 //    }
     /**
-     * Sets the node to kinematic mode. in this mode the node is not affected by physics
-     * but affects other physics objects. Iits kinetic force is calculated by the amount
-     * of movement it is exposed to and its weight.
+     * Sets the node to kinematic mode. in this mode the node is not affected by
+     * physics but affects other physics objects. Iits kinetic force is
+     * calculated by the amount of movement it is exposed to and its weight.
+     *
      * @param kinematic
      */
     public void setKinematic(boolean kinematic) {
@@ -272,8 +279,11 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void setCcdSweptSphereRadius(long objectId, float radius);
 
     /**
-     * Sets the amount of motion that has to happen in one physics tick to trigger the continuous motion detection<br/>
-     * This avoids the problem of fast objects moving through other objects, set to zero to disable (default)
+     * Sets the amount of motion that has to happen in one physics tick to
+     * trigger the continuous motion detection<br/>
+     * This avoids the problem of fast objects moving through other objects, set
+     * to zero to disable (default)
+     *
      * @param threshold
      */
     public void setCcdMotionThreshold(float threshold) {
@@ -306,6 +316,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the mass of this PhysicsRigidBody, objects with mass=0 are static.
+     *
      * @param mass
      */
     public void setMass(float mass) {
@@ -345,8 +356,9 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Set the local gravity of this PhysicsRigidBody<br/>
-     * Set this after adding the node to the PhysicsSpace,
-     * the PhysicsSpace assigns its current gravity to the physics node when its added.
+     * Set this after adding the node to the PhysicsSpace, the PhysicsSpace
+     * assigns its current gravity to the physics node when its added.
+     *
      * @param gravity the gravity vector to set
      */
     public void setGravity(Vector3f gravity) {
@@ -363,6 +375,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the friction of this physics object
+     *
      * @param friction the friction of this physics object
      */
     public void setFriction(float friction) {
@@ -389,10 +402,11 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     public void setLinearDamping(float linearDamping) {
         setDamping(objectId, linearDamping, getAngularDamping());
     }
-    
+
     public void setAngularDamping(float angularDamping) {
         setAngularDamping(objectId, angularDamping);
     }
+
     private native void setAngularDamping(long objectId, float factor);
 
     public float getLinearDamping() {
@@ -414,7 +428,9 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native float getRestitution(long objectId);
 
     /**
-     * The "bouncyness" of the PhysicsRigidBody, best performance if restitution=0
+     * The "bouncyness" of the PhysicsRigidBody, best performance if
+     * restitution=0
+     *
      * @param restitution
      */
     public void setRestitution(float restitution) {
@@ -425,6 +441,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Get the current angular velocity of this PhysicsRigidBody
+     *
      * @return the current linear velocity
      */
     public Vector3f getAngularVelocity() {
@@ -437,6 +454,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Get the current angular velocity of this PhysicsRigidBody
+     *
      * @param vec the vector to store the velocity in
      */
     public void getAngularVelocity(Vector3f vec) {
@@ -445,6 +463,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the angular velocity of this PhysicsRigidBody
+     *
      * @param vec the angular velocity of this PhysicsRigidBody
      */
     public void setAngularVelocity(Vector3f vec) {
@@ -456,6 +475,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Get the current linear velocity of this PhysicsRigidBody
+     *
      * @return the current linear velocity
      */
     public Vector3f getLinearVelocity() {
@@ -468,6 +488,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Get the current linear velocity of this PhysicsRigidBody
+     *
      * @param vec the vector to store the velocity in
      */
     public void getLinearVelocity(Vector3f vec) {
@@ -476,6 +497,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the linear velocity of this PhysicsRigidBody
+     *
      * @param vec the linear velocity of this PhysicsRigidBody
      */
     public void setLinearVelocity(Vector3f vec) {
@@ -486,9 +508,11 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void setLinearVelocity(long objectId, Vector3f vec);
 
     /**
-     * Apply a force to the PhysicsRigidBody, only applies force if the next physics update call
-     * updates the physics space.<br>
-     * To apply an impulse, use applyImpulse, use applyContinuousForce to apply continuous force.
+     * Apply a force to the PhysicsRigidBody, only applies force if the next
+     * physics update call updates the physics space.<br>
+     * To apply an impulse, use applyImpulse, use applyContinuousForce to apply
+     * continuous force.
+     *
      * @param force the force
      * @param location the location of the force
      */
@@ -500,10 +524,10 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void applyForce(long objectId, Vector3f force, Vector3f location);
 
     /**
-     * Apply a force to the PhysicsRigidBody, only applies force if the next physics update call
-     * updates the physics space.<br>
+     * Apply a force to the PhysicsRigidBody, only applies force if the next
+     * physics update call updates the physics space.<br>
      * To apply an impulse, use applyImpulse.
-     * 
+     *
      * @param force the force
      */
     public void applyCentralForce(Vector3f force) {
@@ -514,10 +538,10 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void applyCentralForce(long objectId, Vector3f force);
 
     /**
-     * Apply a force to the PhysicsRigidBody, only applies force if the next physics update call
-     * updates the physics space.<br>
+     * Apply a force to the PhysicsRigidBody, only applies force if the next
+     * physics update call updates the physics space.<br>
      * To apply an impulse, use applyImpulse.
-     * 
+     *
      * @param torque the torque
      */
     public void applyTorque(Vector3f torque) {
@@ -529,6 +553,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Apply an impulse to the PhysicsRigidBody in the next physics update.
+     *
      * @param impulse applied impulse
      * @param rel_pos location relative to object
      */
@@ -540,7 +565,9 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void applyImpulse(long objectId, Vector3f impulse, Vector3f rel_pos);
 
     /**
-     * Apply a torque impulse to the PhysicsRigidBody in the next physics update.
+     * Apply a torque impulse to the PhysicsRigidBody in the next physics
+     * update.
+     *
      * @param vec
      */
     public void applyTorqueImpulse(Vector3f vec) {
@@ -552,7 +579,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Clear all forces from the PhysicsRigidBody
-     * 
+     *
      */
     public void clearForces() {
         clearForces(objectId);
@@ -576,7 +603,8 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void setCollisionShape(long objectId, long collisionShapeId);
 
     /**
-     * reactivates this PhysicsRigidBody when it has been deactivated because it was not moving
+     * reactivates this PhysicsRigidBody when it has been deactivated because it
+     * was not moving
      */
     public void activate() {
         activate(objectId);
@@ -591,8 +619,10 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native boolean isActive(long objectId);
 
     /**
-     * sets the sleeping thresholds, these define when the object gets deactivated
-     * to save ressources. Low values keep the object active when it barely moves
+     * sets the sleeping thresholds, these define when the object gets
+     * deactivated to save ressources. Low values keep the object active when it
+     * barely moves
+     *
      * @param linear the linear sleeping threshold
      * @param angular the angular sleeping threshold
      */
@@ -629,11 +659,12 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     public float getAngularFactor() {
         return getAngularFactor(null).getX();
     }
-	
+
     public Vector3f getAngularFactor(Vector3f store) {
-    	// doing like this prevent from breaking the API
-        if(store == null) 
+        // doing like this prevent from breaking the API
+        if (store == null) {
             store = new Vector3f();
+        }
         getAngularFactor(objectId, store);
         return store;
     }
@@ -645,25 +676,24 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     }
 
     public void setAngularFactor(Vector3f factor) {
-	setAngularFactor(objectId, factor);
+        setAngularFactor(objectId, factor);
     }
 
     private native void setAngularFactor(long objectId, Vector3f factor);
 
     public Vector3f getLinearFactor() {
         Vector3f vec = new Vector3f();
-	getLinearFactor(objectId, vec);
+        getLinearFactor(objectId, vec);
         return vec;
     }
 
     private native void getLinearFactor(long objectId, Vector3f vec);
 
     public void setLinearFactor(Vector3f factor) {
-	setLinearFactor(objectId, factor);
+        setLinearFactor(objectId, factor);
     }
 
     private native void setLinearFactor(long objectId, Vector3f factor);
-
 
     /**
      * do not use manually, joints are added automatically
@@ -675,15 +705,17 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     }
 
     /**
-     * 
+     *
      */
     public void removeJoint(PhysicsJoint joint) {
         joints.remove(joint);
     }
 
     /**
-     * Returns a list of connected joints. This list is only filled when
-     * the PhysicsRigidBody is actually added to the physics space or loaded from disk.
+     * Returns a list of connected joints. This list is only filled when the
+     * PhysicsRigidBody is actually added to the physics space or loaded from
+     * disk.
+     *
      * @return list of active joints connected to this PhysicsRigidBody
      */
     public List<PhysicsJoint> getJoints() {
@@ -700,7 +732,13 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
         capsule.write(getGravity(), "gravity", Vector3f.ZERO);
         capsule.write(getFriction(), "friction", 0.5f);
         capsule.write(getRestitution(), "restitution", 0);
-        capsule.write(getAngularFactor(), "angularFactor", 1);
+        Vector3f angularFactor = getAngularFactor(null);
+        if (angularFactor.x == angularFactor.y && angularFactor.y == angularFactor.z) {
+            capsule.write(getAngularFactor(), "angularFactor", 1);
+        } else {
+            capsule.write(getAngularFactor(null), "angularFactor", Vector3f.UNIT_XYZ);
+            capsule.write(getLinearFactor(), "linearFactor", Vector3f.UNIT_XYZ);
+        }
         capsule.write(kinematic, "kinematic", false);
 
         capsule.write(getLinearDamping(), "linearDamping", 0);
@@ -730,7 +768,13 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
         setKinematic(capsule.readBoolean("kinematic", false));
 
         setRestitution(capsule.readFloat("restitution", 0));
-        setAngularFactor(capsule.readFloat("angularFactor", 1));
+        Vector3f angularFactor = (Vector3f) capsule.readSavable("angularFactor", Vector3f.NAN.clone());
+        if(angularFactor == Vector3f.NAN) {
+            setAngularFactor(capsule.readFloat("angularFactor", 1));
+        } else {
+            setAngularFactor(angularFactor);
+            setLinearFactor((Vector3f) capsule.readSavable("linearFactor", Vector3f.UNIT_XYZ.clone()));
+        }
         setDamping(capsule.readFloat("linearDamping", 0), capsule.readFloat("angularDamping", 0));
         setSleepingThresholds(capsule.readFloat("linearSleepingThreshold", 0.8f), capsule.readFloat("angularSleepingThreshold", 1.0f));
         setCcdMotionThreshold(capsule.readFloat("ccdMotionThreshold", 0));

--- a/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
@@ -51,9 +51,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * <p>
- * PhysicsRigidBody - Basic physics object</p>
- *
+ * <p>PhysicsRigidBody - Basic physics object</p>
  * @author normenhansen
  */
 public class PhysicsRigidBody extends PhysicsCollisionObject {
@@ -68,7 +66,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Creates a new PhysicsRigidBody with the supplied collision shape
-     *
      * @param child
      * @param shape
      */
@@ -137,7 +134,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the physics object location
-     *
      * @param location the location of the actual physics object
      */
     public void setPhysicsLocation(Vector3f location) {
@@ -148,7 +144,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the physics object rotation
-     *
      * @param rotation the rotation of the actual physics object
      */
     public void setPhysicsRotation(Matrix3f rotation) {
@@ -159,7 +154,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the physics object rotation
-     *
      * @param rotation the rotation of the actual physics object
      */
     public void setPhysicsRotation(Quaternion rotation) {
@@ -255,10 +249,9 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 //        return Converter.convert(tempTrans.basis, rotation);
 //    }
     /**
-     * Sets the node to kinematic mode. in this mode the node is not affected by
-     * physics but affects other physics objects. Iits kinetic force is
-     * calculated by the amount of movement it is exposed to and its weight.
-     *
+     * Sets the node to kinematic mode. in this mode the node is not affected by physics
+     * but affects other physics objects. Iits kinetic force is calculated by the amount
+     * of movement it is exposed to and its weight.
      * @param kinematic
      */
     public void setKinematic(boolean kinematic) {
@@ -279,11 +272,8 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void setCcdSweptSphereRadius(long objectId, float radius);
 
     /**
-     * Sets the amount of motion that has to happen in one physics tick to
-     * trigger the continuous motion detection<br/>
-     * This avoids the problem of fast objects moving through other objects, set
-     * to zero to disable (default)
-     *
+     * Sets the amount of motion that has to happen in one physics tick to trigger the continuous motion detection<br/>
+     * This avoids the problem of fast objects moving through other objects, set to zero to disable (default)
      * @param threshold
      */
     public void setCcdMotionThreshold(float threshold) {
@@ -316,7 +306,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the mass of this PhysicsRigidBody, objects with mass=0 are static.
-     *
      * @param mass
      */
     public void setMass(float mass) {
@@ -356,9 +345,8 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Set the local gravity of this PhysicsRigidBody<br/>
-     * Set this after adding the node to the PhysicsSpace, the PhysicsSpace
-     * assigns its current gravity to the physics node when its added.
-     *
+     * Set this after adding the node to the PhysicsSpace,
+     * the PhysicsSpace assigns its current gravity to the physics node when its added.
      * @param gravity the gravity vector to set
      */
     public void setGravity(Vector3f gravity) {
@@ -375,7 +363,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the friction of this physics object
-     *
      * @param friction the friction of this physics object
      */
     public void setFriction(float friction) {
@@ -402,11 +389,10 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     public void setLinearDamping(float linearDamping) {
         setDamping(objectId, linearDamping, getAngularDamping());
     }
-
+    
     public void setAngularDamping(float angularDamping) {
         setAngularDamping(objectId, angularDamping);
     }
-
     private native void setAngularDamping(long objectId, float factor);
 
     public float getLinearDamping() {
@@ -428,9 +414,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native float getRestitution(long objectId);
 
     /**
-     * The "bouncyness" of the PhysicsRigidBody, best performance if
-     * restitution=0
-     *
+     * The "bouncyness" of the PhysicsRigidBody, best performance if restitution=0
      * @param restitution
      */
     public void setRestitution(float restitution) {
@@ -441,7 +425,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Get the current angular velocity of this PhysicsRigidBody
-     *
      * @return the current linear velocity
      */
     public Vector3f getAngularVelocity() {
@@ -454,7 +437,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Get the current angular velocity of this PhysicsRigidBody
-     *
      * @param vec the vector to store the velocity in
      */
     public void getAngularVelocity(Vector3f vec) {
@@ -463,7 +445,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the angular velocity of this PhysicsRigidBody
-     *
      * @param vec the angular velocity of this PhysicsRigidBody
      */
     public void setAngularVelocity(Vector3f vec) {
@@ -475,7 +456,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Get the current linear velocity of this PhysicsRigidBody
-     *
      * @return the current linear velocity
      */
     public Vector3f getLinearVelocity() {
@@ -488,7 +468,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Get the current linear velocity of this PhysicsRigidBody
-     *
      * @param vec the vector to store the velocity in
      */
     public void getLinearVelocity(Vector3f vec) {
@@ -497,7 +476,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Sets the linear velocity of this PhysicsRigidBody
-     *
      * @param vec the linear velocity of this PhysicsRigidBody
      */
     public void setLinearVelocity(Vector3f vec) {
@@ -508,11 +486,9 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void setLinearVelocity(long objectId, Vector3f vec);
 
     /**
-     * Apply a force to the PhysicsRigidBody, only applies force if the next
-     * physics update call updates the physics space.<br>
-     * To apply an impulse, use applyImpulse, use applyContinuousForce to apply
-     * continuous force.
-     *
+     * Apply a force to the PhysicsRigidBody, only applies force if the next physics update call
+     * updates the physics space.<br>
+     * To apply an impulse, use applyImpulse, use applyContinuousForce to apply continuous force.
      * @param force the force
      * @param location the location of the force
      */
@@ -524,10 +500,10 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void applyForce(long objectId, Vector3f force, Vector3f location);
 
     /**
-     * Apply a force to the PhysicsRigidBody, only applies force if the next
-     * physics update call updates the physics space.<br>
+     * Apply a force to the PhysicsRigidBody, only applies force if the next physics update call
+     * updates the physics space.<br>
      * To apply an impulse, use applyImpulse.
-     *
+     * 
      * @param force the force
      */
     public void applyCentralForce(Vector3f force) {
@@ -538,10 +514,10 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void applyCentralForce(long objectId, Vector3f force);
 
     /**
-     * Apply a force to the PhysicsRigidBody, only applies force if the next
-     * physics update call updates the physics space.<br>
+     * Apply a force to the PhysicsRigidBody, only applies force if the next physics update call
+     * updates the physics space.<br>
      * To apply an impulse, use applyImpulse.
-     *
+     * 
      * @param torque the torque
      */
     public void applyTorque(Vector3f torque) {
@@ -553,7 +529,6 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Apply an impulse to the PhysicsRigidBody in the next physics update.
-     *
      * @param impulse applied impulse
      * @param rel_pos location relative to object
      */
@@ -565,9 +540,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void applyImpulse(long objectId, Vector3f impulse, Vector3f rel_pos);
 
     /**
-     * Apply a torque impulse to the PhysicsRigidBody in the next physics
-     * update.
-     *
+     * Apply a torque impulse to the PhysicsRigidBody in the next physics update.
      * @param vec
      */
     public void applyTorqueImpulse(Vector3f vec) {
@@ -579,7 +552,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
 
     /**
      * Clear all forces from the PhysicsRigidBody
-     *
+     * 
      */
     public void clearForces() {
         clearForces(objectId);
@@ -603,8 +576,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native void setCollisionShape(long objectId, long collisionShapeId);
 
     /**
-     * reactivates this PhysicsRigidBody when it has been deactivated because it
-     * was not moving
+     * reactivates this PhysicsRigidBody when it has been deactivated because it was not moving
      */
     public void activate() {
         activate(objectId);
@@ -619,10 +591,8 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     private native boolean isActive(long objectId);
 
     /**
-     * sets the sleeping thresholds, these define when the object gets
-     * deactivated to save ressources. Low values keep the object active when it
-     * barely moves
-     *
+     * sets the sleeping thresholds, these define when the object gets deactivated
+     * to save ressources. Low values keep the object active when it barely moves
      * @param linear the linear sleeping threshold
      * @param angular the angular sleeping threshold
      */
@@ -676,24 +646,25 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     }
 
     public void setAngularFactor(Vector3f factor) {
-        setAngularFactor(objectId, factor);
+	setAngularFactor(objectId, factor);
     }
 
     private native void setAngularFactor(long objectId, Vector3f factor);
 
     public Vector3f getLinearFactor() {
         Vector3f vec = new Vector3f();
-        getLinearFactor(objectId, vec);
+	getLinearFactor(objectId, vec);
         return vec;
     }
 
     private native void getLinearFactor(long objectId, Vector3f vec);
 
     public void setLinearFactor(Vector3f factor) {
-        setLinearFactor(objectId, factor);
+	setLinearFactor(objectId, factor);
     }
 
     private native void setLinearFactor(long objectId, Vector3f factor);
+
 
     /**
      * do not use manually, joints are added automatically
@@ -705,17 +676,15 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     }
 
     /**
-     *
+     * 
      */
     public void removeJoint(PhysicsJoint joint) {
         joints.remove(joint);
     }
 
     /**
-     * Returns a list of connected joints. This list is only filled when the
-     * PhysicsRigidBody is actually added to the physics space or loaded from
-     * disk.
-     *
+     * Returns a list of connected joints. This list is only filled when
+     * the PhysicsRigidBody is actually added to the physics space or loaded from disk.
      * @return list of active joints connected to this PhysicsRigidBody
      */
     public List<PhysicsJoint> getJoints() {


### PR DESCRIPTION
This modification allow to "lock" a degree of freedom of one rigidBody, without joint. This ability is only available with native bullet. 
This can be useful for using bullet for 2D game (maybe not the best option), this can be done like so : 
```java
body.setAngularFactor(new Vector3f(0,0,1)); // <-- only rotate on Z axis
body.setLinearFactor(new Vector3f(1,1,0)); // <-- only move on a 2D plane (X-Y)
```
You can also set a value between [0;1] to "reduce" the movement / rotation. 
Using angular/linear factor do not preserve the conservation of energy. (the factor only scale the "forces")
