### PR TITLE
Fixed wrong BoundingBox transformation, when using negative scaling values

### DIFF
--- a/jme3-core/src/main/java/com/jme3/bounding/BoundingBox.java
+++ b/jme3-core/src/main/java/com/jme3/bounding/BoundingBox.java
@@ -314,7 +314,7 @@ public class BoundingBox extends BoundingVolume {
         transMatrix.absoluteLocal();
 
         Vector3f scale = trans.getScale();
-        vars.vect1.set(xExtent * scale.x, yExtent * scale.y, zExtent * scale.z);
+        vars.vect1.set(xExtent * FastMath.abs(scale.x), yExtent * FastMath.abs(scale.y), zExtent * FastMath.abs(scale.z));
         transMatrix.mult(vars.vect1, vars.vect2);
         // Assign the biggest rotations after scales.
         box.xExtent = FastMath.abs(vars.vect2.getX());


### PR DESCRIPTION
I'm using jMonkeyEngine to display content, that was created for DirectX, and therefore I have to use a negative scaled z axis.

The bounding box of a rotated and negative scaled object, is totally messed up.
![wrongboundingbox](https://cloud.githubusercontent.com/assets/9250103/9991830/bdbb0914-606d-11e5-9588-48f07af7ca42.PNG)

Using the absolute value of scale, when calculating the scaled bounding box extent, eliminates the problem.
![fixedboundingbox](https://cloud.githubusercontent.com/assets/9250103/9991833/c3e33b5e-606d-11e5-8e97-8582e287cf2a.PNG)
