### PR TITLE
Fixes Issues #313 & #64 : Calculation Errors for custom Meshes & Deprecation of VB.updateData()

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/Statistics.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Statistics.java
@@ -128,6 +128,9 @@ public class Statistics {
         if( !enabled )
             return;
             
+        if (mesh.getTriangleCount(lod) < 0 || mesh.getVertexCount() < 0)
+            throw new IllegalStateException("Invalid triangle or vertex count on this mesh. Call .updateCounts() before rendering");
+        
         numObjects += 1;
         numTriangles += mesh.getTriangleCount(lod) * count;
         numVertices += mesh.getVertexCount() * count;

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -719,6 +719,7 @@ public class Mesh implements Savable, Cloneable {
     }
 
     private int computeNumElements(int bufSize){
+        if (bufSize == 0) return 0;
         switch (mode){
             case Triangles:
                 return bufSize / 3;

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -753,6 +753,40 @@ public class Mesh implements Savable, Cloneable {
     }
 
     /**
+     * Called to update the data in a buffer with new data. Can only
+     * be called after {@link VertexBuffer#setupData(com.jme3.scene.VertexBuffer.Usage, int, com.jme3.scene.VertexBuffer.Format, java.nio.Buffer) }
+     * has been called on buffer. Note that it is fine to call this method on the
+     * data already set, e.g. updateBuffer(vb, vb.getData()), this will just
+     * set the proper update flag indicating the data should be sent to the GPU
+     * again.
+     * 
+     * @param buffer The VertexBuffer to effect.
+     * @param data The data buffer to set
+     */
+    public void updateBuffer(VertexBuffer buffer, Buffer data){
+        if (buffer.getId() != -1){
+            // request to update data is okay
+        }
+
+        // Check if the data buffer is read-only which is a sign
+        // of a bug on the part of the caller
+        if (data != null && data.isReadOnly()) {
+            throw new IllegalArgumentException( "VertexBuffer data cannot be read-only." );
+        }
+
+        // will force renderer to call glBufferData again
+        if (data != null && (buffer.data.getClass() != data.getClass() || data.limit() != buffer.lastLimit)){
+            buffer.dataSizeChanged = true;
+            buffer.lastLimit = data.limit();
+        }
+        
+        buffer.data = data;
+        buffer.setUpdateNeeded();
+        
+        if (buffer.dataSizeChanged) // Don't update Counts if they stayed the same
+            updateCounts();
+    }
+    /**
      * Update the {@link #getVertexCount() vertex} and 
      * {@link #getTriangleCount() triangle} counts for this mesh
      * based on the current data. This method should be called

--- a/jme3-core/src/main/java/com/jme3/scene/VertexBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/VertexBuffer.java
@@ -676,6 +676,7 @@ public class VertexBuffer extends NativeObject implements Savable, Cloneable {
      * call Mesh.updateCounts() otherwise bizarre errors can occur.
      * 
      * @param data The data buffer to set
+     * @deprecated call {@link Mesh#updateBuffer(VertexBuffer, Buffer) } instead.
      */
     public void updateData(Buffer data){
         if (id != -1){


### PR DESCRIPTION
Quite a simple commit:
- computeNumElements could return -2 depending on the Mode (TRIANGLE_STIRP) and now it always returns zero as it should.

- The Statistics-Render will now crash when there is an erroneous Mesh (without proper tri/vert count).
Note: This also means that a clean ```Geometry g = new Geometry("Geo", new Mesh());```will lead to a crash as the plain constructor doesn't set the tri/vert count.

Also note that when you use BasicGameTemplate the vert-count goes up by 4 when adding an "empty" Mesh, this is because the object-count goes up from 9 to 10 and thus requiring another digit.

Edit: Sorry, I was unable to open two separate pull requests since Github always wants to use the newest version of my fork :/ What would've been the right way? One branch for each new feature? (Like each issue?)
