### PR TITLE
Branch v3.1 alpha1

### DIFF
--- a/jme3-networking/src/main/java/com/jme3/network/Client.java
+++ b/jme3-networking/src/main/java/com/jme3/network/Client.java
@@ -31,8 +31,9 @@
  */
 package com.jme3.network;
 
-import com.jme3.network.service.ClientServiceManager;
+import java.nio.BufferOverflowException;
 
+import com.jme3.network.service.ClientServiceManager;
 
 /**
  *  Represents a remote connection to a server that can be used
@@ -41,19 +42,70 @@ import com.jme3.network.service.ClientServiceManager;
  *  @version   $Revision$
  *  @author    Paul Speed
  */
-public interface Client extends MessageConnection
-{
+public interface Client extends MessageConnection {
     /**
-     *  Starts the client allowing it to begin processing incoming
-     *  messages and delivering them to listeners.
+     *  Adds a listener that will be notified about connection
+     *  state changes.
      */
-    public void start();
+    public void addClientStateListener( ClientStateListener listener );
+
+    /**
+     *  Adds a listener that will be notified when any connection errors
+     *  occur.  If a client has no error listeners then the default behavior
+     *  is to close the connection and provide an appropriate DisconnectInfo
+     *  to any ClientStateListeners.  If the application adds its own error
+     *  listeners then it must take care of closing the connection itself.
+     */
+    public void addErrorListener( ErrorListener<? super Client> listener );
+
+    /**
+     *  Adds a listener that will be notified when any message or object
+     *  is received from the server.
+     */
+    public void addMessageListener( MessageListener<? super Client> listener );
+
+    /**
+     *  Adds a listener that will be notified when messages of the specified
+     *  types are received.
+     */
+    public void addMessageListener( MessageListener<? super Client> listener, Class... classes );
+
+    /**
+     *  Closes this connection to the server.
+     */
+    public void close();
+
+    /**
+     *  Returns the 'game name' for servers to which this client should be able
+     *  to connect.  This should match the 'game name' set on the server or this
+     *  client will be turned away.
+     */
+    public String getGameName();
+
+    /**
+     *  Returns a unique ID for this client within the remote
+     *  server or -1 if this client isn't fully connected to the
+     *  server.
+     */
+    public int getId();
+
+    /**
+     *  Returns the manager for client services.  Client services extend
+     *  the functionality of the client.
+     */
+    public ClientServiceManager getServices();
+
+    /**
+     *  Returns the game-specific version of the server this client should
+     *  be able to connect to.
+     */
+    public int getVersion();
 
     /**
      *  Returns true if this client is fully connected to the
      *  host.
      */
-    public boolean isConnected();     
+    public boolean isConnected();
 
     /**
      *  Returns true if this client has been started and is still
@@ -62,95 +114,51 @@ public interface Client extends MessageConnection
     public boolean isStarted();
 
     /**
-     *  Returns a unique ID for this client within the remote
-     *  server or -1 if this client isn't fully connected to the
-     *  server.
-     */
-    public int getId();     
- 
-    /**
-     *  Returns the 'game name' for servers to which this client should be able
-     *  to connect.  This should match the 'game name' set on the server or this
-     *  client will be turned away.
-     */
-    public String getGameName();
- 
-    /**
-     *  Returns the game-specific version of the server this client should
-     *  be able to connect to.
-     */   
-    public int getVersion();
-
-    /**
-     *  Returns the manager for client services.  Client services extend
-     *  the functionality of the client.
-     */
-    public ClientServiceManager getServices();     
- 
-    /**
-     *  Sends a message to the server.
-     */   
-    public void send( Message message );
- 
-    /**
-     *  Sends a message to the other end of the connection using
-     *  the specified alternate channel.
-     */   
-    public void send( int channel, Message message );
- 
-    /**
-     *  Closes this connection to the server.
-     */
-    public void close();         
-
-    /**
-     *  Adds a listener that will be notified about connection
-     *  state changes.
-     */
-    public void addClientStateListener( ClientStateListener listener ); 
-
-    /**
      *  Removes a previously registered connection listener.
      */
-    public void removeClientStateListener( ClientStateListener listener ); 
+    public void removeClientStateListener( ClientStateListener listener );
 
     /**
-     *  Adds a listener that will be notified when any message or object
-     *  is received from the server.
+     *  Removes a previously registered error listener.
      */
-    public void addMessageListener( MessageListener<? super Client> listener ); 
-
-    /**
-     *  Adds a listener that will be notified when messages of the specified
-     *  types are received.
-     */
-    public void addMessageListener( MessageListener<? super Client> listener, Class... classes ); 
+    public void removeErrorListener( ErrorListener<? super Client> listener );
 
     /**
      *  Removes a previously registered wildcard listener.  This does
      *  not remove this listener from any type-specific registrations.
      */
-    public void removeMessageListener( MessageListener<? super Client> listener ); 
+    public void removeMessageListener( MessageListener<? super Client> listener );
 
     /**
      *  Removes a previously registered type-specific listener from
      *  the specified types.
      */
-    public void removeMessageListener( MessageListener<? super Client> listener, Class... classes ); 
-    
-    /**
-     *  Adds a listener that will be notified when any connection errors
-     *  occur.  If a client has no error listeners then the default behavior
-     *  is to close the connection and provide an appropriate DisconnectInfo
-     *  to any ClientStateListeners.  If the application adds its own error
-     *  listeners then it must take care of closing the connection itself.
-     */
-    public void addErrorListener( ErrorListener<? super Client> listener ); 
+    public void removeMessageListener( MessageListener<? super Client> listener, Class... classes );
 
     /**
-     *  Removes a previously registered error listener.
+     *  Sends a message to the other end of the connection using
+     *  the specified alternate channel.
      */
-    public void removeErrorListener( ErrorListener<? super Client> listener ); 
+    @Override
+    public void send( int channel, Message message );
+
+    /**
+     *  Sends a message to the server.
+     */
+    @Override
+    public void send( Message message );
+
+    /**
+     * Sets the size the server should use when allocating a buffer for a single message. If serialized
+     * messages exceed this size, respective calls to send or broadcast will throw a {@link BufferOverflowException}
+     * (Defaults to 32K)
+     * @param size in bytes
+     */
+    public void setMaximumMessageSize( int size );
+
+    /**
+     *  Starts the client allowing it to begin processing incoming
+     *  messages and delivering them to listeners.
+     */
+    public void start();
 }
-
-

--- a/jme3-networking/src/main/java/com/jme3/network/Server.java
+++ b/jme3-networking/src/main/java/com/jme3/network/Server.java
@@ -31,6 +31,7 @@
  */
 package com.jme3.network;
 
+import java.nio.BufferOverflowException;
 import java.util.Collection;
 
 import com.jme3.network.service.HostedServiceManager;
@@ -38,34 +39,49 @@ import com.jme3.network.service.HostedServiceManager;
 /**
  *  Represents a host that can send and receive messages to
  *  a set of remote client connections.
- *  
+ *
  *  @version   $Revision$
  *  @author    Paul Speed
  */
-public interface Server
-{
+public interface Server {
     /**
-     *  Returns the 'game name' for this server.  This should match the
-     *  'game name' set on connecting clients or they will be turned away.
+     *  Adds an alternate channel to the server, using the specified port.  This is an
+     *  entirely separate connection where messages are sent and received in parallel
+     *  to the two primary default channels.  All channels must be added before the connection
+     *  is started.
+     *  Returns the ID of the created channel for use when specifying the channel in send or
+     *  broadcast calls.  The ID is returned entirely out of convenience since the IDs
+     *  are predictably incremented.  The first channel is 0, second is 1, and so on.
      */
-    public String getGameName();
- 
-    /**
-     *  Returns the game-specific version of this server used for detecting
-     *  mismatched clients.
-     */   
-    public int getVersion();
+    public int addChannel( int port );
 
     /**
-     *  Returns the manager for hosted services.  Hosted services extend
-     *  the functionality of the server.
+     *  Adds a listener that will be notified when new hosted connections
+     *  arrive.
      */
-    public HostedServiceManager getServices();     
+    public void addConnectionListener( ConnectionListener listener );
 
     /**
-     *  Sends the specified message to all connected clients.
-     */ 
-    public void broadcast( Message message );
+     *  Adds a listener that will be notified when any message or object
+     *  is received from one of the clients.
+     *
+     *  <p>Note about MessageListener multithreading: on the server, message events may
+     *  be delivered by more than one thread depending on the server
+     *  implementation used.  Listener implementations should treat their
+     *  shared data structures accordingly and set them up for multithreaded
+     *  access.  The only threading guarantee is that for a single
+     *  HostedConnection, there will only ever be one thread at a time
+     *  and the messages will always be delivered to that connection in the
+     *  order that they were delivered.  This is the only restriction placed
+     *  upon server message dispatch pool implementations.</p>
+     */
+    public void addMessageListener( MessageListener<? super HostedConnection> listener );
+
+    /**
+     *  Adds a listener that will be notified when messages of the specified
+     *  types are received from one of the clients.
+     */
+    public void addMessageListener( MessageListener<? super HostedConnection> listener, Class... classes );
 
     /**
      *  Sends the specified message to all connected clients that match
@@ -80,11 +96,11 @@ public interface Server
      *    // Broadcast to all connections exception source
      *    server.broadcast( Filters.notEqualTo( source ), message );
      *  </pre>
-     */ 
+     */
     public void broadcast( Filter<? super HostedConnection> filter, Message message );
 
     /**
-     *  Sends the specified message over the specified alternate channel to all connected 
+     *  Sends the specified message over the specified alternate channel to all connected
      *  clients that match the filter.  If no filter is specified then this is the same as
      *  calling broadcast(message) and the message will be delivered to
      *  all connections.
@@ -96,98 +112,87 @@ public interface Server
      *    // Broadcast to all connections exception source
      *    server.broadcast( Filters.notEqualTo( source ), message );
      *  </pre>
-     */ 
+     */
     public void broadcast( int channel, Filter<? super HostedConnection> filter, Message message );
 
     /**
-     *  Start the server so that it will began accepting new connections
-     *  and processing messages.
+     *  Sends the specified message to all connected clients.
      */
-    public void start();
+    public void broadcast( Message message );
 
-    /**
-     *  Adds an alternate channel to the server, using the specified port.  This is an 
-     *  entirely separate connection where messages are sent and received in parallel 
-     *  to the two primary default channels.  All channels must be added before the connection
-     *  is started.
-     *  Returns the ID of the created channel for use when specifying the channel in send or 
-     *  broadcast calls.  The ID is returned entirely out of convenience since the IDs
-     *  are predictably incremented.  The first channel is 0, second is 1, and so on.
-     */
-    public int addChannel( int port ); 
-
-    /**
-     *  Returns true if the server has been started.
-     */
-    public boolean isRunning();     
- 
     /**
      *  Closes all client connections, stops and running processing threads, and
      *  closes the host connection.
-     */   
+     */
     public void close();
- 
+
     /**
      *  Retrieves a hosted connection by ID.
      */
-    public HostedConnection getConnection( int id );     
- 
+    public HostedConnection getConnection( int id );
+
     /**
      *  Retrieves a read-only collection of all currently connected connections.
      */
-    public Collection<HostedConnection> getConnections(); 
- 
+    public Collection<HostedConnection> getConnections();
+
+    /**
+     *  Returns the 'game name' for this server.  This should match the
+     *  'game name' set on connecting clients or they will be turned away.
+     */
+    public String getGameName();
+
+    /**
+     *  Returns the manager for hosted services.  Hosted services extend
+     *  the functionality of the server.
+     */
+    public HostedServiceManager getServices();
+
+    /**
+     *  Returns the game-specific version of this server used for detecting
+     *  mismatched clients.
+     */
+    public int getVersion();
+
     /**
      *  Returns true if the server has active connections at the time of this
      *  call.
      */
     public boolean hasConnections();
-    
-    /**
-     *  Adds a listener that will be notified when new hosted connections
-     *  arrive.
-     */
-    public void addConnectionListener( ConnectionListener listener );
- 
-    /**
-     *  Removes a previously registered connection listener.
-     */   
-    public void removeConnectionListener( ConnectionListener listener );     
-    
-    /**
-     *  Adds a listener that will be notified when any message or object
-     *  is received from one of the clients.
-     *
-     *  <p>Note about MessageListener multithreading: on the server, message events may
-     *  be delivered by more than one thread depending on the server
-     *  implementation used.  Listener implementations should treat their
-     *  shared data structures accordingly and set them up for multithreaded 
-     *  access.  The only threading guarantee is that for a single
-     *  HostedConnection, there will only ever be one thread at a time
-     *  and the messages will always be delivered to that connection in the 
-     *  order that they were delivered.  This is the only restriction placed
-     *  upon server message dispatch pool implementations.</p>   
-     */
-    public void addMessageListener( MessageListener<? super HostedConnection> listener ); 
 
     /**
-     *  Adds a listener that will be notified when messages of the specified
-     *  types are received from one of the clients.
+     *  Returns true if the server has been started.
      */
-    public void addMessageListener( MessageListener<? super HostedConnection> listener, Class... classes ); 
+    public boolean isRunning();
+
+    /**
+     *  Removes a previously registered connection listener.
+     */
+    public void removeConnectionListener( ConnectionListener listener );
 
     /**
      *  Removes a previously registered wildcard listener.  This does
      *  not remove this listener from any type-specific registrations.
      */
-    public void removeMessageListener( MessageListener<? super HostedConnection> listener ); 
+    public void removeMessageListener( MessageListener<? super HostedConnection> listener );
 
     /**
      *  Removes a previously registered type-specific listener from
      *  the specified types.
      */
-    public void removeMessageListener( MessageListener<? super HostedConnection> listener, Class... classes ); 
-    
-     
-}
+    public void removeMessageListener( MessageListener<? super HostedConnection> listener, Class... classes );
 
+    /**
+     * Sets the size the server should use when allocating a buffer for a single message. If serialized
+     * messages exceed this size, respective calls to send or broadcast will throw a {@link BufferOverflowException}
+     * (Defaults to 32K)
+     * @param size in bytes
+     */
+    public void setMaximumMessageSize( int size );
+
+    /**
+    *  Start the server so that it will began accepting new connections
+    *  and processing messages.
+    */
+    public void start();
+}

--- a/jme3-networking/src/main/java/com/jme3/network/base/DefaultClient.java
+++ b/jme3-networking/src/main/java/com/jme3/network/base/DefaultClient.java
@@ -31,21 +31,27 @@
  */
 package com.jme3.network.base;
 
-import com.jme3.network.*;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.jme3.network.Client;
+import com.jme3.network.ClientStateListener;
 import com.jme3.network.ClientStateListener.DisconnectInfo;
+import com.jme3.network.ErrorListener;
+import com.jme3.network.Message;
+import com.jme3.network.MessageListener;
 import com.jme3.network.kernel.Connector;
 import com.jme3.network.message.ChannelInfoMessage;
 import com.jme3.network.message.ClientRegistrationMessage;
 import com.jme3.network.message.DisconnectMessage;
 import com.jme3.network.service.ClientServiceManager;
 import com.jme3.network.service.serializer.ClientSerializerRegistrationsService;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.*;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  *  A default implementation of the Client interface that delegates
@@ -54,10 +60,23 @@ import java.util.logging.Logger;
  *  @version   $Revision$
  *  @author    Paul Speed
  */
-public class DefaultClient implements Client
-{
-    static final Logger log = Logger.getLogger(DefaultClient.class.getName());
-    
+public class DefaultClient implements Client {
+    protected class Redispatch implements MessageListener<Object>, ErrorListener<Object> {
+        @Override
+        public void handleError( Object source, Throwable t ) {
+            // Only doing the DefaultClient.this to make the code
+            // checker happy... it compiles fine without it but I
+            // don't like red lines in my editor. :P
+            DefaultClient.this.handleError( t );
+        }
+
+        @Override
+        public void messageReceived( Object source, Message m ) {
+            dispatch( m );
+        }
+    }
+
+    static final Logger log = Logger.getLogger( DefaultClient.class.getName() );
     // First two channels are reserved for reliable and
     // unreliable.  Note: channels are endpoint specific so these
     // constants and the handling need not have anything to do with
@@ -65,79 +84,356 @@ public class DefaultClient implements Client
     // separate.
     private static final int CH_RELIABLE = 0;
     private static final int CH_UNRELIABLE = 1;
+
     private static final int CH_FIRST = 2;
-        
-    private ThreadLocal<ByteBuffer> dataBuffer = new ThreadLocal<ByteBuffer>();
-    
+
+    private final ThreadLocal<ByteBuffer> dataBuffer = new ThreadLocal<ByteBuffer>();
     private int id = -1;
     private boolean isRunning = false;
-    private CountDownLatch connecting = new CountDownLatch(1);
-    private String gameName;
-    private int version;
-    private MessageListenerRegistry<Client> messageListeners = new MessageListenerRegistry<Client>();
-    private List<ClientStateListener> stateListeners = new CopyOnWriteArrayList<ClientStateListener>();
-    private List<ErrorListener<? super Client>> errorListeners = new CopyOnWriteArrayList<ErrorListener<? super Client>>();
-    private Redispatch dispatcher = new Redispatch();
-    private List<ConnectorAdapter> channels = new ArrayList<ConnectorAdapter>();    
- 
+    private final CountDownLatch connecting = new CountDownLatch( 1 );
+    private final String gameName;
+    private final int version;
+    private final MessageListenerRegistry<Client> messageListeners = new MessageListenerRegistry<Client>();
+    private final List<ClientStateListener> stateListeners = new CopyOnWriteArrayList<ClientStateListener>();
+    private final List<ErrorListener<? super Client>> errorListeners = new CopyOnWriteArrayList<ErrorListener<? super Client>>();
+    private final Redispatch dispatcher = new Redispatch();
+
+    private final List<ConnectorAdapter> channels = new ArrayList<ConnectorAdapter>();
+
     private ConnectorFactory connectorFactory;
-    
-    private ClientServiceManager services;
-    
-    public DefaultClient( String gameName, int version )
-    {
+    private final ClientServiceManager services;
+
+    private int maxMessageSize;
+
+    public DefaultClient( String gameName, int version ) {
+        maxMessageSize = 1 << 15;
         this.gameName = gameName;
         this.version = version;
-        this.services = new ClientServiceManager(this);
+        services = new ClientServiceManager( this );
         addStandardServices();
     }
-    
-    public DefaultClient( String gameName, int version, Connector reliable, Connector fast,
-                          ConnectorFactory connectorFactory )
-    {
+
+    public DefaultClient( String gameName, int version, Connector reliable, Connector fast, ConnectorFactory connectorFactory ) {
         this( gameName, version );
         setPrimaryConnectors( reliable, fast, connectorFactory );
     }
 
+    @Override
+    public void addClientStateListener( ClientStateListener listener ) {
+        stateListeners.add( listener );
+    }
+
+    @Override
+    public void addErrorListener( ErrorListener<? super Client> listener ) {
+        errorListeners.add( listener );
+    }
+
+    @Override
+    public void addMessageListener( MessageListener<? super Client> listener ) {
+        messageListeners.addMessageListener( listener );
+    }
+
+    @Override
+    public void addMessageListener( MessageListener<? super Client> listener, Class... classes ) {
+        messageListeners.addMessageListener( listener, classes );
+    }
+
     protected void addStandardServices() {
-        services.addService(new ClientSerializerRegistrationsService());
+        services.addService( new ClientSerializerRegistrationsService() );
     }
 
-    protected void setPrimaryConnectors( Connector reliable, Connector fast, ConnectorFactory connectorFactory )
-    {
-        if( reliable == null )
-            throw new IllegalArgumentException( "The reliable connector cannot be null." );            
-        if( isRunning )
-            throw new IllegalStateException( "Client is already started." );
-        if( !channels.isEmpty() )
-            throw new IllegalStateException( "Channels already exist." );
-            
-        this.connectorFactory = connectorFactory;
-        channels.add(new ConnectorAdapter(reliable, dispatcher, dispatcher, true));
-        if( fast != null ) {
-            channels.add(new ConnectorAdapter(fast, dispatcher, dispatcher, false));
-        } else {
-            // Add the null adapter to keep the indexes right
-            channels.add(null);
-        }
-    }  
-
-    protected void checkRunning()
-    {
-        if( !isRunning )
+    protected void checkRunning() {
+        if (!isRunning) {
             throw new IllegalStateException( "Client is not started." );
+        }
     }
- 
-    public void start()
-    {
-        if( isRunning )
+
+    @Override
+    public void close() {
+        checkRunning();
+
+        closeConnections( null );
+    }
+
+    protected void closeConnections( DisconnectInfo info ) {
+        if (!isRunning) {
+            return;
+        }
+
+        // Let the services get a chance to stop before we
+        // kill the connection.
+        services.stop();
+
+        // Send a close message
+
+        // Tell the thread it's ok to die
+        for (final ConnectorAdapter ca : channels) {
+            if (ca == null) {
+                continue;
+            }
+            ca.close();
+        }
+
+        // Wait for the threads?
+
+        // Just in case we never fully connected
+        connecting.countDown();
+
+        fireDisconnected( info );
+
+        isRunning = false;
+
+        // Terminate the services
+        services.terminate();
+    }
+
+    protected void configureChannels( long tempId, int[] ports ) {
+
+        try {
+            for (int i = 0; i < ports.length; i++) {
+                final Connector c = connectorFactory.createConnector( i, ports[i] );
+                final ConnectorAdapter ca = new ConnectorAdapter( c, dispatcher, dispatcher, true );
+                final int ch = channels.size();
+                channels.add( ca );
+
+                // Need to send the connection its hook-up registration
+                // and start it.
+                ca.start();
+                ClientRegistrationMessage reg;
+                reg = new ClientRegistrationMessage();
+                reg.setId( tempId );
+                reg.setReliable( true );
+                send( ch, reg, false );
+            }
+        }
+        catch (final IOException e) {
+            throw new RuntimeException( "Error configuring channels", e );
+        }
+    }
+
+    protected void dispatch( Message m ) {
+        // Pull off the connection management messages we're
+        // interested in and then pass on the rest.
+        if (m instanceof ClientRegistrationMessage) {
+            final ClientRegistrationMessage crm = (ClientRegistrationMessage) m;
+            // See if it has a real ID
+            if (crm.getId() >= 0) {
+                // Then we've gotten our real id
+                id = (int) crm.getId();
+                log.log( Level.FINE, "Connection established, id:{0}.", id );
+                connecting.countDown();
+                fireConnected();
+            }
+            else {
+                // Else it's a message letting us know that the
+                // hosted services have been started
+                startServices();
+            }
+            return;
+        }
+        else if (m instanceof ChannelInfoMessage) {
+            // This is an interum step in the connection process and
+            // now we need to add a bunch of connections
+            configureChannels( ((ChannelInfoMessage) m).getId(), ((ChannelInfoMessage) m).getPorts() );
+            return;
+        }
+        else if (m instanceof DisconnectMessage) {
+            // Can't do too much else yet
+            final String reason = ((DisconnectMessage) m).getReason();
+            log.log( Level.SEVERE, "Connection terminated, reason:{0}.", reason );
+            final DisconnectInfo info = new DisconnectInfo();
+            info.reason = reason;
+            closeConnections( info );
+        }
+
+        // Make sure client MessageListeners are called single-threaded
+        // since it could receive messages from the TCP and UDP
+        // thread simultaneously.
+        synchronized (this) {
+            messageListeners.messageReceived( this, m );
+        }
+    }
+
+    protected void fireConnected() {
+        for (final ClientStateListener l : stateListeners) {
+            l.clientConnected( this );
+        }
+    }
+
+    protected void fireDisconnected( DisconnectInfo info ) {
+        for (final ClientStateListener l : stateListeners) {
+            l.clientDisconnected( this, info );
+        }
+    }
+
+    @Override
+    public String getGameName() {
+        return gameName;
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public ClientServiceManager getServices() {
+        return services;
+    }
+
+    @Override
+    public int getVersion() {
+        return version;
+    }
+
+    /**
+     *  Either calls the ErrorListener or closes the connection
+     *  if there are no listeners.
+     */
+    protected void handleError( Throwable t ) {
+        // If there are no listeners then close the connection with
+        // a reason
+        if (errorListeners.isEmpty()) {
+            log.log( Level.SEVERE, "Termining connection due to unhandled error", t );
+            final DisconnectInfo info = new DisconnectInfo();
+            info.reason = "Connection Error";
+            info.error = t;
+            closeConnections( info );
+            return;
+        }
+
+        for (final ErrorListener l : errorListeners) {
+            l.handleError( this, t );
+        }
+    }
+
+    @Override
+    public boolean isConnected() {
+        return id != -1 && isRunning;
+    }
+
+    @Override
+    public boolean isStarted() {
+        return isRunning;
+    }
+
+    @Override
+    public void removeClientStateListener( ClientStateListener listener ) {
+        stateListeners.remove( listener );
+    }
+
+    @Override
+    public void removeErrorListener( ErrorListener<? super Client> listener ) {
+        errorListeners.remove( listener );
+    }
+
+    @Override
+    public void removeMessageListener( MessageListener<? super Client> listener ) {
+        messageListeners.removeMessageListener( listener );
+    }
+
+    @Override
+    public void removeMessageListener( MessageListener<? super Client> listener, Class... classes ) {
+        messageListeners.removeMessageListener( listener, classes );
+    }
+
+    @Override
+    public void send( int channel, Message message ) {
+        if (channel >= 0) {
+            // Make sure we aren't still connecting.  Channels
+            // won't be valid until we are fully connected since
+            // we receive the channel list from the server.
+            // The default channels don't require the connection
+            // to be fully up before sending.
+            waitForConnected();
+        }
+
+        if (channel < CHANNEL_DEFAULT_RELIABLE || channel + CH_FIRST >= channels.size()) {
+            throw new IllegalArgumentException( "Channel is undefined:" + channel );
+        }
+        send( channel + CH_FIRST, message, true );
+    }
+
+    protected void send( int channel, Message message, boolean waitForConnected ) {
+        checkRunning();
+
+        if (waitForConnected) {
+            // Make sure we aren't still connecting
+            waitForConnected();
+        }
+
+        ByteBuffer buffer = dataBuffer.get();
+        if (buffer == null) {
+            buffer = ByteBuffer.allocate( maxMessageSize + 2 );
+            dataBuffer.set( buffer );
+        }
+        buffer.clear();
+
+        // Convert the message to bytes
+        buffer = MessageProtocol.messageToBuffer( message, buffer );
+
+        // Since we share the buffer between invocations, we will need to
+        // copy this message's part out of it.  This is because we actually
+        // do the send on a background thread.
+        final byte[] temp = new byte[buffer.remaining()];
+        System.arraycopy( buffer.array(), buffer.position(), temp, 0, buffer.remaining() );
+        buffer = ByteBuffer.wrap( temp );
+
+        channels.get( channel ).write( buffer );
+    }
+
+    @Override
+    public void send( Message message ) {
+        if (message.isReliable() || channels.get( CH_UNRELIABLE ) == null) {
+            send( CH_RELIABLE, message, true );
+        }
+        else {
+            send( CH_UNRELIABLE, message, true );
+        }
+    }
+
+    @Override
+    public void setMaximumMessageSize( int size ) {
+        if (size <= 0) {
+            throw new IllegalArgumentException( "size must not be <= 0" );
+        }
+        maxMessageSize = size;
+    }
+
+    protected void setPrimaryConnectors( Connector reliable, Connector fast, ConnectorFactory connectorFactory ) {
+        if (reliable == null) {
+            throw new IllegalArgumentException( "The reliable connector cannot be null." );
+        }
+        if (isRunning) {
             throw new IllegalStateException( "Client is already started." );
-            
+        }
+        if (!channels.isEmpty()) {
+            throw new IllegalStateException( "Channels already exist." );
+        }
+
+        this.connectorFactory = connectorFactory;
+        channels.add( new ConnectorAdapter( reliable, dispatcher, dispatcher, true ) );
+        if (fast != null) {
+            channels.add( new ConnectorAdapter( fast, dispatcher, dispatcher, false ) );
+        }
+        else {
+            // Add the null adapter to keep the indexes right
+            channels.add( null );
+        }
+    }
+
+    @Override
+    public void start() {
+        if (isRunning) {
+            throw new IllegalStateException( "Client is already started." );
+        }
+
         // Start up the threads and stuff for the
         // connectors that we have
-        for( ConnectorAdapter ca : channels ) {
-            if( ca == null )
+        for (final ConnectorAdapter ca : channels) {
+            if (ca == null) {
                 continue;
+            }
             ca.start();
         }
 
@@ -154,324 +450,47 @@ public class DefaultClient implements Client
         // is roughtly related to system start time, adding these two
         // together should be plenty unique for our purposes.  It wouldn't
         // hurt to reconcile with IP on the server side, though.
-        long tempId = System.currentTimeMillis() + System.nanoTime();
+        final long tempId = System.currentTimeMillis() + System.nanoTime();
 
         // Set it true here so we can send some messages.
-        isRunning = true;        
-                
+        isRunning = true;
+
         ClientRegistrationMessage reg;
         reg = new ClientRegistrationMessage();
-        reg.setId(tempId);
-        reg.setGameName(getGameName());
-        reg.setVersion(getVersion());
-        reg.setReliable(true);
-        send(CH_RELIABLE, reg, false);
-        
+        reg.setId( tempId );
+        reg.setGameName( getGameName() );
+        reg.setVersion( getVersion() );
+        reg.setReliable( true );
+        send( CH_RELIABLE, reg, false );
+
         // Send registration messages to any other configured
         // connectors
         reg = new ClientRegistrationMessage();
-        reg.setId(tempId);
-        reg.setReliable(false);
-        for( int ch = CH_UNRELIABLE; ch < channels.size(); ch++ ) {
-            if( channels.get(ch) == null )
+        reg.setId( tempId );
+        reg.setReliable( false );
+        for (int ch = CH_UNRELIABLE; ch < channels.size(); ch++) {
+            if (channels.get( ch ) == null) {
                 continue;
-            send(ch, reg, false);
+            }
+            send( ch, reg, false );
         }
-    }    
-
-    public boolean isStarted() {
-        return isRunning;
     }
 
-    protected void waitForConnected()
-    {
-        if( isConnected() )
+    protected void startServices() {
+        // Let the services know we are finally started
+        services.start();
+    }
+
+    protected void waitForConnected() {
+        if (isConnected()) {
             return;
-            
+        }
+
         try {
             connecting.await();
-        } catch( InterruptedException e ) {
+        }
+        catch (final InterruptedException e) {
             throw new RuntimeException( "Interrupted waiting for connect", e );
         }
     }
-
-    public boolean isConnected()
-    {
-        return id != -1 && isRunning; 
-    }     
-
-    public int getId()
-    {   
-        return id;
-    }     
- 
-    public String getGameName()
-    {
-        return gameName;
-    }
-
-    public int getVersion()
-    {
-        return version;
-    }
-    
-    public ClientServiceManager getServices() 
-    {
-        return services;
-    }
-   
-    public void send( Message message )
-    {
-        if( message.isReliable() || channels.get(CH_UNRELIABLE) == null ) {
-            send(CH_RELIABLE, message, true);
-        } else {
-            send(CH_UNRELIABLE, message, true);
-        }
-    }
- 
-    public void send( int channel, Message message )
-    {
-        if( channel >= 0 ) {
-            // Make sure we aren't still connecting.  Channels
-            // won't be valid until we are fully connected since
-            // we receive the channel list from the server.
-            // The default channels don't require the connection
-            // to be fully up before sending.  
-            waitForConnected();
-        }
-    
-        if( channel < CHANNEL_DEFAULT_RELIABLE || channel + CH_FIRST >= channels.size() ) {
-            throw new IllegalArgumentException( "Channel is undefined:" + channel );
-        }
-        send(channel + CH_FIRST, message, true);
-    }
-    
-    protected void send( int channel, Message message, boolean waitForConnected )
-    {
-        checkRunning();
- 
-        if( waitForConnected ) {       
-            // Make sure we aren't still connecting
-            waitForConnected();
-        }
-        
-        ByteBuffer buffer = dataBuffer.get();
-        if( buffer == null ) {
-            buffer = ByteBuffer.allocate( 65536 + 2 );
-            dataBuffer.set(buffer);
-        }
-        buffer.clear();        
- 
-        // Convert the message to bytes
-        buffer = MessageProtocol.messageToBuffer(message, buffer);
-                
-        // Since we share the buffer between invocations, we will need to 
-        // copy this message's part out of it.  This is because we actually
-        // do the send on a background thread.       
-        byte[] temp = new byte[buffer.remaining()];
-        System.arraycopy(buffer.array(), buffer.position(), temp, 0, buffer.remaining());
-        buffer = ByteBuffer.wrap(temp);
-        
-        channels.get(channel).write(buffer);
-    }
- 
-    public void close()
-    {
-        checkRunning();
- 
-        closeConnections( null );
-    }         
-
-    protected void closeConnections( DisconnectInfo info )
-    {
-        if( !isRunning )
-            return;
-
-        // Let the services get a chance to stop before we
-        // kill the connection.
-        services.stop();
-        
-        // Send a close message
-    
-        // Tell the thread it's ok to die
-        for( ConnectorAdapter ca : channels ) {
-            if( ca == null )
-                continue;
-            ca.close();
-        }
-        
-        // Wait for the threads?
-
-        // Just in case we never fully connected
-        connecting.countDown();
-        
-        fireDisconnected(info);
-        
-        isRunning = false;
-        
-        // Terminate the services
-        services.terminate();            
-    }         
-
-    public void addClientStateListener( ClientStateListener listener )
-    {
-        stateListeners.add( listener );
-    } 
-
-    public void removeClientStateListener( ClientStateListener listener )
-    {
-        stateListeners.remove( listener );
-    } 
-
-    public void addMessageListener( MessageListener<? super Client> listener )
-    {
-        messageListeners.addMessageListener( listener );
-    } 
-
-    public void addMessageListener( MessageListener<? super Client> listener, Class... classes )
-    {
-        messageListeners.addMessageListener( listener, classes );
-    } 
-
-    public void removeMessageListener( MessageListener<? super Client> listener )
-    {
-        messageListeners.removeMessageListener( listener );
-    } 
-
-    public void removeMessageListener( MessageListener<? super Client> listener, Class... classes )
-    {
-        messageListeners.removeMessageListener( listener, classes );
-    } 
-
-    public void addErrorListener( ErrorListener<? super Client> listener )
-    {
-        errorListeners.add( listener );
-    } 
-
-    public void removeErrorListener( ErrorListener<? super Client> listener )
-    {
-        errorListeners.remove( listener );
-    } 
- 
-    protected void fireConnected()
-    {
-        for( ClientStateListener l : stateListeners ) {
-            l.clientConnected( this );
-        }            
-    }
-
-    protected void startServices() 
-    {
-        // Let the services know we are finally started
-        services.start();      
-    }
-    
-    protected void fireDisconnected( DisconnectInfo info )
-    {
-        for( ClientStateListener l : stateListeners ) {
-            l.clientDisconnected( this, info );
-        }            
-    }
- 
-    /**
-     *  Either calls the ErrorListener or closes the connection
-     *  if there are no listeners.  
-     */ 
-    protected void handleError( Throwable t )
-    {
-        // If there are no listeners then close the connection with
-        // a reason
-        if( errorListeners.isEmpty() ) {
-            log.log( Level.SEVERE, "Termining connection due to unhandled error", t );
-            DisconnectInfo info = new DisconnectInfo();
-            info.reason = "Connection Error";
-            info.error = t;
-            closeConnections(info);
-            return;
-        }
-    
-        for( ErrorListener l : errorListeners ) {
-            l.handleError( this, t );
-        } 
-    }
- 
-    protected void configureChannels( long tempId, int[] ports ) {
-
-        try {               
-            for( int i = 0; i < ports.length; i++ ) {
-                Connector c = connectorFactory.createConnector( i, ports[i] );
-                ConnectorAdapter ca = new ConnectorAdapter(c, dispatcher, dispatcher, true);
-                int ch = channels.size(); 
-                channels.add( ca );
-                
-                // Need to send the connection its hook-up registration
-                // and start it.
-                ca.start(); 
-                ClientRegistrationMessage reg;
-                reg = new ClientRegistrationMessage();
-                reg.setId(tempId);
-                reg.setReliable(true);
-                send( ch, reg, false );
-            }
-        } catch( IOException e ) {
-            throw new RuntimeException( "Error configuring channels", e );
-        }
-    }
- 
-    protected void dispatch( Message m )
-    {
-        // Pull off the connection management messages we're
-        // interested in and then pass on the rest.
-        if( m instanceof ClientRegistrationMessage ) {
-            ClientRegistrationMessage crm = (ClientRegistrationMessage)m; 
-            // See if it has a real ID
-            if( crm.getId() >= 0 ) {
-                // Then we've gotten our real id
-                this.id = (int)crm.getId();
-                log.log( Level.FINE, "Connection established, id:{0}.", this.id );
-                connecting.countDown();
-                fireConnected();
-            } else {
-                // Else it's a message letting us know that the 
-                // hosted services have been started
-                startServices();
-            }
-            return;
-        } else if( m instanceof ChannelInfoMessage ) {
-            // This is an interum step in the connection process and
-            // now we need to add a bunch of connections
-            configureChannels( ((ChannelInfoMessage)m).getId(), ((ChannelInfoMessage)m).getPorts() );
-            return; 
-        } else if( m instanceof DisconnectMessage ) {
-            // Can't do too much else yet
-            String reason = ((DisconnectMessage)m).getReason();
-            log.log( Level.SEVERE, "Connection terminated, reason:{0}.", reason );
-            DisconnectInfo info = new DisconnectInfo();
-            info.reason = reason;
-            closeConnections(info);
-        }
-    
-        // Make sure client MessageListeners are called single-threaded
-        // since it could receive messages from the TCP and UDP
-        // thread simultaneously.
-        synchronized( this ) {
-            messageListeners.messageReceived( this, m );
-        }
-    }
- 
-    protected class Redispatch implements MessageListener<Object>, ErrorListener<Object>
-    {
-        public void messageReceived( Object source, Message m )
-        {
-            dispatch( m );
-        }
-        
-        public void handleError( Object source, Throwable t )
-        {
-            // Only doing the DefaultClient.this to make the code
-            // checker happy... it compiles fine without it but I
-            // don't like red lines in my editor. :P
-            DefaultClient.this.handleError( t );   
-        }
-    }    
 }

--- a/jme3-networking/src/main/java/com/jme3/network/base/DefaultServer.java
+++ b/jme3-networking/src/main/java/com/jme3/network/base/DefaultServer.java
@@ -31,7 +31,27 @@
  */
 package com.jme3.network.base;
 
-import com.jme3.network.*;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.jme3.network.ConnectionListener;
+import com.jme3.network.Filter;
+import com.jme3.network.HostedConnection;
+import com.jme3.network.Message;
+import com.jme3.network.MessageConnection;
+import com.jme3.network.MessageListener;
+import com.jme3.network.Server;
 import com.jme3.network.kernel.Endpoint;
 import com.jme3.network.kernel.Kernel;
 import com.jme3.network.message.ChannelInfoMessage;
@@ -39,14 +59,6 @@ import com.jme3.network.message.ClientRegistrationMessage;
 import com.jme3.network.message.DisconnectMessage;
 import com.jme3.network.service.HostedServiceManager;
 import com.jme3.network.service.serializer.ServerSerializerRegistrationsService;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  *  A default implementation of the Server interface that delegates
@@ -55,82 +67,223 @@ import java.util.logging.Logger;
  *  @version   $Revision$
  *  @author    Paul Speed
  */
-public class DefaultServer implements Server
-{
-    static final Logger log = Logger.getLogger(DefaultServer.class.getName());
+public class DefaultServer implements Server {
+    protected class Connection implements HostedConnection {
+        private final int id;
+        private boolean closed;
+        private final Endpoint[] channels;
+        private int setChannelCount = 0;
+
+        private final Map<String, Object> sessionData = new ConcurrentHashMap<String, Object>();
+
+        public Connection( int channelCount ) {
+            id = nextId.getAndIncrement();
+            channels = new Endpoint[channelCount];
+        }
+
+        @Override
+        public Set<String> attributeNames() {
+            return Collections.unmodifiableSet( sessionData.keySet() );
+        }
+
+        @Override
+        public void close( String reason ) {
+            // Send a reason
+            final DisconnectMessage m = new DisconnectMessage();
+            m.setType( DisconnectMessage.KICK );
+            m.setReason( reason );
+            m.setReliable( true );
+            send( m );
+
+            // Just close the reliable endpoint
+            // fast will be cleaned up as a side-effect
+            // when closeConnection() is called by the
+            // connectionClosed() endpoint callback.
+            if (channels[CH_RELIABLE] != null) {
+                // Close with flush so we make sure our
+                // message gets out
+                channels[CH_RELIABLE].close( true );
+            }
+        }
+
+        protected void closeConnection() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+
+            // Make sure all endpoints are closed.  Note: reliable
+            // should always already be closed through all paths that I
+            // can conceive... but it doesn't hurt to be sure.
+            for (final Endpoint p : channels) {
+                if (p == null) {
+                    continue;
+                }
+                p.close();
+            }
+
+            fireConnectionRemoved( this );
+        }
+
+        @Override
+        public String getAddress() {
+            return channels[CH_RELIABLE] == null ? null : channels[CH_RELIABLE].getAddress();
+        }
+
+        @Override
+        @SuppressWarnings( "unchecked" )
+        public <T> T getAttribute( String name ) {
+            return (T) sessionData.get( name );
+        }
+
+        @Override
+        public int getId() {
+            return id;
+        }
+
+        @Override
+        public Server getServer() {
+            return DefaultServer.this;
+        }
+
+        boolean hasEndpoint( Endpoint p ) {
+            for (final Endpoint e : channels) {
+                if (p == e) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        boolean isComplete() {
+            return setChannelCount == channels.length;
+        }
+
+        @Override
+        public void send( int channel, Message message ) {
+            checkChannel( channel );
+            final ByteBuffer buffer = ByteBuffer.allocate( maxMessageSize );
+            MessageProtocol.messageToBuffer( message, buffer );
+            channels[channel + CH_FIRST].send( buffer );
+        }
+
+        @Override
+        public void send( Message message ) {
+            final ByteBuffer buffer = ByteBuffer.allocate( maxMessageSize );
+            MessageProtocol.messageToBuffer( message, buffer );
+            if (message.isReliable() || channels[CH_UNRELIABLE] == null) {
+                channels[CH_RELIABLE].send( buffer );
+            }
+            else {
+                channels[CH_UNRELIABLE].send( buffer );
+            }
+        }
+
+        @Override
+        public Object setAttribute( String name, Object value ) {
+            if (value == null) {
+                return sessionData.remove( name );
+            }
+            return sessionData.put( name, value );
+        }
+
+        void setChannel( int channel, Endpoint p ) {
+            if (channels[channel] != null && channels[channel] != p) {
+                throw new RuntimeException( "Channel has already been set:" + channel + " = " + channels[channel] + ", cannot be set to:" + p );
+            }
+            channels[channel] = p;
+            if (p != null) {
+                setChannelCount++;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "Connection[ id=" + id + ", reliable=" + channels[CH_RELIABLE] + ", fast=" + channels[CH_UNRELIABLE] + " ]";
+        }
+    }
+
+    protected class FilterAdapter implements Filter<Endpoint> {
+        private final Filter<? super HostedConnection> delegate;
+
+        public FilterAdapter( Filter<? super HostedConnection> delegate ) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean apply( Endpoint input ) {
+            final HostedConnection conn = getConnection( input );
+            if (conn == null) {
+                return false;
+            }
+            return delegate.apply( conn );
+        }
+    }
+
+    protected class Redispatch implements MessageListener<HostedConnection> {
+        @Override
+        public void messageReceived( HostedConnection source, Message m ) {
+            dispatch( source, m );
+        }
+    }
+
+    static final Logger log = Logger.getLogger( DefaultServer.class.getName() );
 
     // First two channels are reserved for reliable and
     // unreliable
     private static final int CH_RELIABLE = 0;
     private static final int CH_UNRELIABLE = 1;
     private static final int CH_FIRST = 2;
-    
     private boolean isRunning = false;
-    private AtomicInteger nextId = new AtomicInteger(0);
-    private String gameName;
-    private int version;
-    private KernelFactory kernelFactory = KernelFactory.DEFAULT;
-    private KernelAdapter reliableAdapter;
+    private final AtomicInteger nextId = new AtomicInteger( 0 );
+    private final String gameName;
+    private final int version;
+    private final KernelFactory kernelFactory = KernelFactory.DEFAULT;
+    private final KernelAdapter reliableAdapter;
     private KernelAdapter fastAdapter;
-    private List<KernelAdapter> channels = new ArrayList<KernelAdapter>();
-    private List<Integer> alternatePorts = new ArrayList<Integer>();
-    private Redispatch dispatcher = new Redispatch();
-    private Map<Integer,HostedConnection> connections = new ConcurrentHashMap<Integer,HostedConnection>();
-    private Map<Endpoint,HostedConnection> endpointConnections 
-                            = new ConcurrentHashMap<Endpoint,HostedConnection>();
-    
+    private final List<KernelAdapter> channels = new ArrayList<KernelAdapter>();
+    private final List<Integer> alternatePorts = new ArrayList<Integer>();
+
+    private final Redispatch dispatcher = new Redispatch();
+
+    private final Map<Integer, HostedConnection> connections = new ConcurrentHashMap<Integer, HostedConnection>();
+    private final Map<Endpoint, HostedConnection> endpointConnections = new ConcurrentHashMap<Endpoint, HostedConnection>();
+
     // Keeps track of clients for whom we've only received the UDP
     // registration message
-    private Map<Long,Connection> connecting = new ConcurrentHashMap<Long,Connection>();
-    
-    private MessageListenerRegistry<HostedConnection> messageListeners 
-                            = new MessageListenerRegistry<HostedConnection>();                        
-    private List<ConnectionListener> connectionListeners = new CopyOnWriteArrayList<ConnectionListener>();
-    
-    private HostedServiceManager services;
-    
-    public DefaultServer( String gameName, int version, Kernel reliable, Kernel fast )
-    {
-        if( reliable == null )
+    private final Map<Long, Connection> connecting = new ConcurrentHashMap<Long, Connection>();
+    private final MessageListenerRegistry<HostedConnection> messageListeners = new MessageListenerRegistry<HostedConnection>();
+    private final List<ConnectionListener> connectionListeners = new CopyOnWriteArrayList<ConnectionListener>();
+
+    private final HostedServiceManager services;
+
+    private int maxMessageSize;
+
+    public DefaultServer( String gameName, int version, Kernel reliable, Kernel fast ) {
+        if (reliable == null) {
             throw new IllegalArgumentException( "Default server reqiures a reliable kernel instance." );
-            
+        }
+
         this.gameName = gameName;
         this.version = version;
-        this.services = new HostedServiceManager(this);        
+        services = new HostedServiceManager( this );
         addStandardServices();
-        
+
         reliableAdapter = new KernelAdapter( this, reliable, dispatcher, true );
         channels.add( reliableAdapter );
-        if( fast != null ) {
+        if (fast != null) {
             fastAdapter = new KernelAdapter( this, fast, dispatcher, false );
             channels.add( fastAdapter );
         }
-    }   
-
-    protected void addStandardServices() {
-        services.addService(new ServerSerializerRegistrationsService());
+        maxMessageSize = 1 << 15;
     }
 
-    public String getGameName()
-    {
-        return gameName;
-    }
-
-    public int getVersion()
-    {
-        return version;
-    }
-    
-    public HostedServiceManager getServices() 
-    {
-        return services;
-    }
-
-    public int addChannel( int port )
-    {
-        if( isRunning )
+    @Override
+    public int addChannel( int port ) {
+        if (isRunning) {
             throw new IllegalStateException( "Channels cannot be added once server is started." );
- 
+        }
+
         // Note: it does bug me that channels aren't 100% universal and
         // setup externally but it requires a more invasive set of changes
         // for "connection types" and some kind of registry of kernel and
@@ -138,510 +291,377 @@ public class DefaultServer implements Server
         // would allow all kinds of channel customization maybe... but for
         // now, we hard-code the standard connections and treat the +2 extras
         // differently.
-            
+
         // Check for consistency with the channels list
-        if( channels.size() - CH_FIRST != alternatePorts.size() )
-            throw new IllegalStateException( "Channel and port lists do not match." ); 
-            
-        try {                                
-            int result = alternatePorts.size(); 
-            alternatePorts.add(port);
-            
-            Kernel kernel = kernelFactory.createKernel(result, port); 
-            channels.add( new KernelAdapter(this, kernel, dispatcher, true) );
-            
-            return result;
-        } catch( IOException e ) {
-            throw new RuntimeException( "Error adding channel for port:" + port, e );
-        } 
-    } 
-
-    protected void checkChannel( int channel )
-    {
-        if( channel < MessageConnection.CHANNEL_DEFAULT_RELIABLE 
-            || channel >= alternatePorts.size() ) {
-            throw new IllegalArgumentException( "Channel is undefined:" + channel );
-        }              
-    }
-
-    public void start()
-    {
-        if( isRunning )
-            throw new IllegalStateException( "Server is already started." );
-            
-        // Initialize the kernels
-        for( KernelAdapter ka : channels ) {
-            ka.initialize();
+        if (channels.size() - CH_FIRST != alternatePorts.size()) {
+            throw new IllegalStateException( "Channel and port lists do not match." );
         }
- 
-        // Start em up
-        for( KernelAdapter ka : channels ) {
-            ka.start();
-        }
-        
-        isRunning = true;
-        
-        // Start the services
-        services.start();             
-    }
 
-    public boolean isRunning()
-    {
-        return isRunning;
-    }     
- 
-    public void close() 
-    {
-        if( !isRunning )
-            throw new IllegalStateException( "Server is not started." );
- 
-        // First stop the services since we are about to
-        // kill the connections they are using
-        services.stop();
- 
         try {
-            // Kill the adpaters, they will kill the kernels
-            for( KernelAdapter ka : channels ) {
-                ka.close();
-            }
-            
-            isRunning = false;
-            
-            // Now terminate all of the services
-            services.terminate();             
-        } catch( InterruptedException e ) {
-            throw new RuntimeException( "Interrupted while closing", e );
-        }                               
-    }
- 
-    public void broadcast( Message message )
-    {
-        broadcast( null, message );
+            final int result = alternatePorts.size();
+            alternatePorts.add( port );
+
+            final Kernel kernel = kernelFactory.createKernel( result, port );
+            channels.add( new KernelAdapter( this, kernel, dispatcher, true ) );
+
+            return result;
+        }
+        catch (final IOException e) {
+            throw new RuntimeException( "Error adding channel for port:" + port, e );
+        }
     }
 
-    public void broadcast( Filter<? super HostedConnection> filter, Message message )
-    {
-        if( connections.isEmpty() )
+    @Override
+    public void addConnectionListener( ConnectionListener listener ) {
+        connectionListeners.add( listener );
+    }
+
+    @Override
+    public void addMessageListener( MessageListener<? super HostedConnection> listener ) {
+        messageListeners.addMessageListener( listener );
+    }
+
+    @Override
+    public void addMessageListener( MessageListener<? super HostedConnection> listener, Class... classes ) {
+        messageListeners.addMessageListener( listener, classes );
+    }
+
+    protected void addStandardServices() {
+        services.addService( new ServerSerializerRegistrationsService() );
+    }
+
+    @Override
+    public void broadcast( Filter<? super HostedConnection> filter, Message message ) {
+        if (connections.isEmpty()) {
             return;
- 
-        ByteBuffer buffer = MessageProtocol.messageToBuffer(message, null);
- 
-        FilterAdapter adapter = filter == null ? null : new FilterAdapter(filter);
-               
-        if( message.isReliable() || fastAdapter == null ) {
+        }
+
+        final ByteBuffer buffer = ByteBuffer.allocate( maxMessageSize );
+        MessageProtocol.messageToBuffer( message, buffer );
+
+        final FilterAdapter adapter = filter == null ? null : new FilterAdapter( filter );
+
+        if (message.isReliable() || fastAdapter == null) {
             // Don't need to copy the data because message protocol is already
             // giving us a fresh buffer
             reliableAdapter.broadcast( adapter, buffer, true, false );
-        } else {
+        }
+        else {
             fastAdapter.broadcast( adapter, buffer, false, false );
-        }               
+        }
     }
 
-    public void broadcast( int channel, Filter<? super HostedConnection> filter, Message message )
-    {
-        if( connections.isEmpty() )
+    @Override
+    public void broadcast( int channel, Filter<? super HostedConnection> filter, Message message ) {
+        if (connections.isEmpty()) {
             return;
+        }
 
-        checkChannel(channel);
-        
-        ByteBuffer buffer = MessageProtocol.messageToBuffer(message, null);
- 
-        FilterAdapter adapter = filter == null ? null : new FilterAdapter(filter);
+        checkChannel( channel );
 
-        channels.get(channel+CH_FIRST).broadcast( adapter, buffer, true, false );               
+        final ByteBuffer buffer = ByteBuffer.allocate( maxMessageSize );
+        MessageProtocol.messageToBuffer( message, buffer );
+
+        final FilterAdapter adapter = filter == null ? null : new FilterAdapter( filter );
+
+        channels.get( channel + CH_FIRST ).broadcast( adapter, buffer, true, false );
     }
 
-    public HostedConnection getConnection( int id )
-    {
-        return connections.get(id);
-    }     
- 
-    public boolean hasConnections()
-    {
-        return !connections.isEmpty();
+    @Override
+    public void broadcast( Message message ) {
+        broadcast( null, message );
     }
- 
-    public Collection<HostedConnection> getConnections()
-    {
-        return Collections.unmodifiableCollection((Collection<HostedConnection>)connections.values());
-    } 
- 
-    public void addConnectionListener( ConnectionListener listener )
-    {
-        connectionListeners.add(listener);   
+
+    protected void checkChannel( int channel ) {
+        if (channel < MessageConnection.CHANNEL_DEFAULT_RELIABLE || channel >= alternatePorts.size()) {
+            throw new IllegalArgumentException( "Channel is undefined:" + channel );
+        }
     }
- 
-    public void removeConnectionListener( ConnectionListener listener )
-    {
-        connectionListeners.remove(listener);   
-    }     
-    
-    public void addMessageListener( MessageListener<? super HostedConnection> listener )
-    {
-        messageListeners.addMessageListener( listener );
-    } 
 
-    public void addMessageListener( MessageListener<? super HostedConnection> listener, Class... classes )
-    {
-        messageListeners.addMessageListener( listener, classes );
-    } 
+    @Override
+    public void close() {
+        if (!isRunning) {
+            throw new IllegalStateException( "Server is not started." );
+        }
 
-    public void removeMessageListener( MessageListener<? super HostedConnection> listener )
-    {
-        messageListeners.removeMessageListener( listener );
-    } 
+        // First stop the services since we are about to
+        // kill the connections they are using
+        services.stop();
 
-    public void removeMessageListener( MessageListener<? super HostedConnection> listener, Class... classes )
-    {
-        messageListeners.removeMessageListener( listener, classes );
+        try {
+            // Kill the adpaters, they will kill the kernels
+            for (final KernelAdapter ka : channels) {
+                ka.close();
+            }
+
+            isRunning = false;
+
+            // Now terminate all of the services
+            services.terminate();
+        }
+        catch (final InterruptedException e) {
+            throw new RuntimeException( "Interrupted while closing", e );
+        }
     }
- 
-    protected void dispatch( HostedConnection source, Message m )
-    {
-        if( source == null ) {
+
+    protected void connectionClosed( Endpoint p ) {
+        if (p.isConnected()) {
+            log.log( Level.FINE, "Connection closed:{0}.", p );
+        }
+        else {
+            log.log( Level.FINE, "Connection closed:{0}.", p );
+        }
+
+        // Try to find the endpoint in all ways that it might
+        // exist.  Note: by this point the raw network channel is
+        // closed already.
+
+        // Also note: this method will be called multiple times per
+        // HostedConnection if it has multiple endpoints.
+
+        Connection removed;
+        synchronized (this) {
+            // Just in case the endpoint was still connecting
+            removeConnecting( p );
+
+            // And the regular management
+            removed = (Connection) endpointConnections.remove( p );
+            if (removed != null) {
+                connections.remove( removed.getId() );
+            }
+
+            log.log( Level.FINE, "Connections size:{0}", connections.size() );
+            log.log( Level.FINE, "Endpoint mappings size:{0}", endpointConnections.size() );
+        }
+
+        // Better not to fire events while we hold a lock
+        // so always do this outside the synch block.
+        // Note: checking removed.closed just to avoid spurious log messages
+        //       since in general we are called back for every endpoint closing.
+        if (removed != null && !removed.closed) {
+
+            log.log( Level.FINE, "Client closed:{0}.", removed );
+
+            removed.closeConnection();
+        }
+    }
+
+    protected void dispatch( HostedConnection source, Message m ) {
+        if (source == null) {
             messageListeners.messageReceived( source, m );
-        } else {
-        
+        }
+        else {
+
             // A semi-heavy handed way to make sure the listener
             // doesn't get called at the same time from two different
             // threads for the same hosted connection.
-            synchronized( source ) {
+            synchronized (source) {
                 messageListeners.messageReceived( source, m );
             }
         }
     }
 
-    protected void fireConnectionAdded( HostedConnection conn )
-    {
-        for( ConnectionListener l : connectionListeners ) {
+    protected void fireConnectionAdded( HostedConnection conn ) {
+        for (final ConnectionListener l : connectionListeners) {
             l.connectionAdded( this, conn );
         }
-    }            
-
-    protected void fireConnectionRemoved( HostedConnection conn )
-    {
-        for( ConnectionListener l : connectionListeners ) {
-            l.connectionRemoved( this, conn );
-        }
-    }            
-
-    protected int getChannel( KernelAdapter ka )
-    {
-        return channels.indexOf(ka);
     }
 
-    protected void registerClient( KernelAdapter ka, Endpoint p, ClientRegistrationMessage m )
-    {
+    protected void fireConnectionRemoved( HostedConnection conn ) {
+        for (final ConnectionListener l : connectionListeners) {
+            l.connectionRemoved( this, conn );
+        }
+    }
+
+    protected int getChannel( KernelAdapter ka ) {
+        return channels.indexOf( ka );
+    }
+
+    protected HostedConnection getConnection( Endpoint endpoint ) {
+        return endpointConnections.get( endpoint );
+    }
+
+    @Override
+    public HostedConnection getConnection( int id ) {
+        return connections.get( id );
+    }
+
+    @Override
+    public Collection<HostedConnection> getConnections() {
+        return Collections.unmodifiableCollection( connections.values() );
+    }
+
+    @Override
+    public String getGameName() {
+        return gameName;
+    }
+
+    @Override
+    public HostedServiceManager getServices() {
+        return services;
+    }
+
+    @Override
+    public int getVersion() {
+        return version;
+    }
+
+    @Override
+    public boolean hasConnections() {
+        return !connections.isEmpty();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return isRunning;
+    }
+
+    protected void registerClient( KernelAdapter ka, Endpoint p, ClientRegistrationMessage m ) {
         Connection addedConnection = null;
 
-        // generally this will only be called by one thread but it's        
+        // generally this will only be called by one thread but it's
         // important enough I won't take chances
-        synchronized( this ) {       
+        synchronized (this) {
             // Grab the random ID that the client created when creating
             // its two registration messages
-            long tempId = m.getId();
- 
+            final long tempId = m.getId();
+
             // See if we already have one
-            Connection c = connecting.remove(tempId);
-            if( c == null ) {
-                c = new Connection(channels.size());
+            Connection c = connecting.remove( tempId );
+            if (c == null) {
+                c = new Connection( channels.size() );
                 log.log( Level.FINE, "Registering client for endpoint, pass 1:{0}.", p );
-            } else {
+            }
+            else {
                 log.log( Level.FINE, "Refining client registration for endpoint:{0}.", p );
-            } 
-          
+            }
+
             // Fill in what we now know
-            int channel = getChannel(ka); 
-            c.setChannel(channel, p);            
+            final int channel = getChannel( ka );
+            c.setChannel( channel, p );
             log.log( Level.FINE, "Setting up channel:{0}", channel );
- 
+
             // If it's channel 0 then this is the initial connection
             // and we will send the connection information
-            if( channel == CH_RELIABLE ) {
+            if (channel == CH_RELIABLE) {
                 // Validate the name and version which is only sent
                 // over the reliable connection at this point.
-                if( !getGameName().equals(m.getGameName()) 
-                    || getVersion() != m.getVersion() ) {
- 
+                if (!getGameName().equals( m.getGameName() ) || getVersion() != m.getVersion()) {
+
                     log.log( Level.FINE, "Kicking client due to name/version mismatch:{0}.", c );
-            
+
                     // Need to kick them off... I may regret doing this from within
                     // the sync block but the alternative is more code
-                    c.close( "Server client mismatch, server:" + getGameName() + " v" + getVersion()
-                             + "  client:" + m.getGameName() + " v" + m.getVersion() );
-                    return;                        
+                    c.close( "Server client mismatch, server:" + getGameName() + " v" + getVersion() + "  client:" + m.getGameName() + " v" + m.getVersion() );
+                    return;
                 }
-                
+
                 // Else send the extra channel information to the client
-                if( !alternatePorts.isEmpty() ) {
-                    ChannelInfoMessage cim = new ChannelInfoMessage( m.getId(), alternatePorts );
-                    c.send(cim);
+                if (!alternatePorts.isEmpty()) {
+                    final ChannelInfoMessage cim = new ChannelInfoMessage( m.getId(), alternatePorts );
+                    c.send( cim );
                 }
             }
 
-            if( c.isComplete() ) {             
+            if (c.isComplete()) {
                 // Then we are fully connected
-                if( connections.put( c.getId(), c ) == null ) {
-                
-                    for( Endpoint cp : c.channels ) {
-                        if( cp == null )
+                if (connections.put( c.getId(), c ) == null) {
+
+                    for (final Endpoint cp : c.channels) {
+                        if (cp == null) {
                             continue;
+                        }
                         endpointConnections.put( cp, c );
-                    } 
- 
-                    addedConnection = c;               
+                    }
+
+                    addedConnection = c;
                 }
-            } else {
+            }
+            else {
                 // Need to keep getting channels so we'll keep it in
                 // the map
-                connecting.put(tempId, c);
-            } 
+                connecting.put( tempId, c );
+            }
         }
- 
+
         // Best to do this outside of the synch block to avoid
         // over synchronizing which is the path to deadlocks
-        if( addedConnection != null ) {       
+        if (addedConnection != null) {
             log.log( Level.FINE, "Client registered:{0}.", addedConnection );
-            
+
             // Send the ID back to the client letting it know it's
             // fully connected.
             m = new ClientRegistrationMessage();
             m.setId( addedConnection.getId() );
-            m.setReliable(true);
-            addedConnection.send(m);
-            
+            m.setReliable( true );
+            addedConnection.send( m );
+
             // Now we can notify the listeners about the
             // new connection.
             fireConnectionAdded( addedConnection );
-            
+
             // Send a second registration message with an invalid ID
             // to let the connection know that it can start its services
             m = new ClientRegistrationMessage();
-            m.setId(-1);
-            m.setReliable(true);
-            addedConnection.send(m);            
-        }            
+            m.setId( -1 );
+            m.setReliable( true );
+            addedConnection.send( m );
+        }
     }
 
-    protected HostedConnection getConnection( Endpoint endpoint )
-    {
-        return endpointConnections.get(endpoint);       
-    } 
-
-    protected void removeConnecting( Endpoint p ) 
-    {
+    protected void removeConnecting( Endpoint p ) {
         // No easy lookup for connecting Connections
         // from endpoint.
-        for( Map.Entry<Long,Connection> e : connecting.entrySet() ) {
-            if( e.getValue().hasEndpoint(p) ) {
-                connecting.remove(e.getKey());
+        for (final Map.Entry<Long, Connection> e : connecting.entrySet()) {
+            if (e.getValue().hasEndpoint( p )) {
+                connecting.remove( e.getKey() );
                 return;
-            } 
+            }
         }
     }
 
-    protected void connectionClosed( Endpoint p )
-    {
-        if( p.isConnected() ) {
-            log.log( Level.FINE, "Connection closed:{0}.", p );
-        } else {
-            log.log( Level.FINE, "Connection closed:{0}.", p );
-        }
-        
-        // Try to find the endpoint in all ways that it might
-        // exist.  Note: by this point the raw network channel is 
-        // closed already.
-    
-        // Also note: this method will be called multiple times per
-        // HostedConnection if it has multiple endpoints.
- 
-        Connection removed;
-        synchronized( this ) {             
-            // Just in case the endpoint was still connecting
-            removeConnecting(p);
-
-            // And the regular management
-            removed = (Connection)endpointConnections.remove(p);
-            if( removed != null ) {
-                connections.remove( removed.getId() );                
-            }
-            
-            log.log( Level.FINE, "Connections size:{0}", connections.size() );
-            log.log( Level.FINE, "Endpoint mappings size:{0}", endpointConnections.size() );
-        }
-        
-        // Better not to fire events while we hold a lock
-        // so always do this outside the synch block.
-        // Note: checking removed.closed just to avoid spurious log messages
-        //       since in general we are called back for every endpoint closing.
-        if( removed != null && !removed.closed ) {
-        
-            log.log( Level.FINE, "Client closed:{0}.", removed );
-            
-            removed.closeConnection();
-        }
+    @Override
+    public void removeConnectionListener( ConnectionListener listener ) {
+        connectionListeners.remove( listener );
     }
 
-    protected class Connection implements HostedConnection
-    {
-        private int id;
-        private boolean closed;
-        private Endpoint[] channels;
-        private int setChannelCount = 0; 
-       
-        private Map<String,Object> sessionData = new ConcurrentHashMap<String,Object>();       
-        
-        public Connection( int channelCount )
-        {
-            id = nextId.getAndIncrement();
-            channels = new Endpoint[channelCount];
+    @Override
+    public void removeMessageListener( MessageListener<? super HostedConnection> listener ) {
+        messageListeners.removeMessageListener( listener );
+    }
+
+    @Override
+    public void removeMessageListener( MessageListener<? super HostedConnection> listener, Class... classes ) {
+        messageListeners.removeMessageListener( listener, classes );
+    }
+
+    @Override
+    public void setMaximumMessageSize( int size ) {
+        if (size <= 0) {
+            throw new IllegalArgumentException( "size must not be <= 0" );
         }
-        
-        boolean hasEndpoint( Endpoint p )
-        {
-            for( Endpoint e : channels ) {
-                if( p == e ) {
-                    return true;
-                }
-            }
-            return false;
-        }
- 
-        void setChannel( int channel, Endpoint p )
-        {
-            if( channels[channel] != null && channels[channel] != p ) {
-                throw new RuntimeException( "Channel has already been set:" + channel 
-                                            + " = " + channels[channel] + ", cannot be set to:" + p );
-            }
-            channels[channel] = p;
-            if( p != null )
-                setChannelCount++;
-        }
-        
-        boolean isComplete()
-        {
-            return setChannelCount == channels.length;
-        }
- 
-        public Server getServer()
-        {   
-            return DefaultServer.this;
-        }     
-       
-        public int getId()
-        {
-            return id;
-        }
- 
-        public String getAddress()
-        {            
-            return channels[CH_RELIABLE] == null ? null : channels[CH_RELIABLE].getAddress();
-        }
-       
-        public void send( Message message )
-        {
-            ByteBuffer buffer = MessageProtocol.messageToBuffer(message, null);
-            if( message.isReliable() || channels[CH_UNRELIABLE] == null ) {
-                channels[CH_RELIABLE].send( buffer );
-            } else {
-                channels[CH_UNRELIABLE].send( buffer );
-            }
+        maxMessageSize = size;
+    }
+
+    @Override
+    public void start() {
+        if (isRunning) {
+            throw new IllegalStateException( "Server is already started." );
         }
 
-        public void send( int channel, Message message )
-        {
-            checkChannel(channel);
-            ByteBuffer buffer = MessageProtocol.messageToBuffer(message, null);
-            channels[channel+CH_FIRST].send(buffer);
+        // Initialize the kernels
+        for (final KernelAdapter ka : channels) {
+            ka.initialize();
         }
- 
-        protected void closeConnection()
-        {
-            if( closed ) 
-                return;
-            closed = true;
-            
-            // Make sure all endpoints are closed.  Note: reliable
-            // should always already be closed through all paths that I
-            // can conceive... but it doesn't hurt to be sure. 
-            for( Endpoint p : channels ) {
-                if( p == null ) 
-                    continue;
-                p.close();
-            }
-        
-            fireConnectionRemoved( this );
-        }
-        
-        public void close( String reason )
-        {
-            // Send a reason
-            DisconnectMessage m = new DisconnectMessage();
-            m.setType( DisconnectMessage.KICK );
-            m.setReason( reason );
-            m.setReliable( true );
-            send( m );
-            
-            // Just close the reliable endpoint
-            // fast will be cleaned up as a side-effect
-            // when closeConnection() is called by the
-            // connectionClosed() endpoint callback.
-            if( channels[CH_RELIABLE] != null ) {
-                // Close with flush so we make sure our
-                // message gets out
-                channels[CH_RELIABLE].close(true);
-            }
-        }
-        
-        public Object setAttribute( String name, Object value )
-        {
-            if( value == null )
-                return sessionData.remove(name);
-            return sessionData.put(name, value);
-        }
-    
-        @SuppressWarnings("unchecked")
-        public <T> T getAttribute( String name )
-        {
-            return (T)sessionData.get(name);
-        }             
 
-        public Set<String> attributeNames()
-        {
-            return Collections.unmodifiableSet(sessionData.keySet());
-        }           
-        
-        @Override
-        public String toString()
-        {
-            return "Connection[ id=" + id + ", reliable=" + channels[CH_RELIABLE] 
-                                     + ", fast=" + channels[CH_UNRELIABLE] + " ]"; 
-        }  
-    } 
+        // Start em up
+        for (final KernelAdapter ka : channels) {
+            ka.start();
+        }
 
-    protected class Redispatch implements MessageListener<HostedConnection>
-    {
-        public void messageReceived( HostedConnection source, Message m )
-        {
-            dispatch( source, m );
-        }
-    }                                          
-     
-    protected class FilterAdapter implements Filter<Endpoint>
-    {
-        private Filter<? super HostedConnection> delegate;
-        
-        public FilterAdapter( Filter<? super HostedConnection> delegate )
-        {
-            this.delegate = delegate;
-        }
-        
-        public boolean apply( Endpoint input )
-        {
-            HostedConnection conn = getConnection( input );
-            if( conn == null )
-                return false;
-            return delegate.apply(conn);
-        } 
-    }     
+        isRunning = true;
+
+        // Start the services
+        services.start();
+    }
 }

--- a/jme3-networking/src/main/java/com/jme3/network/serializing/Serializable.java
+++ b/jme3-networking/src/main/java/com/jme3/network/serializing/Serializable.java
@@ -31,9 +31,10 @@
  */
 package com.jme3.network.serializing;
 
-import com.jme3.network.serializing.serializers.FieldSerializer;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+
+import com.jme3.network.serializing.serializers.FieldSerializer;
 
 /**
  * Use this annotation when a class is going to be transferred
@@ -41,8 +42,9 @@ import java.lang.annotation.RetentionPolicy;
  *
  * @author Lars Wesselius
  */
-@Retention(RetentionPolicy.RUNTIME)
+@Retention( RetentionPolicy.RUNTIME )
 public @interface Serializable {
-    Class serializer() default FieldSerializer.class;
     short id() default 0;
+
+    Class<? extends Serializer> serializer() default FieldSerializer.class;
 }

--- a/jme3-networking/src/main/java/com/jme3/network/serializing/Serializer.java
+++ b/jme3-networking/src/main/java/com/jme3/network/serializing/Serializer.java
@@ -31,21 +31,59 @@
  */
 package com.jme3.network.serializing;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.util.AbstractCollection;
+import java.util.AbstractList;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.Vector;
+import java.util.WeakHashMap;
+import java.util.jar.Attributes;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import com.jme3.math.Vector3f;
 import com.jme3.network.message.ChannelInfoMessage;
 import com.jme3.network.message.ClientRegistrationMessage;
 import com.jme3.network.message.DisconnectMessage;
 import com.jme3.network.message.GZIPCompressedMessage;
 import com.jme3.network.message.ZIPCompressedMessage;
-import com.jme3.network.serializing.serializers.*;
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.ByteBuffer;
-import java.util.*;
-import java.util.jar.Attributes;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import com.jme3.network.serializing.serializers.ArraySerializer;
+import com.jme3.network.serializing.serializers.BooleanSerializer;
+import com.jme3.network.serializing.serializers.ByteSerializer;
+import com.jme3.network.serializing.serializers.CharSerializer;
+import com.jme3.network.serializing.serializers.CollectionSerializer;
+import com.jme3.network.serializing.serializers.DateSerializer;
+import com.jme3.network.serializing.serializers.DoubleSerializer;
+import com.jme3.network.serializing.serializers.EnumSerializer;
+import com.jme3.network.serializing.serializers.FieldSerializer;
+import com.jme3.network.serializing.serializers.FloatSerializer;
+import com.jme3.network.serializing.serializers.GZIPSerializer;
+import com.jme3.network.serializing.serializers.IntSerializer;
+import com.jme3.network.serializing.serializers.LongSerializer;
+import com.jme3.network.serializing.serializers.MapSerializer;
+import com.jme3.network.serializing.serializers.SerializableSerializer;
+import com.jme3.network.serializing.serializers.ShortSerializer;
+import com.jme3.network.serializing.serializers.StringSerializer;
+import com.jme3.network.serializing.serializers.Vector3Serializer;
+import com.jme3.network.serializing.serializers.ZIPSerializer;
 
 /**
  * The main serializer class, which will serialize objects such that
@@ -55,121 +93,357 @@ import java.util.logging.Logger;
  * @author Lars Wesselius
  */
 public abstract class Serializer {
-    protected static final Logger log = Logger.getLogger(Serializer.class.getName());
+    protected static final Logger log = Logger.getLogger( Serializer.class.getName() );
 
-    private static final SerializerRegistration NULL_CLASS = new SerializerRegistration( null, Void.class, (short)-1 );
+    private static final SerializerRegistration NULL_CLASS = new SerializerRegistration( null, Void.class, (short) -1 );
 
-    private static final Map<Short, SerializerRegistration> idRegistrations         = new HashMap<Short, SerializerRegistration>();
-    private static final Map<Class, SerializerRegistration> classRegistrations      = new HashMap<Class, SerializerRegistration>();
-    private static final List<SerializerRegistration> registrations                 = new ArrayList<SerializerRegistration>();
+    private static final Map<Short, SerializerRegistration> idRegistrations = new HashMap<Short, SerializerRegistration>();
+    private static final Map<Class, SerializerRegistration> classRegistrations = new HashMap<Class, SerializerRegistration>();
+    private static final List<SerializerRegistration> registrations = new ArrayList<SerializerRegistration>();
 
-    private static final Serializer                         fieldSerializer         = new FieldSerializer();
-    private static final Serializer                         serializableSerializer  = new SerializableSerializer();
-    private static final Serializer                         arraySerializer         = new ArraySerializer();
+    private static final Serializer fieldSerializer = new FieldSerializer();
+    private static final Serializer serializableSerializer = new SerializableSerializer();
+    private static final Serializer arraySerializer = new ArraySerializer();
 
     private static short nextAvailableId = -2; // historically the first ID was always -2
 
     private static boolean strictRegistration = true;
 
     private static volatile boolean locked = false;
-    
 
     // Registers the classes we already have serializers for.
     static {
 
         // Preregister some fixed serializers so that they don't move
         // if the list below is modified.  Automatic ID generation will
-        // skip these IDs.    
-        registerClassForId( DisconnectMessage.SERIALIZER_ID, DisconnectMessage.class, 
-                            new DisconnectMessage.DisconnectSerializer() );
-        registerClassForId( ClientRegistrationMessage.SERIALIZER_ID, ClientRegistrationMessage.class, 
-                            new ClientRegistrationMessage.ClientRegistrationSerializer() );
-         
-    
-    
-        registerClass(boolean.class,   new BooleanSerializer());
-        registerClass(byte.class,      new ByteSerializer());
-        registerClass(char.class,      new CharSerializer());
-        registerClass(short.class,     new ShortSerializer());
-        registerClass(int.class,       new IntSerializer());
-        registerClass(long.class,      new LongSerializer());
-        registerClass(float.class,     new FloatSerializer());
-        registerClass(double.class,    new DoubleSerializer());
+        // skip these IDs.
+        registerClassForId( DisconnectMessage.SERIALIZER_ID, DisconnectMessage.class, new DisconnectMessage.DisconnectSerializer() );
+        registerClassForId( ClientRegistrationMessage.SERIALIZER_ID, ClientRegistrationMessage.class,
+                        new ClientRegistrationMessage.ClientRegistrationSerializer() );
 
-        registerClass(Boolean.class,   new BooleanSerializer());
-        registerClass(Byte.class,      new ByteSerializer());
-        registerClass(Character.class, new CharSerializer());
-        registerClass(Short.class,     new ShortSerializer());
-        registerClass(Integer.class,   new IntSerializer());
-        registerClass(Long.class,      new LongSerializer());
-        registerClass(Float.class,     new FloatSerializer());
-        registerClass(Double.class,    new DoubleSerializer());
-        registerClass(String.class,    new StringSerializer());
+        registerClass( boolean.class, new BooleanSerializer() );
+        registerClass( byte.class, new ByteSerializer() );
+        registerClass( char.class, new CharSerializer() );
+        registerClass( short.class, new ShortSerializer() );
+        registerClass( int.class, new IntSerializer() );
+        registerClass( long.class, new LongSerializer() );
+        registerClass( float.class, new FloatSerializer() );
+        registerClass( double.class, new DoubleSerializer() );
 
-        registerClass(Vector3f.class,  new Vector3Serializer());
+        registerClass( Boolean.class, new BooleanSerializer() );
+        registerClass( Byte.class, new ByteSerializer() );
+        registerClass( Character.class, new CharSerializer() );
+        registerClass( Short.class, new ShortSerializer() );
+        registerClass( Integer.class, new IntSerializer() );
+        registerClass( Long.class, new LongSerializer() );
+        registerClass( Float.class, new FloatSerializer() );
+        registerClass( Double.class, new DoubleSerializer() );
+        registerClass( String.class, new StringSerializer() );
 
-        registerClass(Date.class,      new DateSerializer());
-        
+        registerClass( Vector3f.class, new Vector3Serializer() );
+
+        registerClass( Date.class, new DateSerializer() );
+
         // all the Collection classes go here
-        registerClass(AbstractCollection.class,         new CollectionSerializer());
-        registerClass(AbstractList.class,               new CollectionSerializer());
-        registerClass(AbstractSet.class,                new CollectionSerializer());
-        registerClass(ArrayList.class,                  new CollectionSerializer());
-        registerClass(HashSet.class,                    new CollectionSerializer());
-        registerClass(LinkedHashSet.class,              new CollectionSerializer());
-        registerClass(LinkedList.class,                 new CollectionSerializer());
-        registerClass(TreeSet.class,                    new CollectionSerializer());
-        registerClass(Vector.class,                     new CollectionSerializer());
-        
+        registerClass( AbstractCollection.class, new CollectionSerializer() );
+        registerClass( AbstractList.class, new CollectionSerializer() );
+        registerClass( AbstractSet.class, new CollectionSerializer() );
+        registerClass( ArrayList.class, new CollectionSerializer() );
+        registerClass( HashSet.class, new CollectionSerializer() );
+        registerClass( LinkedHashSet.class, new CollectionSerializer() );
+        registerClass( LinkedList.class, new CollectionSerializer() );
+        registerClass( TreeSet.class, new CollectionSerializer() );
+        registerClass( Vector.class, new CollectionSerializer() );
+
         // All the Map classes go here
-        registerClass(AbstractMap.class,                new MapSerializer());
-        registerClass(Attributes.class,                 new MapSerializer());
-        registerClass(HashMap.class,                    new MapSerializer());
-        registerClass(Hashtable.class,                  new MapSerializer());
-        registerClass(IdentityHashMap.class,            new MapSerializer());
-        registerClass(TreeMap.class,                    new MapSerializer());
-        registerClass(WeakHashMap.class,                new MapSerializer());
-        
-        registerClass(Enum.class,      new EnumSerializer());
-        registerClass(GZIPCompressedMessage.class, new GZIPSerializer());
-        registerClass(ZIPCompressedMessage.class, new ZIPSerializer());
+        registerClass( AbstractMap.class, new MapSerializer() );
+        registerClass( Attributes.class, new MapSerializer() );
+        registerClass( HashMap.class, new MapSerializer() );
+        registerClass( Hashtable.class, new MapSerializer() );
+        registerClass( IdentityHashMap.class, new MapSerializer() );
+        registerClass( TreeMap.class, new MapSerializer() );
+        registerClass( WeakHashMap.class, new MapSerializer() );
 
-        registerClass(ChannelInfoMessage.class);
-    }
-    
-    /**
-     *  When set to true, classes that do not have intrinsic IDs in their
-     *  @Serializable will not be auto-registered during write.  Defaults
-     *  to true since this is almost never desired behavior with the way
-     *  this code works.  Set to false to get the old permissive behavior.
-     */
-    public static void setStrictRegistration( boolean b ) {
-        strictRegistration = b;
+        registerClass( Enum.class, new EnumSerializer() );
+        registerClass( GZIPCompressedMessage.class, new GZIPSerializer() );
+        registerClass( ZIPCompressedMessage.class, new ZIPSerializer() );
+
+        registerClass( ChannelInfoMessage.class );
     }
 
-    public static SerializerRegistration registerClass(Class cls) {
-        return registerClass(cls, true);
-    }
-    
-    public static void registerClasses(Class... classes) {
-        for( Class c : classes ) {
-            registerClass(c);
+    private static List<Class> findClasses( File dir, String pkgName ) throws ClassNotFoundException {
+        final List<Class> classes = new ArrayList<Class>();
+        if (!dir.exists()) {
+            return classes;
         }
+        final File[] files = dir.listFiles();
+        for (final File file : files) {
+            if (file.isDirectory()) {
+                assert !file.getName().contains( "." );
+                classes.addAll( findClasses( file, pkgName + "." + file.getName() ) );
+            }
+            else if (file.getName().endsWith( ".class" )) {
+                classes.add( Class.forName( pkgName + '.' + file.getName().substring( 0, file.getName().length() - 6 ) ) );
+            }
+        }
+        return classes;
     }
-    
+
+    public static Serializer getExactSerializer( Class cls ) {
+        return classRegistrations.get( cls ).getSerializer();
+    }
+
+    public static SerializerRegistration getExactSerializerRegistration( Class cls ) {
+        return classRegistrations.get( cls );
+    }
+
+    public static Serializer getSerializer( Class cls ) {
+        return getSerializer( cls, true );
+    }
+
+    public static Serializer getSerializer( Class cls, boolean failOnMiss ) {
+        return getSerializerRegistration( cls, failOnMiss ).getSerializer();
+    }
+
+    public static SerializerRegistration getSerializerRegistration( Class cls ) {
+        return getSerializerRegistration( cls, strictRegistration );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    public static SerializerRegistration getSerializerRegistration( Class cls, boolean failOnMiss ) {
+        final SerializerRegistration reg = classRegistrations.get( cls );
+
+        if (reg != null) {
+            return reg;
+        }
+
+        for (final Map.Entry<Class, SerializerRegistration> entry : classRegistrations.entrySet()) {
+            if (entry.getKey().isAssignableFrom( Serializable.class )) {
+                continue;
+            }
+            if (entry.getKey().isAssignableFrom( cls )) {
+                return entry.getValue();
+            }
+        }
+
+        if (cls.isArray()) {
+            return registerClass( cls, arraySerializer );
+        }
+
+        if (Serializable.class.isAssignableFrom( cls )) {
+            return getExactSerializerRegistration( java.io.Serializable.class );
+        }
+
+        // See if the class could be safely auto-registered
+        if (cls.isAnnotationPresent( Serializable.class )) {
+            final Serializable serializable = (Serializable) cls.getAnnotation( Serializable.class );
+            final short classId = serializable.id();
+            if (classId != 0) {
+                // No reason to fail because the ID is fixed
+                failOnMiss = false;
+            }
+        }
+
+        if (failOnMiss) {
+            throw new IllegalArgumentException( "Class has not been registered:" + cls );
+        }
+        return registerClass( cls, fieldSerializer );
+    }
+
+    public static Collection<SerializerRegistration> getSerializerRegistrations() {
+        return registrations;
+    }
+
+    public static boolean isReadOnly() {
+        return locked;
+    }
+
     private static short nextId() {
-    
+
         // If the ID we are about to return is already in use
         // then skip it.
-        while (idRegistrations.containsKey(nextAvailableId) ) {
-            nextAvailableId--;   
+        while (idRegistrations.containsKey( nextAvailableId )) {
+            nextAvailableId--;
         }
-        
+
         // Return the available ID and post-decrement to get
-        // ready for next time.    
+        // ready for next time.
         return nextAvailableId--;
     }
- 
+
+    /**
+     * Read the class from given buffer and return its SerializerRegistration.
+     *
+     * @param buffer The buffer to read from.
+     * @return The SerializerRegistration, or null if non-existent.
+     */
+    public static SerializerRegistration readClass( ByteBuffer buffer ) {
+        final short classID = buffer.getShort();
+        if (classID == -1) {
+            return NULL_CLASS;
+        }
+        return idRegistrations.get( classID );
+    }
+
+    /**
+     * Read the class and the object.
+     *
+     * @param buffer Buffer to read from.
+     * @return The Object that was read.
+     * @throws IOException If serialization failed.
+     */
+    @SuppressWarnings( "unchecked" )
+    public static Object readClassAndObject( ByteBuffer buffer ) throws IOException {
+        final SerializerRegistration reg = readClass( buffer );
+        if (reg == NULL_CLASS) {
+            return null;
+        }
+        if (reg == null) {
+            throw new SerializerException( "Class not found for buffer data." );
+        }
+        return reg.getSerializer().readObject( buffer, reg.getType() );
+    }
+
+    public static SerializerRegistration registerClass( Class<?> cls ) {
+        return registerClass( cls, true );
+    }
+
+    /**
+     * Registers the specified class. The failOnMiss flag controls whether or
+     * not this method returns null for failed registration or throws an exception.
+     * @param cls the class to register (must be annotated with {@link Serializable})
+     * @param failOnMiss controls if the method should throw an exception, or uses defaults on error
+     * @return a SerializerRegistration or null if failOnMiss is set to false
+     */
+    public static SerializerRegistration registerClass( Class<?> cls, boolean failOnMiss ) {
+        if (cls == null) {
+            throw new IllegalArgumentException( "cls must not be null" );
+        }
+
+        if (cls.isAnnotationPresent( Serializable.class )) {
+            final Serializable serializable = cls.getAnnotation( Serializable.class );
+
+            final Class<? extends Serializer> serializerClass = serializable.serializer();
+            short classId = serializable.id();
+            if (classId == 0) {
+                classId = nextId();
+            }
+            Serializer serializer = null;
+
+            try {
+                serializer = serializerClass.newInstance();
+            }
+            catch (InstantiationException | IllegalAccessException e) {
+                if (failOnMiss) {
+                    throw new IllegalStateException( e );
+                }
+                else {
+                    log.log( Level.WARNING, "Failed to instantiate serializer (" + serializerClass.getName() + ") for class: " + cls.getName() + " with error "
+                                    + e.getMessage() + ". Falling back to FieldSerializer" );
+                }
+            }
+
+            if (serializer == null) {
+                serializer = fieldSerializer;
+            }
+
+            final SerializerRegistration existingReg = getExactSerializerRegistration( cls );
+
+            if (existingReg != null) {
+                classId = existingReg.getId();
+            }
+
+            return registerClassForId( classId, cls, serializer );
+        }
+        else if (failOnMiss) {
+            throw new IllegalArgumentException( "Class is not marked @Serializable:" + cls );
+        }
+        else {
+            return null;
+        }
+    }
+
+    public static SerializerRegistration registerClass( Class<?> cls, Serializer serializer ) {
+        final SerializerRegistration existingReg = getExactSerializerRegistration( cls );
+
+        short id;
+        if (existingReg != null) {
+            id = existingReg.getId();
+        }
+        else {
+            id = nextId();
+        }
+        return registerClassForId( id, cls, serializer );
+    }
+
+    public static void registerClasses( Class... classes ) {
+        for (final Class c : classes) {
+            registerClass( c );
+        }
+    }
+
+    /**
+     *  Directly registers a class for a specific ID.  Generally, use the regular
+     *  registerClass() method.  This method is intended for framework code that might
+     *  be maintaining specific ID maps across client and server.
+     */
+    public static SerializerRegistration registerClassForId( short id, Class cls, Serializer serializer ) {
+
+        if (locked) {
+            throw new RuntimeException( "Serializer registry locked trying to register class:" + cls );
+        }
+
+        final SerializerRegistration reg = new SerializerRegistration( serializer, cls, id );
+
+        idRegistrations.put( id, reg );
+        classRegistrations.put( cls, reg );
+
+        log.log( Level.FINE, "Registered class[" + id + "]:{0} to:" + serializer, cls );
+
+        serializer.initialize( cls );
+
+        // Add the class after so that dependency order is preserved if the
+        // serializer registers its own classes.
+        registrations.add( reg );
+
+        return reg;
+    }
+
+    /**
+     *  @deprecated This cannot be implemented in a reasonable way that works in
+     *              all deployment methods.
+     */
+    @Deprecated
+    public static SerializerRegistration[] registerPackage( String pkgName ) {
+        try {
+            final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            final String path = pkgName.replace( '.', '/' );
+            final Enumeration<URL> resources = classLoader.getResources( path );
+            final List<File> dirs = new ArrayList<File>();
+            while (resources.hasMoreElements()) {
+                final URL resource = resources.nextElement();
+                dirs.add( new File( resource.getFile() ) );
+            }
+            final ArrayList<Class> classes = new ArrayList<Class>();
+            for (final File directory : dirs) {
+                classes.addAll( findClasses( directory, pkgName ) );
+            }
+
+            final SerializerRegistration[] registeredClasses = new SerializerRegistration[classes.size()];
+            for (int i = 0; i != classes.size(); ++i) {
+                final Class clz = classes.get( i );
+                registeredClasses[i] = registerClass( clz, false );
+            }
+            return registeredClasses;
+        }
+        catch (final Exception e) {
+            e.printStackTrace();
+        }
+        return new SerializerRegistration[0];
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////
+
     /**
      *  Can put the registry in a read-only state such that additional attempts
      *  to register classes will fail.  This can be used by servers to lock the
@@ -180,215 +454,14 @@ public abstract class Serializer {
         locked = b;
     }
 
-    public static boolean isReadOnly() {
-        return locked;
-    }
- 
     /**
-     *  Directly registers a class for a specific ID.  Generally, use the regular
-     *  registerClass() method.  This method is intended for framework code that might
-     *  be maintaining specific ID maps across client and server.
+     *  When set to true, classes that do not have intrinsic IDs in their
+     *  @Serializable will not be auto-registered during write.  Defaults
+     *  to true since this is almost never desired behavior with the way
+     *  this code works.  Set to false to get the old permissive behavior.
      */
-    public static SerializerRegistration registerClassForId( short id, Class cls, Serializer serializer ) {
- 
-        if( locked ) {
-            throw new RuntimeException("Serializer registry locked trying to register class:" + cls);
-        }
- 
-        SerializerRegistration reg = new SerializerRegistration(serializer, cls, id);        
-
-        idRegistrations.put(id, reg);
-        classRegistrations.put(cls, reg);
-        
-        log.log( Level.FINE, "Registered class[" + id + "]:{0} to:" + serializer, cls );
-
-        serializer.initialize(cls);
-
-        // Add the class after so that dependency order is preserved if the
-        // serializer registers its own classes.
-        registrations.add(reg);
-
-        return reg;    
-    }
-    
-    /**
-     *  Registers the specified class. The failOnMiss flag controls whether or
-     *  not this method returns null for failed registration or throws an exception.
-     */
-    @SuppressWarnings("unchecked")
-    public static SerializerRegistration registerClass(Class cls, boolean failOnMiss) {
-        if (cls.isAnnotationPresent(Serializable.class)) {
-            Serializable serializable = (Serializable)cls.getAnnotation(Serializable.class);
-
-            Class serializerClass = serializable.serializer();
-            short classId = serializable.id();
-            if (classId == 0) classId = nextId();
-
-            Serializer serializer = getSerializer(serializerClass, false);
-
-            if (serializer == null) serializer = fieldSerializer;
-
-            SerializerRegistration existingReg = getExactSerializerRegistration(cls);
-
-            if (existingReg != null) classId = existingReg.getId();
-            
-            SerializerRegistration reg = new SerializerRegistration(serializer, cls, classId);
-
-            return registerClassForId( classId, cls, serializer );
-        }
-        if (failOnMiss) {
-            throw new IllegalArgumentException( "Class is not marked @Serializable:" + cls );            
-        }
-        return null;
-    }
-
-    /**
-     *  @deprecated This cannot be implemented in a reasonable way that works in
-     *              all deployment methods.
-     */
-    @Deprecated
-    public static SerializerRegistration[] registerPackage(String pkgName) {
-        try {
-            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-            String path = pkgName.replace('.', '/');
-            Enumeration<URL> resources = classLoader.getResources(path);
-            List<File> dirs = new ArrayList<File>();
-            while (resources.hasMoreElements()) {
-                URL resource = resources.nextElement();
-                dirs.add(new File(resource.getFile()));
-            }
-            ArrayList<Class> classes = new ArrayList<Class>();
-            for (File directory : dirs) {
-                classes.addAll(findClasses(directory, pkgName));
-            }
-
-            SerializerRegistration[] registeredClasses = new SerializerRegistration[classes.size()];
-            for (int i = 0; i != classes.size(); ++i) {
-                Class clz = classes.get(i);
-                registeredClasses[i] = registerClass(clz, false);
-            }
-            return registeredClasses;
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return new SerializerRegistration[0];
-    }
-
-    private static List<Class> findClasses(File dir, String pkgName) throws ClassNotFoundException {
-        List<Class> classes = new ArrayList<Class>();
-        if (!dir.exists()) {
-            return classes;
-        }
-        File[] files = dir.listFiles();
-        for (File file : files) {
-            if (file.isDirectory()) {
-                assert !file.getName().contains(".");
-                classes.addAll(findClasses(file, pkgName + "." + file.getName()));
-            } else if (file.getName().endsWith(".class")) {
-                classes.add(Class.forName(pkgName + '.' + file.getName().substring(0, file.getName().length() - 6)));
-            }
-        }
-        return classes;
-    }
-
-    public static SerializerRegistration registerClass(Class cls, Serializer serializer) {
-        SerializerRegistration existingReg = getExactSerializerRegistration(cls);
-
-        short id;
-        if (existingReg != null) { 
-            id = existingReg.getId();
-        } else {
-            id = nextId();
-        }            
-        return registerClassForId( id, cls, serializer );
-    }
-
-    public static Serializer getExactSerializer(Class cls) {
-        return classRegistrations.get(cls).getSerializer();
-    }
-
-    public static Serializer getSerializer(Class cls) {
-        return getSerializer(cls, true);
-    }
-    
-    public static Serializer getSerializer(Class cls, boolean failOnMiss) {
-        return getSerializerRegistration(cls, failOnMiss).getSerializer();
-    }
-
-    public static Collection<SerializerRegistration> getSerializerRegistrations() {
-        return registrations;
-    }
-
-    public static SerializerRegistration getExactSerializerRegistration(Class cls) {
-        return classRegistrations.get(cls);
-    }
-    
-    public static SerializerRegistration getSerializerRegistration(Class cls) {
-        return getSerializerRegistration(cls, strictRegistration); 
-    }
-    
-    @SuppressWarnings("unchecked")
-    public static SerializerRegistration getSerializerRegistration(Class cls, boolean failOnMiss) {
-        SerializerRegistration reg = classRegistrations.get(cls);
-
-        if (reg != null) return reg;
-
-        for (Map.Entry<Class, SerializerRegistration> entry : classRegistrations.entrySet()) {
-            if (entry.getKey().isAssignableFrom(Serializable.class)) continue;
-            if (entry.getKey().isAssignableFrom(cls)) return entry.getValue();
-        }
-
-        if (cls.isArray()) return registerClass(cls, arraySerializer);
-
-        if (Serializable.class.isAssignableFrom(cls)) { 
-            return getExactSerializerRegistration(java.io.Serializable.class);
-        }
-
-        // See if the class could be safely auto-registered
-        if (cls.isAnnotationPresent(Serializable.class)) {
-            Serializable serializable = (Serializable)cls.getAnnotation(Serializable.class);
-            short classId = serializable.id();
-            if( classId != 0 ) {
-                // No reason to fail because the ID is fixed
-                failOnMiss = false;
-            }
-        }            
-        
-        if( failOnMiss ) {
-            throw new IllegalArgumentException( "Class has not been registered:" + cls );
-        }
-        return registerClass(cls, fieldSerializer);
-    }
-
-
-    ///////////////////////////////////////////////////////////////////////////////////
-
-
-    /**
-     * Read the class from given buffer and return its SerializerRegistration.
-     *
-     * @param buffer The buffer to read from.
-     * @return The SerializerRegistration, or null if non-existent.
-     */
-    public static SerializerRegistration readClass(ByteBuffer buffer) {
-        short classID = buffer.getShort();
-        if (classID == -1) return NULL_CLASS;
-        return idRegistrations.get(classID);
-    }
-
-    /**
-     * Read the class and the object.
-     *
-     * @param buffer Buffer to read from.
-     * @return The Object that was read.
-     * @throws IOException If serialization failed.
-     */
-    @SuppressWarnings("unchecked")
-    public static Object readClassAndObject(ByteBuffer buffer) throws IOException {
-        SerializerRegistration reg = readClass(buffer);
-        if (reg == NULL_CLASS) return null;
-        if (reg == null) throw new SerializerException( "Class not found for buffer data." );
-        return reg.getSerializer().readObject(buffer, reg.getType());
+    public static void setStrictRegistration( boolean b ) {
+        strictRegistration = b;
     }
 
     /**
@@ -398,12 +471,12 @@ public abstract class Serializer {
      * @param type The class to write.
      * @return The SerializerRegistration that's registered to the class.
      */
-    public static SerializerRegistration writeClass(ByteBuffer buffer, Class type) throws IOException {
-        SerializerRegistration reg = getSerializerRegistration(type);
+    public static SerializerRegistration writeClass( ByteBuffer buffer, Class type ) throws IOException {
+        final SerializerRegistration reg = getSerializerRegistration( type );
         if (reg == null) {
             throw new SerializerException( "Class not registered:" + type );
         }
-        buffer.putShort(reg.getId());
+        buffer.putShort( reg.getId() );
         return reg;
     }
 
@@ -414,13 +487,23 @@ public abstract class Serializer {
      * @param object The object to write.
      * @throws IOException If serializing fails.
      */
-    public static void writeClassAndObject(ByteBuffer buffer, Object object) throws IOException {
+    public static void writeClassAndObject( ByteBuffer buffer, Object object ) throws IOException {
         if (object == null) {
-            buffer.putShort((short)-1);
+            buffer.putShort( (short) -1 );
             return;
         }
-        SerializerRegistration reg = writeClass(buffer, object.getClass());
-        reg.getSerializer().writeObject(buffer, object);
+        final SerializerRegistration reg = writeClass( buffer, object.getClass() );
+        reg.getSerializer().writeObject( buffer, object );
+    }
+
+    /**
+     * Registration for when a serializer may need to cache something.
+     *
+     * Override to use.
+     *
+     * @param clazz The class that has been registered to the serializer.
+     */
+    public void initialize( Class clazz ) {
     }
 
     /**
@@ -431,7 +514,7 @@ public abstract class Serializer {
      * @return The object read.
      * @throws IOException If deserializing fails.
      */
-    public abstract <T> T readObject(ByteBuffer data, Class<T> c) throws IOException;
+    public abstract <T> T readObject( ByteBuffer data, Class<T> c ) throws IOException;
 
     /**
      * Write an object to the buffer, effectively serializing it.
@@ -440,14 +523,5 @@ public abstract class Serializer {
      * @param object The object to serialize.
      * @throws IOException If serializing fails.
      */
-    public abstract void writeObject(ByteBuffer buffer, Object object) throws IOException;
-
-    /**
-     * Registration for when a serializer may need to cache something.
-     *
-     * Override to use.
-     *
-     * @param clazz The class that has been registered to the serializer.
-     */
-    public void initialize(Class clazz) { }
+    public abstract void writeObject( ByteBuffer buffer, Object object ) throws IOException;
 }


### PR DESCRIPTION
As the master head failed to run for me, I branched of the 3.1.alpha1 tag. Sorry for the clutter in the diff, but I ran the classes I edited through my code cleaner/formatter and many indentations, alphabetical/qualifier method ordering and missing final tags were changed. 

This PR fixes two things:
1. Fixing issue 394, when specifying the Serializer class through the @Serializable annotation. The edit took place in  public static SerializerRegistration registerClass( Class<?> cls, boolean failOnMiss ) in Serializer.java
and now correctly uses reflection to instantiates the Serializer rather than looking up the Serializer for the SerializerClass.
2. It adds a new feature: I needed to send Savables larger than 32K over a message,the relevant changes are in the send/broadcast methods in DefaultClient and DefaultServer. I also added a new method to their respective interface to configure the buffer size dynamically.

This also fixes an issue that the SavableSerializer had, the ByteBuffer..Streams did not implement the Output/InputBufferStream contract correctly. This only showed when either of them is wrapped in a Buffered..Stream and buffers larger than 32K are read/written. 

If you decide to discard the >32K buffers feature for DefaultClient/Server, I recommend to use the fixed SavableSerializer anyhow.