### PR TITLE
GImpactCollisionShape : fix for #188, added updateBound()

### DIFF
--- a/jme3-bullet-native/src/native/cpp/com_jme3_bullet_collision_shapes_GImpactCollisionShape.cpp
+++ b/jme3-bullet-native/src/native/cpp/com_jme3_bullet_collision_shapes_GImpactCollisionShape.cpp
@@ -51,6 +51,7 @@ extern "C" {
         jmeClasses::initJavaClasses(env);
         btTriangleIndexVertexArray* array = reinterpret_cast<btTriangleIndexVertexArray*>(meshId);
         btGImpactMeshShape* shape = new btGImpactMeshShape(array);
+        shape->updateBound();
         return reinterpret_cast<jlong>(shape);
     }
 


### PR DESCRIPTION
I hope this will fix the issue #188 , i didn't have a test case : /
( added a call to updateBound() just after creating the shape ) 