### PR TITLE
Changed isUnitVector method on Vector3f to use lengthSquared

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -416,7 +416,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * or false otherwise.
      */
     public boolean isUnitVector(){
-        float len = length();
+        float len = lengthSquared();
         return 0.99f < len && len < 1.01f;
     }
 


### PR DESCRIPTION
Currently, Vector3f's isUnitVector() method is using length() instead of lengthSquared(), thus, a useless sqrt calculation.