### PR TITLE
Make 'Q' and 'Z' move flyCam along its up vector

### DIFF
--- a/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
+++ b/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
@@ -356,7 +356,7 @@ public class FlyByCamera implements AnalogListener, ActionListener {
     }
 
     protected void riseCamera(float value){
-        Vector3f vel = new Vector3f(0, value * moveSpeed, 0);
+        Vector3f vel = initialUpVec.mult(value * moveSpeed);
         Vector3f pos = cam.getLocation().clone();
 
         if (motionAllowed != null)


### PR DESCRIPTION
In FlyByCamera, rather than hardcoding them to be along the Y axis, 'Q' and 'Z' now move with and against respectively whatever direction has been set as its up vector (using setUpVector).