### PR TITLE
Improved ShaderNodes

### DIFF
--- a/sdk/jme3-materialeditor/src/com/jme3/gde/materialdefinition/EditableMatDefFile.java
+++ b/sdk/jme3-materialeditor/src/com/jme3/gde/materialdefinition/EditableMatDefFile.java
@@ -186,7 +186,7 @@ public class EditableMatDefFile {
             return "";
         } catch (Exception e) {
             Exceptions.printStackTrace(e);
-            return "error generating shader " + e.getMessage();
+            return "Error generating shader: " + e.getMessage();
         }
     }
 

--- a/sdk/jme3-materialeditor/src/com/jme3/gde/materialdefinition/MatDefDataObject.java
+++ b/sdk/jme3-materialeditor/src/com/jme3/gde/materialdefinition/MatDefDataObject.java
@@ -142,6 +142,7 @@ public class MatDefDataObject extends MultiDataObject {
         findAssetManager();
         final MatDefMetaData metaData = new MatDefMetaData(this);
         lookupContents.add(metaData);
+        lookupContents.add(new MatDefNavigatorPanel());
         pf.addFileChangeListener(new FileChangeAdapter() {
             @Override
             public void fileChanged(FileEvent fe) {

--- a/sdk/jme3-materialeditor/src/com/jme3/gde/materials/MaterialPreviewRenderer.java
+++ b/sdk/jme3-materialeditor/src/com/jme3/gde/materials/MaterialPreviewRenderer.java
@@ -148,7 +148,7 @@ public class MaterialPreviewRenderer implements SceneListener {
         });
     }
 
-    private int lastErrorHash = 0;
+    private static int lastErrorHash = 0;
 
     private void smartLog(String expText, String message) {
         int hash = message.hashCode();
@@ -183,7 +183,8 @@ public class MaterialPreviewRenderer implements SceneListener {
             //compilation error, the shader code will be output to the console
             //the following code will output the error
             //System.err.println(e.getMessage());
-            Logger.getLogger(MaterialDebugAppState.class.getName()).log(Level.SEVERE, e.getMessage());
+            //Logger.getLogger(MaterialDebugAppState.class.getName()).log(Level.SEVERE, e.getMessage());
+            smartLog("{0}", e.getMessage());
 
             java.awt.EventQueue.invokeLater(new Runnable() {
                 public void run() {


### PR DESCRIPTION
 * Fixed a NPE when trying to select a Node. Now you can properly remove/edit nodes
 * "smartLog" now compares the hash across different instances (Two Material Previews led to duplicate log messages)
 * Using smartLog for CompilationErrors now to not spam the log with 60 FPS

The Lookup failed because there was no Instance of ```MatDefNavigatorPanel```.
Now everything works as intended (You can remove Nodes, change their properties, or at least select them without a crash.)

When you produce a shader compilation error, you have the same error printed three times (wireframe (geometry), solid (color) and a third). This doesn't happen anymore, since the hash is now static.

However I am uncertain because of such an example:
When you have two instances, one constantly printing a and one constantly printing b. Then smartLog wouldn't work. Since we have three Renderers with the same Material this is very unlikely.