### PR TITLE
Fix FBO depth support in OpenGL ES 2.0

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLImageFormats.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLImageFormats.java
@@ -206,9 +206,14 @@ public final class GLImageFormats {
         
         // Need to check if Caps.DepthTexture is supported prior to using for textures
         // But for renderbuffers its OK.
-        format(formatToGL, Format.Depth,   GL.GL_DEPTH_COMPONENT,    GL.GL_DEPTH_COMPONENT, GL.GL_UNSIGNED_BYTE);
         format(formatToGL, Format.Depth16, GL.GL_DEPTH_COMPONENT16,  GL.GL_DEPTH_COMPONENT, GL.GL_UNSIGNED_SHORT);
         
+        // NOTE: OpenGL ES 2.0 does not support DEPTH_COMPONENT as internal format -- fallback to 16-bit depth.
+        if (caps.contains(Caps.OpenGLES20)) {
+            format(formatToGL, Format.Depth, GL.GL_DEPTH_COMPONENT16, GL.GL_DEPTH_COMPONENT, GL.GL_UNSIGNED_BYTE);
+        } else {
+            format(formatToGL, Format.Depth, GL.GL_DEPTH_COMPONENT, GL.GL_DEPTH_COMPONENT, GL.GL_UNSIGNED_BYTE);
+        }
         if (caps.contains(Caps.OpenGL20)) {
             format(formatToGL, Format.Depth24, GL2.GL_DEPTH_COMPONENT24,  GL.GL_DEPTH_COMPONENT, GL.GL_UNSIGNED_INT);
         }


### PR DESCRIPTION
Fixes `Format.Depth` support in OpenGL ES 2.0. The spec does not allow usage of `GL_DEPTH_COMPONENT` in `glRenderbufferStorage`:
https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glRenderbufferStorage.xml

>internalformat
>Specifies the color-renderable, depth-renderable, or stencil-renderable format of the renderbuffer. Must be one of the following symbolic constants: 
		    GL_RGBA4, 
		    GL_RGB565, 
		    GL_RGB5_A1, 
		    GL_DEPTH_COMPONENT16, or
		    GL_STENCIL_INDEX8.