### PR TITLE
OpenCL for jME3 - some missing features

### DIFF
--- a/jme3-core/src/main/java/com/jme3/opencl/AbstractOpenCLObject.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/AbstractOpenCLObject.java
@@ -43,8 +43,9 @@ public abstract class AbstractOpenCLObject implements OpenCLObject {
         this.releaser = releaser;
     }
     @Override
-    public void register() {
+    public AbstractOpenCLObject register() {
         OpenCLObjectManager.getInstance().registerObject(this);
+		return this;
     }
     @Override
     public void release() {

--- a/jme3-core/src/main/java/com/jme3/opencl/Buffer.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/Buffer.java
@@ -423,5 +423,10 @@ public abstract class Buffer extends AbstractOpenCLObject {
         //default implementation, overwrite for better performance
         releaseBufferForSharingAsync(queue).release();
     }
-    
+
+	@Override
+	public String toString() {
+		return "Buffer (" + getSize() + "B)";
+	}
+
 }

--- a/jme3-core/src/main/java/com/jme3/opencl/Buffer.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/Buffer.java
@@ -52,6 +52,12 @@ public abstract class Buffer extends AbstractOpenCLObject {
     protected Buffer(ObjectReleaser releaser) {
         super(releaser);
     }
+
+	@Override
+	public Buffer register() {
+		super.register();
+		return this;
+	}
     
     /**
      * @return the size of the buffer in bytes.

--- a/jme3-core/src/main/java/com/jme3/opencl/CommandQueue.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/CommandQueue.java
@@ -43,10 +43,23 @@ package com.jme3.opencl;
  * @author shaman
  */
 public abstract class CommandQueue extends AbstractOpenCLObject {
+	
+	protected Device device;
 
-    protected CommandQueue(ObjectReleaser releaser) {
+    protected CommandQueue(ObjectReleaser releaser, Device device) {
         super(releaser);
+		this.device = device;
     }
+
+	/**
+	 * Returns the device associated with this command queue.
+	 * It can be used to query properties of the device that is used to execute
+	 * the commands issued to this command queue.
+	 * @return the associated device
+	 */
+	public Device getDevice() {
+		return device;
+	}
     
     /**
      * Issues all previously queued OpenCL commands in command_queue to the

--- a/jme3-core/src/main/java/com/jme3/opencl/CommandQueue.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/CommandQueue.java
@@ -51,6 +51,12 @@ public abstract class CommandQueue extends AbstractOpenCLObject {
 		this.device = device;
     }
 
+	@Override
+	public CommandQueue register() {
+		super.register();
+		return this;
+	}
+
 	/**
 	 * Returns the device associated with this command queue.
 	 * It can be used to query properties of the device that is used to execute

--- a/jme3-core/src/main/java/com/jme3/opencl/Context.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/Context.java
@@ -72,6 +72,12 @@ public abstract class Context extends AbstractOpenCLObject {
         super(releaser);
     }
 
+	@Override
+	public Context register() {
+		super.register();
+		return this;
+	}
+
     /**
      * Returns all available devices for this context.
      * These devices all belong to the same {@link Platform}.

--- a/jme3-core/src/main/java/com/jme3/opencl/Context.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/Context.java
@@ -436,4 +436,10 @@ public abstract class Context extends AbstractOpenCLObject {
      * @return the new program
      */
     public abstract Program createProgramFromBinary(ByteBuffer binaries, Device device);
+
+	@Override
+	public String toString() {
+		return "Context (" + getDevices() + ')';
+	}
+
 }

--- a/jme3-core/src/main/java/com/jme3/opencl/Event.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/Event.java
@@ -43,6 +43,12 @@ public abstract class Event extends AbstractOpenCLObject {
     protected Event(ObjectReleaser releaser) {
         super(releaser);
     }
+
+	@Override
+	public Event register() {
+		super.register();
+		return this;
+	}
 	
     /**
      * Waits until the action has finished (blocking).

--- a/jme3-core/src/main/java/com/jme3/opencl/Image.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/Image.java
@@ -532,6 +532,26 @@ memory layout in which channels are stored in the image.
         //default implementation, overwrite it for performance improvements
         releaseImageForSharingAsync(queue).release();
     }
+
+	@Override
+	public String toString() {
+		StringBuilder str = new StringBuilder();
+		str.append("Image (");
+		ImageType t = getImageType();
+		str.append(t);
+		str.append(", w=").append(getWidth());
+		if (t == ImageType.IMAGE_2D || t == ImageType.IMAGE_3D) {
+			str.append(", h=").append(getHeight());
+		}
+		if (t == ImageType.IMAGE_3D) {
+			str.append(", d=").append(getDepth());
+		}
+		if (t == ImageType.IMAGE_1D_ARRAY || t == ImageType.IMAGE_2D_ARRAY) {
+			str.append(", arrays=").append(getArraySize());
+		}
+		str.append(", ").append(getImageFormat());
+		str.append(')');
+		return str.toString();
+	}
     
-    //TODO: add variants of the above two methods that don't create the event object, but release the event immediately
 }

--- a/jme3-core/src/main/java/com/jme3/opencl/Image.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/Image.java
@@ -249,7 +249,13 @@ memory layout in which channels are stored in the image.
     protected Image(ObjectReleaser releaser) {
         super(releaser);
     }
-    
+	
+	@Override
+	public Image register() {
+		super.register();
+		return this;
+	}
+	
     /**
      * @return the width of the image
      */

--- a/jme3-core/src/main/java/com/jme3/opencl/Kernel.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/Kernel.java
@@ -424,7 +424,12 @@ public abstract class Kernel extends AbstractOpenCLObject {
         setArgs(args);
         RunNoEvent(queue);
     }
-    
+
+	@Override
+	public String toString() {
+		return "Kernel (" + getName() + ")";
+	}
+	
     /**
      * A placeholder for kernel arguments representing local kernel memory.
      * This defines the size of available shared memory of a {@code __shared} kernel
@@ -468,6 +473,12 @@ public abstract class Kernel extends AbstractOpenCLObject {
             }
             return true;
         }
+
+		@Override
+		public String toString() {
+			return "LocalMem (" + size + "B)";
+		}
+		
     }
 
     /**
@@ -519,6 +530,12 @@ public abstract class Kernel extends AbstractOpenCLObject {
             }
             return true;
         }
+
+		@Override
+		public String toString() {
+			return "LocalMemPerElement (" + size + "B)";
+		}
+		
     }
 
     /**
@@ -623,6 +640,21 @@ public abstract class Kernel extends AbstractOpenCLObject {
             }
             return true;
         }
+
+		@Override
+		public String toString() {
+			StringBuilder str = new StringBuilder();
+			str.append("WorkSize[");
+			for (int i=0; i<dimension; ++i) {
+				if (i>0) {
+					str.append(", ");
+				}
+				str.append(sizes[i]);
+			}
+			str.append(']');
+			return str.toString();
+		}
+		
     }
     
 }

--- a/jme3-core/src/main/java/com/jme3/opencl/Kernel.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/Kernel.java
@@ -97,6 +97,12 @@ public abstract class Kernel extends AbstractOpenCLObject {
         this.workGroupSize = new WorkSize(0);
     }
 
+	@Override
+	public Kernel register() {
+		super.register();
+		return this;
+	}
+	
     /**
      * @return the name of the kernel as defined in the program source code
      */

--- a/jme3-core/src/main/java/com/jme3/opencl/OpenCLObject.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/OpenCLObject.java
@@ -61,6 +61,7 @@ public interface OpenCLObject {
     ObjectReleaser getReleaser();
     /**
      * Releases this native object.
+	 * 
      * Should delegate to {@code getReleaser().release()}.
      */
     void release();
@@ -70,6 +71,10 @@ public interface OpenCLObject {
      * {@link OpenCLObjectManager}, you have to release it manually 
      * by calling {@link #release() }.
      * Without registering or releasing, a memory leak might occur.
+	 * <br>
+	 * Returns {@code this} to allow calls like
+	 * {@code Buffer buffer = clContext.createBuffer(1024).register();}.
+	 * @return {@code this}
      */
-    void register();
+    OpenCLObject register();
 }

--- a/jme3-core/src/main/java/com/jme3/opencl/Program.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/Program.java
@@ -49,6 +49,12 @@ public abstract class Program extends AbstractOpenCLObject {
     protected Program(ObjectReleaser releaser) {
         super(releaser);
     }
+	
+	@Override
+	public Program register() {
+		super.register();
+		return this;
+	}
     
     /**
      * Builds this program with the specified argument string on the specified

--- a/jme3-examples/src/main/java/jme3test/opencl/TestContextSwitching.java
+++ b/jme3-examples/src/main/java/jme3test/opencl/TestContextSwitching.java
@@ -131,8 +131,7 @@ public class TestContextSwitching extends SimpleApplication implements ScreenCon
         
         if (testBuffer == null && clContext != null && !bufferCreated) {
             try {
-                testBuffer = clContext.createBuffer(1024);
-                testBuffer.register();
+                testBuffer = clContext.createBuffer(1024).register();
                 LOG.info("Test buffer created");
             } catch (OpenCLException ex) {
                 LOG.log(Level.SEVERE, "Unable to create buffer", ex);

--- a/jme3-examples/src/main/java/jme3test/opencl/TestVertexBufferSharing.java
+++ b/jme3-examples/src/main/java/jme3test/opencl/TestVertexBufferSharing.java
@@ -115,8 +115,7 @@ public class TestVertexBufferSharing extends SimpleApplication {
     private void initOpenCL1() {
         clContext = context.getOpenCLContext();
         Device device = clContext.getDevices().get(0);
-        clQueue = clContext.createQueue(device);
-        clQueue.register();
+        clQueue = clContext.createQueue(device).register();
         //create kernel
         Program program = null;
         File tmpFolder = JmeSystem.getStorageFolder();
@@ -156,15 +155,13 @@ public class TestVertexBufferSharing extends SimpleApplication {
             }
             LOG.info("create new program from sources");
         }
-        program.register();
-        kernel = program.createKernel("ScaleKernel");
-        kernel.register();
+		program.register();
+        kernel = program.createKernel("ScaleKernel").register();
     }
     private void initOpenCL2() {
         //bind vertex buffer to OpenCL
         VertexBuffer vb = geom.getMesh().getBuffer(VertexBuffer.Type.Position);
-        buffer = clContext.bindVertexBuffer(vb, MemoryAccess.READ_WRITE);
-        buffer.register();
+        buffer = clContext.bindVertexBuffer(vb, MemoryAccess.READ_WRITE).register();
         ws = new com.jme3.opencl.Kernel.WorkSize(geom.getMesh().getVertexCount());
     }
     private void updateOpenCL(float tpf) {

--- a/jme3-examples/src/main/java/jme3test/opencl/TestWriteToTexture.java
+++ b/jme3-examples/src/main/java/jme3test/opencl/TestWriteToTexture.java
@@ -122,8 +122,7 @@ public class TestWriteToTexture extends SimpleApplication implements AnalogListe
     
     private void initOpenCL1() {
         clContext = context.getOpenCLContext();
-        clQueue = clContext.createQueue();
-        clQueue.register();
+        clQueue = clContext.createQueue().register();
         programCache = new ProgramCache(clContext);
         //create kernel
         String cacheID = getClass().getName()+".Julia";
@@ -135,14 +134,12 @@ public class TestWriteToTexture extends SimpleApplication implements AnalogListe
             programCache.saveToCache(cacheID, program);
         }
         program.register();
-        kernel = program.createKernel("JuliaSet");
-        kernel.register();
+        kernel = program.createKernel("JuliaSet").register();
         C = new Vector2f(0.12f, -0.2f);
     }
     private void initOpenCL2() {
         //bind image to OpenCL
-        texCL = clContext.bindImage(tex, MemoryAccess.WRITE_ONLY);
-        texCL.register();
+        texCL = clContext.bindImage(tex, MemoryAccess.WRITE_ONLY).register();
     }
     private void updateOpenCL(float tpf) {
         //aquire resource

--- a/jme3-jogl/src/main/java/com/jme3/opencl/jocl/JoclCommandQueue.java
+++ b/jme3-jogl/src/main/java/com/jme3/opencl/jocl/JoclCommandQueue.java
@@ -32,11 +32,9 @@
 package com.jme3.opencl.jocl;
 
 import com.jme3.opencl.CommandQueue;
-import com.jme3.opencl.OpenCLObjectManager;
-import com.jogamp.opencl.CLCommandQueue;
+import com.jme3.opencl.Device;
 import com.jogamp.opencl.CLPlatform;
 import com.jogamp.opencl.llb.CL;
-import com.jogamp.opencl.llb.CLCommandQueueBinding;
 
 /**
  *
@@ -47,8 +45,8 @@ public class JoclCommandQueue extends CommandQueue {
     final CL cl;
     final long id;
 
-    public JoclCommandQueue(long id) {
-        super(new ReleaserImpl(id));
+    public JoclCommandQueue(long id, Device device) {
+        super(new ReleaserImpl(id), device);
         this.id = id;
         this.cl = CLPlatform.getLowLevelCLInterface();
     }

--- a/jme3-jogl/src/main/java/com/jme3/opencl/jocl/JoclContext.java
+++ b/jme3-jogl/src/main/java/com/jme3/opencl/jocl/JoclContext.java
@@ -88,7 +88,7 @@ public class JoclContext extends Context {
         long properties = 0;
         long q = cl.clCreateCommandQueue(id, d, properties, Utils.errorBuffer);
         Utils.checkError(Utils.errorBuffer, "clCreateCommandQueue");
-        return new JoclCommandQueue(q);
+        return new JoclCommandQueue(q, device);
     }
     
     @Override

--- a/jme3-jogl/src/main/java/com/jme3/opencl/jocl/JoclPlatform.java
+++ b/jme3-jogl/src/main/java/com/jme3/opencl/jocl/JoclPlatform.java
@@ -124,4 +124,9 @@ public final class JoclPlatform implements Platform {
         return platform.getExtensions();
     }
 
+	@Override
+	public String toString() {
+		return getName();
+	}
+
 }

--- a/jme3-lwjgl/src/main/java/com/jme3/opencl/lwjgl/LwjglCommandQueue.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/opencl/lwjgl/LwjglCommandQueue.java
@@ -32,6 +32,7 @@
 package com.jme3.opencl.lwjgl;
 
 import com.jme3.opencl.CommandQueue;
+import com.jme3.opencl.Device;
 import com.jme3.opencl.OpenCLObjectManager;
 import org.lwjgl.opencl.CL10;
 import org.lwjgl.opencl.CLCommandQueue;
@@ -44,8 +45,8 @@ public class LwjglCommandQueue extends CommandQueue {
 
     private final CLCommandQueue queue;
 
-    public LwjglCommandQueue(CLCommandQueue queue) {
-        super(new ReleaserImpl(queue));
+    public LwjglCommandQueue(CLCommandQueue queue, Device device) {
+        super(new ReleaserImpl(queue), device);
         this.queue = queue;
     }
     

--- a/jme3-lwjgl/src/main/java/com/jme3/opencl/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/opencl/lwjgl/LwjglContext.java
@@ -79,7 +79,7 @@ public class LwjglContext extends Context {
         long properties = 0;
         CLCommandQueue q = CL10.clCreateCommandQueue(context, d, properties, Utils.errorBuffer);
         Utils.checkError(Utils.errorBuffer, "clCreateCommandQueue");
-        return new LwjglCommandQueue(q);
+        return new LwjglCommandQueue(q, device);
     }
     
     @Override

--- a/jme3-lwjgl/src/main/java/com/jme3/opencl/lwjgl/LwjglPlatform.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/opencl/lwjgl/LwjglPlatform.java
@@ -124,4 +124,9 @@ public final class LwjglPlatform implements Platform {
         return Arrays.asList(platform.getInfoString(CL10.CL_PLATFORM_EXTENSIONS).split(" "));
     }
 
+	@Override
+	public String toString() {
+		return getName();
+	}
+
 }

--- a/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/LwjglCommandQueue.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/LwjglCommandQueue.java
@@ -32,6 +32,7 @@
 package com.jme3.opencl.lwjgl;
 
 import com.jme3.opencl.CommandQueue;
+import com.jme3.opencl.Device;
 import org.lwjgl.opencl.CL10;
 
 /**
@@ -42,8 +43,8 @@ public class LwjglCommandQueue extends CommandQueue {
 
     private final long queue;
 
-    public LwjglCommandQueue(long queue) {
-        super(new ReleaserImpl(queue));
+    public LwjglCommandQueue(long queue, Device device) {
+        super(new ReleaserImpl(queue), device);
         this.queue = queue;
     }
     

--- a/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/LwjglContext.java
@@ -79,7 +79,7 @@ public class LwjglContext extends Context {
         long properties = 0;
         long q = CL10.clCreateCommandQueue(context, d, properties, Utils.errorBuffer);
         Utils.checkError(Utils.errorBuffer, "clCreateCommandQueue");
-        return new LwjglCommandQueue(q);
+        return new LwjglCommandQueue(q, device);
     }
     
     @Override

--- a/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/LwjglPlatform.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/LwjglPlatform.java
@@ -125,4 +125,9 @@ public final class LwjglPlatform implements Platform {
         return Arrays.asList(Info.clGetPlatformInfoStringASCII(platform.address(), CL10.CL_PLATFORM_EXTENSIONS).split(" "));
     }
 
+	@Override
+	public String toString() {
+		return getName();
+	}
+
 }


### PR DESCRIPTION
Hi,
after working some time with the wrapper, I found three important missing features that improved the workflow once implemented.

- missing `toString()` methods, useful for debugging
- added getter method for the device in the command queue, necessary e.g. to query the work group size
-  the `register()` methods for the automatic garbage collection of OpenCL objects now returns `this`. This is important so that e.g. `Buffer b = clContext.createBuffer(1).register();` can be written in one line