### PR TITLE
Finally fixing this

### DIFF
--- a/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.cpp
+++ b/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.cpp
@@ -52,7 +52,9 @@ extern "C" {
         btMotionState* motionState = reinterpret_cast<btMotionState*>(motionstatId);
         btCollisionShape* shape = reinterpret_cast<btCollisionShape*>(shapeId);
         btVector3 localInertia = btVector3();
-        shape->calculateLocalInertia(mass, localInertia);
+	if(mass > 0){
+	        shape->calculateLocalInertia(mass, localInertia);
+	}
         btRigidBody* body = new btRigidBody(mass, motionState, shape, localInertia);
         body->setUserPointer(NULL);
         return reinterpret_cast<jlong>(body);


### PR DESCRIPTION
Long overdue fix for: 

(in short calculating inertia on mass=0 objects can cause NAN depending on compiler parameters, these NAN will contaminate every other float they come in contact with, resulting in suddenly vanishing objects on jme side, as the nan position/rotation cannot be rendered and is outside frustum.

https://hub.jmonkeyengine.org/t/jmonkey-3-1-native-bullet-bug/33595/3
http://www.bulletphysics.org/Bullet/phpBB3/viewtopic.php?p=12158&f=9&t=

Signed-off-by: Kai Boernert <kai-boernert@visiongamestudios.de>