### PR TITLE
Simplified the AudioNode constructors (#342)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/audio/AudioNode.java
+++ b/jme3-core/src/main/java/com/jme3/audio/AudioNode.java
@@ -33,6 +33,7 @@ package com.jme3.audio;
 
 import com.jme3.asset.AssetManager;
 import com.jme3.asset.AssetNotFoundException;
+import com.jme3.audio.AudioData.DataType;
 import com.jme3.export.InputCapsule;
 import com.jme3.export.JmeExporter;
 import com.jme3.export.JmeImporter;
@@ -86,7 +87,6 @@ public class AudioNode extends Node implements AudioSource {
     protected float innerAngle = 360;
     protected float outerAngle = 360;
     protected boolean positional = true;
-    protected Type type = null;
 
     /**
      * <code>Status</code> indicates the current status of the audio node.
@@ -114,26 +114,6 @@ public class AudioNode extends Node implements AudioSource {
     }
 
     /**
-     * <code>Type</code> indicates how to retrieve the audio data.
-     * It replaced the old "stream" and "streamCache" parameters.
-     * It defines whether the whole file is read and buffered or
-     * if it is read gradually from disk.
-     */
-    public enum Type {
-        /**
-         * The audio data will be loaded as whole and be buffered in memory.
-         * Use this for short sounds.
-         */
-        Buffered,
-        
-        /**
-         * The audio data will be streamed gradually from disk.
-         * Use this for longer sounds.
-         * Note: looping and seeking <b>is</b> supported.
-         */
-        Streaming,
-    }
-    /**
      * Creates a new <code>AudioNode</code> without any audio data set.
      */
     public AudioNode() {
@@ -147,22 +127,17 @@ public class AudioNode extends Node implements AudioSource {
      */
     public AudioNode(AudioData audioData, AudioKey audioKey) {
         setAudioData(audioData, audioKey);
-        if (audioKey.isStream()) {
-            type = Type.Streaming;
-        } else {
-            type = Type.Buffered;
-        }
     }
     
     /**
      * Creates a new <code>AudioNode</code> with the given audio file.
      * @param assetManager The asset manager to use to load the audio file
      * @param name The filename of the audio file
-     * @param type The type. If <code>Type.Streaming</code>, the audio will be streamed gradually from disk,
-     *             otherwise it will be buffered (<code>Type.Buffered</code>)
+     * @param type The type. If <code>{@link com.jme3.audio.AudioData.DataType}.Stream</code>, the audio will be streamed gradually from disk,
+     *             otherwise it will be buffered (<code>{@link com.jme3.audio.AudioData.DataType}.Buffer</code>)
      */
-    public AudioNode(AssetManager assetManager, String name, Type type) {
-        this(assetManager, name, type == Type.Streaming, true);
+    public AudioNode(AssetManager assetManager, String name, DataType type) {
+        this(assetManager, name, type == DataType.Stream, true);
     }
 
     /**
@@ -177,16 +152,11 @@ public class AudioNode extends Node implements AudioSource {
      * be read entirely but not decoded, allowing features such as 
      * seeking, looping and determining duration.
      * 
-     * @deprecated Use {@link AudioNode#AudioNode(com.jme3.asset.AssetManager, java.lang.String, com.jme3.audio.AudioNode.Type)} instead
+     * @deprecated Use {@link AudioNode#AudioNode(com.jme3.asset.AssetManager, java.lang.String, com.jme3.audio.AudioData.DataType)} instead
      */
     public AudioNode(AssetManager assetManager, String name, boolean stream, boolean streamCache) {
         this.audioKey = new AudioKey(name, stream, streamCache);
         this.data = (AudioData) assetManager.loadAsset(audioKey);
-        if (stream) {
-            type = Type.Streaming;
-        } else {
-            type = Type.Buffered;
-        }
     }
 
     /**
@@ -197,7 +167,7 @@ public class AudioNode extends Node implements AudioSource {
      * @param stream If true, the audio will be streamed gradually from disk, 
      *               otherwise, it will be buffered.
      * 
-     * @deprecated Use {@link AudioNode#AudioNode(com.jme3.asset.AssetManager, java.lang.String, com.jme3.audio.AudioNode.Type)} instead
+     * @deprecated Use {@link AudioNode#AudioNode(com.jme3.asset.AssetManager, java.lang.String, com.jme3.audio.AudioData.DataType)} instead
      */
     public AudioNode(AssetManager assetManager, String name, boolean stream) {
         this(assetManager, name, stream, true); // Always streamCached
@@ -213,7 +183,7 @@ public class AudioNode extends Node implements AudioSource {
      * @deprecated AudioRenderer parameter is ignored.
      */
     public AudioNode(AudioRenderer audioRenderer, AssetManager assetManager, String name) {
-        this(assetManager, name, Type.Buffered);
+        this(assetManager, name, DataType.Buffer);
     }
     
     /**
@@ -221,10 +191,10 @@ public class AudioNode extends Node implements AudioSource {
      * 
      * @param assetManager The asset manager to use to load the audio file
      * @param name The filename of the audio file
-     * @deprecated Use {@link AudioNode#AudioNode(com.jme3.asset.AssetManager, java.lang.String, com.jme3.audio.AudioNode.Type)} instead
+     * @deprecated Use {@link AudioNode#AudioNode(com.jme3.asset.AssetManager, java.lang.String, com.jme3.audio.AudioData.DataType) } instead
      */
     public AudioNode(AssetManager assetManager, String name) {
-        this(assetManager, name, Type.Buffered);
+        this(assetManager, name, DataType.Buffer);
     }
     
     protected AudioRenderer getRenderer() {
@@ -330,12 +300,6 @@ public class AudioNode extends Node implements AudioSource {
 
         data = audioData;
         this.audioKey = audioKey;
-        
-        if (audioKey.isStream()) {
-            type = Type.Streaming;
-        } else {
-            type = Type.Buffered;
-        }
     }
 
     /**
@@ -364,14 +328,16 @@ public class AudioNode extends Node implements AudioSource {
     }
 
     /**
-     * This is set only once in the constructor.
-     * It defines, whether the underlying Data is Buffered or
-     * Streamed continuously.
+     * Get the Type of the underlying AudioData to see if it's streamed or buffered.
+     * This is a shortcut to getAudioData().getType()
      * <b>Warning</b>: Can return null!
-     * @return The {@link Type} of the audio node.
+     * @return The {@link com.jme3.audio.AudioData.DataType} of the audio node.
      */
-    public Type getType() {
-        return type;
+    public DataType getType() {
+        if (data == null)
+            return null;
+        else
+            return data.getDataType();
     }
     
     /**


### PR DESCRIPTION
Yeah, I just tried to implement #342.
I was uncertain on how the "jme-style" would be for that enum, so I took an inner-class enum, however moving it out it just a matter of two key presses :)

I did not remove the constructors but only deprecated them to not break existing code.
I was also unsure about deprecating ```AudioNode(AssetManager assetManager, String name)```, simply because it's a constructor where one doesn't have to think about types at all.

When merged/alpha 2 drops, I will add the Wiki accordingly :) 