### PR TITLE
'UseAlpha' parameter for the Lighting.j3md Material

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/Lighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/Lighting.frag
@@ -103,7 +103,12 @@ void main(){
       vec4 diffuseColor = vec4(1.0);
     #endif
 
-    float alpha = DiffuseSum.a * diffuseColor.a;
+    #ifdef USE_ALPHA
+        float alpha = DiffuseSum.a * diffuseColor.a;
+    #else
+        float alpha = DiffuseSum.a;
+    #endif
+    
     #ifdef ALPHAMAP
        alpha = alpha * texture2D(m_AlphaMap, newTexCoord).r;
     #endif

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/Lighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/Lighting.j3md
@@ -6,6 +6,9 @@ MaterialDef Phong Lighting {
         // For better performance
         Boolean VertexLighting
 
+        // Use the alpha channel of the diffuse map
+        Boolean UseAlpha : true
+
         // Alpha threshold for fragment discarding
         Float AlphaDiscardThreshold 
 
@@ -137,6 +140,7 @@ MaterialDef Phong Lighting {
             VERTEX_COLOR : UseVertexColor
             VERTEX_LIGHTING : VertexLighting           
             MATERIAL_COLORS : UseMaterialColors         
+            USE_ALPHA : UseAlpha
             DIFFUSEMAP : DiffuseMap
             NORMALMAP : NormalMap
             SPECULARMAP : SpecularMap
@@ -176,6 +180,7 @@ MaterialDef Phong Lighting {
             VERTEX_COLOR : UseVertexColor
             VERTEX_LIGHTING : VertexLighting            
             MATERIAL_COLORS : UseMaterialColors
+            USE_ALPHA : UseAlpha
             DIFFUSEMAP : DiffuseMap
             NORMALMAP : NormalMap
             SPECULARMAP : SpecularMap

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/SPLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/SPLighting.frag
@@ -114,7 +114,11 @@ void main(){
       vec4 diffuseColor = vec4(1.0);
     #endif
 
-    float alpha = DiffuseSum.a * diffuseColor.a;
+    #ifdef USE_ALPHA
+        float alpha = DiffuseSum.a * diffuseColor.a;
+    #else
+        float alpha = DiffuseSum.a;
+    #endif
 
     #ifdef ALPHAMAP
        alpha = alpha * texture2D(m_AlphaMap, newTexCoord).r;


### PR DESCRIPTION
Readded the `UseAlpha` parameter for the Lighting.j3md Material, and gave it the functionality it always should have had, but never actually had.

The default value is `true`, to ensure backward compatibility.