### PR TITLE
Two small ShaderNodes fixes

### DIFF
--- a/sdk/jme3-materialeditor/src/com/jme3/gde/materialdefinition/editor/MatDefEditorToolBar.java
+++ b/sdk/jme3-materialeditor/src/com/jme3/gde/materialdefinition/editor/MatDefEditorToolBar.java
@@ -8,6 +8,8 @@ package com.jme3.gde.materialdefinition.editor;
 import com.jme3.gde.materialdefinition.fileStructure.TechniqueBlock;
 import java.awt.Component;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JLabel;
@@ -23,7 +25,8 @@ public class MatDefEditorToolBar extends javax.swing.JPanel {
 
     private MatDefEditorlElement parent;
     private final DefaultComboBoxModel<TechniqueBlock> comboModel = new DefaultComboBoxModel<TechniqueBlock>();
-
+    private final static Logger logger = Logger.getLogger(MatDefEditorToolBar.class.getName());
+    
     /**
      * Creates new form MatDefEditorToolBar
      */
@@ -130,6 +133,17 @@ public class MatDefEditorToolBar extends javax.swing.JPanel {
     }// </editor-fold>//GEN-END:initComponents
 
     private void techniqueComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_techniqueComboBoxActionPerformed
+        if (techniqueComboBox.getSelectedItem() == null) {
+            if (techniqueComboBox.getItemCount() > 0) {
+                if (techniqueComboBox.getItemCount() > 1) {
+                    logger.log(Level.WARNING, "No Technique selected, taking the first one!"); /* Don't be over verbose: When there's only one Element, you can't select itself again, thus null */
+                }
+                techniqueComboBox.setSelectedIndex(0); /* Take the first one available */
+            } else {
+                logger.log(Level.WARNING, "No Techniques known for this MaterialDef. Please add one using the button to the right!");
+                return;
+            }
+        }
         parent.switchTechnique((TechniqueBlock) techniqueComboBox.getSelectedItem());
     }//GEN-LAST:event_techniqueComboBoxActionPerformed
 

--- a/sdk/jme3-materialeditor/src/com/jme3/gde/materialdefinition/fileStructure/TechniqueBlock.java
+++ b/sdk/jme3-materialeditor/src/com/jme3/gde/materialdefinition/fileStructure/TechniqueBlock.java
@@ -15,6 +15,8 @@ import com.jme3.util.blockparser.Statement;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.openide.util.WeakListeners;
 
 /**
@@ -28,6 +30,8 @@ public class TechniqueBlock extends UberStatement {
     public static final String ADD_WORLD_PARAM = "addWorldParam";
     public static final String REMOVE_WORLD_PARAM = "removeWorldParam";
     protected String name;
+    
+    private static final Logger logger = Logger.getLogger(TechniqueBlock.class.getName());
 
     protected TechniqueBlock(int lineNumber, String line) {
         super(lineNumber, line);
@@ -102,7 +106,13 @@ public class TechniqueBlock extends UberStatement {
     }
 
     public List<WorldParamBlock> getWorldParams() {
-        return getWorldParameters().getWorldParams();
+        WorldParametersBlock block = getWorldParameters();
+        if (block != null)
+            return getWorldParameters().getWorldParams();
+        else {
+            logger.log(Level.WARNING, "Unable to build ShaderNodes: Could not find any WorldParameters. Most likely the technique {0} is broken.", line);
+            return new ArrayList<WorldParamBlock>();
+        }
     }
 
     public void addWorldParam(WorldParamBlock block) {
@@ -180,8 +190,19 @@ public class TechniqueBlock extends UberStatement {
 
     public List<ShaderNodeBlock> getShaderNodes() {
         List<ShaderNodeBlock> list = new ArrayList<ShaderNodeBlock>();
-        list.addAll(getBlock(VertexShaderNodesBlock.class).getShaderNodes());
-        list.addAll(getBlock(FragmentShaderNodesBlock.class).getShaderNodes());
+        
+        VertexShaderNodesBlock vert_block = getBlock(VertexShaderNodesBlock.class);
+        if (vert_block == null)
+            logger.log(Level.WARNING, "Unable to build ShaderNodes: Could not find any VertexShaderNode. Most likely the technique {0} is broken.", line);
+        else
+            list.addAll(vert_block.getShaderNodes());
+        
+        FragmentShaderNodesBlock frag_block = getBlock(FragmentShaderNodesBlock.class);
+        if (frag_block == null)
+            logger.log(Level.WARNING, "Unable to build ShaderNodes: Could not find any FragmentShaderNode. Most likely the technique {0} is broken.", line);
+        else
+            list.addAll(frag_block.getShaderNodes());
+        
         return list;
     }
 


### PR DESCRIPTION
So whilst playing around with MatDefs I found this two issues:
a) When you only have one technique, you couldn't click into the ComboBox without a crash.
The reason behind this is that you cannot select the same item itself, so closing the box will lead to selected == null.
We fix this by simply taking the first item. If there are multiple available techniques we also print a warning regarding this.

b) When you have an incomplete MatDef, we had a few NPE's which crashed the sdk and hence made switching to another MatDef impossible.
I don't know if Exceptions on a broken (and hence user edited) MatDef are intentional but since the other code checks for null's, I assume it was simply missing :) 

BTW: Example MatDef for b
```
Technique Test {
}
```