### PR TITLE
Fixed softkeyboard's (simulated) backspace not being recognized

### DIFF
--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidInputHandler14.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidInputHandler14.java
@@ -139,8 +139,10 @@ public class AndroidInputHandler14 extends AndroidInputHandler implements View.O
         boolean isJoystick =
                 ((source & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD) ||
                 ((source & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK);
+        boolean isUnknown =
+                (source & android.view.InputDevice.SOURCE_UNKNOWN) == android.view.InputDevice.SOURCE_UNKNOWN;
 
-        if (isTouch && touchInput != null) {
+        if (touchInput != null && (isTouch || (isUnknown && this.touchInput.isSimulateKeyboard()))) {
 //            logger.log(Level.INFO, "onKey source: {0}, isTouch: {1}",
 //                    new Object[]{source, isTouch});
             consumed = touchInput.onKey(event);


### PR DESCRIPTION
More info can be [found here](https://hub.jmonkeyengine.org/t/some-keys-not-registering-keyinputevent-on-android/36747).