### PR TITLE
Fixed sky shader

### DIFF
--- a/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
+++ b/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
@@ -44,8 +44,8 @@ import com.jme3.texture.Image;
 import com.jme3.texture.Image.Format;
 import com.jme3.texture.Texture;
 import com.jme3.texture.TextureCubeMap;
+
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 
 /**
  * <code>SkyFactory</code> is used to create jME {@link Spatial}s that can
@@ -177,42 +177,48 @@ public class SkyFactory {
      */
      public static Spatial createSky(AssetManager assetManager, Texture texture,
             Vector3f normalScale, EnvMapType envMapType, float sphereRadius) {
-        if (texture == null) {
-            throw new IllegalArgumentException("texture cannot be null");
-        }
-        final Sphere sphereMesh = new Sphere(10, 10, sphereRadius, false, true);
+         if (texture == null) {
+             throw new IllegalArgumentException("texture cannot be null");
+         }
+         final Sphere sphereMesh = new Sphere(10, 10, sphereRadius, false, true);
 
-        Geometry sky = new Geometry("Sky", sphereMesh);
-        sky.setQueueBucket(Bucket.Sky);
-        sky.setCullHint(Spatial.CullHint.Never);
-        sky.setModelBound(new BoundingSphere(Float.POSITIVE_INFINITY, Vector3f.ZERO));
+         Geometry sky = new Geometry("Sky", sphereMesh);
+         sky.setQueueBucket(Bucket.Sky);
+         sky.setCullHint(Spatial.CullHint.Never);
+         sky.setModelBound(new BoundingSphere(Float.POSITIVE_INFINITY, Vector3f.ZERO));
 
-        Material skyMat = new Material(assetManager, "Common/MatDefs/Misc/Sky.j3md");
-        skyMat.setVector3("NormalScale", normalScale);
-        switch (envMapType){
-            case CubeMap : 
-                // make sure its a cubemap
-                if (!(texture instanceof TextureCubeMap)) {
-                    Image img = texture.getImage();
-                    texture = new TextureCubeMap();
-                    texture.setImage(img);
-                }
-                break;
-            case SphereMap :     
-                skyMat.setBoolean("SphereMap", true);
-                break;
-            case EquirectMap : 
-                skyMat.setBoolean("EquirectMap", true);
-                break;
-        }
-        texture.setMagFilter(Texture.MagFilter.Bilinear);
-        texture.setMinFilter(Texture.MinFilter.BilinearNoMipMaps);
-        texture.setAnisotropicFilter(0);
-        texture.setWrap(Texture.WrapMode.EdgeClamp);
-        skyMat.setTexture("Texture", texture);
-        sky.setMaterial(skyMat);
+         Material skyMat = new Material(assetManager, "Common/MatDefs/Misc/Sky.j3md");
+         skyMat.setVector3("NormalScale", normalScale);
+         switch (envMapType) {
+             case CubeMap:
+                 // make sure its a cubemap
+                 if (!(texture instanceof TextureCubeMap)) {
+                     Image img = texture.getImage();
+                     texture = new TextureCubeMap();
+                     texture.setImage(img);
+                 }
+                 break;
+             case SphereMap:
+                 skyMat.setBoolean("SphereMap", true);
+                 break;
+             case EquirectMap:
+                 skyMat.setBoolean("EquirectMap", true);
+                 break;
+         }
+         texture.setMagFilter(Texture.MagFilter.Bilinear);
+         texture.setMinFilter(Texture.MinFilter.BilinearNoMipMaps);
+         texture.setAnisotropicFilter(0);
+         texture.setWrap(Texture.WrapMode.EdgeClamp);
 
-        return sky;
+         if (texture instanceof TextureCubeMap) {
+             skyMat.setTexture("Texture", texture);
+         } else {
+             skyMat.setTexture("SimpleTexture", texture);
+         }
+
+         sky.setMaterial(skyMat);
+
+         return sky;
     }
      
     /**

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Sky.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Sky.frag
@@ -1,12 +1,19 @@
 #import "Common/ShaderLib/GLSLCompat.glsllib"
 #import "Common/ShaderLib/Optics.glsllib"
 
-uniform ENVMAP m_Texture;
+uniform textureCube m_Texture;
+uniform sampler2D m_SimpleTexture;
 
 varying vec3 direction;
 
 void main() {
+
     vec3 dir = normalize(direction);
-    gl_FragColor = Optics_GetEnvColor(m_Texture, dir);
+
+    #if defined(CUBE_MAP)
+        gl_FragColor = Optics_GetEnvColor(m_Texture, dir);
+    #else
+        gl_FragColor = Optics_GetEnvColor(m_SimpleTexture, dir);
+    #endif
 }
 

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Sky.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Sky.frag
@@ -1,8 +1,11 @@
 #import "Common/ShaderLib/GLSLCompat.glsllib"
 #import "Common/ShaderLib/Optics.glsllib"
 
-uniform textureCube m_Texture;
-uniform sampler2D m_SimpleTexture;
+#if defined(CUBE_MAP)
+    uniform ENVMAP m_Texture;
+#else
+    uniform sampler2D m_SimpleTexture;
+#endif
 
 varying vec3 direction;
 

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Sky.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Sky.j3md
@@ -1,8 +1,9 @@
 MaterialDef Sky Plane {
     MaterialParameters {
         TextureCubeMap Texture
+        Texture2D SimpleTexture
         Boolean SphereMap
-	Boolean EquirectMap
+	    Boolean EquirectMap
         Vector3 NormalScale
     }
     Technique {
@@ -18,6 +19,7 @@ MaterialDef Sky Plane {
         Defines {
             SPHERE_MAP : SphereMap
 	        EQUIRECT_MAP : EquirectMap
+	        CUBE_MAP : Texture
         }
 
         RenderState {

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Sky.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Sky.j3md
@@ -3,7 +3,7 @@ MaterialDef Sky Plane {
         TextureCubeMap Texture
         Texture2D SimpleTexture
         Boolean SphereMap
-	    Boolean EquirectMap
+        Boolean EquirectMap
         Vector3 NormalScale
     }
     Technique {
@@ -18,8 +18,8 @@ MaterialDef Sky Plane {
 
         Defines {
             SPHERE_MAP : SphereMap
-	        EQUIRECT_MAP : EquirectMap
-	        CUBE_MAP : Texture
+            EQUIRECT_MAP : EquirectMap
+            CUBE_MAP : Texture
         }
 
         RenderState {


### PR DESCRIPTION
Now you can't create a material file of any type for sky, because sky.j3md has the only TextureCubeMap type of used texture even if you don't want to use cube map texture.