### PR TITLE
NullContext thread safety

### DIFF
--- a/jme3-core/src/main/java/com/jme3/system/NullContext.java
+++ b/jme3-core/src/main/java/com/jme3/system/NullContext.java
@@ -96,8 +96,8 @@ public class NullContext implements JmeContext, Runnable {
         }
     }
 
-    private static long timeThen;
-    private static long timeLate;
+    private long timeThen;
+    private long timeLate;
 
     public void sync(int fps) {
         long timeNow;


### PR DESCRIPTION
The fields `timeThen` and  `timeLate` are static. If multiple Applications are launched in different threads in headless mode, sync fails. This can be fixed removing the static modifier of the fields.