### PR TITLE
Removed warning if scale=1,1,1 in CylinderCollisionShape

### DIFF
--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/CylinderCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/CylinderCollisionShape.java
@@ -86,7 +86,9 @@ public class CylinderCollisionShape extends CollisionShape {
      */
     @Override
     public void setScale(Vector3f scale) {
-        Logger.getLogger(this.getClass().getName()).log(Level.WARNING, "CylinderCollisionShape cannot be scaled");
+    	 if (!scale.equals(Vector3f.UNIT_XYZ)) {
+    		 Logger.getLogger(this.getClass().getName()).log(Level.WARNING, "CylinderCollisionShape cannot be scaled");
+    	 }
     }
 
     public void write(JmeExporter ex) throws IOException {

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/CylinderCollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/CylinderCollisionShape.java
@@ -90,7 +90,9 @@ public class CylinderCollisionShape extends CollisionShape {
      */
     @Override
     public void setScale(Vector3f scale) {
-        Logger.getLogger(this.getClass().getName()).log(Level.WARNING, "CylinderCollisionShape cannot be scaled");
+    	 if (!scale.equals(Vector3f.UNIT_XYZ)) {
+    		 Logger.getLogger(this.getClass().getName()).log(Level.WARNING, "CylinderCollisionShape cannot be scaled");
+    	 }
     }
 
     public void write(JmeExporter ex) throws IOException {


### PR DESCRIPTION
<strike>That method just prints a warning, so from my point of view there is no reason to leave the call there.
EDIT: I want to point out that this is an issue because when cylinder shapes are created frequently the logs are polluted with warnings about scaling when the developer isn't actually trying to scale the shape.</strike>
See below.