### PR TITLE
Weakens the flag tests in DDSLoader: some textures lack the DDSCAPS_TEXTURE flag

### DIFF
--- a/jme3-core/src/plugins/java/com/jme3/texture/plugins/DDSLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/texture/plugins/DDSLoader.java
@@ -203,9 +203,9 @@ public class DDSLoader implements AssetLoader {
         texture3D = false;
 
         if (!directx10) {
-            if (!is(caps1, DDSCAPS_TEXTURE)) {
-                throw new IOException("File is not a texture");
-            }
+//            if (!is(caps1, DDSCAPS_TEXTURE)) {
+//                throw new IOException("File is not a texture");
+//            }
 
             if (depth <= 0) {
                 depth = 1;

--- a/jme3-core/src/plugins/java/com/jme3/texture/plugins/DDSLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/texture/plugins/DDSLoader.java
@@ -204,8 +204,7 @@ public class DDSLoader implements AssetLoader {
 
         if (!directx10) {
             if (!is(caps1, DDSCAPS_TEXTURE)) {
-				logger.warning("Texture is missing the DDSCAPS_TEXTURE-flag");
-//                throw new IOException("File is not a texture");
+                logger.warning("Texture is missing the DDSCAPS_TEXTURE-flag");
             }
 
             if (depth <= 0) {

--- a/jme3-core/src/plugins/java/com/jme3/texture/plugins/DDSLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/texture/plugins/DDSLoader.java
@@ -203,9 +203,10 @@ public class DDSLoader implements AssetLoader {
         texture3D = false;
 
         if (!directx10) {
-//            if (!is(caps1, DDSCAPS_TEXTURE)) {
+            if (!is(caps1, DDSCAPS_TEXTURE)) {
+				logger.warning("Texture is missing the DDSCAPS_TEXTURE-flag");
 //                throw new IOException("File is not a texture");
-//            }
+            }
 
             if (depth <= 0) {
                 depth = 1;


### PR DESCRIPTION
Certain dds texture lack the DDSCAPS_TEXTURE-flag, but are still recognized by programs like IrfanView and can also be loaded in the engine.
This commit weakens the check for this flag: Instead of throwing an exception, a warning is logged.

See the attached dds file in the zip for an example of a dds texture that lacks that flag.
With this change, this texture can be loaded normally.
[tiles3.dds.zip](https://github.com/jMonkeyEngine/jmonkeyengine/files/907751/tiles3.dds.zip)

