### PR TITLE
Interpolate particle positions

### DIFF
--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -1021,7 +1021,7 @@ public class ParticleEmitter extends Geometry {
             Particle p = emitParticle(min, max);
             if (p != null){
                 p.life -= tpf;
-                if (lastPos != null) {
+                if (lastPos != null && isInWorldSpace()) {
                     p.position.interpolateLocal(lastPos, 1 - tpf / originalTpf);
                 }
                 if (p.life <= 0){

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -106,6 +106,7 @@ public class ParticleEmitter extends Geometry {
     private boolean worldSpace = true;
     //variable that helps with computations
     private transient Vector3f temp = new Vector3f();
+    private transient Vector3f lastPos;
 
     public static class ParticleEmitterControl implements Control {
 
@@ -1013,12 +1014,16 @@ public class ParticleEmitter extends Geometry {
         
         // Spawns particles within the tpf timeslot with proper age
         float interval = 1f / particlesPerSec;
+        float originalTpf = tpf;
         tpf += timeDifference;
         while (tpf > interval){
             tpf -= interval;
             Particle p = emitParticle(min, max);
             if (p != null){
                 p.life -= tpf;
+                if (lastPos != null) {
+                    p.position.interpolateLocal(lastPos, 1 - tpf / originalTpf);
+                }
                 if (p.life <= 0){
                     freeParticle(lastUsed);
                 }else{
@@ -1027,6 +1032,12 @@ public class ParticleEmitter extends Geometry {
             }
         }
         timeDifference = tpf;
+
+        if (lastPos == null) {
+            lastPos = new Vector3f();
+        }
+
+        lastPos.set(getWorldTranslation());
 
         BoundingBox bbox = (BoundingBox) this.getMesh().getBound();
         bbox.setMinMax(min, max);


### PR DESCRIPTION
Currently there is a problem with ParticleEmitter. It doesn't take into account the the distance it has travelled between updates. Or at least this is my interpretation - I didn't invent this solution. methusalah did. Please see the following threads for more information:

http://hub.jmonkeyengine.org/t/interpolation-of-particle-spawning-point/30385/9
http://hub.jmonkeyengine.org/t/interpolation-of-particle-spawning-point-when-emitter-has-moved/30400

The following images are from my game. FPS is 60 and the emitter emits 2000 particles per second. Projectile's linear speed is 200 world units / s (it uses RigidBodyControl).

Without interpolation
![Without interpolation](http://i.imgur.com/6OXVf0f.png)

With interpolation
![With interpolation](http://i.imgur.com/Ou5gr5e.png)
