### PR TITLE
Texture arrays as render targets, bugfix for shader nodes and new getter and setter in Light class

### DIFF
--- a/jme3-core/src/main/java/com/jme3/light/Light.java
+++ b/jme3-core/src/main/java/com/jme3/light/Light.java
@@ -184,6 +184,22 @@ public abstract class Light implements Savable, Cloneable {
         this.enabled = enabled;
     }
 
+    public boolean isFrustumCheckNeeded() {
+      return frustumCheckNeeded;
+    }
+
+    public void setFrustumCheckNeeded(boolean frustumCheckNeeded) {
+      this.frustumCheckNeeded = frustumCheckNeeded;
+    }
+
+    public boolean isIntersectsFrustum() {
+      return intersectsFrustum;
+    }
+
+    public void setIntersectsFrustum(boolean intersectsFrustum) {
+      this.intersectsFrustum = intersectsFrustum;
+    }
+    
     /**
      * Determines if the light intersects with the given bounding box.
      * <p>

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GL3.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GL3.java
@@ -58,6 +58,7 @@ public interface GL3 extends GL2 {
     public void glBindFragDataLocation(int param1, int param2, String param3); /// GL3+
     public void glBindVertexArray(int param1); /// GL3+
     public void glDeleteVertexArrays(IntBuffer arrays); /// GL3+
+    public void glFramebufferTextureLayer(int param1, int param2, int param3, int param4, int param5); /// GL3+
     public void glGenVertexArrays(IntBuffer param1); /// GL3+
     public String glGetString(int param1, int param2); /// GL3+
 }

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLDebugDesktop.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLDebugDesktop.java
@@ -94,4 +94,10 @@ public class GLDebugDesktop extends GLDebugES implements GL2, GL3, GL4 {
         gl4.glPatchParameter(count);
         checkError();
     }
+
+    @Override
+    public void glFramebufferTextureLayer(int param1, int param2, int param3, int param4, int param5) {
+        gl3.glFramebufferTextureLayer(param1, param2, param3, param4, param5);
+        checkError();
+    }
 }

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -1442,11 +1442,19 @@ public final class GLRenderer implements Renderer {
             setupTextureParams(0, tex);
         }
 
-        glfbo.glFramebufferTexture2DEXT(GLFbo.GL_FRAMEBUFFER_EXT,
-                convertAttachmentSlot(rb.getSlot()),
-                convertTextureType(tex.getType(), image.getMultiSamples(), rb.getFace()),
-                image.getId(),
-                0);
+        if (rb.getLayer() < 0){
+            glfbo.glFramebufferTexture2DEXT(GLFbo.GL_FRAMEBUFFER_EXT,
+                    convertAttachmentSlot(rb.getSlot()),
+                    convertTextureType(tex.getType(), image.getMultiSamples(), rb.getFace()),
+                    image.getId(),
+                    0);
+        } else {
+            gl3.glFramebufferTextureLayer(GLFbo.GL_FRAMEBUFFER_EXT, 
+                    convertAttachmentSlot(rb.getSlot()), 
+                    image.getId(), 
+                    0,
+                    rb.getLayer());
+        }
     }
 
     public void updateFrameBufferAttachment(FrameBuffer fb, RenderBuffer rb) {

--- a/jme3-core/src/main/java/com/jme3/shader/Glsl100ShaderGenerator.java
+++ b/jme3-core/src/main/java/com/jme3/shader/Glsl100ShaderGenerator.java
@@ -258,7 +258,7 @@ public class Glsl100ShaderGenerator extends ShaderGenerator {
         }
        
         for (ShaderNodeVariable var : shaderNode.getDefinition().getOutputs()) {
-            ShaderNodeVariable v = new ShaderNodeVariable(var.getType(), shaderNode.getName(), var.getName());
+            ShaderNodeVariable v = new ShaderNodeVariable(var.getType(), shaderNode.getName(), var.getName(), var.getMultiplicity());
             if (!declaredInputs.contains(shaderNode.getName() + "_" + var.getName())) {
                 if (!isVarying(info, v)) {
                     declareVariable(source, v);
@@ -397,6 +397,11 @@ public class Glsl100ShaderGenerator extends ShaderGenerator {
         source.append(mapping.getLeftVariable().getNameSpace());
         source.append("_");
         source.append(mapping.getLeftVariable().getName());
+        if (mapping.getLeftVariable().getMultiplicity() != null){
+            source.append("[");
+            source.append(mapping.getLeftVariable().getMultiplicity());
+            source.append("]");
+        }
         
         //left swizzle, the variable can't be declared and assigned on the same line. 
         if (mapping.getLeftSwizzling().length() > 0) {

--- a/jme3-core/src/main/java/com/jme3/shader/VarType.java
+++ b/jme3-core/src/main/java/com/jme3/shader/VarType.java
@@ -55,7 +55,7 @@ public enum VarType {
     TextureBuffer(false,true,"sampler1D|sampler1DShadow"),
     Texture2D(false,true,"sampler2D|sampler2DShadow"),
     Texture3D(false,true,"sampler3D"),
-    TextureArray(false,true,"sampler2DArray"),
+    TextureArray(false,true,"sampler2DArray|sampler2DArrayShadow"),
     TextureCubeMap(false,true,"samplerCube"),
     Int("int");
 

--- a/jme3-core/src/main/java/com/jme3/texture/FrameBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/texture/FrameBuffer.java
@@ -97,6 +97,7 @@ public class FrameBuffer extends NativeObject {
         int id = -1;
         int slot = SLOT_UNDEF;
         int face = -1;
+        int layer = -1;
         
         /**
          * @return The image format of the render buffer.
@@ -159,6 +160,10 @@ public class FrameBuffer extends NativeObject {
             }else{
                 return "BufferTarget[format=" + format + "]";
             }
+        }
+
+        public int getLayer() {
+            return this.layer;
         }
     }
 
@@ -332,9 +337,9 @@ public class FrameBuffer extends NativeObject {
      * 
      * @param tex The color texture array to set.
      */
