### PR TITLE
fix errors in how vector projection is calculated

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2017 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -392,7 +392,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     public Vector3f project(Vector3f other){
         float n = this.dot(other); // A . B
         float d = other.lengthSquared(); // |B|^2
-        return new Vector3f(other).normalizeLocal().multLocal(n/d);
+        return new Vector3f(other).multLocal(n/d);
     }
 
     /**
@@ -405,7 +405,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     public Vector3f projectLocal(Vector3f other){
         float n = this.dot(other); // A . B
         float d = other.lengthSquared(); // |B|^2
-        return set(other).normalizeLocal().multLocal(n/d);
+        return set(other).multLocal(n/d);
     }
     
     /**

--- a/jme3-core/src/main/java/com/jme3/math/Vector4f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector4f.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2017 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -317,7 +317,7 @@ public final class Vector4f implements Savable, Cloneable, java.io.Serializable 
     public Vector4f project(Vector4f other){
         float n = this.dot(other); // A . B
         float d = other.lengthSquared(); // |B|^2
-        return new Vector4f(other).normalizeLocal().multLocal(n/d);
+        return new Vector4f(other).multLocal(n/d);
     }
 
     /**


### PR DESCRIPTION
same diff I committed to 'master' on Jan 14, 2017
Without this change, the magnitude of the project() result is incorrect unless 'other' is a unit vector.