### PR TITLE
Ogre importer: Fix for material sharing

### DIFF
--- a/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SceneLoader.java
+++ b/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SceneLoader.java
@@ -71,6 +71,7 @@ public class SceneLoader extends DefaultHandler implements AssetLoader {
     
     private static final Logger logger = Logger.getLogger(SceneLoader.class.getName());
     private SceneMaterialLoader materialLoader = new SceneMaterialLoader();
+    private SceneMeshLoader meshLoader=new SceneMeshLoader();
     private Stack<String> elementStack = new Stack<String>();
     private AssetKey key;
     private String sceneName;
@@ -99,6 +100,7 @@ public class SceneLoader extends DefaultHandler implements AssetLoader {
     }
 
     private void reset() {
+    	meshLoader.reset();
         elementStack.clear();
         nodeIdx = 0;
 
@@ -299,8 +301,12 @@ public class SceneLoader extends DefaultHandler implements AssetLoader {
         entityNode = new com.jme3.scene.Node(name);
         OgreMeshKey meshKey = new OgreMeshKey(meshFile, materialList);
         try {
-            Spatial ogreMesh = assetManager.loadModel(meshKey);
-            entityNode.attachChild(ogreMesh);
+			try{
+				Spatial ogreMesh=(Spatial)meshLoader.load(assetManager.locateAsset(meshKey));
+				entityNode.attachChild(ogreMesh);
+			}catch(IOException e){
+				throw new AssetNotFoundException(meshKey.toString());
+			}
         } catch (AssetNotFoundException ex) {
             if (ex.getMessage().equals(meshFile)) {
                 logger.log(Level.WARNING, "Cannot locate {0} for scene {1}", new Object[]{meshKey, key});

--- a/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SceneMeshLoader.java
+++ b/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SceneMeshLoader.java
@@ -1,0 +1,26 @@
+package com.jme3.scene.plugins.ogre;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.jme3.asset.AssetInfo;
+import com.jme3.asset.AssetKey;
+import com.jme3.scene.Spatial;
+
+public class SceneMeshLoader extends MeshLoader{
+	private Map<AssetKey,Spatial> cache=new HashMap<AssetKey,Spatial>();
+	@Override
+    public Object load(AssetInfo info) throws IOException {
+		AssetKey key=info.getKey();
+		Spatial output=cache.get(key);
+		if(output==null){
+			output=(Spatial)super.load(info);
+			cache.put(key,output);
+		}
+		return output.clone(false);
+	}
+	public void reset(){
+		cache.clear();
+	}
+}


### PR DESCRIPTION
Fix for the issue reported here: https://hub.jmonkeyengine.org/t/ogre-importer-materials-are-not-shared/35663

**Short description of the problem:**
We have an Ogre's .scene with two spatials that share the same material. 
When this scene is imported in the engine, the two spatials no longer share the material but, instead, they own a new instanced of it.
This happens because the SceneLoader loads the objects through the assetManager as if they were unrelated, the assetManager calls _clone(true)_ on the cached models before returning them, this cause the issue.

This patch loads the models directly with an instance of MeshLoader opportunely extended to have an internal cache that is preserved until the scene is fully loaded.