### PR TITLE
Cylinder: removed the modification ofaxisSamples parameter

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/shape/Cylinder.java
+++ b/jme3-core/src/main/java/com/jme3/scene/shape/Cylinder.java
@@ -211,7 +211,7 @@ public class Cylinder extends Mesh {
      */
     public void updateGeometry(int axisSamples, int radialSamples,
             float radius, float radius2, float height, boolean closed, boolean inverted) {
-        this.axisSamples = axisSamples + (closed ? 2 : 0);
+        this.axisSamples = axisSamples;
         this.radialSamples = radialSamples;
         this.radius = radius;
         this.radius2 = radius2;


### PR DESCRIPTION
Removed the modification of the input parameter that lead to a wrong axisSamples member when the cylinder is closed.