### PR TITLE
Added a method for changing a name of an animation.

### DIFF
--- a/jme3-core/src/main/java/com/jme3/animation/AnimControl.java
+++ b/jme3-core/src/main/java/com/jme3/animation/AnimControl.java
@@ -41,6 +41,7 @@ import com.jme3.renderer.ViewPort;
 import com.jme3.scene.Spatial;
 import com.jme3.scene.control.AbstractControl;
 import com.jme3.scene.control.Control;
+import com.jme3.system.Annotations.Internal;
 import com.jme3.util.TempVars;
 import com.jme3.util.clone.Cloner;
 import com.jme3.util.clone.JmeCloneable;
@@ -211,6 +212,7 @@ public final class AnimControl extends AbstractControl implements Cloneable, Jme
      * @param prevName the previous name of an animation.
      * @param newName  the new name of an animation.
      */
+    @Internal
     public void changeAnimName(String prevName, String newName) {
 
         if (!animationMap.containsKey(prevName)) {

--- a/jme3-core/src/main/java/com/jme3/animation/AnimControl.java
+++ b/jme3-core/src/main/java/com/jme3/animation/AnimControl.java
@@ -31,16 +31,20 @@
  */
 package com.jme3.animation;
 
-import com.jme3.export.*;
+import com.jme3.export.InputCapsule;
+import com.jme3.export.JmeExporter;
+import com.jme3.export.JmeImporter;
+import com.jme3.export.OutputCapsule;
+import com.jme3.export.Savable;
 import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.ViewPort;
-import com.jme3.scene.Mesh;
 import com.jme3.scene.Spatial;
 import com.jme3.scene.control.AbstractControl;
 import com.jme3.scene.control.Control;
+import com.jme3.util.TempVars;
 import com.jme3.util.clone.Cloner;
 import com.jme3.util.clone.JmeCloneable;
-import com.jme3.util.TempVars;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -199,6 +203,30 @@ public final class AnimControl extends AbstractControl implements Cloneable, Jme
         }
 
         animationMap.remove(anim.getName());
+    }
+
+    /**
+     * Changes a name of an animation in this control.
+     *
+     * @param prevName the previous name of an animation.
+     * @param newName  the new name of an animation.
+     */
+    public void changeAnimName(String prevName, String newName) {
+
+        if (!animationMap.containsKey(prevName)) {
+            throw new IllegalArgumentException("Given animation does not exist "
+                    + "in this AnimControl");
+        }
+
+        if (animationMap.containsKey(newName)) {
+            throw new IllegalArgumentException("The same animation exist "
+                    + "in this AnimControl");
+        }
+
+        final Animation animation = animationMap.remove(prevName);
+        animation.setName(newName);
+
+        animationMap.put(newName, animation);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/animation/Animation.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Animation.java
@@ -31,12 +31,17 @@
  */
 package com.jme3.animation;
 
-import com.jme3.export.*;
+import com.jme3.export.InputCapsule;
+import com.jme3.export.JmeExporter;
+import com.jme3.export.JmeImporter;
+import com.jme3.export.OutputCapsule;
+import com.jme3.export.Savable;
 import com.jme3.scene.Spatial;
 import com.jme3.util.SafeArrayList;
 import com.jme3.util.TempVars;
 import com.jme3.util.clone.Cloner;
 import com.jme3.util.clone.JmeCloneable;
+
 import java.io.IOException;
 
 /**

--- a/jme3-core/src/main/java/com/jme3/animation/Animation.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Animation.java
@@ -85,6 +85,15 @@ public class Animation implements Savable, Cloneable, JmeCloneable {
     }
 
     /**
+     * Changes the name of the bone animation.
+     *
+     * @param name the new name.
+     */
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    /**
      * Returns the length in seconds of this animation
      * 
      * @return the length in seconds of this animation

--- a/jme3-core/src/main/java/com/jme3/animation/Animation.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Animation.java
@@ -37,6 +37,7 @@ import com.jme3.export.JmeImporter;
 import com.jme3.export.OutputCapsule;
 import com.jme3.export.Savable;
 import com.jme3.scene.Spatial;
+import com.jme3.system.Annotations.Internal;
 import com.jme3.util.SafeArrayList;
 import com.jme3.util.TempVars;
 import com.jme3.util.clone.Cloner;
@@ -94,6 +95,7 @@ public class Animation implements Savable, Cloneable, JmeCloneable {
      *
      * @param name the new name.
      */
+    @Internal
     public void setName(final String name) {
         this.name = name;
     }


### PR DESCRIPTION
It needs to support name editing in my editor and I can't see any reasons why not. SDK uses a strange method for name editing:
```
                    Animation anim = control.getAnim(oldName);
                    Animation newAnim = new Animation(newName, anim.getLength());
                    newAnim.setTracks(anim.getTracks());
                    control.removeAnim(anim);
                    control.addAnim(newAnim);
```