### PR TITLE
Let lwjgl respect the AlphaBits setting

### DIFF
--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
@@ -301,7 +301,7 @@ public class LwjglCanvas extends LwjglAbstractDisplay implements JmeCanvasContex
             // crashes on bad drivers
             if (pbufferFormat == null){
                 pbufferFormat = new PixelFormat(settings.getBitsPerPixel(),
-                                                0,
+                                                settings.getAlphaBits(),
                                                 settings.getDepthBits(),
                                                 settings.getStencilBits(),
                                                 0, // samples
@@ -315,7 +315,7 @@ public class LwjglCanvas extends LwjglAbstractDisplay implements JmeCanvasContex
             if (canvasFormat == null){
                 int samples = getNumSamplesToUse();
                 canvasFormat = new PixelFormat(settings.getBitsPerPixel(),
-                                               0,
+                                               settings.getAlphaBits(),
                                                settings.getDepthBits(),
                                                settings.getStencilBits(),
                                                samples,

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
@@ -84,7 +84,7 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
 
         int samples = getNumSamplesToUse();
         PixelFormat pf = new PixelFormat(settings.getBitsPerPixel(),
-                                         0,
+                                         settings.getAlphaBits(),
                                          settings.getDepthBits(),
                                          settings.getStencilBits(),
                                          samples, 
@@ -99,6 +99,7 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
 
         boolean pixelFormatChanged = false;
         if (created.get() && (pixelFormat.getBitsPerPixel() != pf.getBitsPerPixel()
+        					||pixelFormat.getAlphaBits() != pf.getAlphaBits()
                             ||pixelFormat.getDepthBits() != pf.getDepthBits()
                             ||pixelFormat.getStencilBits() != pf.getStencilBits()
                             ||pixelFormat.getSamples() != pf.getSamples())){

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglOffscreenBuffer.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglOffscreenBuffer.java
@@ -62,7 +62,7 @@ public class LwjglOffscreenBuffer extends LwjglContext implements Runnable {
 
         int samples = getNumSamplesToUse();
         pixelFormat = new PixelFormat(settings.getBitsPerPixel(),
-                                      0,
+                                      settings.getAlphaBits(),
                                       settings.getDepthBits(),
                                       settings.getStencilBits(),
                                       samples);


### PR DESCRIPTION
lwjgl now respects `AppSettings.getAlphaBits()` when creating its PixelFormat.