### PR TITLE
Fixed #652

### DIFF
--- a/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/textures/blending/TextureBlenderAWT.java
+++ b/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/textures/blending/TextureBlenderAWT.java
@@ -174,6 +174,8 @@ public class TextureBlenderAWT extends AbstractTextureBlender {
         // float blendFactor = this.blendFactor * (1f - ((1f - pixelColor[3]) * materialColor[3]));
         // float oneMinusFactor = 1f - blendFactor;
 
+        float col;
+        
         switch (blendType) {
             case MTEX_BLEND:
                 result[0] = blendFactor * pixelColor[0] + oneMinusFactor * materialColor[0];

--- a/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/textures/blending/TextureBlenderAWT.java
+++ b/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/textures/blending/TextureBlenderAWT.java
@@ -163,8 +163,16 @@ public class TextureBlenderAWT extends AbstractTextureBlender {
      *            the blender context
      */
     protected void blendPixel(float[] result, float[] materialColor, float[] pixelColor, BlenderContext blenderContext) {
+        // We calculate first the importance of the texture (colFactor * texAlphaValue)
         float blendFactor = this.blendFactor * pixelColor[3];
-        float oneMinusFactor = 1.0f - blendFactor, col;
+        // Then, we get the object material factor ((1 - texture importance) * matAlphaValue) 
+        float oneMinusFactor = (1f - blendFactor) * materialColor[3];
+        // Finally, we can get the final blendFactor, which is 1 - the material factor.
+        blendFactor = 1f - oneMinusFactor;
+        
+        // --- Compact method ---
+        // float blendFactor = this.blendFactor * (1f - ((1f - pixelColor[3]) * materialColor[3]));
+        // float oneMinusFactor = 1f - blendFactor;
 
         switch (blendType) {
             case MTEX_BLEND:


### PR DESCRIPTION
The issue was due to the texture blending with the object material. By default the material is gray (hence, a gray border). If the material color in blender is set to another color this is being the artifact's color. It can bee seen where the alpha in the texture isn't totally 0 or 1.
The current implementation weren't taking in account the material transparency when blending, so the fix is basically to use it just like blender does.

https://hub.jmonkeyengine.org/t/multiple-blender-importer-changes-fixes/38568
