### PR TITLE
add PointSize to Unshaded matdef, test with SkeletonDebugger

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/debug/SkeletonInterBoneWire.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/SkeletonInterBoneWire.java
@@ -73,7 +73,6 @@ public class SkeletonInterBoneWire extends Mesh {
         }
 
         this.setMode(Mode.Points);
-        this.setPointSize(1);
         this.boneLengths = boneLengths;
 
         VertexBuffer pb = new VertexBuffer(Type.Position);

--- a/jme3-core/src/main/java/com/jme3/scene/debug/SkeletonPoints.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/SkeletonPoints.java
@@ -84,7 +84,6 @@ public class SkeletonPoints extends Mesh {
         pb.setupData(Usage.Stream, 3, Format.Float, fpb);
         this.setBuffer(pb);
 
-        this.setPointSize(7);
         this.updateCounts();
 
     }

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.j3md
@@ -5,6 +5,7 @@ MaterialDef Unshaded {
         Texture2D LightMap
         Color Color (Color)
         Boolean VertexColor (UseVertexColor)
+        Float PointSize : 1.0
         Boolean SeparateTexCoord
 
         // Texture of the glowing parts of the material
@@ -71,6 +72,7 @@ MaterialDef Unshaded {
             HAS_COLORMAP : ColorMap
             HAS_LIGHTMAP : LightMap
             HAS_VERTEXCOLOR : VertexColor
+            HAS_POINTSIZE : PointSize
             HAS_COLOR : Color
             NUM_BONES : NumberOfBones
             DISCARD_ALPHA : AlphaDiscardThreshold
@@ -176,6 +178,7 @@ MaterialDef Unshaded {
             HAS_GLOWCOLOR : GlowColor
             NUM_BONES : NumberOfBones
 	    INSTANCING : UseInstancing
+            HAS_POINTSIZE : PointSize
         }
     }
 }

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.vert
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.vert
@@ -16,7 +16,9 @@ varying vec2 texCoord1;
 varying vec2 texCoord2;
 
 varying vec4 vertColor;
-uniform float m_PointSize;
+#ifdef HAS_POINTSIZE
+    uniform float m_PointSize;
+#endif
 
 void main(){
     #ifdef NEED_TEXCOORD1

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.vert
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.vert
@@ -16,6 +16,7 @@ varying vec2 texCoord1;
 varying vec2 texCoord2;
 
 varying vec4 vertColor;
+uniform float m_PointSize;
 
 void main(){
     #ifdef NEED_TEXCOORD1
@@ -28,6 +29,10 @@ void main(){
 
     #ifdef HAS_VERTEXCOLOR
         vertColor = inColor;
+    #endif
+
+    #ifdef HAS_POINTSIZE
+        gl_PointSize = m_PointSize;
     #endif
 
     vec4 modelSpacePos = vec4(inPosition, 1.0);

--- a/jme3-examples/src/main/java/jme3test/model/anim/TestAnimBlendBug.java
+++ b/jme3-examples/src/main/java/jme3test/model/anim/TestAnimBlendBug.java
@@ -115,7 +115,8 @@ public class TestAnimBlendBug extends SimpleApplication implements ActionListene
         SkeletonDebugger skeletonDebug = new SkeletonDebugger("skeleton1", control1.getSkeleton());
         Material mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
         mat.getAdditionalRenderState().setWireframe(true);
-        mat.setColor("Color", ColorRGBA.Green);
+        mat.setColor("Color", ColorRGBA.Red);
+        mat.setFloat("PointSize", 7f);
         mat.getAdditionalRenderState().setDepthTest(false);
         skeletonDebug.setMaterial(mat);
         model1.attachChild(skeletonDebug);

--- a/jme3-examples/src/main/java/jme3test/model/anim/TestOgreComplexAnim.java
+++ b/jme3-examples/src/main/java/jme3test/model/anim/TestOgreComplexAnim.java
@@ -106,6 +106,7 @@ public class TestOgreComplexAnim extends SimpleApplication {
         Material mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
         mat.getAdditionalRenderState().setWireframe(true);
         mat.setColor("Color", ColorRGBA.Green);
+        mat.setFloat("PointSize", 7f);
         mat.getAdditionalRenderState().setDepthTest(false);
         skeletonDebug.setMaterial(mat);
 


### PR DESCRIPTION
In 3.0, SkeletonDebugger used Mesh.setPointSize() to highlight the joints. Now that setPointSize() is disabled, users of SkeletonDebugger need materials that set gl_PointSize. In JmeTests, SkeletonDebugger is always used with Unshaded.j3md, so that seems the logical place for it.