### PR TITLE
build: upload on bintray from travis when a git tag is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,4 @@ before_install:
 
 after_success:
   - '[ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && ./gradlew uploadArchives || :'
-  - '[ -n "$TRAVIS_TAG"" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && ./gradlew bintrayUpload || :'
+  - '[ -n "$TRAVIS_TAG" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && ./gradlew bintrayUpload || :'

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,6 @@ before_install:
   # wget http://dl.google.com/android/ndk/android-ndk-r10c-linux-x86_64.bin -O ndk.bin
   # 7z x ndk.bin -y > /dev/null
   # export ANDROID_NDK=`pwd`/android-ndk-r10c
+
+after_success:
+  - '[ -n "$TRAVIS_TAG"" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && ./gradlew bintrayUpload || :'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
 script:
   - ./gradlew check
   - ./gradlew createZipDistribution
-  - "[ $TRAVIS_BRANCH == 'master' ] && [ $TRAVIS_PULL_REQUEST == 'false' ] && ./gradlew uploadArchives || :"
 
 before_deploy:
   - export RELEASE_DIST=$(ls build/distributions/*.zip)
@@ -56,4 +55,5 @@ before_install:
   # export ANDROID_NDK=`pwd`/android-ndk-r10c
 
 after_success:
+  - '[ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && ./gradlew uploadArchives || :'
   - '[ -n "$TRAVIS_TAG"" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && ./gradlew bintrayUpload || :'

--- a/bintray.gradle
+++ b/bintray.gradle
@@ -1,0 +1,26 @@
+//
+// This file is to be applied to some subproject.
+//
+
+apply plugin: 'com.jfrog.bintray'
+
+bintray {
+    user = bintray_user
+    key = bintray_api_key
+    configurations = ['archives']
+    pkg {
+        repo = 'org.jmonkeyengine'
+        userOrg = 'jmonkeyengine'
+        name = project.name
+        desc = POM_DESCRIPTION
+        websiteUrl = POM_URL
+        licenses = ['BSD New']
+        vcsUrl = POM_SCM_CONNECTION
+        labels = ['jmonkeyengine']
+    }
+}
+
+bintrayUpload.onlyIf {
+    (bintray_api_key.length() > 0) &&
+    !(version ==~ /.*SNAPSHOT/)
+}

--- a/bintray.gradle
+++ b/bintray.gradle
@@ -8,6 +8,7 @@ bintray {
     user = bintray_user
     key = bintray_api_key
     configurations = ['archives']
+    dryRun = false 
     pkg {
         repo = 'org.jmonkeyengine'
         userOrg = 'jmonkeyengine'
@@ -15,10 +16,12 @@ bintray {
         desc = POM_DESCRIPTION
         websiteUrl = POM_URL
         licenses = ['BSD New']
-        vcsUrl = POM_SCM_CONNECTION
+        vcsUrl = POM_SCM_URL
         labels = ['jmonkeyengine']
     }
 }
+
+bintrayUpload.dependsOn(writeFullPom)
 
 bintrayUpload.onlyIf {
     (bintray_api_key.length() > 0) &&

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@ import org.gradle.api.artifacts.*
 
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5'
     }
 }
 
@@ -17,6 +18,9 @@ apply from: file('upload.gradle')
 subprojects {
     if(!project.name.equals('jme3-android-examples')) {
         apply from: rootProject.file('common.gradle')
+        if (!['jme3-testdata', 'sdk'].contains(project.name)) {
+            apply from: rootProject.file('bintray.gradle')
+        }
     } else {
         apply from: rootProject.file('common-android-app.gradle')
     }

--- a/common.gradle
+++ b/common.gradle
@@ -5,7 +5,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
-group = 'com.jme3'
+group = 'org.jmonkeyengine'
 version = jmePomVersion
 
 sourceCompatibility = '1.6'

--- a/common.gradle
+++ b/common.gradle
@@ -81,40 +81,8 @@ def pomConfig = {
     // from http://hub.jmonkeyengine.org/introduction/team/
     developers {
         developer {
-            name 'Kirill Vainer'
-            id 'Momoko_Fan'
-        }
-        developer {
-            name 'Erlend Sogge Heggen'
-            id 'erlend_sh'
-        }
-        developer {
-            name 'Skye Book'
-            id 'sbook'
-        }
-        developer {
-            name 'Normen Hansen'
-            id 'normen'
-        }
-        developer {
-            name 'Ruth Kusterer'
-            id 'zathras'
-        }
-        developer {
-            name 'Rémy Bouquet'
-            id 'nehon'
-        }
-        developer {
-            name 'Paul Speed'
-            id 'pspeed'
-        }
-        developer {
-            name 'Brent Owens'
-            id 'Sploreg'
-        }
-        developer {
-            name 'Eric Potter'
-            id 'iwgeric'
+            name 'jMonkeyEngine Team'
+            id 'jMonkeyEngine'
         }
     }
 }

--- a/common.gradle
+++ b/common.gradle
@@ -61,12 +61,84 @@ task javadocJar(type: Jar, dependsOn: javadoc, description: 'Creates a jar from 
     from javadoc.destinationDir
 }
 
+def pomConfig = {
+    name POM_NAME
+    description POM_DESCRIPTION
+    url POM_URL
+    inceptionYear '2016'
+    scm {
+        url POM_SCM_URL
+        connection POM_SCM_CONNECTION
+        developerConnection POM_SCM_DEVELOPER_CONNECTION
+    }
+    licenses {
+        license {
+            name POM_LICENSE_NAME
+            url POM_LICENSE_URL
+            distribution POM_LICENSE_DISTRIBUTION
+        }
+    }
+    // from http://hub.jmonkeyengine.org/introduction/team/
+    developers {
+        developer {
+            name 'Kirill Vainer'
+            id 'Momoko_Fan'
+        }
+        developer {
+            name 'Erlend Sogge Heggen'
+            id 'erlend_sh'
+        }
+        developer {
+            name 'Skye Book'
+            id 'sbook'
+        }
+        developer {
+            name 'Normen Hansen'
+            id 'normen'
+        }
+        developer {
+            name 'Ruth Kusterer'
+            id 'zathras'
+        }
+        developer {
+            name 'Rémy Bouquet'
+            id 'nehon'
+        }
+        developer {
+            name 'Paul Speed'
+            id 'pspeed'
+        }
+        developer {
+            name 'Brent Owens'
+            id 'Sploreg'
+        }
+        developer {
+            name 'Eric Potter'
+            id 'iwgeric'
+        }
+    }
+}
+
+// workaround to be able to use same custom pom with 'maven' and 'bintray' plugin
+task writeFullPom {
+    ext.pomFile = "$mavenPomDir/${project.name}-${project.version}.pom"
+    outputs.file pomFile
+    doLast {
+        pom {
+            project pomConfig
+        }.writeTo(pomFile)
+    }
+}
+install.dependsOn(writeFullPom)
+uploadArchives.dependsOn(writeFullPom)
+
 artifacts {
     archives jar
     archives sourcesJar
     if(buildJavaDoc == "true"){
         archives javadocJar
     }
+    archives writeFullPom.outputs.files[0]
 }
 
 uploadArchives {
@@ -80,23 +152,7 @@ uploadArchives {
              authentication(userName: "www-updater", privateKey: "private/www-updater.key")
         }
         
-        pom.project {
-            name POM_NAME
-            description POM_DESCRIPTION
-            url POM_URL
-            scm {
-                url POM_SCM_URL
-                connection POM_SCM_CONNECTION
-                developerConnection POM_SCM_DEVELOPER_CONNECTION
-            }
-            licenses {
-                license {
-                    name POM_LICENSE_NAME
-                    url POM_LICENSE_URL
-                    distribution POM_LICENSE_DISTRIBUTION
-                }
-            }
-        }
+        pom.project pomConfig
     }
 }
 

--- a/common.gradle
+++ b/common.gradle
@@ -129,6 +129,7 @@ task writeFullPom {
         }.writeTo(pomFile)
     }
 }
+assemble.dependsOn(writeFullPom)
 install.dependsOn(writeFullPom)
 uploadArchives.dependsOn(writeFullPom)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,3 +37,7 @@ POM_SCM_DEVELOPER_CONNECTION=scm:git:git@github.com:jMonkeyEngine/jmonkeyengine.
 POM_LICENSE_NAME=New BSD (3-clause) License
 POM_LICENSE_URL=http://opensource.org/licenses/BSD-3-Clause
 POM_LICENSE_DISTRIBUTION=repo
+
+# Bintray settings to override in $HOME/.gradle/gradle.properties or ENV or commandline
+bintray_user=
+bintray_api_key=

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -109,6 +109,7 @@ task createBaseXml(dependsOn: configurations.corelibs) <<{
         dep.dependencyProject.configurations.archives.allArtifacts.each{ artifact->
             if(artifact.classifier == "sources"){
             } else if(artifact.classifier == "javadoc"){
+            } else if(artifact.file.name.endsWith('.pom')) {
             } else{
                 if(!jmeJarFiles.contains(artifact.file)){
                     jmeJarFiles.add(artifact.file)

--- a/version.gradle
+++ b/version.gradle
@@ -76,7 +76,11 @@ task configureVersionInfo {
         jmeFullVersion = jmeMainVersion
         jmePomVersion  = jmeVersion
         
-        if (jmeBranchName != "master") {
+        if (jmeGitTag.startsWith(jmeMainVersion)) {
+            jmeVersionTag = ""
+            jmePomVersion = jmeGitTag
+        }
+        if (jmeBranchName != "master" && jmeVersionTag == "SNAPSHOT") {
             jmeFullVersion += "-${jmeBranchName}"
             jmePomVersion  += "-${jmeBranchName}"
             

--- a/version.gradle
+++ b/version.gradle
@@ -3,27 +3,31 @@
  =====================
  
  Nightly Build Snapshot
+ * git tag:
  * Full Version: 3.1-5124
  * POM Version: 3.1.0-SNAPSHOT
  * NBM Revision: 5124
  * NBM UC Suffix: nightly/3.1/plugins
 
  Nightly Build Snapshot (PBRIsComing branch)
+ * git tag:
  * Full Version: 3.1-PBRIsComing-5124
  * POM Version: 3.1.0-PBRIsComing-SNAPSHOT
  * NBM Revision: 5124
  * NBM UC Suffix: PBRIsComing-nightly/3.1/plugins
 
  Alpha1 Release
+ * git tag: v3.1.0-alpha1
  * Full Version: 3.1-alpha1
  * POM Version: 3.1.0-alpha1
- * NBM Revision: 1
+ * NBM Revision: 0
  * NBM UC Suffix: stable/3.1/plugins
  
  Final Release
+ * git tag: v3.1.0
  * Full Version: 3.1
  * POM Version: 3.1.0
- * NBM Revision: 5
+ * NBM Revision: 0
  * NBM UC Suffix: stable/3.1/plugins
  */ 
 
@@ -52,6 +56,63 @@ ext {
     jmeNbmUcSuffix  = "unknown"
 }
 
+def getReleaseInfo(String tag) {
+    if (tag == null) {
+        // not a tagged commit
+        return null;
+    }
+    if (!tag.startsWith("v")) {
+        // syntax error
+        return null;
+    }
+    tag = tag.substring(1)
+
+    String[] parts = tag.split("-");
+    String mainVersion;
+    boolean prerelease;
+    String releaseName = null;
+
+    if (parts.length == 2) {
+        // prerelease
+        prerelease = true;
+        mainVersion = parts[0];
+        releaseName = parts[1];
+        if (releaseName.size() == 0) {
+            // syntax error
+            return null;
+        }
+    } else if (parts.length == 1) {
+        // final release
+        prerelease = false;
+        mainVersion = parts[0];
+    } else {
+        // error
+        return null;
+    }
+
+    if (mainVersion.size() == 0) {
+        // syntax error
+        return null;
+    }
+
+    parts = mainVersion.split("\\.");
+    if (parts.size() != 3) {
+        // syntax error
+        return null;
+    }
+
+    String baseVersion = parts[0] + "." + parts[1];
+
+    return [
+        "tag" : tag,
+        "baseVersion" : baseVersion,
+        "mainVersion" : mainVersion,
+        "prerelease" :  prerelease,
+        "releaseName" : releaseName,
+        "releaseSuffix": (prerelease ? "-${releaseName}": "")
+    ]
+}
+
 task configureVersionInfo {
     try {
         def grgit = Grgit.open(project.file('.'))
@@ -59,56 +120,40 @@ task configureVersionInfo {
         jmeGitHash = grgit.head().id
         jmeShortGitHash = grgit.head().abbreviatedId
         jmeBranchName = grgit.branch.current.name
-        jmeGitTag = grgit.describe()
-        if (jmeGitTag == null) jmeGitTag = ""
-        
-        if (System.env.TRAVIS_BRANCH != null) {
-            jmeBranchName = System.env.TRAVIS_BRANCH
-        }
-        if (System.env.TRAVIS_TAG != null) {
-            jmeGitTag = System.env.TRAVIS_TAG
-        }
-        if (System.env.TRAVIS_PULL_REQUEST != null && 
-            System.env.TRAVIS_PULL_REQUEST != "false") {
-            jmeBranchName += "-pr-" + System.env.TRAVIS_PULL_REQUEST
-        }
-        
-        jmeFullVersion = jmeMainVersion
-        jmePomVersion  = jmeVersion
-        
-        if (jmeGitTag.startsWith(jmeMainVersion)) {
-            jmeVersionTag = ""
-            jmePomVersion = jmeGitTag
-        }
-        if (jmeBranchName != "master" && jmeVersionTag == "SNAPSHOT") {
-            jmeFullVersion += "-${jmeBranchName}"
-            jmePomVersion  += "-${jmeBranchName}"
-            
-            jmeNbmUcSuffix = "${jmeBranchName}-"
+        //gtgit.describe doesn't behave like git describe and it doens't support any option
+        //jmeGitTag = grgit.describe() ?: System.env.TRAVIS_TAG
+        jmeGitTag = "git describe --tags --exact-match --dirty".execute().text.trim() ?: System.env.TRAVIS_TAG
+
+        def releaseInfo = getReleaseInfo(jmeGitTag)
+        if (releaseInfo != null) {
+            jmeFullVersion = "${releaseInfo.baseVersion}${releaseInfo.releaseSuffix}"
+            jmePomVersion = "${releaseInfo.mainVersion}${releaseInfo.releaseSuffix}"
+            jmeNbmRevision = "0"
+            jmeNbmUcSuffix = "stable/${releaseInfo.baseVersion}/plugins"
         } else {
-            jmeNbmUcSuffix = ""
-        }
-        
-        if (jmeVersionTag == "SNAPSHOT") {
-            jmeNbmUcSuffix += "nightly"
-        } else {
-            jmeNbmUcSuffix += "stable"
-        }
-        
-        jmeNbmUcSuffix += "/" + jmeMainVersion + "/plugins"
-        
-        if (jmeVersionTag == "SNAPSHOT") {
+            // SNAPSHOT
+            jmeFullVersion = jmeMainVersion
+            jmePomVersion  = jmeVersion
+            if (System.env.TRAVIS_BRANCH != null) {
+                jmeBranchName = System.env.TRAVIS_BRANCH
+            }
+            if (System.env.TRAVIS_PULL_REQUEST != null && 
+                System.env.TRAVIS_PULL_REQUEST != "false") {
+                jmeBranchName += "-pr-" + System.env.TRAVIS_PULL_REQUEST
+            }
+            if (jmeBranchName != "master") {
+                jmeFullVersion += "-${jmeBranchName}"
+                jmePomVersion  += "-${jmeBranchName}"
+                jmeNbmUcSuffix = "${jmeBranchName}-"
+            } else {
+                jmeNbmUcSuffix = ""
+            }
+            jmeNbmUcSuffix += "nightly/" + jmeMainVersion + "/plugins"
             jmeFullVersion += "-${jmeRevision}"
             jmePomVersion  += "-SNAPSHOT"
             jmeNbmRevision = jmeRevision
-        } else if (jmeVersionTag == "") {
-            jmeNbmRevision = jmeVersionTagID
-        } else {
-            jmeFullVersion += "-${jmeVersionTag}"
-            jmePomVersion  += "-${jmeVersionTag}"
-            jmeNbmRevision = jmeVersionTagID
         }
-        
+            
         logger.warn("Full Version: ${jmeFullVersion}")
         logger.warn("POM Version: ${jmePomVersion}")
         logger.warn("NBM Revision: ${jmeNbmRevision}")

--- a/version.gradle
+++ b/version.gradle
@@ -116,13 +116,12 @@ def getReleaseInfo(String tag) {
 task configureVersionInfo {
     try {
         def grgit = Grgit.open(project.file('.'))
-        jmeRevision = grgit.log(includes:['HEAD']).size()
-        jmeGitHash = grgit.head().id
-        jmeShortGitHash = grgit.head().abbreviatedId
+        def head = grgit.head()
+        jmeRevision = grgit.log(includes: [head]).size()
+        jmeGitHash = head.id
+        jmeShortGitHash = head.abbreviatedId
         jmeBranchName = grgit.branch.current.name
-        //gtgit.describe doesn't behave like git describe and it doens't support any option
-        //jmeGitTag = grgit.describe() ?: System.env.TRAVIS_TAG
-        jmeGitTag = "git describe --tags --exact-match --dirty".execute().text.trim() ?: System.env.TRAVIS_TAG
+        jmeGitTag = grgit.tag.list().find { it.commit == head } ?: System.env.TRAVIS_TAG
 
         def releaseInfo = getReleaseInfo(jmeGitTag)
         if (releaseInfo != null) {


### PR DESCRIPTION
The commit will allow to publish (in dry mode) from travis to bintray in repository https://bintray.com/jmonkeyengine/org.jmonkeyengine when a tag (starting with jmeMainVersion) is pushed.

## Setup
* On bintray
  * create account on bintray (eg using github identity provider )
  * ask me or Erlend to register the account as member of the organization jmonkeyengine to be able to upload artifacts
* On travis
  * register 2 env variables (I prefer to setup in the settings'panel, but I guess using secure in .travis.yml should work)
    * `ORG_GRADLE_PROJECT_bintray_user` with the bintray account name, could be displayed in build.log
    * `ORG_GRADLE_PROJECT_bintray_api_key` with the bintray api key of the account (from https://bintray.com/profile/edit), could NOT be displayed in build.log 

## Apply:
* On desktop
set a git tag that start by jmeMainVersion (3.1 today) and push.
```
git tag 3.1.0-alpha2
git push --tags
```
The tag will be used as version and jmePomVersion
* After build connect + login on bintray, the artifact should be uploaded in the repostory but not published (I disable the auto-publish (dry = false) until we test the process). So you can choose to publish or to discard the uploaded artifacts. Login is required to see the panel or info about "uploaded but not published data)

## Try on local:

* setup the env variable or setup bintray_user and bintray_api_key into your $HOME/.gradle/gradle.properties
* git tag or define TRAVIS_TAG (env variable) with a value that start by "3.1" (eg "3.1.0-myversion")
* call `./gradlew bintrayUpload`