### PR TITLE
Fix GImpact passing through other shapes.

### DIFF
--- a/jme3-bullet-native/src/native/cpp/jmePhysicsSpace.cpp
+++ b/jme3-bullet-native/src/native/cpp/jmePhysicsSpace.cpp
@@ -147,6 +147,8 @@ void jmePhysicsSpace::createPhysicsSpace(jfloat minX, jfloat minY, jfloat minZ, 
     } else {
         dispatcher = new btCollisionDispatcher(collisionConfiguration);
     }
+    btGImpactCollisionAlgorithm::registerAlgorithm(dispatcher);
+    
 
     // the default constraint solver. For parallel processing you can use a different solver (see Extras/BulletMultiThreaded)
     if (threading) {

--- a/jme3-bullet-native/src/native/cpp/jmePhysicsSpace.h
+++ b/jme3-bullet-native/src/native/cpp/jmePhysicsSpace.h
@@ -48,6 +48,7 @@
 #include "BulletCollision/CollisionDispatch/btSimulationIslandManager.h"
 #include "BulletCollision/NarrowPhaseCollision/btManifoldPoint.h"
 #include "BulletCollision/NarrowPhaseCollision/btPersistentManifold.h"
+#include "BulletCollision/Gimpact/btGImpactCollisionAlgorithm.h"
 
 /**
  * Author: Normen Hansen


### PR DESCRIPTION
btGImpactCollisionAlgorithm hasn't been registered for physics spaces, causing Gimpact collisions to not be detected.
This pr solves it.