### PR TITLE
Fixes tab stops in BitmapText / BitmapFont (3.1)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/font/BitmapFont.java
+++ b/jme3-core/src/main/java/com/jme3/font/BitmapFont.java
@@ -86,6 +86,8 @@ public class BitmapFont implements Savable {
         Bottom
     }
 
+    static final float DEFAULT_TAB_WIDTH = 50.0f;
+
     private BitmapCharacterSet charSet;
     private Material[] pages;
 
@@ -215,6 +217,11 @@ public class BitmapFont implements Savable {
                 firstCharOfLine = true;
                 continue;
             }
+            if(theChar == '\t') {
+                lineWidth = (float)Math.floor(lineWidth / DEFAULT_TAB_WIDTH) * DEFAULT_TAB_WIDTH;
+                lineWidth += DEFAULT_TAB_WIDTH;
+            }
+
             BitmapCharacter c = charSet.getCharacter((int) theChar);
             if (c != null){
                 if (theChar == '\\' && i<text.length()-1 && text.charAt(i+1)=='#'){

--- a/jme3-core/src/main/java/com/jme3/font/BitmapText.java
+++ b/jme3-core/src/main/java/com/jme3/font/BitmapText.java
@@ -369,7 +369,9 @@ public class BitmapText extends Node {
     }
 
     /**
-     * @param tabs tab positions
+     * Sets the positions at where the text continues after a tab character.<br>
+     * These tab stops need to be sorted from smallest to biggest value.
+     * @param tabs Sorted tab positions. Use <code>null</code> to reset tab positions.
      */
     public void setTabPosition(float... tabs) {
         block.setTabPosition(tabs);
@@ -378,7 +380,9 @@ public class BitmapText extends Node {
     }
 
     /**
-     * used for the tabs over the last tab position.
+     * Used for all tabs after the last custom tab position
+     * (see {@link #setTabPosition(float...) setTabPosition}).<br>
+     * This value is also used when no custom tab positions are set.
      * @param width tab size
      */
     public void setTabWidth(float width) {

--- a/jme3-core/src/main/java/com/jme3/font/LetterQuad.java
+++ b/jme3-core/src/main/java/com/jme3/font/LetterQuad.java
@@ -306,8 +306,6 @@ class LetterQuad {
     }
 
     void update(StringBlock block) {
-        final float[] tabs = block.getTabPosition();
-        final float tabWidth = block.getTabWidth();
         final Rectangle bound = getBound(block);
         sizeScale = block.getSize() / font.getCharSet().getRenderedSize();
         lineY = computeLineY(block);
@@ -320,16 +318,9 @@ class LetterQuad {
             xAdvance = 0;
         } else if (isTab()) {
             x0 = previous.getNextX();
-            width = tabWidth;
+            width = block.calcNextTabPosition(x0) - x0;
             y0 = lineY;
             height = 0;
-            if (tabs != null && x0 < tabs[tabs.length-1]) {
-                for (int i = 0; i < tabs.length-1; i++) {
-                    if (x0 > tabs[i] && x0 < tabs[i+1]) {
-                        width = tabs[i+1] - x0;
-                    }
-                }
-            }
             xAdvance = width;
         } else if (bitmapChar == null) {
             x0 = getPrevious().getX1();

--- a/jme3-core/src/main/java/com/jme3/font/StringBlock.java
+++ b/jme3-core/src/main/java/com/jme3/font/StringBlock.java
@@ -53,7 +53,7 @@ class StringBlock implements Cloneable {
     private int lineCount;
     private LineWrapMode wrapType = LineWrapMode.Word;
     private float[] tabPos;
-    private float tabWidth = 50;
+    private float tabWidth = BitmapFont.DEFAULT_TAB_WIDTH;
     private char ellipsisChar = 0x2026;
 
     /**
@@ -91,6 +91,7 @@ class StringBlock implements Cloneable {
             clone.color = color.clone();
             if (textBox != null)
                 clone.textBox = textBox.clone();
+            // tabPos is read-only and replaced on write.
             return clone;
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
@@ -172,22 +173,6 @@ class StringBlock implements Cloneable {
     void setLineWrapMode(LineWrapMode wrap) {
         this.wrapType = wrap;
     }
-    
-    void setTabWidth(float tabWidth) {
-        this.tabWidth = tabWidth;
-    }
-
-    void setTabPosition(float[] tabs) {
-        this.tabPos = tabs;
-    }
-    
-    float getTabWidth() {
-        return tabWidth;
-    }
-    
-    float[] getTabPosition() {
-        return tabPos;
-    }
 
     void setEllipsisChar(char c) {
         this.ellipsisChar = c;
@@ -195,5 +180,31 @@ class StringBlock implements Cloneable {
 
     int getEllipsisChar() {
         return ellipsisChar;
+    }
+    
+    void setTabWidth(float tabWidth) {
+        this.tabWidth = tabWidth;
+    }
+
+    void setTabPosition(float[] tabs) {
+        if(tabs != null && tabs.length > 0) {
+            this.tabPos = tabs.clone();
+        } else {
+            this.tabPos = null;
+        }
+    }
+
+    float calcNextTabPosition(float posX) {
+        // If there is an upcoming user-set tab stop, use that one.
+        if (tabPos != null && posX < tabPos[tabPos.length-1]) {
+            for (int i = 0; i < tabPos.length; i++) {
+                if (posX < tabPos[i]) {
+                    return tabPos[i];
+                }
+            }
+        }
+
+        // No upcoming tab stops available, use default tab width.
+        return (float)Math.floor(posX / tabWidth) * tabWidth + tabWidth;
     }
 }


### PR DESCRIPTION
The first explicitly set tab stop was always skipped. For all non-explicitly set tab stops it inserted a fixed spacing. This commit changes the behaviour so tabs are aligned to columns.
It also adds handling of tabs to BitmapFont.getLineWidth() which ignored tabs before.

[This was discussed in the forum.](https://hub.jmonkeyengine.org/t/tabs-in-bitmaptext/37495).
I made a pull request so this isn't forgotten.

Explanation of changes:
- BitmapFont: Added a constant DEFAULT_TAB_WIDTH. It is package private to not pollute namespace. Also added handling of tabs to getLineWidth().

- BitmapText: Only changed Javadoc. An important precondition is that the tab positions are sorted. I refrained from adding an Arrays.sort() call because the user shouldn't pay for what he doesn't need.

- LetterQuad: Removed faulty tab width calculation. It's in StringBlock now.

- StringBlock: Uses DEFAULT_TAB_WIDTH constant when instantiated. Removed the getters for tabWidth/tabPos. Added calculation of tab position at the bottom. The only way "tabPos" can leave this class now is through cloning. But since the array-reference is overwritten in setTabPosition(), it can safely be shared across cloned instances. The tabPos array is cloned in the setter to prevent modifications through the original reference.