### PR TITLE
fix mixed up javadoc description of euler angles

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -217,7 +217,7 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
 
     /**
      * <code>fromAngles</code> builds a quaternion from the Euler rotation
-     * angles (y,r,p).
+     * angles (pitch,yaw,roll).
      *
      * @param angles
      *            the Euler angles of rotation (in radians).
@@ -233,8 +233,7 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
 
     /**
      * <code>fromAngles</code> builds a Quaternion from the Euler rotation
-     * angles (x,y,z) aka (pitch, yaw, rall)). Note that we are applying in order: (y, z, x) aka (yaw, roll, pitch) but
-     * we've ordered them in x, y, and z for convenience.
+     * angles (x,y,z) aka (pitch,yaw,roll).
      * @see <a href="http://www.euclideanspace.com/maths/geometry/rotations/conversions/eulerToQuaternion/index.htm">http://www.euclideanspace.com/maths/geometry/rotations/conversions/eulerToQuaternion/index.htm</a>
      * 
      * @param xAngle
@@ -277,7 +276,7 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
 
     /**
      * <code>toAngles</code> returns this quaternion converted to Euler
-     * rotation angles (yaw,roll,pitch).<br/>
+     * rotation angles (pitch,yaw,roll).<br/>
      * Note that the result is not always 100% accurate due to the implications of euler angles.
      * @see <a href="http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/index.htm">http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/index.htm</a>
      * 

--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -233,7 +233,8 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
 
     /**
      * <code>fromAngles</code> builds a Quaternion from the Euler rotation
-     * angles (x,y,z) aka (pitch,yaw,roll).
+     * angles (x,y,z) aka (pitch,yaw,roll). Note that we are applying in order: (y,z,x) aka (yaw,roll,pitch) but
+     * we've ordered them in x, y, and z for convenience.
      * @see <a href="http://www.euclideanspace.com/maths/geometry/rotations/conversions/eulerToQuaternion/index.htm">http://www.euclideanspace.com/maths/geometry/rotations/conversions/eulerToQuaternion/index.htm</a>
      * 
      * @param xAngle

--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -308,9 +308,9 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
             angles[2] = -FastMath.HALF_PI;
             angles[0] = 0;
         } else {
-            angles[1] = FastMath.atan2(2 * y * w - 2 * x * z, sqx - sqy - sqz + sqw); // roll or heading 
-            angles[2] = FastMath.asin(2 * test / unit); // pitch or attitude
-            angles[0] = FastMath.atan2(2 * x * w - 2 * y * z, -sqx + sqy - sqz + sqw); // yaw or bank
+            angles[1] = FastMath.atan2(2 * y * w - 2 * x * z, sqx - sqy - sqz + sqw);
+            angles[2] = FastMath.asin(2 * test / unit);
+            angles[0] = FastMath.atan2(2 * x * w - 2 * y * z, -sqx + sqy - sqz + sqw);
         }
         return angles;
     }


### PR DESCRIPTION
I've noticed that the javadoc of the euler angle methods was incorrect and confusing, so I created this PR

- remove confusing description to fromAngles()
- fix incorrect description of toAngles()
- fix typo rall => roll