### PR TITLE
Fixed a possible bug in TextureAtlas.java

### DIFF
--- a/jme3-core/src/tools/java/jme3tools/optimize/TextureAtlas.java
+++ b/jme3-core/src/tools/java/jme3tools/optimize/TextureAtlas.java
@@ -155,7 +155,7 @@ public class TextureAtlas {
                 return false;
             } else {
                 if (normal != null && normal.getKey() != null) {
-                    addTexture(diffuse, "NormalMap", keyName);
+                    addTexture(normal, "NormalMap", keyName);
                 }
                 if (specular != null && specular.getKey() != null) {
                     addTexture(specular, "SpecularMap", keyName);


### PR DESCRIPTION
It seems that the variable was the wrong one when adding the normal texture to the atlas.

Link to the post where this is talked: http://hub.jmonkeyengine.org/t/fixed-a-possible-bug-in-textureatlas-java/34653