### PR TITLE
Fix incorrect normal map shading in PBRLighting.

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -65,8 +65,7 @@ varying vec3 wPosition;
   
 #if defined(NORMALMAP) || defined(PARALLAXMAP)
   uniform sampler2D m_NormalMap;   
-  varying vec3 wTangent;
-  varying vec3 wBinormal;
+  varying vec4 wTangent;
 #endif
 varying vec3 wNormal;
 
@@ -79,7 +78,7 @@ void main(){
     vec3 viewDir = normalize(g_CameraPosition - wPosition);
 
     #if defined(NORMALMAP) || defined(PARALLAXMAP)
-        mat3 tbnMat = mat3(normalize(wTangent.xyz) , normalize(wBinormal.xyz) , normalize(wNormal.xyz));       
+      mat3 tbnMat = mat3(wTangent.xyz, wTangent.w * cross( (wNormal), (wTangent.xyz)), wNormal.xyz);
     #endif
 
     #if (defined(PARALLAXMAP) || (defined(NORMALMAP_PARALLAX) && defined(NORMALMAP)))
@@ -139,7 +138,7 @@ void main(){
       //see http://hub.jmonkeyengine.org/forum/topic/parallax-mapping-fundamental-bug/#post-256898
       //for more explanation.
       vec3 normal = normalize((normalHeight.xyz * vec3(2.0,-2.0,2.0) - vec3(1.0,-1.0,1.0)));
-      normal = tbnMat * normal;
+      normal = normalize(tbnMat * normal);
       //normal = normalize(normal * inverse(tbnMat));
     #else
       vec3 normal = normalize(wNormal);            

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.vert
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.vert
@@ -25,8 +25,7 @@ varying vec3 wNormal;
 varying vec3 wPosition;
 #if defined(NORMALMAP) || defined(PARALLAXMAP)
     attribute vec4 inTangent;
-    varying vec3 wTangent;
-    varying vec3 wBinormal;
+    varying vec4 wTangent;
 #endif
 
 void main(){
@@ -55,8 +54,7 @@ void main(){
     wNormal  = TransformWorld(vec4(modelSpaceNorm,0.0)).xyz;
 
     #if defined(NORMALMAP) || defined(PARALLAXMAP)
-      wTangent = TransformWorld(vec4(modelSpaceTan,0.0)).xyz;
-      wBinormal = cross(wNormal, wTangent)* inTangent.w;            
+      wTangent = vec4(TransformWorld(vec4(modelSpaceTan,0.0)).xyz,inTangent.w);
     #endif
 
     Color = m_BaseColor;


### PR DESCRIPTION
With the new Mikk Tangent Space generator this fix in the shader should produce correct shading results.
BiNormal/biTangent needs to be calculated in the fragment shader and the final normal has to be normalized.
http://i.imgur.com/gz9pRUP.png
https://hub.jmonkeyengine.org/t/normal-map-shading-problems/34947/91