-    public void setColorTexture(TextureArray tex){
+    public void setColorTexture(TextureArray tex, int layer){
         clearColorTargets();
-        addColorTexture(tex);
+        addColorTexture(tex, layer);
     }
     
     /**
@@ -391,7 +396,7 @@ public class FrameBuffer extends NativeObject {
      * 
      * @param tex The texture array to add.
      */
-    public void addColorTexture(TextureArray tex) {
+    public void addColorTexture(TextureArray tex, int layer) {
         if (id != -1)
             throw new UnsupportedOperationException("FrameBuffer already initialized.");
 
@@ -402,6 +407,7 @@ public class FrameBuffer extends NativeObject {
         colorBuf.slot = colorBufs.size();
         colorBuf.tex = tex;
         colorBuf.format = img.getFormat();
+        colorBuf.layer = layer;
 
         colorBufs.add(colorBuf);
     }
@@ -449,7 +455,20 @@ public class FrameBuffer extends NativeObject {
         depthBuf.tex = tex;
         depthBuf.format = img.getFormat();
     }
+    public void setDepthTexture(TextureArray tex, int layer){
+        if (id != -1)
+            throw new UnsupportedOperationException("FrameBuffer already initialized.");
 
+        Image img = tex.getImage();
+        checkSetTexture(tex, true);
+        
+        depthBuf = new RenderBuffer();
+        depthBuf.slot = img.getFormat().isDepthStencilFormat() ?  SLOT_DEPTH_STENCIL : SLOT_DEPTH;
+        depthBuf.tex = tex;
+        depthBuf.format = img.getFormat();
+        depthBuf.layer = layer;
+    }
+    
     /**
      * @return The number of color buffers attached to this texture. 
      */

--- a/jme3-core/src/main/java/com/jme3/texture/FrameBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/texture/FrameBuffer.java
@@ -325,6 +325,19 @@ public class FrameBuffer extends NativeObject {
     }
     
     /**
+     * Set the color texture array to use for this framebuffer.
+     * This automatically clears all existing textures added previously
+     * with {@link FrameBuffer#addColorTexture } and adds this texture as the
+     * only target.
+     * 
+     * @param tex The color texture array to set.
+     */
+    public void setColorTexture(TextureArray tex){
+        clearColorTargets();
+        addColorTexture(tex);
+    }
+    
+    /**
      * Set the color texture to use for this framebuffer.
      * This automatically clears all existing textures added previously
      * with {@link FrameBuffer#addColorTexture } and adds this texture as the
@@ -355,6 +368,30 @@ public class FrameBuffer extends NativeObject {
      * @param tex The texture to add.
      */
     public void addColorTexture(Texture2D tex) {
+        if (id != -1)
+            throw new UnsupportedOperationException("FrameBuffer already initialized.");
+
+        Image img = tex.getImage();
+        checkSetTexture(tex, false);
+
+        RenderBuffer colorBuf = new RenderBuffer();
+        colorBuf.slot = colorBufs.size();
+        colorBuf.tex = tex;
+        colorBuf.format = img.getFormat();
+
+        colorBufs.add(colorBuf);
+    }
+    
+    /**
+     * Add a color texture array to use for this framebuffer.
+     * If MRT is enabled, then each subsequently added texture can be
+     * rendered to through a shader that writes to the array <code>gl_FragData</code>.
+     * If MRT is not enabled, then the index set with {@link FrameBuffer#setTargetIndex(int) }
+     * is rendered to by the shader.
+     * 
+     * @param tex The texture array to add.
+     */
+    public void addColorTexture(TextureArray tex) {
         if (id != -1)
             throw new UnsupportedOperationException("FrameBuffer already initialized.");
 

--- a/jme3-core/src/plugins/java/com/jme3/material/plugins/ShaderNodeLoaderDelegate.java
+++ b/jme3-core/src/plugins/java/com/jme3/material/plugins/ShaderNodeLoaderDelegate.java
@@ -752,6 +752,7 @@ public class ShaderNodeLoaderDelegate {
             }
             right.setNameSpace(node.getName());
             right.setType(var.getType());
+            right.setMultiplicity(var.getMultiplicity());
             mapping.setRightVariable(right);            
             storeVaryings(node, mapping.getRightVariable());
 

--- a/jme3-jogl/src/main/java/com/jme3/renderer/jogl/JoglGL.java
+++ b/jme3-jogl/src/main/java/com/jme3/renderer/jogl/JoglGL.java
@@ -600,4 +600,9 @@ public class JoglGL implements GL, GL2, GL3, GL4 {
         checkLimit(arrays);
         GLContext.getCurrentGL().getGL2ES3().glDeleteVertexArrays(arrays.limit(), arrays);
     }
+
+    @Override
+    public void glFramebufferTextureLayer(int param1, int param2, int param3, int param4, int param5) {
+        GLContext.getCurrentGL().getGL3().glFramebufferTextureLayer(param1, param2, param3, param4, param5);
+    }
 }

--- a/jme3-lwjgl/src/main/java/com/jme3/renderer/lwjgl/LwjglGL.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/renderer/lwjgl/LwjglGL.java
@@ -457,4 +457,9 @@ public final class LwjglGL implements GL, GL2, GL3, GL4 {
         checkLimit(arrays);
         ARBVertexArrayObject.glDeleteVertexArrays(arrays);
     }
+
+    @Override
+    public void glFramebufferTextureLayer(int param1, int param2, int param3, int param4, int param5) {
+        GL30.glFramebufferTextureLayer(param1, param2, param3, param4, param5);
+    }
 }

--- a/jme3-lwjgl3/src/main/java/com/jme3/renderer/lwjgl/LwjglGL.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/renderer/lwjgl/LwjglGL.java
@@ -486,4 +486,9 @@ public class LwjglGL implements GL, GL2, GL3, GL4 {
         checkLimit(arrays);
         ARBVertexArrayObject.glDeleteVertexArrays(arrays);
     }
+
+    @Override
+    public void glFramebufferTextureLayer(int param1, int param2, int param3, int param4, int param5) {
+        GL30.glFramebufferTextureLayer(param1, param2, param3, param4, param5);
+    }
 }


### PR DESCRIPTION
These are necessary changes to implement improved shadow rendering.

Recreation of this pull request: [old pull request](https://github.com/jMonkeyEngine/jmonkeyengine/pull/452) for master branch instead of PBR branch.

Texture arrays can now be set as render targets for color and depth buffers.
Also fixed an issue with the shader node generation, when using array variables the multiplicity was missing.
Added getters and setters in the Light class for frustumCheckNeeded and intersectsFrustum, to be able to implement a custom light filter.

Forum: http://hub.jmonkeyengine.org/t/improved-shadow-renderer/33496/50
