### PR TITLE
Added method to see if VertexBuffer is not used

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -2236,17 +2236,13 @@ public final class GLRenderer implements Renderer {
 
     public void updateBufferData(VertexBuffer vb) {
         int bufId = vb.getId();
-        boolean created = false;
         if (bufId == -1) {
             // create buffer
             gl.glGenBuffers(intBuf1);
             bufId = intBuf1.get(0);
             vb.setId(bufId);
             objManager.registerObject(vb);
-
             //statistics.onNewVertexBuffer();
-
-            created = true;
         }
 
         // bind buffer
@@ -2293,7 +2289,6 @@ public final class GLRenderer implements Renderer {
             default:
                 throw new UnsupportedOperationException("Unknown buffer format.");
         }
-
         vb.clearUpdateNeeded();
     }
 
@@ -2335,7 +2330,8 @@ public final class GLRenderer implements Renderer {
         Attribute attrib = context.boundShader.getAttribute(vb.getBufferType());
         int loc = attrib.getLocation();
         if (loc == -1) {
-            return; // not defined
+        	vb.setUnused(true);
+        	return; // not defined
         }
         if (loc == -2) {
             loc = gl.glGetAttribLocation(context.boundShaderProgram, "in" + vb.getBufferType().name());
@@ -2343,12 +2339,15 @@ public final class GLRenderer implements Renderer {
             // not really the name of it in the shader (inPosition) but
             // the internal name of the enum (Position).
             if (loc < 0) {
+            	vb.setUnused(true);
                 attrib.setLocation(-1);
                 return; // not available in shader.
             } else {
                 attrib.setLocation(loc);
             }
         }
+
+    	vb.setUnused(false);
 
         if (vb.isInstanced()) {
             if (!caps.contains(Caps.MeshInstancing)) {

--- a/jme3-core/src/main/java/com/jme3/scene/VertexBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/VertexBuffer.java
@@ -335,6 +335,7 @@ public class VertexBuffer extends NativeObject implements Savable, Cloneable {
     protected boolean normalized = false;
     protected int instanceSpan = 0;
     protected transient boolean dataSizeChanged = false;
+    protected boolean unused;
 
     /**
      * Creates an empty, uninitialized buffer.
@@ -713,6 +714,14 @@ public class VertexBuffer extends NativeObject implements Savable, Cloneable {
         dataSizeChanged = false;
     }
 
+    public void setUnused(boolean v){
+    	unused=v;
+    }
+    
+    public boolean isUnused(){
+    	return unused;
+    }
+    
     /**
      * Converts single floating-point data to {@link Format#Half half} floating-point data.
      */


### PR DESCRIPTION
Since updateBufferData is not called for VertexBuffers that are not available in the shader, their updateNeeded state will stay set to true, while logically should be false, since those buffers won't ever be updated.

updateBufferData cannot be called on unused buffers without breaking the existing code (i.e. material switching).

This commit contains the most straightforward way i can think about for fixing this problem.

Refering to http://hub.jmonkeyengine.org/t/see-if-a-mesh-has-been-changed/35346/6
