### PR TITLE
Fixed collision group listeners not being notified

### DIFF
--- a/jme3-bullet-native/src/native/cpp/jmeClasses.cpp
+++ b/jme3-bullet-native/src/native/cpp/jmeClasses.cpp
@@ -40,6 +40,7 @@ jclass jmeClasses::PhysicsSpace;
 jmethodID jmeClasses::PhysicsSpace_preTick;
 jmethodID jmeClasses::PhysicsSpace_postTick;
 jmethodID jmeClasses::PhysicsSpace_addCollisionEvent;
+jmethodID jmeClasses::PhysicsSpace_notifyCollisionGroupListeners;
 
 jclass jmeClasses::PhysicsGhostObject;
 jmethodID jmeClasses::PhysicsGhostObject_addOverlappingObject;
@@ -137,6 +138,7 @@ void jmeClasses::initJavaClasses(JNIEnv* env) {
     PhysicsSpace_preTick = env->GetMethodID(PhysicsSpace, "preTick_native", "(F)V");
     PhysicsSpace_postTick = env->GetMethodID(PhysicsSpace, "postTick_native", "(F)V");
     PhysicsSpace_addCollisionEvent = env->GetMethodID(PhysicsSpace, "addCollisionEvent_native","(Lcom/jme3/bullet/collision/PhysicsCollisionObject;Lcom/jme3/bullet/collision/PhysicsCollisionObject;J)V");
+    PhysicsSpace_notifyCollisionGroupListeners = env->GetMethodID(PhysicsSpace, "notifyCollisionGroupListeners_native","(Lcom/jme3/bullet/collision/PhysicsCollisionObject;Lcom/jme3/bullet/collision/PhysicsCollisionObject;)Z");
     if (env->ExceptionCheck()) {
         env->Throw(env->ExceptionOccurred());
         return;

--- a/jme3-bullet-native/src/native/cpp/jmeClasses.h
+++ b/jme3-bullet-native/src/native/cpp/jmeClasses.h
@@ -46,6 +46,7 @@ public:
     static jmethodID PhysicsSpace_addCollisionEvent;
     static jclass PhysicsGhostObject;
     static jmethodID PhysicsGhostObject_addOverlappingObject;
+    static jmethodID PhysicsSpace_notifyCollisionGroupListeners;
 
     static jclass Vector3f;
     static jmethodID Vector3f_set;

--- a/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
@@ -334,6 +334,19 @@ public class PhysicsSpace {
     private void addCollisionEvent_native(PhysicsCollisionObject node, PhysicsCollisionObject node1, long manifoldPointObjectId) {
 //        System.out.println("addCollisionEvent:"+node.getObjectId()+" "+ node1.getObjectId());
         collisionEvents.add(eventFactory.getEvent(PhysicsCollisionEvent.TYPE_PROCESSED, node, node1, manifoldPointObjectId));
+
+        // Notify group listeners
+        if((node.getCollideWithGroups() & node1.getCollisionGroup()) > 0
+                || (node1.getCollideWithGroups() & node.getCollisionGroup()) > 0){
+            PhysicsCollisionGroupListener listener = collisionGroupListeners.get(node.getCollisionGroup());
+            PhysicsCollisionGroupListener listener1 = collisionGroupListeners.get(node1.getCollisionGroup());
+            if(listener != null){
+                listener.collide(node, node1);
+            }
+            if(listener1 != null && node.getCollisionGroup() != node1.getCollisionGroup()){
+                listener1.collide(node, node1);
+            }
+        }
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
@@ -339,15 +339,16 @@ public class PhysicsSpace {
     private boolean notifyCollisionGroupListeners_native(PhysicsCollisionObject node, PhysicsCollisionObject node1){
         PhysicsCollisionGroupListener listener = collisionGroupListeners.get(node.getCollisionGroup());
         PhysicsCollisionGroupListener listener1 = collisionGroupListeners.get(node1.getCollisionGroup());
+        boolean result = true;
+        
         if(listener != null){
-            if(!listener.collide(node, node1)){
-                return false;
-            }
+            result = listener.collide(node, node1);
         }
         if(listener1 != null && node.getCollisionGroup() != node1.getCollisionGroup()){
-            return listener1.collide(node, node1);
+            result = listener1.collide(node, node1) && result;
         }
-        return true;
+        
+        return result;
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
@@ -334,19 +334,20 @@ public class PhysicsSpace {
     private void addCollisionEvent_native(PhysicsCollisionObject node, PhysicsCollisionObject node1, long manifoldPointObjectId) {
 //        System.out.println("addCollisionEvent:"+node.getObjectId()+" "+ node1.getObjectId());
         collisionEvents.add(eventFactory.getEvent(PhysicsCollisionEvent.TYPE_PROCESSED, node, node1, manifoldPointObjectId));
-
-        // Notify group listeners
-        if((node.getCollideWithGroups() & node1.getCollisionGroup()) > 0
-                || (node1.getCollideWithGroups() & node.getCollisionGroup()) > 0){
-            PhysicsCollisionGroupListener listener = collisionGroupListeners.get(node.getCollisionGroup());
-            PhysicsCollisionGroupListener listener1 = collisionGroupListeners.get(node1.getCollisionGroup());
-            if(listener != null){
-                listener.collide(node, node1);
-            }
-            if(listener1 != null && node.getCollisionGroup() != node1.getCollisionGroup()){
-                listener1.collide(node, node1);
+    }
+    
+    private boolean notifyCollisionGroupListeners_native(PhysicsCollisionObject node, PhysicsCollisionObject node1){
+        PhysicsCollisionGroupListener listener = collisionGroupListeners.get(node.getCollisionGroup());
+        PhysicsCollisionGroupListener listener1 = collisionGroupListeners.get(node1.getCollisionGroup());
+        if(listener != null){
+            if(!listener.collide(node, node1)){
+                return false;
             }
         }
+        if(listener1 != null && node.getCollisionGroup() != node1.getCollisionGroup()){
+            return listener1.collide(node, node1);
+        }
+        return true;
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
@@ -237,12 +237,12 @@ public class PhysicsSpace {
                             || (collisionObject1.getCollideWithGroups() & collisionObject.getCollisionGroup()) > 0) {
                         PhysicsCollisionGroupListener listener = collisionGroupListeners.get(collisionObject.getCollisionGroup());
                         PhysicsCollisionGroupListener listener1 = collisionGroupListeners.get(collisionObject1.getCollisionGroup());
-                        if (listener != null) {
-                            return listener.collide(collisionObject, collisionObject1);
-                        } else if (listener1 != null) {
-                            return listener1.collide(collisionObject, collisionObject1);
+                        if(listener != null){
+                            collides = listener.collide(collisionObject, collisionObject1);
                         }
-                        return true;
+                        if(listener1 != null && collisionObject.getCollisionGroup() != collisionObject1.getCollisionGroup()){
+                            collides = listener1.collide(collisionObject, collisionObject1) && collides;
+                        }
                     } else {
                         return false;
                     }


### PR DESCRIPTION
In native bullet, group collision listeners we're never notified when a collision occurred for a group. This fixes the issue.

See http://hub.jmonkeyengine.org/t/physicscollisiongrouplistener-possibly-broken-in-native-bullet/35277/7