### PR TITLE
Fix for MTR Framebuffers

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -1675,16 +1675,15 @@ public final class GLRenderer implements Renderer {
                                 + " by the video hardware!");
                     }
 
-                    if (context.boundDrawBuf != MRT_OFF + fb.getNumColorBuffers()) {
-                        intBuf16.clear();
-                        for (int i = 0; i < fb.getNumColorBuffers(); i++) {
-                            intBuf16.put(GLFbo.GL_COLOR_ATTACHMENT0_EXT + i);
-                        }
-
-                        intBuf16.flip();
-                        glext.glDrawBuffers(intBuf16);
-                        context.boundDrawBuf = MRT_OFF + fb.getNumColorBuffers();
+                    intBuf16.clear();
+                    for (int i = 0; i < fb.getNumColorBuffers(); i++) {
+                        intBuf16.put(GLFbo.GL_COLOR_ATTACHMENT0_EXT + i);
                     }
+
+                    intBuf16.flip();
+                    glext.glDrawBuffers(intBuf16);
+                    context.boundDrawBuf = MRT_OFF + fb.getNumColorBuffers();
+                    
                 } else {
                     RenderBuffer rb = fb.getColorBuffer(fb.getTargetIndex());
                     // select this draw buffer


### PR DESCRIPTION
The problem: Happens with two MTR framebuffers with same number of color attachements.
If we set a frame buffer frame1, then later frame2.
r.setFrameBuffer(frame1);
r.setFrameBuffer(frame2);
Frame2 buffer will not output to multiple targets. Only its first target will be rendered.
This patch fixes that problem.