### PR TITLE
added a pre-order traversal of the scene graph

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Geometry.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Geometry.java
@@ -458,7 +458,7 @@ public class Geometry extends Spatial {
     }
 
     @Override
-    public void depthFirstTraversal(SceneGraphVisitor visitor) {
+    public void depthFirstTraversal(SceneGraphVisitor visitor, DFSMode mode) {
         visitor.visit(this);
     }
 

--- a/jme3-core/src/main/java/com/jme3/scene/Node.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Node.java
@@ -770,11 +770,18 @@ public class Node extends Spatial {
         }
     }
     @Override
-    public void depthFirstTraversal(SceneGraphVisitor visitor) {
-        for (Spatial child : children.getArray()) {
-            child.depthFirstTraversal(visitor);
+    public void depthFirstTraversal(SceneGraphVisitor visitor, DFSMode mode) {
+        if (mode == DFSMode.POST_ORDER) {
+            for (Spatial child : children.getArray()) {
+                child.depthFirstTraversal(visitor);
+            }
+            visitor.visit(this);
+        } else { //pre order
+            visitor.visit(this);
+            for (Spatial child : children.getArray()) {
+                child.depthFirstTraversal(visitor);
+            }
         }
-        visitor.visit(this);
     }
     @Override
     protected void breadthFirstTraversal(SceneGraphVisitor visitor, Queue<Spatial> queue) {

--- a/jme3-core/src/main/java/com/jme3/scene/Spatial.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Spatial.java
@@ -1798,10 +1798,35 @@ public abstract class Spatial implements Savable, Cloneable, Collidable, Cloneab
     }
 
     /**
-     * Visit each scene graph element ordered by DFS
+     * Visit each scene graph element ordered by DFS with the default post order mode.
      * @param visitor
+     * @see #depthFirstTraversal(com.jme3.scene.SceneGraphVisitor, com.jme3.scene.Spatial.DFSMode) 
      */
-    public abstract void depthFirstTraversal(SceneGraphVisitor visitor);
+    public void depthFirstTraversal(SceneGraphVisitor visitor) {
+        depthFirstTraversal(visitor, DFSMode.POST_ORDER);
+    }
+    
+    /**
+     * Specifies the mode of the depth first search.
+     */
+    public static enum DFSMode {
+        /**
+         * Pre order: the current spatial is visited first, then its children.
+         */
+        PRE_ORDER,
+        /**
+         * Post order: the children are visited first, then the parent.
+         */
+        POST_ORDER;
+    }
+    
+    /**
+     * Visit each scene graph element ordered by DFS.
+     * There are two modes: pre order and post order.
+     * @param visitor
+     * @param mode the traversal mode: pre order or post order
+     */
+    public abstract void depthFirstTraversal(SceneGraphVisitor visitor, DFSMode mode);
 
     /**
      * Visit each scene graph element ordered by BFS


### PR DESCRIPTION
This is a clean rework of an older pull request #170 .
This time with an enum to specify pre-order or post-order and without merge conflicts.