### PR TITLE
Added missed gl versions

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/Caps.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Caps.java
@@ -129,6 +129,26 @@ public enum Caps {
      */
     OpenGL40,
     /**
+     * Supports OpenGL 4.1
+     */
+    OpenGL41,
+    /**
+     * Supports OpenGL 4.2
+     */
+    OpenGL42,
+    /**
+     * Supports OpenGL 4.3
+     */
+    OpenGL43,
+    /**
+     * Supports OpenGL 4.4
+     */
+    OpenGL44,
+    /**
+     * Supports OpenGL 4.5
+     */
+    OpenGL45,
+    /**
      * Do not use.
      * 
      * @deprecated do not use.
@@ -174,6 +194,26 @@ public enum Caps {
      * Supports GLSL 4.0
      */
     GLSL400,
+    /**
+     * Supports GLSL 4.1
+     */
+    GLSL410,
+    /**
+     * Supports GLSL 4.2
+     */
+    GLSL420,
+    /**
+     * Supports GLSL 4.3
+     */
+    GLSL430,
+    /**
+     * Supports GLSL 4.4
+     */
+    GLSL440,
+    /**
+     * Supports GLSL 4.5
+     */
+    GLSL450,
     /**
      * Supports reading from textures inside the vertex shader.
      */
@@ -486,6 +526,18 @@ public enum Caps {
                         if (!caps.contains(Caps.GLSL150)) return false;
                     case 330:
                         if (!caps.contains(Caps.GLSL330)) return false;
+                    case 400:
+                        if (!caps.contains(Caps.GLSL400)) return false;
+                    case 410:
+                        if (!caps.contains(Caps.GLSL410)) return false;
+                    case 420:
+                        if (!caps.contains(Caps.GLSL420)) return false;
+                    case 430:
+                        if (!caps.contains(Caps.GLSL430)) return false;
+                    case 440:
+                        if (!caps.contains(Caps.GLSL440)) return false;
+                    case 450:
+                        if (!caps.contains(Caps.GLSL450)) return false;
                     default:
                         return false;
                 }

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -180,23 +180,38 @@ public final class GLRenderer implements Renderer {
             caps.add(Caps.OpenGL20);
             if (oglVer >= 210) {
                 caps.add(Caps.OpenGL21);
-                if (oglVer >= 300) {
-                    caps.add(Caps.OpenGL30);
-                    if (oglVer >= 310) {
-                        caps.add(Caps.OpenGL31);
-                        if (oglVer >= 320) {
-                            caps.add(Caps.OpenGL32);
-                        }
-                        if (oglVer >= 330) {
-                            caps.add(Caps.OpenGL33);
-                            caps.add(Caps.GeometryShader);
-                        }
-                        if (oglVer >= 400) {
-                            caps.add(Caps.OpenGL40);
-                            caps.add(Caps.TesselationShader);
-                        }
-                    }
-                }
+            }
+            if (oglVer >= 300) {
+                caps.add(Caps.OpenGL30);
+            }
+            if (oglVer >= 310) {
+                caps.add(Caps.OpenGL31);
+            }
+            if (oglVer >= 320) {
+                caps.add(Caps.OpenGL32);
+            }
+            if (oglVer >= 330) {
+                caps.add(Caps.OpenGL33);
+                caps.add(Caps.GeometryShader);
+            }
+            if (oglVer >= 400) {
+                caps.add(Caps.OpenGL40);
+                caps.add(Caps.TesselationShader);
+            }
+            if (oglVer >= 410) {
+                caps.add(Caps.OpenGL41);
+            }
+            if (oglVer >= 420) {
+                caps.add(Caps.OpenGL42);
+            }
+            if (oglVer >= 430) {
+                caps.add(Caps.OpenGL43);
+            }
+            if (oglVer >= 440) {
+                caps.add(Caps.OpenGL44);
+            }
+            if (oglVer >= 450) {
+                caps.add(Caps.OpenGL45);
             }
         }
 
@@ -209,6 +224,16 @@ public final class GLRenderer implements Renderer {
                 }
                 // so that future OpenGL revisions wont break jme3
                 // fall through intentional
+            case 450:
+                caps.add(Caps.GLSL450);
+            case 440:
+                caps.add(Caps.GLSL440);
+            case 430:
+                caps.add(Caps.GLSL430);
+            case 420:
+                caps.add(Caps.GLSL420);
+            case 410:
+                caps.add(Caps.GLSL410);
             case 400:
                 caps.add(Caps.GLSL400);
             case 330:

--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -85,6 +85,76 @@ public final class AppSettings extends HashMap<String, Object> {
     public static final String LWJGL_OPENGL3 = "LWJGL-OpenGL3";
 
     /**
+     * Use LWJGL as the display system and force using the OpenGL3.3 renderer.
+     * <p>
+     * If the underlying system does not support OpenGL3.3, then the context
+     * initialization will throw an exception.
+     *
+     * @see AppSettings#setRenderer(java.lang.String)
+     */
+    public static final String LWJGL_OPENGL33 = "LWJGL-OpenGL33";
+
+    /**
+     * Use LWJGL as the display system and force using the OpenGL4.0 renderer.
+     * <p>
+     * If the underlying system does not support OpenGL4.0, then the context
+     * initialization will throw an exception.
+     *
+     * @see AppSettings#setRenderer(java.lang.String)
+     */
+    public static final String LWJGL_OPENGL4 = "LWJGL-OpenGL4";
+
+    /**
+     * Use LWJGL as the display system and force using the OpenGL4.1 renderer.
+     * <p>
+     * If the underlying system does not support OpenGL4.1, then the context
+     * initialization will throw an exception.
+     *
+     * @see AppSettings#setRenderer(java.lang.String)
+     */
+    public static final String LWJGL_OPENGL41 = "LWJGL-OpenGL41";
+
+    /**
+     * Use LWJGL as the display system and force using the OpenGL4.2 renderer.
+     * <p>
+     * If the underlying system does not support OpenGL4.2, then the context
+     * initialization will throw an exception.
+     *
+     * @see AppSettings#setRenderer(java.lang.String)
+     */
+    public static final String LWJGL_OPENGL42 = "LWJGL-OpenGL42";
+
+    /**
+     * Use LWJGL as the display system and force using the OpenGL4.3 renderer.
+     * <p>
+     * If the underlying system does not support OpenGL4.3, then the context
+     * initialization will throw an exception.
+     *
+     * @see AppSettings#setRenderer(java.lang.String)
+     */
+    public static final String LWJGL_OPENGL43 = "LWJGL-OpenGL43";
+
+    /**
+     * Use LWJGL as the display system and force using the OpenGL4.4 renderer.
+     * <p>
+     * If the underlying system does not support OpenGL4.4, then the context
+     * initialization will throw an exception.
+     *
+     * @see AppSettings#setRenderer(java.lang.String)
+     */
+    public static final String LWJGL_OPENGL44 = "LWJGL-OpenGL44";
+
+    /**
+     * Use LWJGL as the display system and force using the OpenGL4.5 renderer.
+     * <p>
+     * If the underlying system does not support OpenGL4.5, then the context
+     * initialization will throw an exception.
+     *
+     * @see AppSettings#setRenderer(java.lang.String)
+     */
+    public static final String LWJGL_OPENGL45 = "LWJGL-OpenGL45";
+
+    /**
      * Use the LWJGL OpenAL based renderer for audio capabilities.
      *
      * @see AppSettings#setAudioRenderer(java.lang.String)

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -159,14 +159,24 @@ public abstract class LwjglContext implements JmeContext {
     }
 
     protected void initContextFirstTime() {
-        final GLCapabilities capabilities = createCapabilities(settings.getRenderer().equals(AppSettings.LWJGL_OPENGL3));
+
+        final String renderer = settings.getRenderer();
+        final GLCapabilities capabilities = createCapabilities(!renderer.equals(AppSettings.LWJGL_OPENGL2));
 
         if (!capabilities.OpenGL20) {
             throw new RendererException("OpenGL 2.0 or higher is required for jMonkeyEngine");
         }
 
-        if (settings.getRenderer().equals(AppSettings.LWJGL_OPENGL2)
-                || settings.getRenderer().equals(AppSettings.LWJGL_OPENGL3)) {
+        if (renderer.equals(AppSettings.LWJGL_OPENGL2)
+                || renderer.equals(AppSettings.LWJGL_OPENGL3)
+                || renderer.equals(AppSettings.LWJGL_OPENGL33)
+                || renderer.equals(AppSettings.LWJGL_OPENGL4)
+                || renderer.equals(AppSettings.LWJGL_OPENGL41)
+                || renderer.equals(AppSettings.LWJGL_OPENGL42)
+                || renderer.equals(AppSettings.LWJGL_OPENGL43)
+                || renderer.equals(AppSettings.LWJGL_OPENGL44)
+                || renderer.equals(AppSettings.LWJGL_OPENGL45)) {
+
             GL gl = new LwjglGL();
             GLExt glext = new LwjglGLExt();
             GLFbo glfbo;
@@ -196,18 +206,18 @@ public abstract class LwjglContext implements JmeContext {
                 glfbo = (GLFbo) GLTracer.createDesktopGlTracer(glfbo, GLFbo.class);
             }
 
-            renderer = new GLRenderer(gl, glext, glfbo);
-            renderer.initialize();
+            this.renderer = new GLRenderer(gl, glext, glfbo);
+            this.renderer.initialize();
         } else {
-            throw new UnsupportedOperationException("Unsupported renderer: " + settings.getRenderer());
+            throw new UnsupportedOperationException("Unsupported renderer: " + renderer);
         }
 
         if (capabilities.GL_ARB_debug_output && settings.getBoolean("GraphicsDebug")) {
             ARBDebugOutput.glDebugMessageCallbackARB(new LwjglGLDebugOutputHandler(), 0);
         }
 
-        renderer.setMainFrameBufferSrgb(settings.isGammaCorrection());
-        renderer.setLinearizeSrgbImages(settings.isGammaCorrection());
+        this.renderer.setMainFrameBufferSrgb(settings.isGammaCorrection());
+        this.renderer.setLinearizeSrgbImages(settings.isGammaCorrection());
 
         // Init input
         if (keyInput != null) {

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -32,48 +32,9 @@
 
 package com.jme3.system.lwjgl;
 
-import static org.lwjgl.glfw.GLFW.GLFW_ALPHA_BITS;
-import static org.lwjgl.glfw.GLFW.GLFW_BLUE_BITS;
-import static org.lwjgl.glfw.GLFW.GLFW_CONTEXT_VERSION_MAJOR;
-import static org.lwjgl.glfw.GLFW.GLFW_CONTEXT_VERSION_MINOR;
-import static org.lwjgl.glfw.GLFW.GLFW_DEPTH_BITS;
-import static org.lwjgl.glfw.GLFW.GLFW_FALSE;
-import static org.lwjgl.glfw.GLFW.GLFW_GREEN_BITS;
-import static org.lwjgl.glfw.GLFW.GLFW_OPENGL_CORE_PROFILE;
-import static org.lwjgl.glfw.GLFW.GLFW_OPENGL_DEBUG_CONTEXT;
-import static org.lwjgl.glfw.GLFW.GLFW_OPENGL_FORWARD_COMPAT;
-import static org.lwjgl.glfw.GLFW.GLFW_OPENGL_PROFILE;
-import static org.lwjgl.glfw.GLFW.GLFW_RED_BITS;
-import static org.lwjgl.glfw.GLFW.GLFW_REFRESH_RATE;
-import static org.lwjgl.glfw.GLFW.GLFW_RESIZABLE;
-import static org.lwjgl.glfw.GLFW.GLFW_SAMPLES;
-import static org.lwjgl.glfw.GLFW.GLFW_SRGB_CAPABLE;
-import static org.lwjgl.glfw.GLFW.GLFW_STENCIL_BITS;
-import static org.lwjgl.glfw.GLFW.GLFW_STEREO;
-import static org.lwjgl.glfw.GLFW.GLFW_TRUE;
-import static org.lwjgl.glfw.GLFW.GLFW_VISIBLE;
-import static org.lwjgl.glfw.GLFW.glfwCreateWindow;
-import static org.lwjgl.glfw.GLFW.glfwDefaultWindowHints;
-import static org.lwjgl.glfw.GLFW.glfwDestroyWindow;
-import static org.lwjgl.glfw.GLFW.glfwGetPrimaryMonitor;
-import static org.lwjgl.glfw.GLFW.glfwGetVideoMode;
-import static org.lwjgl.glfw.GLFW.glfwInit;
-import static org.lwjgl.glfw.GLFW.glfwMakeContextCurrent;
-import static org.lwjgl.glfw.GLFW.glfwPollEvents;
-import static org.lwjgl.glfw.GLFW.glfwSetErrorCallback;
-import static org.lwjgl.glfw.GLFW.glfwSetWindowFocusCallback;
-import static org.lwjgl.glfw.GLFW.glfwSetWindowIcon;
-import static org.lwjgl.glfw.GLFW.glfwSetWindowPos;
-import static org.lwjgl.glfw.GLFW.glfwSetWindowSizeCallback;
-import static org.lwjgl.glfw.GLFW.glfwSetWindowTitle;
-import static org.lwjgl.glfw.GLFW.glfwShowWindow;
-import static org.lwjgl.glfw.GLFW.glfwSwapBuffers;
-import static org.lwjgl.glfw.GLFW.glfwSwapInterval;
-import static org.lwjgl.glfw.GLFW.glfwWindowHint;
-import static org.lwjgl.glfw.GLFW.glfwWindowShouldClose;
+import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.opengl.GL11.GL_FALSE;
 import static org.lwjgl.system.MemoryUtil.NULL;
-
 import com.jme3.input.JoyInput;
 import com.jme3.input.KeyInput;
 import com.jme3.input.MouseInput;
@@ -86,15 +47,10 @@ import com.jme3.system.JmeContext;
 import com.jme3.system.JmeSystem;
 import com.jme3.system.NanoTimer;
 import com.jme3.util.BufferUtils;
-
 import org.lwjgl.Version;
-import org.lwjgl.glfw.GLFWErrorCallback;
-import org.lwjgl.glfw.GLFWImage;
-import org.lwjgl.glfw.GLFWVidMode;
-import org.lwjgl.glfw.GLFWWindowFocusCallback;
-import org.lwjgl.glfw.GLFWWindowSizeCallback;
+import org.lwjgl.glfw.*;
 
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -196,12 +152,38 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
         glfwDefaultWindowHints();
 
-        if (settings.getRenderer().equals(AppSettings.LWJGL_OPENGL3)) {
-            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-            glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+        final String renderer = settings.getRenderer();
+
+        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+        if (renderer.equals(AppSettings.LWJGL_OPENGL3)) {
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+        } else if (renderer.equals(AppSettings.LWJGL_OPENGL33)) {
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+        } else if (renderer.equals(AppSettings.LWJGL_OPENGL4)) {
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+        } else if (renderer.equals(AppSettings.LWJGL_OPENGL41)) {
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+        } else if (renderer.equals(AppSettings.LWJGL_OPENGL42)) {
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+        } else if (renderer.equals(AppSettings.LWJGL_OPENGL43)) {
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+        } else if (renderer.equals(AppSettings.LWJGL_OPENGL44)) {
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 4);
+        } else if (renderer.equals(AppSettings.LWJGL_OPENGL45)) {
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 5);
         } else {
+            glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE);
+            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_ANY_PROFILE);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
         }


### PR DESCRIPTION
I think we need to have a possibility to set core profile of most GL version, not only 3.2. Some drivers work correctly only in the case when you use a core profile, but when we use a core profile, we have limits to use features from higher versions. For example Intel Graphics on Linux, which can't use features from 3+ Open GL without a core profile. At this moment, we can use only core profile for the version 3.2, it isn't enough for example if you want to use geometry/tesselation shaders.