### PR TITLE
Fixes the bug of shallow copies when cloning lights

### DIFF
--- a/jme3-core/src/main/java/com/jme3/light/DirectionalLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/DirectionalLight.java
@@ -146,4 +146,10 @@ public class DirectionalLight extends Light {
         direction = (Vector3f) ic.readSavable("direction", null);
     }
 
+    @Override
+    public DirectionalLight clone() {
+        DirectionalLight l = (DirectionalLight)super.clone();
+        l.direction = direction.clone();
+        return l;
+    }
 }

--- a/jme3-core/src/main/java/com/jme3/light/DirectionalLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/DirectionalLight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, 2015 jMonkeyEngine
+ * Copyright (c) 2009-2012, 2015-2016 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-core/src/main/java/com/jme3/light/Light.java
+++ b/jme3-core/src/main/java/com/jme3/light/Light.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, 2015 jMonkeyEngine
+ * Copyright (c) 2009-2012, 2015-2016 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-core/src/main/java/com/jme3/light/Light.java
+++ b/jme3-core/src/main/java/com/jme3/light/Light.java
@@ -228,7 +228,9 @@ public abstract class Light implements Savable, Cloneable {
     @Override
     public Light clone(){
         try {
-            return (Light) super.clone();
+            Light l = (Light) super.clone();
+            l.color = color.clone();
+            return l;
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
         }

--- a/jme3-core/src/main/java/com/jme3/light/PointLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/PointLight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, 2015 jMonkeyEngine
+ * Copyright (c) 2009-2012, 2015-2016 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-core/src/main/java/com/jme3/light/PointLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/PointLight.java
@@ -241,4 +241,11 @@ public class PointLight extends Light {
             this.invRadius = 0;
         }
     }
+
+    @Override
+    public PointLight clone() {
+        PointLight p = (PointLight)super.clone();
+        p.position = position.clone();
+        return p;
+    }
 }

--- a/jme3-core/src/main/java/com/jme3/light/SpotLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/SpotLight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, 2015 jMonkeyEngine
+ * Copyright (c) 2009-2012, 2015-2016 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-core/src/main/java/com/jme3/light/SpotLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/SpotLight.java
@@ -448,5 +448,13 @@ public class SpotLight extends Light {
             this.invSpotRange = 0;
         }
     }
+
+    @Override
+    public SpotLight clone() {
+        SpotLight s = (SpotLight)super.clone();
+        s.direction = direction.clone();
+        s.position = position.clone();
+        return s;
+    }
 }
 


### PR DESCRIPTION
Soo this PR requires a bit of explanation I think.
I did **not** use "throws CloneNotSupportedException" even though NetBeans suggests it.
I simply don't since we already consume that exception in Class "Light" and we currently have no reason to throw it (XYZLight will always be Clonable)

Casting super.clone(); is valid because Object.clone() will clone the runtime implementation so in DirectionalLight we will really have a DirectionalLight (see http://stackoverflow.com/a/12213417)

The last thing: I hope it's okay that DirectionalLight.clone() returns a DirectionalLight? This saves us from useless "instanceof" and cloning on the user-level since "covariant returns" are allowed since Java 5 (returning a subclass of the overriden method's return type)