### PR TITLE
Add/remove all PhysicsControls even when a RigidBodyControl is present

### DIFF
--- a/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
@@ -487,9 +487,10 @@ public class PhysicsSpace {
      * @param spatial the rootnode containing the physics objects
      */
     public void addAll(Spatial spatial) {
+        add(spatial);
+
         if (spatial.getControl(RigidBodyControl.class) != null) {
             RigidBodyControl physicsNode = spatial.getControl(RigidBodyControl.class);
-            add(physicsNode);
             //add joints with physicsNode as BodyA
             List<PhysicsJoint> joints = physicsNode.getJoints();
             for (Iterator<PhysicsJoint> it1 = joints.iterator(); it1.hasNext();) {
@@ -499,8 +500,6 @@ public class PhysicsSpace {
                     add(physicsJoint);
                 }
             }
-        } else {
-            add(spatial);
         }
         //recursion
         if (spatial instanceof Node) {
@@ -529,10 +528,9 @@ public class PhysicsSpace {
                     //remove(physicsJoint.getBodyB());
                 }
             }
-            remove(physicsNode);
-        } else if (spatial.getControl(PhysicsControl.class) != null) {
-            remove(spatial);
         }
+            
+        remove(spatial);
         //recursion
         if (spatial instanceof Node) {
             List<Spatial> children = ((Node) spatial).getChildren();

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
@@ -458,9 +458,10 @@ public class PhysicsSpace {
      * @param spatial the rootnode containing the physics objects
      */
     public void addAll(Spatial spatial) {
+        add(spatial);
+
         if (spatial.getControl(RigidBodyControl.class) != null) {
             RigidBodyControl physicsNode = spatial.getControl(RigidBodyControl.class);
-            add(physicsNode);
             //add joints with physicsNode as BodyA
             List<PhysicsJoint> joints = physicsNode.getJoints();
             for (Iterator<PhysicsJoint> it1 = joints.iterator(); it1.hasNext();) {
@@ -470,8 +471,6 @@ public class PhysicsSpace {
                     add(physicsJoint);
                 }
             }
-        } else {
-            add(spatial);
         }
         //recursion
         if (spatial instanceof Node) {
@@ -500,10 +499,9 @@ public class PhysicsSpace {
                     //remove(physicsJoint.getBodyB());
                 }
             }
-            remove(physicsNode);
-        } else if (spatial.getControl(PhysicsControl.class) != null) {
-            remove(spatial);
         }
+        
+        remove(spatial);
         //recursion
         if (spatial instanceof Node) {
             List<Spatial> children = ((Node) spatial).getChildren();


### PR DESCRIPTION
The current implementation of addAll / removeAll doesn't remove rest of the PhysicsControls if the spatial has a RigidBodyControl.

This pull request removes the else-branch so that add / remove is always called for the spatial. Add / remove is no longer present in the `if (spatial.getControl(RigidBodyControl.class) != null)` -branch to prevent the RigidBodyControl from being added / removed twice, thus it only handles joints.
