### PR TITLE
Updated KeyListener for enter and escape.

### DIFF
--- a/jme3-examples/src/main/java/jme3test/TestChooser.java
+++ b/jme3-examples/src/main/java/jme3test/TestChooser.java
@@ -343,16 +343,28 @@ public class TestChooser extends JDialog {
                 }
             }
         });
-        list.addKeyListener(new KeyAdapter() {
+        //For key typed events, the getKeyCode method always returns VK_UNDEFINED.
+        //Use Key Bindings instead.
+        Action doEnter = new AbstractAction() {
             @Override
-            public void keyTyped(KeyEvent e) {
-                if (e.getKeyCode() == KeyEvent.VK_ENTER) {
-                    startApp(selectedClass);
-                } else if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
-                    dispose();
-                }
+            public void actionPerformed(ActionEvent e) {
+                startApp(selectedClass);
             }
-        });
+        };
+        KeyStroke enterKey = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0);
+        list.getInputMap().put(enterKey, "doEnter");
+        list.getActionMap().put("doEnter", doEnter);
+        //For key typed events, the getKeyCode method always returns VK_UNDEFINED.         
+        //Use Key Bindings instead.
+        Action doEscape = new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                dispose();
+            }
+        };
+        KeyStroke escapeKey = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
+        list.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(escapeKey, "doEscape");
+        list.getActionMap().put("doEscape", doEscape);
 
         final JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
         mainPanel.add(buttonPanel, BorderLayout.PAGE_END);


### PR DESCRIPTION
Listener does not work for newer versions of java. For key typed events, the getKeyCode method always returns VK_UNDEFINED so e.getKeyCode() == KeyEvent.VK_ENTER and e.getKeyCode() == KeyEvent.VK_ESCAPE will never be true.

Edit: Forgot to include the forum post.
https://hub.jmonkeyengine.org/t/testchooser-infinite-loop/38500