### PR TITLE
Get normals and tangent synced with mikk tangent space.

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -78,9 +78,7 @@ void main(){
     vec3 viewDir = normalize(g_CameraPosition - wPosition);
 
     #if defined(NORMALMAP) || defined(PARALLAXMAP)
-      vec3 tan = normalize(wTangent.xyz);
-      vec3 norm = normalize(wNormal);
-      mat3 tbnMat = mat3(tan, wTangent.w * cross(norm, tan), norm.xyz);
+        mat3 tbnMat = mat3(wTangent.xyz, wTangent.w * cross( (wNormal), (wTangent.xyz)), wNormal.xyz);
     #endif
 
     #if (defined(PARALLAXMAP) || (defined(NORMALMAP_PARALLAX) && defined(NORMALMAP)))

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.vert
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.vert
@@ -51,10 +51,10 @@ void main(){
     #endif
 
     wPosition = TransformWorld(modelSpacePos).xyz;
-    wNormal  = TransformWorld(vec4(modelSpaceNorm,0.0)).xyz;
+    wNormal  = TransformWorldNormal(modelSpaceNorm);
 
     #if defined(NORMALMAP) || defined(PARALLAXMAP)
-      wTangent = vec4(TransformWorld(vec4(modelSpaceTan,0.0)).xyz,inTangent.w);
+      wTangent = vec4(TransformWorldNormal(modelSpaceTan),inTangent.w);
     #endif
 
     Color = m_BaseColor;

--- a/jme3-core/src/main/resources/Common/ShaderLib/Instancing.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/Instancing.glsllib
@@ -60,14 +60,16 @@ vec4 TransformWorldViewProjection(vec4 position)
     return g_ViewProjectionMatrix * TransformWorld(position);
 }
 
-vec3 TransformNormal(vec3 vec)
-{
+vec3 TransformWorldNormal(vec3 vec) {
     vec4 quat = vec4(inInstanceData[0].w, inInstanceData[1].w,
                      inInstanceData[2].w, inInstanceData[3].w);
 
-    vec3 worldNormal = vec + vec3(2.0) * cross(cross(vec, quat.xyz) + vec3(quat.w) * vec, quat.xyz);
-    
-    return (g_ViewMatrix * vec4(worldNormal, 0.0)).xyz;
+    return vec + vec3(2.0) * cross(cross(vec, quat.xyz) + vec3(quat.w) * vec, quat.xyz);
+}
+
+vec3 TransformNormal(vec3 vec)
+{
+    return (g_ViewMatrix * vec4(TransformWorldNormal(vec), 0.0)).xyz;
 }
 
 // Prevent user from using g_** matrices which will have invalid data in this case.
@@ -97,4 +99,9 @@ vec3 TransformNormal(vec3 normal) {
 	return g_NormalMatrix * normal;
 }
 
+vec3 TransformWorldNormal(vec3 normal) {
+    return normalize((g_WorldMatrix * vec4(normal,0.0)).xyz);
+}
+
+ 
 #endif


### PR DESCRIPTION
The normal maps calculated in mikk tangent space expect unnormalized (interpolated) tangent and world normals in the fragment shader, because of this they have to be normalized in the vertex shader.