### PR TITLE
Added handling of exception on SkeletonControl

### DIFF
--- a/jme3-core/src/main/java/com/jme3/animation/SkeletonControl.java
+++ b/jme3-core/src/main/java/com/jme3/animation/SkeletonControl.java
@@ -158,7 +158,12 @@ public class SkeletonControl extends AbstractControl implements Cloneable, JmeCl
             }
         }
 
-        switchToHardware();
+        try {
+            switchToHardware();
+        } catch (final Exception e) {
+            Logger.getLogger(SkeletonControl.class.getName()).log(Level.WARNING, "Could not enable HW skinning due to error:", e);
+            return false;
+        }
         
         try {
             rm.preloadScene(spatial);


### PR DESCRIPTION
I had this problem with several model imported from Blender.

WARNING: Could not enable HW skinning due to error:
java.lang.NullPointerException
    at com.jme3.scene.Mesh.prepareForAnim(Mesh.java:439)
    at com.jme3.animation.SkeletonControl.switchToHardware(SkeletonControl.java:127)
    at com.jme3.animation.SkeletonControl.testHardwareSupported(SkeletonControl.java:160)
    at com.jme3.animation.SkeletonControl.controlRender(SkeletonControl.java:281)
    at com.jme3.scene.control.AbstractControl.render(AbstractControl.java:119)
    at com.jme3.scene.Spatial.runControlRender(Spatial.java:681)
    at com.jme3.renderer.RenderManager.renderSubScene(RenderManager.java:667)
    at com.jme3.renderer.RenderManager.renderSubScene(RenderManager.java:677)
    at com.jme3.renderer.RenderManager.renderSubScene(RenderManager.java:677)
    at com.jme3.renderer.RenderManager.renderSubScene(RenderManager.java:677)
    at com.jme3.renderer.RenderManager.renderSubScene(RenderManager.java:677)
    at com.jme3.renderer.RenderManager.renderSubScene(RenderManager.java:677)
    at com.jme3.renderer.RenderManager.renderSubScene(RenderManager.java:677)
    at com.jme3.renderer.RenderManager.renderScene(RenderManager.java:656)
    at com.jme3.renderer.RenderManager.renderViewPort(RenderManager.java:1038)
    at com.jme3.renderer.RenderManager.render(RenderManager.java:1097)
    at com.jme3.app.SimpleApplication.update(SimpleApplication.java:260)
    at com.ss.editor.Editor.update(Editor.java:353)
    at com.jme3.system.lwjgl.LwjglWindow.runLoop(LwjglWindow.java:369)
    at com.jme3.system.lwjgl.LwjglWindow.run(LwjglWindow.java:452)
    at java.lang.Thread.run(Thread.java:745)
