### PR TITLE
Fixed IllegalArgumentException when removing a LodControl from a spatial

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/control/LodControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/LodControl.java
@@ -121,17 +121,23 @@ public class LodControl extends AbstractControl implements Cloneable, JmeCloneab
 
     @Override
     public void setSpatial(Spatial spatial) {
-        if (!(spatial instanceof Geometry)) {
+        if (spatial != null && !(spatial instanceof Geometry)) {
             throw new IllegalArgumentException("LodControl can only be attached to Geometry!");
         }
 
         super.setSpatial(spatial);
-        Geometry geom = (Geometry) spatial;
-        Mesh mesh = geom.getMesh();
-        numLevels = mesh.getNumLodLevels();
-        numTris = new int[numLevels];
-        for (int i = numLevels - 1; i >= 0; i--) {
-            numTris[i] = mesh.getTriangleCount(i);
+        
+        if(spatial != null) {
+            Geometry geom = (Geometry) spatial;
+            Mesh mesh = geom.getMesh();
+            numLevels = mesh.getNumLodLevels();
+            numTris = new int[numLevels];
+            for (int i = numLevels - 1; i >= 0; i--) {
+                numTris[i] = mesh.getTriangleCount(i);
+            }
+        } else {
+            numLevels = 0;
+            numTris = null;
         }
     }
 


### PR DESCRIPTION
LodControl throws an exception when the spatial being added to isn't a geometry, however, when the controls is removed it calls setSpatial with a null value triggering the exception throw. Now checking for this null value case.