### PR TITLE
Optimise Strings concatenation

### DIFF
--- a/jme3-core/src/main/java/com/jme3/util/NativeObject.java
+++ b/jme3-core/src/main/java/com/jme3/util/NativeObject.java
@@ -145,7 +145,9 @@ public abstract class NativeObject implements Cloneable {
 
     @Override
     public String toString(){
-        return "Native" + getClass().getSimpleName() + " " + id;
+        return new StringBuilder("Native")
+                .append(getClass().getSimpleName()).append(" ").append(id)
+                .toString();
     }
 
     /**


### PR DESCRIPTION
In the ```toString()``` method concatenation will be performed during the runtime, because not all parameters are ```String``` type literals.
That is why it is better to use ```StringBuilder``` here.