### PR TITLE
Fixed the Issue where removing a Control didn't set the dirty flag

### DIFF
--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeAnimControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeAnimControl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2009-2010 jMonkeyEngine
+ *  Copyright (c) 2009-2016 jMonkeyEngine
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -34,19 +34,13 @@ package com.jme3.gde.core.sceneexplorer.nodes;
 import com.jme3.animation.AnimControl;
 import com.jme3.gde.core.icons.IconList;
 import com.jme3.gde.core.properties.AnimationProperty;
-import com.jme3.gde.core.scene.SceneApplication;
 import com.jme3.gde.core.sceneexplorer.nodes.actions.TrackVisibilityPopup;
-import com.jme3.scene.Spatial;
 import java.awt.Image;
-import java.io.IOException;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import javax.swing.Action;
 import org.openide.actions.DeleteAction;
 import org.openide.loaders.DataObject;
 import org.openide.nodes.Node;
 import org.openide.nodes.Sheet;
-import org.openide.util.Exceptions;
 import org.openide.util.HelpCtx;
 import org.openide.util.actions.BooleanStateAction;
 import org.openide.util.actions.SystemAction;
@@ -57,7 +51,7 @@ import org.openide.util.actions.SystemAction;
  */
 @org.openide.util.lookup.ServiceProvider(service = SceneExplorerNode.class)
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class JmeAnimControl extends AbstractSceneExplorerNode {
+public class JmeAnimControl extends JmeControl {
 
     private AnimControl animControl;
     private JmeAnimation playingAnimation = null;
@@ -78,6 +72,7 @@ public class JmeAnimControl extends AbstractSceneExplorerNode {
         lookupContents.add(animControl);
         setName("AnimControl");
         children.setAnimControl(this);
+        control = animControl;
     }
 
     @Override
@@ -130,40 +125,6 @@ public class JmeAnimControl extends AbstractSceneExplorerNode {
     }
 
     @Override
-    protected void fireSave(boolean modified) {
-        Node parent = getParentNode();
-        if (parent instanceof AbstractSceneExplorerNode) {
-            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
-            par.fireSave(modified);
-        }
-    }
-    
-    @Override
-    public boolean canDestroy() {
-        return !readOnly;
-    }
-
-    @Override
-    public void destroy() throws IOException {
-        super.destroy();
-        final Spatial spat = getParentNode().getLookup().lookup(Spatial.class);
-        try {
-            fireSave(true);
-            SceneApplication.getApplication().enqueue(new Callable<Void>() {
-
-                public Void call() throws Exception {
-                    spat.removeControl(animControl);
-                    return null;
-                }
-            }).get();
-            ((AbstractSceneExplorerNode) getParentNode()).refresh(true);
-        } catch (InterruptedException ex) {
-            Exceptions.printStackTrace(ex);
-        } catch (ExecutionException ex) {
-            Exceptions.printStackTrace(ex);
-        }
-    }
-
     public Class getExplorerObjectClass() {
         return AnimControl.class;
     }

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeAnimControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeAnimControl.java
@@ -130,6 +130,15 @@ public class JmeAnimControl extends AbstractSceneExplorerNode {
     }
 
     @Override
+    protected void fireSave(boolean modified) {
+        Node parent = getParentNode();
+        if (parent instanceof AbstractSceneExplorerNode) {
+            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
+            par.fireSave(modified);
+        }
+    }
+    
+    @Override
     public boolean canDestroy() {
         return !readOnly;
     }
@@ -139,6 +148,7 @@ public class JmeAnimControl extends AbstractSceneExplorerNode {
         super.destroy();
         final Spatial spat = getParentNode().getLookup().lookup(Spatial.class);
         try {
+            fireSave(true);
             SceneApplication.getApplication().enqueue(new Callable<Void>() {
 
                 public Void call() throws Exception {

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeCharacterControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeCharacterControl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2009-2010 jMonkeyEngine
+ *  Copyright (c) 2009-2016 jMonkeyEngine
  *  All rights reserved.
  * 
  *  Redistribution and use in source and binary forms, with or without
@@ -34,20 +34,10 @@ package com.jme3.gde.core.sceneexplorer.nodes;
 import com.jme3.bullet.collision.shapes.CollisionShape;
 import com.jme3.bullet.control.CharacterControl;
 import com.jme3.gde.core.icons.IconList;
-import com.jme3.gde.core.scene.SceneApplication;
 import com.jme3.math.Vector3f;
-import com.jme3.scene.Spatial;
 import java.awt.Image;
-import java.io.IOException;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import javax.swing.Action;
-import org.openide.actions.DeleteAction;
 import org.openide.loaders.DataObject;
-import org.openide.nodes.Node;
 import org.openide.nodes.Sheet;
-import org.openide.util.Exceptions;
-import org.openide.util.actions.SystemAction;
 
 /**
  *
@@ -55,7 +45,7 @@ import org.openide.util.actions.SystemAction;
  */
 @org.openide.util.lookup.ServiceProvider(service=SceneExplorerNode.class)
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class JmeCharacterControl extends AbstractSceneExplorerNode {
+public class JmeCharacterControl extends JmeControl {
 
     private static Image smallImage = IconList.player.getImage();
     private CharacterControl geom;
@@ -68,6 +58,7 @@ public class JmeCharacterControl extends AbstractSceneExplorerNode {
         getLookupContents().add(this);
         getLookupContents().add(spatial);
         this.geom = spatial;
+        control = spatial;
         setName("CharacterControl");
     }
 
@@ -79,51 +70,6 @@ public class JmeCharacterControl extends AbstractSceneExplorerNode {
     @Override
     public Image getOpenedIcon(int type) {
         return smallImage;
-    }
-
-    @Override
-    public Action[] getActions(boolean context) {
-        return new SystemAction[]{
-                    //                    SystemAction.get(CopyAction.class),
-                    //                    SystemAction.get(CutAction.class),
-                    //                    SystemAction.get(PasteAction.class),
-                    SystemAction.get(DeleteAction.class)
-                };
-    }
-    
-    @Override
-    protected void fireSave(boolean modified) {
-        Node parent = getParentNode();
-        if (parent instanceof AbstractSceneExplorerNode) {
-            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
-            par.fireSave(modified);
-        }
-    }
-
-    @Override
-    public boolean canDestroy() {
-        return !readOnly;
-    }
-    
-    @Override
-    public void destroy() throws IOException {
-        super.destroy();
-        final Spatial spat=getParentNode().getLookup().lookup(Spatial.class);
-        try {
-            fireSave(true);
-            SceneApplication.getApplication().enqueue(new Callable<Void>() {
-
-                public Void call() throws Exception {
-                    spat.removeControl(geom);
-                    return null;
-                }
-            }).get();
-            ((AbstractSceneExplorerNode)getParentNode()).refresh(true);
-        } catch (InterruptedException ex) {
-            Exceptions.printStackTrace(ex);
-        } catch (ExecutionException ex) {
-            Exceptions.printStackTrace(ex);
-        }
     }
 
     @Override
@@ -154,6 +100,7 @@ public class JmeCharacterControl extends AbstractSceneExplorerNode {
 
     }
 
+    @Override
     public Class getExplorerObjectClass() {
         return CharacterControl.class;
     }

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeCharacterControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeCharacterControl.java
@@ -42,12 +42,11 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import javax.swing.Action;
-import javax.swing.ImageIcon;
 import org.openide.actions.DeleteAction;
 import org.openide.loaders.DataObject;
+import org.openide.nodes.Node;
 import org.openide.nodes.Sheet;
 import org.openide.util.Exceptions;
-import org.openide.util.ImageUtilities;
 import org.openide.util.actions.SystemAction;
 
 /**
@@ -91,17 +90,27 @@ public class JmeCharacterControl extends AbstractSceneExplorerNode {
                     SystemAction.get(DeleteAction.class)
                 };
     }
+    
+    @Override
+    protected void fireSave(boolean modified) {
+        Node parent = getParentNode();
+        if (parent instanceof AbstractSceneExplorerNode) {
+            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
+            par.fireSave(modified);
+        }
+    }
 
     @Override
     public boolean canDestroy() {
         return !readOnly;
     }
-
+    
     @Override
     public void destroy() throws IOException {
         super.destroy();
         final Spatial spat=getParentNode().getLookup().lookup(Spatial.class);
         try {
+            fireSave(true);
             SceneApplication.getApplication().enqueue(new Callable<Void>() {
 
                 public Void call() throws Exception {

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeControl.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2009-2016 jMonkeyEngine
+ *  All rights reserved.
+ * 
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are
+ *  met:
+ * 
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ *  * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * 
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ *  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ *  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.gde.core.sceneexplorer.nodes;
+
+import com.jme3.gde.core.scene.SceneApplication;
+import com.jme3.scene.Spatial;
+import com.jme3.scene.control.Control;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import javax.swing.Action;
+import org.openide.actions.DeleteAction;
+import org.openide.loaders.DataObject;
+import org.openide.nodes.Children;
+import org.openide.nodes.Node;
+import org.openide.util.Exceptions;
+import org.openide.util.actions.SystemAction;
+
+/**
+ * The JmeControl implements the Base Behavior of each Control-Node
+ * @author MeFisto94
+ */
+
+
+public abstract class JmeControl extends AbstractSceneExplorerNode {
+
+    protected Control control;
+    public JmeControl() {
+        super();
+    }
+
+    public JmeControl(Children children, DataObject dataObject) {
+        super(children, dataObject);
+    }
+
+    public JmeControl(DataObject dataObject) {
+        super(dataObject);
+    }
+
+    public JmeControl(Children children) {
+        super(children);
+    }
+    
+    @Override
+    public Action[] getActions(boolean context) {
+        return new SystemAction[]{
+                    //                    SystemAction.get(CopyAction.class),
+                    //                    SystemAction.get(CutAction.class),
+                    //                    SystemAction.get(PasteAction.class),
+                    SystemAction.get(DeleteAction.class)
+                };
+    }
+
+    @Override
+    public boolean canDestroy() {
+        return !readOnly;
+    }
+    
+    @Override
+    public void destroy() throws IOException {
+        super.destroy();
+        
+        if (control == null)
+            return;
+        
+        final Spatial spat = getParentNode().getLookup().lookup(Spatial.class);
+        try {
+            fireSave(true);
+            SceneApplication.getApplication().enqueue(new Callable<Void>() {
+
+                public Void call() throws Exception {
+                    spat.removeControl(control);
+                    return null;
+                }
+            }).get();
+            ((AbstractSceneExplorerNode) getParentNode()).refresh(true);
+        } catch (InterruptedException ex) {
+            Exceptions.printStackTrace(ex);
+        } catch (ExecutionException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+    }
+    
+    /* Controls have a parental node containing them */
+    @Override
+    protected void fireSave(boolean modified) {
+        super.fireSave(true);
+        Node parent = getParentNode();
+        if (parent instanceof AbstractSceneExplorerNode) {
+            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
+            par.fireSave(modified);
+        }
+    }
+}

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeGenericControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeGenericControl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2009-2010 jMonkeyEngine
+ *  Copyright (c) 2009-2016 jMonkeyEngine
  *  All rights reserved.
  * 
  *  Redistribution and use in source and binary forms, with or without
@@ -32,29 +32,18 @@
 package com.jme3.gde.core.sceneexplorer.nodes;
 
 import com.jme3.gde.core.icons.IconList;
-import com.jme3.gde.core.scene.SceneApplication;
-import com.jme3.scene.Spatial;
 import com.jme3.scene.control.Control;
 import java.awt.Image;
-import java.io.IOException;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import javax.swing.Action;
-import org.openide.actions.DeleteAction;
 import org.openide.loaders.DataObject;
-import org.openide.nodes.Node;
 import org.openide.nodes.Sheet;
-import org.openide.util.Exceptions;
-import org.openide.util.actions.SystemAction;
 
 /**
  *
  * @author normenhansen
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class JmeGenericControl extends AbstractSceneExplorerNode {
+public class JmeGenericControl extends JmeControl {
 
-    private final Control control;
     private static final Image smallImage = IconList.wheel.getImage();
 
     public JmeGenericControl(Control control, DataObject dataObject) {
@@ -63,6 +52,7 @@ public class JmeGenericControl extends AbstractSceneExplorerNode {
         this.control = control;
         addToLookup(this);
         addToLookup(control);
+        this.control = control;
         setName(control.getClass().getSimpleName());
     }
 
@@ -112,49 +102,11 @@ public class JmeGenericControl extends AbstractSceneExplorerNode {
     }
 
     @Override
-    public Action[] getActions(boolean context) {
-        return new SystemAction[]{
-                    //                    SystemAction.get(CopyAction.class),
-                    //                    SystemAction.get(CutAction.class),
-                    //                    SystemAction.get(PasteAction.class),
-                    SystemAction.get(DeleteAction.class)
-                };
-    }
-
-    @Override
-    protected void fireSave(boolean modified) {
-        Node parent = getParentNode();
-        if (parent instanceof AbstractSceneExplorerNode) {
-            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
-            par.fireSave(modified);
-        }
-    }
-
-    @Override
     public boolean canDestroy() {
         return true;
     }
-
+ 
     @Override
-    public void destroy() throws IOException {
-        super.destroy();
-        final Spatial spat = getParentNode().getLookup().lookup(Spatial.class);
-        try {
-            fireSave(true);
-            SceneApplication.getApplication().enqueue(new Callable<Void>() {
-                public Void call() throws Exception {
-                    spat.removeControl(control);
-                    return null;
-                }
-            }).get();
-            ((AbstractSceneExplorerNode) getParentNode()).refresh(true);
-        } catch (InterruptedException ex) {
-            Exceptions.printStackTrace(ex);
-        } catch (ExecutionException ex) {
-            Exceptions.printStackTrace(ex);
-        }
-    }
-    
     public Class getExplorerObjectClass() {
         return control.getClass();
     }

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeGenericControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeGenericControl.java
@@ -32,7 +32,6 @@
 package com.jme3.gde.core.sceneexplorer.nodes;
 
 import com.jme3.gde.core.icons.IconList;
-import com.jme3.gde.core.properties.ScenePropertyChangeListener;
 import com.jme3.gde.core.scene.SceneApplication;
 import com.jme3.scene.Spatial;
 import com.jme3.scene.control.Control;
@@ -43,6 +42,7 @@ import java.util.concurrent.ExecutionException;
 import javax.swing.Action;
 import org.openide.actions.DeleteAction;
 import org.openide.loaders.DataObject;
+import org.openide.nodes.Node;
 import org.openide.nodes.Sheet;
 import org.openide.util.Exceptions;
 import org.openide.util.actions.SystemAction;
@@ -122,6 +122,15 @@ public class JmeGenericControl extends AbstractSceneExplorerNode {
     }
 
     @Override
+    protected void fireSave(boolean modified) {
+        Node parent = getParentNode();
+        if (parent instanceof AbstractSceneExplorerNode) {
+            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
+            par.fireSave(modified);
+        }
+    }
+
+    @Override
     public boolean canDestroy() {
         return true;
     }
@@ -131,6 +140,7 @@ public class JmeGenericControl extends AbstractSceneExplorerNode {
         super.destroy();
         final Spatial spat = getParentNode().getLookup().lookup(Spatial.class);
         try {
+            fireSave(true);
             SceneApplication.getApplication().enqueue(new Callable<Void>() {
                 public Void call() throws Exception {
                     spat.removeControl(control);

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeGhostControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeGhostControl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2009-2010 jMonkeyEngine
+ *  Copyright (c) 2009-2016 jMonkeyEngine
  *  All rights reserved.
  * 
  *  Redistribution and use in source and binary forms, with or without
@@ -34,21 +34,11 @@ package com.jme3.gde.core.sceneexplorer.nodes;
 import com.jme3.bullet.collision.shapes.CollisionShape;
 import com.jme3.bullet.control.GhostControl;
 import com.jme3.gde.core.icons.IconList;
-import com.jme3.gde.core.scene.SceneApplication;
 import com.jme3.math.Quaternion;
 import com.jme3.math.Vector3f;
-import com.jme3.scene.Spatial;
 import java.awt.Image;
-import java.io.IOException;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import javax.swing.Action;
-import org.openide.actions.DeleteAction;
 import org.openide.loaders.DataObject;
-import org.openide.nodes.Node;
 import org.openide.nodes.Sheet;
-import org.openide.util.Exceptions;
-import org.openide.util.actions.SystemAction;
 
 /**
  *
@@ -56,7 +46,7 @@ import org.openide.util.actions.SystemAction;
  */
 @org.openide.util.lookup.ServiceProvider(service=SceneExplorerNode.class)
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class JmeGhostControl extends AbstractSceneExplorerNode {
+public class JmeGhostControl extends JmeControl {
 
     private static Image smallImage = IconList.ghostControl.getImage();
     private GhostControl geom;
@@ -69,6 +59,7 @@ public class JmeGhostControl extends AbstractSceneExplorerNode {
         getLookupContents().add(this);
         getLookupContents().add(spatial);
         this.geom = spatial;
+        control = spatial;
         setName("GhostControl");
     }
 
@@ -80,51 +71,6 @@ public class JmeGhostControl extends AbstractSceneExplorerNode {
     @Override
     public Image getOpenedIcon(int type) {
         return smallImage;
-    }
-
-    @Override
-    public Action[] getActions(boolean context) {
-        return new SystemAction[]{
-                    //                    SystemAction.get(CopyAction.class),
-                    //                    SystemAction.get(CutAction.class),
-                    //                    SystemAction.get(PasteAction.class),
-                    SystemAction.get(DeleteAction.class)
-                };
-    }
-
-    @Override
-    protected void fireSave(boolean modified) {
-        Node parent = getParentNode();
-        if (parent instanceof AbstractSceneExplorerNode) {
-            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
-            par.fireSave(modified);
-        }
-    }
-
-    @Override
-    public boolean canDestroy() {
-        return !readOnly;
-    }
-
-    @Override
-    public void destroy() throws IOException {
-        super.destroy();
-        final Spatial spat=getParentNode().getLookup().lookup(Spatial.class);
-        try {
-            fireSave(true);
-            SceneApplication.getApplication().enqueue(new Callable<Void>() {
-
-                public Void call() throws Exception {
-                    spat.removeControl(geom);
-                    return null;
-                }
-            }).get();
-            ((AbstractSceneExplorerNode)getParentNode()).refresh(true);
-        } catch (InterruptedException ex) {
-            Exceptions.printStackTrace(ex);
-        } catch (ExecutionException ex) {
-            Exceptions.printStackTrace(ex);
-        }
     }
 
     @Override
@@ -150,6 +96,7 @@ public class JmeGhostControl extends AbstractSceneExplorerNode {
 
     }
 
+    @Override
     public Class getExplorerObjectClass() {
         return GhostControl.class;
     }

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeGhostControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeGhostControl.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutionException;
 import javax.swing.Action;
 import org.openide.actions.DeleteAction;
 import org.openide.loaders.DataObject;
+import org.openide.nodes.Node;
 import org.openide.nodes.Sheet;
 import org.openide.util.Exceptions;
 import org.openide.util.actions.SystemAction;
@@ -92,6 +93,15 @@ public class JmeGhostControl extends AbstractSceneExplorerNode {
     }
 
     @Override
+    protected void fireSave(boolean modified) {
+        Node parent = getParentNode();
+        if (parent instanceof AbstractSceneExplorerNode) {
+            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
+            par.fireSave(modified);
+        }
+    }
+
+    @Override
     public boolean canDestroy() {
         return !readOnly;
     }
@@ -101,6 +111,7 @@ public class JmeGhostControl extends AbstractSceneExplorerNode {
         super.destroy();
         final Spatial spat=getParentNode().getLookup().lookup(Spatial.class);
         try {
+            fireSave(true);
             SceneApplication.getApplication().enqueue(new Callable<Void>() {
 
                 public Void call() throws Exception {

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeRigidBodyControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeRigidBodyControl.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutionException;
 import javax.swing.Action;
 import org.openide.actions.DeleteAction;
 import org.openide.loaders.DataObject;
+import org.openide.nodes.Node;
 import org.openide.nodes.Sheet;
 import org.openide.util.Exceptions;
 import org.openide.util.actions.SystemAction;
@@ -90,6 +91,15 @@ public class JmeRigidBodyControl extends AbstractSceneExplorerNode {
                     SystemAction.get(DeleteAction.class)
                 };
     }
+    
+    @Override
+    protected void fireSave(boolean modified) {
+        Node parent = getParentNode();
+        if (parent instanceof AbstractSceneExplorerNode) {
+            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
+            par.fireSave(modified);
+        }
+    }
 
     @Override
     public boolean canDestroy() {
@@ -101,6 +111,7 @@ public class JmeRigidBodyControl extends AbstractSceneExplorerNode {
         super.destroy();
         final Spatial spat=getParentNode().getLookup().lookup(Spatial.class);
         try {
+            fireSave(true);
             SceneApplication.getApplication().enqueue(new Callable<Void>() {
 
                 public Void call() throws Exception {

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeRigidBodyControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeRigidBodyControl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2009-2010 jMonkeyEngine
+ *  Copyright (c) 2009-2016 jMonkeyEngine
  *  All rights reserved.
  * 
  *  Redistribution and use in source and binary forms, with or without
@@ -34,21 +34,11 @@ package com.jme3.gde.core.sceneexplorer.nodes;
 import com.jme3.bullet.collision.shapes.CollisionShape;
 import com.jme3.bullet.control.RigidBodyControl;
 import com.jme3.gde.core.icons.IconList;
-import com.jme3.gde.core.scene.SceneApplication;
 import com.jme3.math.Quaternion;
 import com.jme3.math.Vector3f;
-import com.jme3.scene.Spatial;
 import java.awt.Image;
-import java.io.IOException;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import javax.swing.Action;
-import org.openide.actions.DeleteAction;
 import org.openide.loaders.DataObject;
-import org.openide.nodes.Node;
 import org.openide.nodes.Sheet;
-import org.openide.util.Exceptions;
-import org.openide.util.actions.SystemAction;
 
 /**
  *
@@ -56,7 +46,7 @@ import org.openide.util.actions.SystemAction;
  */
 @org.openide.util.lookup.ServiceProvider(service=SceneExplorerNode.class)
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class JmeRigidBodyControl extends AbstractSceneExplorerNode {
+public class JmeRigidBodyControl extends JmeControl {
 
     private static Image smallImage = IconList.physicsControl.getImage();
     private RigidBodyControl geom;
@@ -69,6 +59,7 @@ public class JmeRigidBodyControl extends AbstractSceneExplorerNode {
         getLookupContents().add(spatial);
         getLookupContents().add(this);
         this.geom = spatial;
+        control = spatial;
         setName("PhysicsControl");
     }
 
@@ -80,51 +71,6 @@ public class JmeRigidBodyControl extends AbstractSceneExplorerNode {
     @Override
     public Image getOpenedIcon(int type) {
         return smallImage;
-    }
-
-    @Override
-    public Action[] getActions(boolean context) {
-        return new SystemAction[]{
-                    //                    SystemAction.get(CopyAction.class),
-                    //                    SystemAction.get(CutAction.class),
-                    //                    SystemAction.get(PasteAction.class),
-                    SystemAction.get(DeleteAction.class)
-                };
-    }
-    
-    @Override
-    protected void fireSave(boolean modified) {
-        Node parent = getParentNode();
-        if (parent instanceof AbstractSceneExplorerNode) {
-            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
-            par.fireSave(modified);
-        }
-    }
-
-    @Override
-    public boolean canDestroy() {
-        return !readOnly;
-    }
-
-    @Override
-    public void destroy() throws IOException {
-        super.destroy();
-        final Spatial spat=getParentNode().getLookup().lookup(Spatial.class);
-        try {
-            fireSave(true);
-            SceneApplication.getApplication().enqueue(new Callable<Void>() {
-
-                public Void call() throws Exception {
-                    spat.removeControl(geom);
-                    return null;
-                }
-            }).get();
-            ((AbstractSceneExplorerNode)getParentNode()).refresh(true);
-        } catch (InterruptedException ex) {
-            Exceptions.printStackTrace(ex);
-        } catch (ExecutionException ex) {
-            Exceptions.printStackTrace(ex);
-        }
     }
 
     @Override
@@ -161,6 +107,7 @@ public class JmeRigidBodyControl extends AbstractSceneExplorerNode {
 
     }
 
+    @Override
     public Class getExplorerObjectClass() {
         return RigidBodyControl.class;
     }

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeSkeletonControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeSkeletonControl.java
@@ -107,7 +107,16 @@ public class JmeSkeletonControl extends AbstractSceneExplorerNode {
                     SystemAction.get(DeleteAction.class)
                 };
     }
-
+    
+    @Override
+    protected void fireSave(boolean modified) {
+        Node parent = getParentNode();
+        if (parent instanceof AbstractSceneExplorerNode) {
+            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
+            par.fireSave(modified);
+        }
+    }
+    
     @Override
     public boolean canDestroy() {
         return !readOnly;
@@ -118,6 +127,7 @@ public class JmeSkeletonControl extends AbstractSceneExplorerNode {
         super.destroy();
         final Spatial spat = getParentNode().getLookup().lookup(Spatial.class);
         try {
+            fireSave(true);
             SceneApplication.getApplication().enqueue(new Callable<Void>() {
 
                 public Void call() throws Exception {

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeSkeletonControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeSkeletonControl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2009-2010 jMonkeyEngine
+ *  Copyright (c) 2009-2016 jMonkeyEngine
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -33,19 +33,10 @@ package com.jme3.gde.core.sceneexplorer.nodes;
 
 import com.jme3.animation.SkeletonControl;
 import com.jme3.gde.core.icons.IconList;
-import com.jme3.gde.core.scene.SceneApplication;
-import com.jme3.scene.Spatial;
 import java.awt.Image;
-import java.io.IOException;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import javax.swing.Action;
-import org.openide.actions.DeleteAction;
 import org.openide.loaders.DataObject;
 import org.openide.nodes.Node;
 import org.openide.nodes.Sheet;
-import org.openide.util.Exceptions;
-import org.openide.util.actions.SystemAction;
 
 /**
  *
@@ -53,7 +44,7 @@ import org.openide.util.actions.SystemAction;
  */
 @org.openide.util.lookup.ServiceProvider(service = SceneExplorerNode.class)
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class JmeSkeletonControl extends AbstractSceneExplorerNode {
+public class JmeSkeletonControl extends JmeControl {
 
     private SkeletonControl skeletonControl;
     private static Image smallImage = IconList.skeletonControl.getImage();
@@ -64,6 +55,7 @@ public class JmeSkeletonControl extends AbstractSceneExplorerNode {
     public JmeSkeletonControl(SkeletonControl skeletonControl, JmeBoneChildren children) {
         super(children);
         this.skeletonControl = skeletonControl;
+        control = skeletonControl;
         lookupContents.add(this);
         lookupContents.add(skeletonControl);
         setName("SkeletonControl");
@@ -99,50 +91,6 @@ public class JmeSkeletonControl extends AbstractSceneExplorerNode {
     }
 
     @Override
-    public Action[] getActions(boolean context) {
-        return new SystemAction[]{
-                    //                    SystemAction.get(CopyAction.class),
-                    //                    SystemAction.get(CutAction.class),
-                    //                    SystemAction.get(PasteAction.class),
-                    SystemAction.get(DeleteAction.class)
-                };
-    }
-    
-    @Override
-    protected void fireSave(boolean modified) {
-        Node parent = getParentNode();
-        if (parent instanceof AbstractSceneExplorerNode) {
-            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
-            par.fireSave(modified);
-        }
-    }
-    
-    @Override
-    public boolean canDestroy() {
-        return !readOnly;
-    }
-
-    @Override
-    public void destroy() throws IOException {
-        super.destroy();
-        final Spatial spat = getParentNode().getLookup().lookup(Spatial.class);
-        try {
-            fireSave(true);
-            SceneApplication.getApplication().enqueue(new Callable<Void>() {
-
-                public Void call() throws Exception {
-                    spat.removeControl(skeletonControl);
-                    return null;
-                }
-            }).get();
-            ((AbstractSceneExplorerNode) getParentNode()).refresh(true);
-        } catch (InterruptedException ex) {
-            Exceptions.printStackTrace(ex);
-        } catch (ExecutionException ex) {
-            Exceptions.printStackTrace(ex);
-        }
-    }
-
     public Class getExplorerObjectClass() {
         return SkeletonControl.class;
     }

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeTerrainLodControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeTerrainLodControl.java
@@ -93,6 +93,15 @@ public class JmeTerrainLodControl extends AbstractSceneExplorerNode {
                     //SystemAction.get(DeleteAction.class)
                 };
     }
+    
+    @Override
+    protected void fireSave(boolean modified) {
+        Node parent = getParentNode();
+        if (parent instanceof AbstractSceneExplorerNode) {
+            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
+            par.fireSave(modified);
+        }
+    }
 
     @Override
     public boolean canDestroy() {
@@ -104,6 +113,7 @@ public class JmeTerrainLodControl extends AbstractSceneExplorerNode {
         super.destroy();
         final Spatial spat = getParentNode().getLookup().lookup(Spatial.class);
         try {
+            fireSave(true);
             SceneApplication.getApplication().enqueue(new Callable<Void>() {
 
                 public Void call() throws Exception {

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeTerrainLodControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeTerrainLodControl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2009-2010 jMonkeyEngine
+ *  Copyright (c) 2009-2016 jMonkeyEngine
  *  All rights reserved.
  * 
  *  Redistribution and use in source and binary forms, with or without
@@ -34,12 +34,10 @@ package com.jme3.gde.core.sceneexplorer.nodes;
 
 import com.jme3.gde.core.icons.IconList;
 import com.jme3.gde.core.scene.SceneApplication;
-import com.jme3.scene.Spatial;
 import com.jme3.terrain.geomipmap.TerrainLodControl;
 import com.jme3.terrain.geomipmap.lodcalc.DistanceLodCalculator;
 import com.jme3.terrain.geomipmap.lodcalc.PerspectiveLodCalculator;
 import java.awt.Image;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -58,7 +56,7 @@ import org.openide.util.actions.SystemAction;
  */
 @org.openide.util.lookup.ServiceProvider(service=SceneExplorerNode.class)
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class JmeTerrainLodControl extends AbstractSceneExplorerNode {
+public class JmeTerrainLodControl extends JmeControl {
     
     private static Image smallImage = IconList.wheel.getImage();
     private TerrainLodControl terrainLodControl;
@@ -71,6 +69,7 @@ public class JmeTerrainLodControl extends AbstractSceneExplorerNode {
         getLookupContents().add(control);
         getLookupContents().add(this);
         this.terrainLodControl = control;
+        this.control = control;
         setName("TerrainLodControl");
     }
     
@@ -93,41 +92,6 @@ public class JmeTerrainLodControl extends AbstractSceneExplorerNode {
                     //SystemAction.get(DeleteAction.class)
                 };
     }
-    
-    @Override
-    protected void fireSave(boolean modified) {
-        Node parent = getParentNode();
-        if (parent instanceof AbstractSceneExplorerNode) {
-            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
-            par.fireSave(modified);
-        }
-    }
-
-    @Override
-    public boolean canDestroy() {
-        return !readOnly;
-    }
-
-    @Override
-    public void destroy() throws IOException {
-        super.destroy();
-        final Spatial spat = getParentNode().getLookup().lookup(Spatial.class);
-        try {
-            fireSave(true);
-            SceneApplication.getApplication().enqueue(new Callable<Void>() {
-
-                public Void call() throws Exception {
-                    spat.removeControl(terrainLodControl);
-                    return null;
-                }
-            }).get();
-            ((AbstractSceneExplorerNode) getParentNode()).refresh(true);
-        } catch (InterruptedException ex) {
-            Exceptions.printStackTrace(ex);
-        } catch (ExecutionException ex) {
-            Exceptions.printStackTrace(ex);
-        }
-    }
 
     @Override
     protected Sheet createSheet() {
@@ -147,6 +111,7 @@ public class JmeTerrainLodControl extends AbstractSceneExplorerNode {
 
     }
 
+    @Override
     public Class getExplorerObjectClass() {
         return TerrainLodControl.class;
     }

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeVehicleControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeVehicleControl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2009-2010 jMonkeyEngine
+ *  Copyright (c) 2009-2016 jMonkeyEngine
  *  All rights reserved.
  * 
  *  Redistribution and use in source and binary forms, with or without
@@ -38,9 +38,7 @@ import com.jme3.gde.core.icons.IconList;
 import com.jme3.gde.core.scene.SceneApplication;
 import com.jme3.math.Quaternion;
 import com.jme3.math.Vector3f;
-import com.jme3.scene.Spatial;
 import java.awt.Image;
-import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -60,7 +58,7 @@ import org.openide.util.actions.SystemAction;
  */
 @org.openide.util.lookup.ServiceProvider(service = SceneExplorerNode.class)
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class JmeVehicleControl extends AbstractSceneExplorerNode {
+public class JmeVehicleControl extends JmeControl {
 
     private static Image smallImage = IconList.vehicle.getImage();
     private VehicleControl vehicle;
@@ -73,6 +71,7 @@ public class JmeVehicleControl extends AbstractSceneExplorerNode {
         getLookupContents().add(vehicle);
         getLookupContents().add(this);
         this.vehicle = vehicle;
+        control = vehicle;
         setName("VehicleControl");
     }
 
@@ -84,51 +83,6 @@ public class JmeVehicleControl extends AbstractSceneExplorerNode {
     @Override
     public Image getOpenedIcon(int type) {
         return smallImage;
-    }
-
-    @Override
-    public Action[] getActions(boolean context) {
-        return new SystemAction[]{
-                    //                    SystemAction.get(CopyAction.class),
-                    //                    SystemAction.get(CutAction.class),
-                    //                    SystemAction.get(PasteAction.class),
-                    SystemAction.get(DeleteAction.class)
-                };
-    }
-    
-    @Override
-    protected void fireSave(boolean modified) {
-        Node parent = getParentNode();
-        if (parent instanceof AbstractSceneExplorerNode) {
-            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
-            par.fireSave(modified);
-        }
-    }
-
-    @Override
-    public boolean canDestroy() {
-        return !readOnly;
-    }
-
-    @Override
-    public void destroy() throws IOException {
-        super.destroy();
-        final Spatial spat = getParentNode().getLookup().lookup(Spatial.class);
-        try {
-            fireSave(true);
-            SceneApplication.getApplication().enqueue(new Callable<Void>() {
-
-                public Void call() throws Exception {
-                    spat.removeControl(vehicle);
-                    return null;
-                }
-            }).get();
-            ((AbstractSceneExplorerNode) getParentNode()).refresh(true);
-        } catch (InterruptedException ex) {
-            Exceptions.printStackTrace(ex);
-        } catch (ExecutionException ex) {
-            Exceptions.printStackTrace(ex);
-        }
     }
 
     @Override
@@ -172,6 +126,7 @@ public class JmeVehicleControl extends AbstractSceneExplorerNode {
 
     }
 
+    @Override
     public Class getExplorerObjectClass() {
         return VehicleControl.class;
     }

--- a/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeVehicleControl.java
+++ b/sdk/jme3-core/src/com/jme3/gde/core/sceneexplorer/nodes/JmeVehicleControl.java
@@ -95,6 +95,15 @@ public class JmeVehicleControl extends AbstractSceneExplorerNode {
                     SystemAction.get(DeleteAction.class)
                 };
     }
+    
+    @Override
+    protected void fireSave(boolean modified) {
+        Node parent = getParentNode();
+        if (parent instanceof AbstractSceneExplorerNode) {
+            AbstractSceneExplorerNode par=(AbstractSceneExplorerNode)parent;
+            par.fireSave(modified);
+        }
+    }
 
     @Override
     public boolean canDestroy() {
@@ -106,6 +115,7 @@ public class JmeVehicleControl extends AbstractSceneExplorerNode {
         super.destroy();
         final Spatial spat = getParentNode().getLookup().lookup(Spatial.class);
         try {
+            fireSave(true);
             SceneApplication.getApplication().enqueue(new Callable<Void>() {
 
                 public Void call() throws Exception {


### PR DESCRIPTION
See http://hub.jmonkeyengine.org/t/dirty-flag-not-set-when-deleting-model-controls/35216
btw: Fix Imports removed some unused imports and the "fireSave" Override is lent from JmeLight.java