### PR TITLE
Added a method for changing a name of an animation.

### DIFF
--- a/jme3-core/src/main/java/com/jme3/animation/Animation.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Animation.java
@@ -85,6 +85,15 @@ public class Animation implements Savable, Cloneable, JmeCloneable {
     }
 
     /**
+     * Changes the name of the bone animation.
+     *
+     * @param name the new name.
+     */
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    /**
      * Returns the length in seconds of this animation
      * 
      * @return the length in seconds of this animation


### PR DESCRIPTION
It needs to support name editing in my editor and I can't see any reasons why not. SDK uses a strange method for name editing:
```
                    Animation anim = control.getAnim(oldName);
                    Animation newAnim = new Animation(newName, anim.getLength());
                    newAnim.setTracks(anim.getTracks());
                    control.removeAnim(anim);
                    control.addAnim(newAnim);
```