### PR TITLE
Fixed: If Instancing is activated you only see shadows

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -118,6 +118,8 @@ MaterialDef PBR Lighting {
             WorldViewProjectionMatrix
             CameraPosition
             WorldMatrix
+            ViewProjectionMatrix
+            ViewMatrix
         }
 
         Defines {         


### PR DESCRIPTION
When the pbr material was introduced someone forgot to keep the instancing in mind which uses :
            ViewProjectionMatrix
            ViewMatrix
I added these.