### PR TITLE
Removed the override that avoided a CompoundCollisionShape to be scaled

### DIFF
--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/CompoundCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/CompoundCollisionShape.java
@@ -119,14 +119,6 @@ public class CompoundCollisionShape extends CollisionShape {
         return children;
     }
 
-    /**
-     * WARNING - CompoundCollisionShape scaling has no effect.
-     */
-    @Override
-    public void setScale(Vector3f scale) {
-        Logger.getLogger(this.getClass().getName()).log(Level.WARNING, "CompoundCollisionShape cannot be scaled");
-    }
-
     private native long createShape();
     
     private native long addChildShape(long objectId, long childId, Vector3f location, Matrix3f rotation);


### PR DESCRIPTION
There is no explanation why this should be required, and NemesisMate says he tested it, and could not reproduce some of the older issues. It might have been solved with changes since then.