### PR TITLE
Mesh point doc fix

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Geometry.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Geometry.java
@@ -506,6 +506,7 @@ public class Geometry extends Spatial {
     /**
      *  The old clone() method that did not use the new Cloner utility.
      */
+    @Override
     public Geometry oldClone(boolean cloneMaterial) {
         Geometry geomClone = (Geometry) super.clone(cloneMaterial);
 

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -63,8 +63,7 @@ import java.util.ArrayList;
  * All visible elements in a scene are represented by meshes.
  * Meshes may contain three types of geometric primitives:
  * <ul>
- * <li>Points - Every vertex represents a single point in space,
- * the size of {@link Mode#Points points} is determined via the vertex shader's <code>gl_PointSize</code> output.
+ * <li>Points - Every vertex represents a single point in space.
  * Points can also be used for {@link RenderState#setPointSprite(boolean) point
  * sprite} mode.</li>
  * <li>Lines - 2 vertices represent a line segment, with the width specified
@@ -82,8 +81,8 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
      */
     public enum Mode {
         /**
-         * A primitive is a single point in space. The size of the points
-         * can be specified with {@link Mesh#setPointSize(float) }.
+         * A primitive is a single point in space. The size of {@link Mode#Points points} are
+         * determined via the vertex shader's <code>gl_PointSize</code> output.
          */
         Points(true),
 

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -64,7 +64,7 @@ import java.util.ArrayList;
  * Meshes may contain three types of geometric primitives:
  * <ul>
  * <li>Points - Every vertex represents a single point in space,
- * the size of each point is specified via {@link Mesh#setPointSize(float) }.
+ * the size of {@link Mode#Points points} is determined via the vertex shader's <code>gl_PointSize</code> output.
  * Points can also be used for {@link RenderState#setPointSprite(boolean) point
  * sprite} mode.</li>
  * <li>Lines - 2 vertices represent a line segment, with the width specified


### PR DESCRIPTION
Reflecting the updated Mesh.setPointSize() documentation in other parts of the class.