### PR TITLE
Version 3.1.0 is now stable, both for the SDK and the Engine itself.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ jMonkeyEngine
 
 [![Build Status](https://travis-ci.org/jMonkeyEngine/jmonkeyengine.svg?branch=master)](https://travis-ci.org/jMonkeyEngine/jmonkeyengine)
 
-jMonkeyEngine is a 3D game engine for adventurous Java developers. It’s open source, cross platform and cutting edge. And it is all beautifully documented. The 3.0 branch is the latest stable version of the jMonkeyEngine 3 SDK, a complete game development suite. We'll be frequently submitting stable 3.0.x updates until the major 3.1 version arrives.
+jMonkeyEngine is a 3D game engine for adventurous Java developers. It’s open-source, cross-platform, and cutting-edge. 3.1.0 is the latest stable version of the jMonkeyEngine 3 SDK, a complete game development suite. We'll release 3.1.x updates until the major 3.2 release arrives.
 
 The engine is used by several commercial game studios and computer-science courses. Here's a taste:
 


### PR DESCRIPTION
Now that 3.1.0 is stable, the master README.md can stop pointing people toward the 3.0.10 release.