### PR TITLE
Node doesn't invalidate updateList upon clone()

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Node.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Node.java
@@ -687,6 +687,7 @@ public class Node extends Spatial {
 //            childClone.parent = nodeClone;
 //            nodeClone.children.add(childClone);
 //        }
+        nodeClone.invalidateUpdateList();
         return nodeClone;
     }
 


### PR DESCRIPTION
Seems to me that cloning the scene graph doesn't work as intended:

Calling Node#clone(boolean) on the root Node will correctly clone all Spatials and their Controls (it's in Spatial#clone(boolean) ), but will not call Node#invalidateUpdateList() afterwards.

Once you call Node#update(float) on the clone of the root Node, the Spatials and Controls in the original scene graph will be updated. 

Possible workaround is to attach a dummy Spatial to the cloned root node and immediately remove it. That will trigger the updateList being rebuild. However, clearing the clone's update list seems more like the proper way to do it.