### PR TITLE
Update Bundle.propreties to jME3.1

### DIFF
--- a/sdk/jme3-welcome-screen/src/com/jme3/gde/welcome/Bundle.properties
+++ b/sdk/jme3-welcome-screen/src/com/jme3/gde/welcome/Bundle.properties
@@ -3,6 +3,6 @@ OpenIDE-Module-Long-Description=\
     The jMonkeyEngine GDE Welcome Screen
 OpenIDE-Module-Name=Welcome Screen
 OpenIDE-Module-Short-Description=The jMonkeyEngine GDE Welcome Screen
-WelcomeScreenTopComponent.http.link=http://hub.jmonkeyengine.org/wiki/doku.php/sdk:welcome:3_0?do=export_xhtmlbody
+WelcomeScreenTopComponent.http.link=http://hub.jmonkeyengine.org/wiki/doku.php/sdk:welcome:3_1?do=export_xhtmlbody
 WelcomeScreenTopComponent.rss.link=http://hub.jmonkeyengine.org/feed/rdf/
 WelcomeScreenTopComponent.local.link=nbres:/com/jme3/gde/docs/sdk/welcome/local.html


### PR DESCRIPTION
Updated welcome screen to say "You are running the latest preview version of the SDK (jMonkeyEngine SDK 3.1-alpha1)" instead of SDK 3.0.
It gets data from the website like before (literally I just changed one character :smile:)

It fixes one of the bugs described in issue #329