### PR TITLE
recursively detects improperly modified spatials

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Node.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Node.java
@@ -809,15 +809,15 @@ public class Node extends Spatial {
       if (refreshFlags != 0) {
         ArrayList<Spatial> aspt = recursiveFindModifications(null);
         
-        String strSpatialNames = getName();
+        String strSpatialDebugNames = getDebugName();
         for(Spatial spt : aspt){
-          strSpatialNames+=","+spt.getName();
+          strSpatialDebugNames+=","+spt.getDebugName();
         }
         
         throw new IllegalStateException("Scene graph is not properly updated for rendering.\n"
           + "State was changed after rootNode.updateGeometricState() call. \n"
           + "Make sure you do not modify the scene from another thread!\n"
-          + "Problem spatial name(s): " + strSpatialNames);
+          + "Problem spatial DEBUG name(s): " + strSpatialDebugNames);
       }
       
       return super.checkCulling(cam);

--- a/jme3-core/src/main/java/com/jme3/scene/Spatial.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Spatial.java
@@ -391,19 +391,42 @@ public abstract class Spatial implements Savable, Cloneable, Collidable, Cloneab
      * @param name
      *            The spatial's new name.
      */
+    @Deprecated
     public void setName(String name) {
         this.name = name;
     }
-
+    
+    /**
+     * Sets the DEBUG name of this spatial.
+     * Use solely for DEBUG purposes.
+     *
+     * @param name
+     *            The spatial's new DEBUG name.
+     */
+    public void setDebugName(String debugName) {
+      this.name = debugName;
+    }
+    
     /**
      * Returns the name of this spatial.
      *
      * @return This spatial's name.
      */
+    @Deprecated
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns the DEBUG name of this spatial.
+     * Use solely for DEBUG purposes.
+     *
+     * @return This spatial's DEBUG name.
+     */
+    public String getDebugName() {
+        return name;
+    }
+    
     /**
      * Returns the local {@link LightList}, which are the lights
      * that were directly attached to this <code>Spatial</code> through the


### PR DESCRIPTION
It will look for all improperly modified spatials and show enough information to let the developer more precisely identify the problem from [here](https://hub.jmonkeyengine.org/t/a-more-precise-exception-report-about-modifying-the-scene-from-another-thread/34982).

Obs.: the second/newest commit is a proposal clarification method naming deprecation (so nothing will break) basically in favor of:
/* use only for debug purposes */
Spatial.getDebugName() 