### PR TITLE
Removed uneeded casting of assetkey on blender file setup

### DIFF
--- a/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/BlenderLoader.java
+++ b/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/BlenderLoader.java
@@ -49,7 +49,6 @@ import com.jme3.asset.AssetLoader;
 import com.jme3.asset.AssetLocator;
 import com.jme3.asset.AssetManager;
 import com.jme3.asset.BlenderKey;
-import com.jme3.asset.ModelKey;
 import com.jme3.asset.StreamAssetInfo;
 import com.jme3.light.Light;
 import com.jme3.math.ColorRGBA;
@@ -270,12 +269,12 @@ public class BlenderLoader implements AssetLoader {
      */
     protected BlenderContext setup(AssetInfo assetInfo) throws BlenderFileException {
         // registering loaders
-        ModelKey modelKey = (ModelKey) assetInfo.getKey();
+        AssetKey assetKey = assetInfo.getKey();
         BlenderKey blenderKey;
-        if (modelKey instanceof BlenderKey) {
-            blenderKey = (BlenderKey) modelKey;
+        if (assetKey instanceof BlenderKey) {
+            blenderKey = (BlenderKey) assetKey;
         } else {
-            blenderKey = new BlenderKey(modelKey.getName());
+            blenderKey = new BlenderKey(assetKey.getName());
         }
 
         // opening stream


### PR DESCRIPTION
The casting to ModelKey what causing an assetkey exception if passing an AssetKey (ie: using loadAsset instead of loadModel) while it wasn't giving any extra method.