### PR TITLE
fixed a problem with converting blend file when there are unsupported…

### DIFF
--- a/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/textures/TextureHelper.java
+++ b/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/textures/TextureHelper.java
@@ -42,6 +42,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.jme3.asset.AssetInfo;
+import com.jme3.asset.AssetLoadException;
 import com.jme3.asset.AssetManager;
 import com.jme3.asset.AssetNotFoundException;
 import com.jme3.asset.BlenderKey;
@@ -486,7 +487,7 @@ public class TextureHelper extends AbstractBlenderHelper {
                 key.setGenerateMips(generateMipmaps);
                 result = assetManager.loadTexture(key);
                 result.setKey(key);
-            } catch (AssetNotFoundException e) {
+            } catch (AssetNotFoundException | AssetLoadException e) {
                 LOGGER.fine(e.getLocalizedMessage());
             }
         } else {
@@ -522,7 +523,7 @@ public class TextureHelper extends AbstractBlenderHelper {
                         // If texture is found return it;
                         return result;
                     }
-                } catch (AssetNotFoundException e) {
+                } catch (AssetNotFoundException | AssetLoadException e) {
                     LOGGER.fine(e.getLocalizedMessage());
                 }
             }
@@ -532,7 +533,7 @@ public class TextureHelper extends AbstractBlenderHelper {
             try {
                 TextureKey key = new TextureKey(name);
                 assetManager.loadTexture(key);
-            } catch (AssetNotFoundException e) {
+            } catch (AssetNotFoundException | AssetLoadException e) {
                 LOGGER.fine(e.getLocalizedMessage());
             }
         }


### PR DESCRIPTION
Fixed a problem with converting blend file when there are unsupported textures.
for example:
Caused by: com.jme3.asset.AssetLoadException: No loader registered for type "psd"
	at com.jme3.asset.ImplHandler.aquireLoader(ImplHandler.java:200)
	at com.jme3.asset.DesktopAssetManager.loadLocatedAsset(DesktopAssetManager.java:255)
	at com.jme3.asset.DesktopAssetManager.loadAsset(DesktopAssetManager.java:373)
	at com.jme3.asset.DesktopAssetManager.loadTexture(DesktopAssetManager.java:390)
	at com.jme3.scene.plugins.blender.textures.TextureHelper.loadImageFromFile(TextureHelper.java:518)
	at com.jme3.scene.plugins.blender.textures.TextureHelper.loadImageAsTexture(TextureHelper.java:244)
	at com.jme3.scene.plugins.blender.BlenderLoader.load(BlenderLoader.java:133)
	... 7 more