### PR TITLE
Fixes #499: Fix Hardware Skinning in 3.1 

### DIFF
--- a/jme3-core/src/main/java/com/jme3/animation/SkeletonControl.java
+++ b/jme3-core/src/main/java/com/jme3/animation/SkeletonControl.java
@@ -255,7 +255,8 @@ public class SkeletonControl extends AbstractControl implements Cloneable, JmeCl
                     // is operating on this material, in that case, user
                     // is sharing materials between models which is NOT allowed
                     // when hardware skinning used.
-                    throw new UnsupportedOperationException(
+                    
+                    Logger.getLogger(SkeletonControl.class.getName()).log(Level.SEVERE,
                             "Material instances cannot be shared when hardware skinning is used. " +
                             "Ensure all models use unique material instances."
                     );

--- a/jme3-core/src/main/java/com/jme3/material/MatParam.java
+++ b/jme3-core/src/main/java/com/jme3/material/MatParam.java
@@ -309,6 +309,8 @@ When arrays can be inserted in J3M files
         } else if (value instanceof Boolean) {
             Boolean b = (Boolean) value;
             oc.write(b.booleanValue(), "value_bool", false);
+        } else if (value.getClass().isArray() && value instanceof Savable[]) {
+            oc.write((Savable[])value, "value_savable_array", null);
         }
     }
 
@@ -326,6 +328,41 @@ When arrays can be inserted in J3M files
                 break;
             case Int:
                 value = ic.readInt("value_int", 0);
+                break;
+            case Vector2Array:
+                Savable[] savableArray = ic.readSavableArray("value_savable_array", null);
+                if (savableArray != null) {
+                    value = new Vector2f[savableArray.length];
+                    System.arraycopy(savableArray, 0, value, 0, savableArray.length);
+                }
+                break;
+            case Vector3Array:
+                savableArray = ic.readSavableArray("value_savable_array", null);
+                if (savableArray != null) {
+                    value = new Vector3f[savableArray.length];
+                    System.arraycopy(savableArray, 0, value, 0, savableArray.length);
+                }
+                break;
+            case Vector4Array:
+                savableArray = ic.readSavableArray("value_savable_array", null);
+                if (savableArray != null) {
+                    value = new Vector4f[savableArray.length];
+                    System.arraycopy(savableArray, 0, value, 0, savableArray.length);
+                }
+                break;
+            case Matrix3Array:
+                savableArray = ic.readSavableArray("value_savable_array", null);
+                if (savableArray != null) {
+                    value = new Matrix3f[savableArray.length];
+                    System.arraycopy(savableArray, 0, value, 0, savableArray.length);
+                }
+                break;
+            case Matrix4Array:
+                savableArray = ic.readSavableArray("value_savable_array", null);
+                if (savableArray != null) {
+                    value = new Matrix4f[savableArray.length];
+                    System.arraycopy(savableArray, 0, value, 0, savableArray.length);
+                }
                 break;
             default:
                 value = ic.readSavable("value_savable", null);


### PR DESCRIPTION
... by implementing proper Array Serialization for MatParams and making the Shared Materials Check only a warning (it would pop up once each time you load the j3o and if you really use Shared Materials you have weird animations and some log spamming)