### PR TITLE
Reversed raytest results when needed

### DIFF
--- a/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
@@ -49,6 +49,7 @@ import com.jme3.scene.Spatial;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -788,6 +789,11 @@ public class PhysicsSpace {
     public List rayTest(Vector3f from, Vector3f to) {
         List results = new LinkedList();
         rayTest(from, to, results);
+        
+        if(results.getFirst().getHitFraction() > results.getLast().getHitFraction()) {
+            Collections.reverse(results);
+        }
+        
         return (List<PhysicsRayTestResult>) results;
     }
 

--- a/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
@@ -787,14 +787,14 @@ public class PhysicsSpace {
      * PhysicsRayTestResults
      */
     public List rayTest(Vector3f from, Vector3f to) {
-        List results = new LinkedList();
+        LinkedList<PhysicsRayTestResult> results = new LinkedList<PhysicsRayTestResult>();
         rayTest(from, to, results);
         
         if(results.getFirst().getHitFraction() > results.getLast().getHitFraction()) {
             Collections.reverse(results);
         }
         
-        return (List<PhysicsRayTestResult>) results;
+        return results;
     }
 
     /**


### PR DESCRIPTION
In some cases, native-bullet returns the ray results on a reversed order so it leads to unexpected bugs.

More details can be found [here](https://hub.jmonkeyengine.org/t/native-bullet-raytest-randomly-giving-inverted-list/35511).