### PR TITLE
Update LWJGL from 3.0.0 to 3.1.0(3.1.2 requires to change …

### DIFF
--- a/jme3-lwjgl3/build.gradle
+++ b/jme3-lwjgl3/build.gradle
@@ -10,10 +10,22 @@ dependencies {
     compile project(':jme3-core')
     compile project(':jme3-desktop')
 
-    compile group: 'org.lwjgl', name: 'lwjgl', version: lwjglVersion
-    compile group: 'org.lwjgl', name: 'lwjgl-glfw', version: lwjglVersion
-    compile group: 'org.lwjgl', name: 'lwjgl-openal', version: lwjglVersion
-    compile group: 'org.lwjgl', name: 'lwjgl-opencl', version: lwjglVersion
-    compile group: 'org.lwjgl', name: 'lwjgl-opengl', version: lwjglVersion
-    compile group: 'org.lwjgl', name: 'lwjgl-jemalloc', version: lwjglVersion
+    compile "org.lwjgl:lwjgl:${lwjglVersion}"
+    compile "org.lwjgl:lwjgl-glfw:${lwjglVersion}"
+    compile "org.lwjgl:lwjgl-jemalloc:${lwjglVersion}"
+    compile "org.lwjgl:lwjgl-openal:${lwjglVersion}"
+    compile "org.lwjgl:lwjgl-opencl:${lwjglVersion}"
+    compile "org.lwjgl:lwjgl-opengl:${lwjglVersion}"
+    runtime "org.lwjgl:lwjgl:${lwjglVersion}:natives-windows"
+    runtime "org.lwjgl:lwjgl:${lwjglVersion}:natives-linux"
+    runtime "org.lwjgl:lwjgl:${lwjglVersion}:natives-macos"
+    runtime "org.lwjgl:lwjgl-glfw:${lwjglVersion}:natives-windows"
+    runtime "org.lwjgl:lwjgl-glfw:${lwjglVersion}:natives-linux"
+    runtime "org.lwjgl:lwjgl-glfw:${lwjglVersion}:natives-macos"
+    runtime "org.lwjgl:lwjgl-jemalloc:${lwjglVersion}:natives-windows"
+    runtime "org.lwjgl:lwjgl-jemalloc:${lwjglVersion}:natives-linux"
+    runtime "org.lwjgl:lwjgl-jemalloc:${lwjglVersion}:natives-macos"
+    runtime "org.lwjgl:lwjgl-openal:${lwjglVersion}:natives-windows"
+    runtime "org.lwjgl:lwjgl-openal:${lwjglVersion}:natives-linux"
+    runtime "org.lwjgl:lwjgl-openal:${lwjglVersion}:natives-macos"
 }

--- a/jme3-lwjgl3/build.gradle
+++ b/jme3-lwjgl3/build.gradle
@@ -2,7 +2,7 @@ if (!hasProperty('mainClass')) {
     ext.mainClass = ''
 }
 
-def lwjglVersion = '3.0.0'
+def lwjglVersion = '3.1.0'
 
 sourceCompatibility = '1.8'
 
@@ -10,8 +10,10 @@ dependencies {
     compile project(':jme3-core')
     compile project(':jme3-desktop')
 
-    compile "org.lwjgl:lwjgl:${lwjglVersion}"
-    compile "org.lwjgl:lwjgl-platform:${lwjglVersion}:natives-windows"
-    compile "org.lwjgl:lwjgl-platform:${lwjglVersion}:natives-linux"
-    compile "org.lwjgl:lwjgl-platform:${lwjglVersion}:natives-osx"
+    compile group: 'org.lwjgl', name: 'lwjgl', version: lwjglVersion
+    compile group: 'org.lwjgl', name: 'lwjgl-glfw', version: lwjglVersion
+    compile group: 'org.lwjgl', name: 'lwjgl-openal', version: lwjglVersion
+    compile group: 'org.lwjgl', name: 'lwjgl-opencl', version: lwjglVersion
+    compile group: 'org.lwjgl', name: 'lwjgl-opengl', version: lwjglVersion
+    compile group: 'org.lwjgl', name: 'lwjgl-jemalloc', version: lwjglVersion
 }


### PR DESCRIPTION
Update LWJGL from 3.0.0 to 3.1.0(3.1.2 requires to change code), because starting from the version they use other dependencies for native libraries.