### PR TITLE
fix NPE in hovering tank test, running with native bullet

### DIFF
--- a/jme3-examples/src/main/java/jme3test/bullet/PhysicsHoverControl.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/PhysicsHoverControl.java
@@ -94,6 +94,7 @@ public class PhysicsHoverControl extends PhysicsVehicle implements PhysicsContro
         createWheels();
     }
 
+    @Override
     public Control cloneForSpatial(Spatial spatial) {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/jme3-examples/src/main/java/jme3test/bullet/PhysicsHoverControl.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/PhysicsHoverControl.java
@@ -94,7 +94,6 @@ public class PhysicsHoverControl extends PhysicsVehicle implements PhysicsContro
         createWheels();
     }
 
-    @Override
     public Control cloneForSpatial(Spatial spatial) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
@@ -180,6 +179,7 @@ public class PhysicsHoverControl extends PhysicsVehicle implements PhysicsContro
     }
 
     public void setPhysicsSpace(PhysicsSpace space) {
+        createVehicle(space);
         if (space == null) {
             if (this.space != null) {
                 this.space.removeCollisionObject(this);

--- a/jme3-examples/src/main/java/jme3test/bullet/TestHoveringTank.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestHoveringTank.java
@@ -147,13 +147,13 @@ public class TestHoveringTank extends SimpleApplication implements AnalogListene
         spaceCraft.setLocalRotation(new Quaternion(new float[]{0, 0.01f, 0}));
 
         hoverControl = new PhysicsHoverControl(colShape, 500);
-        hoverControl.setCollisionGroup(PhysicsCollisionObject.COLLISION_GROUP_02);
 
         spaceCraft.addControl(hoverControl);
 
 
         rootNode.attachChild(spaceCraft);
         getPhysicsSpace().add(hoverControl);
+        hoverControl.setCollisionGroup(PhysicsCollisionObject.COLLISION_GROUP_02);
 
         ChaseCamera chaseCam = new ChaseCamera(cam, inputManager);
         spaceCraft.addControl(chaseCam);
@@ -168,7 +168,7 @@ public class TestHoveringTank extends SimpleApplication implements AnalogListene
 
         Spatial missile = assetManager.loadModel("Models/SpaceCraft/Rocket.mesh.xml");
         missile.scale(0.5f);
-        missile.rotate(0, FastMath.PI, 0);
+        missile.rotate(FastMath.PI, FastMath.PI, 0);
         missile.updateGeometricState();
 
         BoundingBox box = (BoundingBox) missile.getWorldBound();

--- a/jme3-examples/src/main/java/jme3test/bullet/TestHoveringTank.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestHoveringTank.java
@@ -168,7 +168,7 @@ public class TestHoveringTank extends SimpleApplication implements AnalogListene
 
         Spatial missile = assetManager.loadModel("Models/SpaceCraft/Rocket.mesh.xml");
         missile.scale(0.5f);
-        missile.rotate(FastMath.PI, FastMath.PI, 0);
+        missile.rotate(0, FastMath.PI, 0);
         missile.updateGeometricState();
 
         BoundingBox box = (BoundingBox) missile.getWorldBound();


### PR DESCRIPTION
A NPE is throw when running hovering tank test with native bullet.

```
java.lang.NullPointerException: The vehicle object does not exist.
    at com.jme3.bullet.PhysicsSpace.addVehicle(Native Method)
    at com.jme3.bullet.PhysicsSpace.addRigidBody(PhysicsSpace.java:627)
    at com.jme3.bullet.PhysicsSpace.addCollisionObject(PhysicsSpace.java:426)
    at jme3test.bullet.PhysicsHoverControl.setPhysicsSpace(PhysicsHoverControl.java:189)
    at com.jme3.bullet.PhysicsSpace.add(PhysicsSpace.java:405)
    at jme3test.bullet.TestHoveringTank.buildPlayer(TestHoveringTank.java:156)
    at jme3test.bullet.TestHoveringTank.simpleInitApp(TestHoveringTank.java:128)
```

Because the native vehicle wasn't created in the setPhysicsSpace methode (in PhysicsHoverControl)

---

The collision group must be set after the creation of the native body (when setPhysicsSpace is called).

