### PR TITLE
jogl: some fixes about mouse handler

### DIFF
--- a/jme3-jogl/src/main/java/com/jme3/input/jogl/NewtMouseInput.java
+++ b/jme3-jogl/src/main/java/com/jme3/input/jogl/NewtMouseInput.java
@@ -50,6 +50,8 @@ import com.jogamp.nativewindow.util.DimensionImmutable;
 import com.jogamp.nativewindow.util.PixelFormat;
 import com.jogamp.nativewindow.util.PixelRectangle;
 import com.jogamp.nativewindow.util.Point;
+import com.jogamp.newt.event.WindowAdapter;
+import com.jogamp.newt.event.WindowEvent;
 
 public class NewtMouseInput  implements MouseInput, MouseListener {
     
@@ -106,40 +108,67 @@ public class NewtMouseInput  implements MouseInput, MouseListener {
 
         component = comp;
         component.addMouseListener(this);
+        component.addWindowListener(new WindowAdapter(){
+
+            @Override
+            public void windowGainedFocus(WindowEvent e) {
+                setCursorVisible(visible);
+            }
+
+            @Override
+            public void windowLostFocus(WindowEvent e) {
+                //without those lines,
+                //on Linux (OpenBox) the mouse is not restored if invisible (eg via Alt-Tab)
+                component.setPointerVisible(true);
+                component.confinePointer(false);
+            }
+            
+        });
     }
 
+    @Override
     public void initialize() {
     }
 
+    @Override
     public void destroy() {
     }
 
+    @Override
     public boolean isInitialized() {
         return true;
     }
 
+    @Override
     public void setInputListener(RawInputListener listener) {
         this.listener = listener;
     }
 
+    @Override
     public long getInputTimeNanos() {
         return System.nanoTime();
     }
 
+    @Override
     public void setCursorVisible(boolean visible) {
-        if (this.visible != visible) {
-            lastKnownLocation.setX(0);
-            lastKnownLocation.setY(0);
+        lastKnownLocation.setX(0);
+        lastKnownLocation.setY(0);
 
-            this.visible = visible;
-            component.setPointerVisible(visible);
-            if (!visible) {
-                recenterMouse(component);
-            }
-        }
+        this.visible = visible;
+        component.setPointerVisible(visible);
+        component.confinePointer(!visible);
+        hack_confinePointer();
     }
 
+    private void hack_confinePointer() {
+      if (component.hasFocus() && component.isPointerConfined() && !component.isPointerVisible()) {
+        recenterMouse(component);
+      }
+    }
+    
+    @Override
     public void update() {
+      if (!component.hasFocus()) return;
         if (cursorMoved) {
             int newX = location.getX();
             int newY = location.getY();
@@ -173,15 +202,18 @@ public class NewtMouseInput  implements MouseInput, MouseListener {
         }
     }
 
+    @Override
     public int getButtonCount() {
         return 3;
     }
 
+    @Override
     public void mouseClicked(MouseEvent awtEvt) {
 //        MouseButtonEvent evt = new MouseButtonEvent(getJMEButtonIndex(arg0), false);
 //        listener.onMouseButtonEvent(evt);
     }
 
+    @Override
     public void mousePressed(MouseEvent newtEvt) {
         MouseButtonEvent evt = new MouseButtonEvent(getJMEButtonIndex(newtEvt), true, newtEvt.getX(), newtEvt.getY());
         evt.setTime(newtEvt.getWhen());
@@ -190,7 +222,8 @@ public class NewtMouseInput  implements MouseInput, MouseListener {
         }
     }
 
-    public void mouseReleased(MouseEvent awtEvt) {
+    @Override
+     public void mouseReleased(MouseEvent awtEvt) {
         MouseButtonEvent evt = new MouseButtonEvent(getJMEButtonIndex(awtEvt), false, awtEvt.getX(), awtEvt.getY());
         evt.setTime(awtEvt.getWhen());
         synchronized (eventQueue) {
@@ -198,18 +231,17 @@ public class NewtMouseInput  implements MouseInput, MouseListener {
         }
     }
 
+    @Override
     public void mouseEntered(MouseEvent awtEvt) {
-        if (!visible) {
-            recenterMouse(component);
-        }
+        hack_confinePointer();
     }
 
+    @Override
     public void mouseExited(MouseEvent awtEvt) {
-        if (!visible) {
-            recenterMouse(component);
-        }
+        hack_confinePointer();
     }
 
+    @Override
     public void mouseWheelMoved(MouseEvent awtEvt) {
         //FIXME not sure this is the right way to handle this case
         // [0] should be used when the shift key is down
@@ -218,10 +250,12 @@ public class NewtMouseInput  implements MouseInput, MouseListener {
         cursorMoved = true;
     }
 
+    @Override
     public void mouseDragged(MouseEvent awtEvt) {
         mouseMoved(awtEvt);
     }
 
+    @Override
     public void mouseMoved(MouseEvent awtEvt) {
         if (isRecentering) {
             // MHenze (cylab) Fix Issue 35:
@@ -239,16 +273,14 @@ public class NewtMouseInput  implements MouseInput, MouseListener {
             int dy = awtEvt.getY() - lastKnownLocation.getY();
             location.setX(location.getX() + dx);
             location.setY(location.getY() + dy);
-            if (!visible) {
-                recenterMouse(component);
-            }
+            hack_confinePointer();
             lastKnownLocation.setX(awtEvt.getX());
             lastKnownLocation.setY(awtEvt.getY());
 
             cursorMoved = true;
         }
     }
-
+    
     // MHenze (cylab) Fix Issue 35: A method to generate recenter the mouse to allow the InputSystem to "grab" the mouse
     private void recenterMouse(final GLWindow component) {
         eventsSinceRecenter = 0;
@@ -287,12 +319,13 @@ public class NewtMouseInput  implements MouseInput, MouseListener {
         return index;
     }
 
+    @Override
     public void setNativeCursor(JmeCursor cursor) {
         final ByteBuffer pixels = Buffers.copyIntBufferAsByteBuffer(cursor.getImagesData());
         final DimensionImmutable size = new Dimension(cursor.getWidth(), cursor.getHeight());
         final PixelFormat pixFormat = PixelFormat.RGBA8888;
         final PixelRectangle.GenericPixelRect rec = new PixelRectangle.GenericPixelRect(pixFormat, size, 0, true, pixels);
-        final PointerIcon joglCursor = component.getScreen().getDisplay().createPointerIcon(rec, cursor.getXHotSpot(), cursor.getYHotSpot());
+        final PointerIcon joglCursor = component.getScreen().getDisplay().createPointerIcon(rec, cursor.getXHotSpot(), cursor.getHeight() - cursor.getYHotSpot());
         component.setPointerIcon(joglCursor);
     }
 }


### PR DESCRIPTION
* Y hotspot is top in jogl, and bottom in jme
* in jme when mouse is invisible it should be confined into the window (on mac it could go out of the window)
* when window doesn't has the focus the mouse should not behave like when has the focus like 
  * trying to re-center
  * stay invisible
