### PR TITLE
Fixed infinite loop for context.

### DIFF
--- a/jme3-examples/src/main/java/jme3test/TestChooser.java
+++ b/jme3-examples/src/main/java/jme3test/TestChooser.java
@@ -271,16 +271,23 @@ public class TestChooser extends JDialog {
                 			    Field contextField = LegacyApplication.class.getDeclaredField("context");
                 			    contextField.setAccessible(true);
                 			    JmeContext context = null; 
-                			    while (context == null) {
-                			        context = (JmeContext) contextField.get(app);
-                			        Thread.sleep(100);
-                			    }
-                			    while (!context.isCreated()) {
-                			        Thread.sleep(100);
-                			    }
-                			    while (context.isCreated()) {
-                			        Thread.sleep(100);
-                			    }
+                			    int count = 0;
+                                while (context == null) {
+                                    context = (JmeContext) contextField.get(app);
+                                    Thread.sleep(100);
+                                    count++;
+                                    if (count >= 20) {
+                                        break;
+                                    }
+                                }
+                                if (context != null) {
+                                    while (!context.isCreated()) {
+                                        Thread.sleep(100);
+                                    }
+                                    while (context.isCreated()) {
+                                    Thread.sleep(100);
+                                    }
+                                }
                 			} else {
                                 final Method mainMethod = clazz.getMethod("main", (new String[0]).getClass());
                                 mainMethod.invoke(clazz, new Object[]{new String[0]});


### PR DESCRIPTION
Fix to prevent infinite loop caused when user cancels SettingsDialog rather than continuing, which prevents context from being set for selected app. If user cancels give context 2 seconds.

Edit: Forgot to include the link to forum post.
https://hub.jmonkeyengine.org/t/testchooser-infinite-loop/38500