### PR TITLE
fixing documentation link

### DIFF
--- a/jme3-effects/src/main/java/com/jme3/post/filters/BloomFilter.java
+++ b/jme3-effects/src/main/java/com/jme3/post/filters/BloomFilter.java
@@ -52,7 +52,7 @@ import java.util.ArrayList;
  * There are 2 mode : Scene and Objects.<br>
  * Scene mode extracts the bright parts of the scene to make them glow<br>
  * Object mode make objects glow according to their material's glowMap or their GlowColor<br>
- * @see <a href="http://jmonkeyengine.org/wiki/doku.php/jme3:advanced:bloom_and_glow">advanced:bloom_and_glow</a> for more details
+ * @see <a href="http://jmonkeyengine.github.io/wiki/jme3/advanced/bloom_and_glow.html">advanced:bloom_and_glow</a> for more details
  * 
  * @author Rémy Bouquet aka Nehon
  */


### PR DESCRIPTION
Noticed that this javadoc points to web documentation page that is not existing (probably from before migration), so I changed it to point to correct one.