### PR TITLE
Followup to #549: conditional compilation of LWJGL3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 
 jdk:
   - oraclejdk8
+  - oraclejdk7
+  - openjdk7
 
 addons:
   ssh_known_hosts: updates.jmonkeyengine.org

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,9 @@ include 'jme3-desktop'
 include 'jme3-blender'
 include 'jme3-jogl'
 include 'jme3-lwjgl'
-include 'jme3-lwjgl3'
+if (JavaVersion.current().isJava8Compatible()) {
+    include 'jme3-lwjgl3'
+}
 
 // Other external dependencies
 include 'jme3-jbullet'


### PR DESCRIPTION
LWJGL3 is only included int he build process, if the jdk is at least of version 1.8.
The travis build is edited so that it tests against Java7 and Java8.

This is the followup to pull request #549.
