### PR TITLE
Wireframe, Normal Binormal Tangent displayer appstates

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -2236,17 +2236,13 @@ public final class GLRenderer implements Renderer {
 
     public void updateBufferData(VertexBuffer vb) {
         int bufId = vb.getId();
-        boolean created = false;
         if (bufId == -1) {
             // create buffer
             gl.glGenBuffers(intBuf1);
             bufId = intBuf1.get(0);
             vb.setId(bufId);
             objManager.registerObject(vb);
-
             //statistics.onNewVertexBuffer();
-
-            created = true;
         }
 
         // bind buffer
@@ -2293,7 +2289,6 @@ public final class GLRenderer implements Renderer {
             default:
                 throw new UnsupportedOperationException("Unknown buffer format.");
         }
-
         vb.clearUpdateNeeded();
     }
 
@@ -2335,7 +2330,8 @@ public final class GLRenderer implements Renderer {
         Attribute attrib = context.boundShader.getAttribute(vb.getBufferType());
         int loc = attrib.getLocation();
         if (loc == -1) {
-            return; // not defined
+        	vb.setUnused(true);
+        	return; // not defined
         }
         if (loc == -2) {
             loc = gl.glGetAttribLocation(context.boundShaderProgram, "in" + vb.getBufferType().name());
@@ -2343,12 +2339,15 @@ public final class GLRenderer implements Renderer {
             // not really the name of it in the shader (inPosition) but
             // the internal name of the enum (Position).
             if (loc < 0) {
+            	vb.setUnused(true);
                 attrib.setLocation(-1);
                 return; // not available in shader.
             } else {
                 attrib.setLocation(loc);
             }
         }
+
+    	vb.setUnused(false);
 
         if (vb.isInstanced()) {
             if (!caps.contains(Caps.MeshInstancing)) {

--- a/jme3-core/src/main/java/com/jme3/scene/VertexBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/VertexBuffer.java
@@ -335,6 +335,7 @@ public class VertexBuffer extends NativeObject implements Savable, Cloneable {
     protected boolean normalized = false;
     protected int instanceSpan = 0;
     protected transient boolean dataSizeChanged = false;
+    protected boolean unused;
 
     /**
      * Creates an empty, uninitialized buffer.
@@ -713,6 +714,14 @@ public class VertexBuffer extends NativeObject implements Savable, Cloneable {
         dataSizeChanged = false;
     }
 
+    public void setUnused(boolean v){
+    	unused=v;
+    }
+    
+    public boolean isUnused(){
+    	return unused;
+    }
+    
     /**
      * Converts single floating-point data to {@link Format#Half half} floating-point data.
      */

--- a/jme3-core/src/main/java/com/jme3/scene/debug/AbstractGeometryProcessorDebugAppState.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/AbstractGeometryProcessorDebugAppState.java
@@ -88,7 +88,7 @@ public abstract class AbstractGeometryProcessorDebugAppState extends BaseAppStat
 	}
 
 	@Override
-	public void update(float tpf) {
+	public void update(final float tpf) {
 		updateId++;
 		targetSpatial.depthFirstTraversal(new SceneGraphVisitor(){
 			@Override

--- a/jme3-core/src/main/java/com/jme3/scene/debug/AbstractGeometryProcessorDebugAppState.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/AbstractGeometryProcessorDebugAppState.java
@@ -1,0 +1,177 @@
+package com.jme3.scene.debug;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.jme3.app.Application;
+import com.jme3.app.state.BaseAppState;
+import com.jme3.renderer.RenderManager;
+import com.jme3.renderer.ViewPort;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Mesh;
+import com.jme3.scene.Node;
+import com.jme3.scene.SceneGraphVisitor;
+import com.jme3.scene.Spatial;
+import com.jme3.scene.Spatial.CullHint;
+import com.jme3.scene.VertexBuffer;
+import com.jme3.scene.VertexBuffer.Usage;
+
+/**
+ * Abstract appstate that loops between geometries and trigger a method according to their state.
+ * 
+ * @author Riccardo Balbo
+ */
+public abstract class AbstractGeometryProcessorDebugAppState extends BaseAppState{
+	public static enum GeometryState{
+		PROCESS_FIRST,MESH_UPDATE_REQUIRED,UPDATE,REMOVE
+	}
+
+	private static final Logger log=Logger.getLogger(AbstractGeometryProcessorDebugAppState.class.getName());
+	private static final Level logLevel=Level.FINEST;
+
+	protected Node rootNode;
+	protected Spatial targetSpatial;
+
+	protected RenderManager renderManager;
+	protected ViewPort viewPort;
+
+	protected Application app;
+	protected boolean drawOnTop;
+
+	private String name;
+	private Map<Geometry,Byte> processedGeometries=new HashMap<Geometry,Byte>();
+	private byte updateId=0;
+	private Map<Mesh,ArrayList<Integer>> meshVBsnapshot=new WeakHashMap<Mesh,ArrayList<Integer>>();
+
+	public AbstractGeometryProcessorDebugAppState(String name,Spatial rootNode){
+		targetSpatial=rootNode;
+		this.name=name;
+	}
+
+	@Override
+	public void initialize(Application app) {
+		renderManager=app.getRenderManager();
+		this.app=app;
+		rootNode=new Node(name+"Node");
+		rootNode.setCullHint(CullHint.Never);
+	}
+
+	public void setDrawAlwaysOnTop(boolean v) {
+		drawOnTop=v;
+		if(viewPort!=null) viewPort.setClearFlags(false,v,false);
+	}
+
+	@Override
+	public void render(RenderManager rm) {
+		super.render(rm);
+		if(viewPort!=null){
+			rm.renderScene(rootNode,viewPort);
+		}
+	}
+
+	@Override
+	public void onEnable() {
+		viewPort=renderManager.createMainView(name+"ViewPort",app.getCamera());
+		setDrawAlwaysOnTop(drawOnTop);
+		viewPort.attachScene(rootNode);
+	}
+
+	@Override
+	public void onDisable() {
+		renderManager.removeMainView(viewPort);
+		viewPort=null;
+	}
+
+	@Override
+	public void update(float tpf) {
+		updateId++;
+		targetSpatial.depthFirstTraversal(new SceneGraphVisitor(){
+			@Override
+			public void visit(Spatial spatial) {
+				if(!(spatial instanceof Geometry)) return;
+
+				Geometry geom=(Geometry)spatial;
+				Mesh mesh=geom.getMesh();
+
+				GeometryState action=GeometryState.UPDATE;
+
+				if(processedGeometries.get(spatial)==null) action=GeometryState.PROCESS_FIRST;
+				if(action==GeometryState.UPDATE&&isMeshUpdateNeeded(mesh)) action=GeometryState.MESH_UPDATE_REQUIRED;
+
+				log.log(logLevel,"Execute action {0} on {1}",new Object[]{action,spatial});
+
+				boolean processed=processGeometry(tpf,geom,action);
+				if(processed||action!=GeometryState.PROCESS_FIRST){ // If the action was PROCESS_FIRST but failed, do not add the geometry to the processed list.
+					processedGeometries.put(geom,updateId);
+					log.log(logLevel,"has been processed {0}",processed);
+				}
+			}
+		});
+
+		// Remove references to removed geometries.
+		Iterator<Map.Entry<Geometry,Byte>> processedGeometries_i=processedGeometries.entrySet().iterator();
+		while(processedGeometries_i.hasNext()){
+			Map.Entry<Geometry,Byte> entry=processedGeometries_i.next();
+			if(entry.getValue()!=updateId){
+				Geometry g=entry.getKey();
+				processGeometry(tpf,g,GeometryState.REMOVE);
+				processedGeometries_i.remove();
+				log.log(logLevel,"{0} is removed!",g);
+			}
+		}
+		rootNode.updateLogicalState(tpf);
+		rootNode.updateGeometricState();
+	}
+
+	protected boolean isMeshUpdateNeeded(Mesh m) {
+		ArrayList<Integer> sn_ids=meshVBsnapshot.get(m);
+		ArrayList<Integer> ids=new ArrayList<Integer>();
+
+		boolean updateNeeded=false;
+
+		VertexBuffer[] blist=(VertexBuffer[])m.getBufferList().toArray();
+		int i=0;
+		for(VertexBuffer b:blist){
+			if(b.isUnused()||b.getUsage()==Usage.CpuOnly) continue;
+			boolean vBupdateNeeded=b.isUpdateNeeded()||sn_ids==null;
+			int id=b.getId();
+			ids.add(id);
+			if(!vBupdateNeeded){
+				if(sn_ids.size()<id||sn_ids.get(i)!=id){ // Control the order as well
+					log.log(logLevel,"Mesh {0}: VertexBuffer {1} hash been replaced.",new Object[]{m,b.getBufferType()});
+					vBupdateNeeded=true;
+				}
+			}
+			if(vBupdateNeeded){
+				log.log(logLevel,"Mesh {0}: VertexBuffer {1} need update.",new Object[]{m,b.getBufferType()});
+				updateNeeded=true;
+				//return true; We want to collect the id of every vertexbuffer, so the cycle must continue.
+			}
+			i++;
+		}
+
+		if(!updateNeeded&&ids.size()!=sn_ids.size()){
+			log.log(logLevel,"Mesh {0}: One or more vertexbuffers has been added or removed",m);
+			updateNeeded=true;
+		}
+
+		if(updateNeeded){
+			meshVBsnapshot.put(m,ids);
+			log.log(logLevel,"Mesh {0}:  Store snapshot of buffers: {1}",new Object[]{m,ids});
+			log.log(logLevel,"Mesh {0}: need update.",m);
+		}
+
+		return updateNeeded;
+	}
+
+	public abstract boolean processGeometry(float tpf, Geometry g, GeometryState s);
+
+	@Override
+	protected void cleanup(Application app) {}
+
+}

--- a/jme3-core/src/main/java/com/jme3/scene/debug/TanBnNDebugAppState.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/TanBnNDebugAppState.java
@@ -56,7 +56,7 @@ public class TanBnNDebugAppState extends AbstractGeometryProcessorDebugAppState{
 			if(s==GeometryState.REMOVE) return true;
 		}else if(s==GeometryState.UPDATE){
 			Geometry generated=generatedGeometries.get(g);
-			generated.setLocalTransform(g.getLocalTransform());
+			generated.setLocalTransform(g.getWorldTransform());
 			return true;
 		}
 

--- a/jme3-core/src/main/java/com/jme3/scene/debug/TanBnNDebugAppState.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/TanBnNDebugAppState.java
@@ -1,0 +1,79 @@
+package com.jme3.scene.debug;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.jme3.app.Application;
+import com.jme3.app.SimpleApplication;
+import com.jme3.material.Material;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Mesh;
+import com.jme3.scene.Mesh.Mode;
+import com.jme3.scene.Spatial;
+import com.jme3.util.TangentBinormalGenerator;
+
+/**
+ * AppState that shows tangents for debugging purposes
+ * 
+ * @author Riccardo Balbo
+ */
+public class TanBnNDebugAppState extends AbstractGeometryProcessorDebugAppState{
+	private static final Logger log=Logger.getLogger(TanBnNDebugAppState.class.getName());
+
+	private Map<Geometry,Geometry> generatedGeometries=new HashMap<Geometry,Geometry>();
+	private Material mat;
+
+	private float debugLineLenght=0.1f;
+
+	public TanBnNDebugAppState(SimpleApplication app){
+		super("TanBnNDebug",app.getRootNode());
+	}
+
+	public TanBnNDebugAppState(Spatial rootNode){
+		super("TanBnNDebug",rootNode);
+	}
+
+	@Override
+	public void initialize(Application app) {
+		super.initialize(app);
+		mat=app.getAssetManager().loadMaterial("Common/Materials/VertexColor.j3m");
+	}
+
+	@Override
+	public boolean processGeometry(float tpf, Geometry g, GeometryState s) {
+		Mesh mesh=g.getMesh();
+
+		if(s==GeometryState.REMOVE||s==GeometryState.MESH_UPDATE_REQUIRED){
+			Geometry generated=generatedGeometries.get(g);
+			if(generated!=null){
+				generated.removeFromParent();
+				generatedGeometries.remove(g);
+			}else{
+				log.log(Level.WARNING,"A remove or regen action has been triggered on {0}, but there is no generated geometry.",g);
+			}
+			if(s==GeometryState.REMOVE) return true;
+		}else if(s==GeometryState.UPDATE){
+			Geometry generated=generatedGeometries.get(g);
+			generated.setLocalTransform(g.getLocalTransform());
+			return true;
+		}
+
+		// Works only with triangle based meshes
+		if(mesh.getMode()!=Mode.Triangles) return false;
+
+		Geometry generated=new Geometry(g.getName(),TangentBinormalGenerator.genTbnLines(mesh,debugLineLenght));
+		generated.setMaterial(mat);
+		generated.setLocalTransform(g.getWorldTransform());
+
+		rootNode.attachChild(generated);
+		generatedGeometries.put(g,generated);
+		return true;
+	}
+
+	public void setDebugLinesLength(float l) {
+		debugLineLenght=l;
+	}
+
+}

--- a/jme3-core/src/main/java/com/jme3/scene/debug/WireframeDebugAppState.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/WireframeDebugAppState.java
@@ -1,0 +1,84 @@
+package com.jme3.scene.debug;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.jme3.app.Application;
+import com.jme3.app.SimpleApplication;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Mesh;
+import com.jme3.scene.Mesh.Mode;
+import com.jme3.scene.Spatial;
+
+/**
+ * AppState that shows wireframes for debugging purposes
+ * 
+ * @author Riccardo Balbo
+ */
+public class WireframeDebugAppState extends AbstractGeometryProcessorDebugAppState{
+	private static final Logger log=Logger.getLogger(WireframeDebugAppState.class.getName());
+
+	private Map<Geometry,Geometry> generatedGeometries=new HashMap<Geometry,Geometry>();
+	private Material mat;
+	private ColorRGBA color=ColorRGBA.Blue;
+
+	public WireframeDebugAppState(SimpleApplication app){
+		super("Wireframe",app.getRootNode());
+	}
+
+	public WireframeDebugAppState(Spatial rootNode){
+		super("Wireframe",rootNode);
+	}
+
+	@Override
+	public void initialize(Application app) {
+		super.initialize(app);
+		mat=new Material(app.getAssetManager(),"Common/MatDefs/Misc/Unshaded.j3md");
+		mat.getAdditionalRenderState().setWireframe(true);
+		mat.setColor("Color",color);
+
+	}
+
+	public void setColor(ColorRGBA c) {
+		color=c;
+		if(isInitialized()){
+			mat.setColor("Color",color);
+		}
+	}
+
+	@Override
+	public boolean processGeometry(float tpf, Geometry g, GeometryState s) {
+		Mesh mesh=g.getMesh();
+		if(s==GeometryState.REMOVE||s==GeometryState.MESH_UPDATE_REQUIRED){
+			Geometry generated=generatedGeometries.get(g);
+			if(generated!=null){
+				generated.removeFromParent();
+				generatedGeometries.remove(g);
+			}else{
+				log.log(Level.WARNING,"A remove or regen action has been triggered on {0}, but there is no generated geometry.",g);
+			}
+			if(s==GeometryState.REMOVE) return true;
+		}else if(s==GeometryState.UPDATE){
+			Geometry generated=generatedGeometries.get(g);
+			generated.setLocalTransform(g.getLocalTransform());
+			return true;
+		}
+
+		// Works only with triangle based meshes
+		if(mesh.getMode()!=Mode.Triangles) return false;
+
+		Geometry generated=g.clone();
+		generated.setMaterial(mat);
+
+		generated.setLocalTransform(g.getWorldTransform());
+
+		rootNode.attachChild(generated);
+		generatedGeometries.put(g,generated);
+		return true;
+	}
+
+}

--- a/jme3-core/src/main/java/com/jme3/scene/debug/WireframeDebugAppState.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/WireframeDebugAppState.java
@@ -64,7 +64,7 @@ public class WireframeDebugAppState extends AbstractGeometryProcessorDebugAppSta
 			if(s==GeometryState.REMOVE) return true;
 		}else if(s==GeometryState.UPDATE){
 			Geometry generated=generatedGeometries.get(g);
-			generated.setLocalTransform(g.getLocalTransform());
+			generated.setLocalTransform(g.getWorldTransform());
 			return true;
 		}
 

--- a/jme3-examples/src/main/java/jme3test/scene/TestTanBnNDebugAppState.java
+++ b/jme3-examples/src/main/java/jme3test/scene/TestTanBnNDebugAppState.java
@@ -1,0 +1,114 @@
+package jme3test.scene;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.input.KeyInput;
+import com.jme3.input.controls.ActionListener;
+import com.jme3.input.controls.KeyTrigger;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Mesh;
+import com.jme3.scene.VertexBuffer;
+import com.jme3.scene.VertexBuffer.Type;
+import com.jme3.scene.debug.TanBnNDebugAppState;
+import com.jme3.scene.shape.Sphere;
+import com.jme3.terrain.noise.basis.ImprovedNoise;
+import com.jme3.util.TangentBinormalGenerator;
+
+/**
+ * @author Riccardo Balbo
+ */
+public class TestTanBnNDebugAppState extends SimpleApplication implements ActionListener{
+	private Geometry geom;
+
+	public static void main(String[] args) {
+		TestTanBnNDebugAppState app=new TestTanBnNDebugAppState();
+		app.start();
+	}
+
+	@Override
+	public void onAction(String name, boolean isPressed, float tpf) {
+		if(name.equals("nextStep")&&isPressed){
+			nextStep();
+		}
+	}
+
+	@Override
+	public void simpleInitApp() {
+
+		System.out.println("Bindings: SPACE=nextStep");
+
+		generateGeometry();
+		applyAppState();
+
+		inputManager.addMapping("nextStep",new KeyTrigger(KeyInput.KEY_SPACE));
+		inputManager.addListener(this,"nextStep");
+
+	}
+
+	private void generateGeometry() {
+		Sphere sp=new Sphere(10,10,1f);
+		geom=new Geometry("",sp);
+		TangentBinormalGenerator.generate(geom);
+
+		Material mat=new Material(assetManager,"Common/MatDefs/Misc/Unshaded.j3md");
+		mat.setColor("Color",ColorRGBA.DarkGray);
+		geom.setMaterial(mat);
+		rootNode.attachChild(geom);
+
+	}
+
+	public void applyAppState() {
+		TanBnNDebugAppState appstate=new TanBnNDebugAppState(this);
+		stateManager.attach(appstate);
+	}
+
+	int step=0;
+
+	private void nextStep() {
+		switch(step){
+			case 0:
+				transform(geom);
+				break;
+			case 1:
+				translate(geom);
+				break;
+			case 2:
+				delete(geom);
+				break;
+			default: // reset test
+				generateGeometry();
+				step=-1;
+		}
+		step++;
+	}
+
+	private void transform(Geometry g) {
+		Mesh m=g.getMesh();
+		VertexBuffer posb=m.getBuffer(Type.Position);
+		int elements=posb.getNumElements();
+		for(int i=0;i<elements;i++){
+			Vector3f p=new Vector3f((float)posb.getElementComponent(i,0),(float)posb.getElementComponent(i,1),(float)posb.getElementComponent(i,2));
+
+			p.addLocal(new Vector3f(1,1,1).multLocal(ImprovedNoise.noise(p.x,p.y,p.z)));
+
+			posb.setElementComponent(i,0,p.x);
+			posb.setElementComponent(i,0,p.y);
+			posb.setElementComponent(i,0,p.z);
+		}
+		posb.setUpdateNeeded();
+		TangentBinormalGenerator.generate(geom);
+
+	}
+
+	private void translate(Geometry g) {
+		g.setLocalTranslation(2,-1,0);
+		g.setLocalScale(0.5f);
+	}
+
+	private void delete(Geometry g) {
+		g.removeFromParent();
+	}
+
+}

--- a/jme3-examples/src/main/java/jme3test/scene/TestWireframeDebugAppState.java
+++ b/jme3-examples/src/main/java/jme3test/scene/TestWireframeDebugAppState.java
@@ -1,0 +1,22 @@
+package jme3test.scene;
+
+import com.jme3.math.ColorRGBA;
+import com.jme3.scene.debug.WireframeDebugAppState;
+
+/**
+ * @author Riccardo Balbo
+ */
+public class TestWireframeDebugAppState extends TestTanBnNDebugAppState{
+
+	public static void main(String[] args) {
+		TestWireframeDebugAppState app=new TestWireframeDebugAppState();
+		app.start();
+	}
+
+	@Override
+	public void applyAppState() {
+		WireframeDebugAppState appstate=new WireframeDebugAppState(this);
+		appstate.setColor(ColorRGBA.Yellow); // Default color is blue
+		stateManager.attach(appstate);
+	}
+}


### PR DESCRIPTION
Convenience appstates that show and keep in sync the representation of normal binormal and tangents, and the wireframe on top of existing geometries contained on the node passed as argument to the constructor.

Limitations:
- Doesn't handle shaders transformations.

Require pr #450 