### PR TITLE
Update com_jme3_bullet_objects_PhysicsRigidBody.cpp

### DIFF
--- a/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.cpp
+++ b/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.cpp
@@ -217,7 +217,8 @@ extern "C" {
             body->setActivationState(DISABLE_DEACTIVATION);
         } else {
             body->setCollisionFlags(body->getCollisionFlags() & ~btCollisionObject::CF_KINEMATIC_OBJECT);
-            body->setActivationState(ACTIVE_TAG);
+            //body->setActivationState(ACTIVE_TAG);
+	    body->activate(false);
         }
     }
 

--- a/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.cpp
+++ b/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsRigidBody.cpp
@@ -217,8 +217,8 @@ extern "C" {
             body->setActivationState(DISABLE_DEACTIVATION);
         } else {
             body->setCollisionFlags(body->getCollisionFlags() & ~btCollisionObject::CF_KINEMATIC_OBJECT);
-            //body->setActivationState(ACTIVE_TAG);
-	    body->activate(false);
+	    body->activate(true);
+	    body->forceActivationState(ACTIVE_TAG);
         }
     }
 


### PR DESCRIPTION
Reset deactivation timer.

From docu here: http://www.bulletphysics.org/mediawiki-1.5.8/index.php/Activation_States
..
ACTIVE_TAG
    Means active so that the object having the state could be moved in a step simulation. This is the "normal" state for an object to be in. Use btCollisionObject::activate() to activate an object, not btCollisionObject::setActivationState(ACTIVATE_TAG), or it may get disabled again right away, as the deactivation timer has not been reset. 
..