### PR TITLE
Migrate material things to use jme clonable system

### DIFF
--- a/jme3-core/src/main/java/com/jme3/material/MatParam.java
+++ b/jme3-core/src/main/java/com/jme3/material/MatParam.java
@@ -37,6 +37,9 @@ import com.jme3.math.*;
 import com.jme3.shader.VarType;
 import com.jme3.texture.Texture;
 import com.jme3.texture.Texture.WrapMode;
+import com.jme3.util.clone.Cloner;
+import com.jme3.util.clone.JmeCloneable;
+
 import java.io.IOException;
 
 /**
@@ -45,7 +48,7 @@ import java.io.IOException;
  *
  * @author Kirill Vainer
  */
-public class MatParam implements Savable, Cloneable {
+public class MatParam implements Savable, JmeCloneable {
 
     protected VarType type;
     protected String name;
@@ -288,12 +291,18 @@ When arrays can be inserted in J3M files
     }
 
     @Override
-    public MatParam clone() {
+    public MatParam jmeClone() {
         try {
-            MatParam param = (MatParam) super.clone();
-            return param;
-        } catch (CloneNotSupportedException ex) {
-            throw new AssertionError();
+            return (MatParam) clone();
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void cloneFields(final Cloner cloner, final Object original) {
+        if (!(value instanceof Number || value instanceof Boolean || value instanceof String)) {
+            value = cloner.clone(value);
         }
     }
 
@@ -313,8 +322,8 @@ When arrays can be inserted in J3M files
         } else if (value instanceof Boolean) {
             Boolean b = (Boolean) value;
             oc.write(b.booleanValue(), "value_bool", false);
-        } else if (value.getClass().isArray() && value instanceof Savable[]) {
-            oc.write((Savable[])value, "value_savable_array", null);
+        } else if (value != null && value.getClass().isArray() && value instanceof Savable[]) {
+            oc.write((Savable[]) value, "value_savable_array", null);
         }
     }
 

--- a/jme3-core/src/main/java/com/jme3/material/MatParamTexture.java
+++ b/jme3-core/src/main/java/com/jme3/material/MatParamTexture.java
@@ -38,6 +38,8 @@ import com.jme3.export.OutputCapsule;
 import com.jme3.shader.VarType;
 import com.jme3.texture.Texture;
 import com.jme3.texture.image.ColorSpace;
+import com.jme3.util.clone.Cloner;
+
 import java.io.IOException;
 
 public class MatParamTexture extends MatParam {
@@ -90,12 +92,17 @@ public class MatParamTexture extends MatParam {
     }
 
     @Override
+    public void cloneFields(final Cloner cloner, final Object original) {
+        super.cloneFields(cloner, original);
+        texture = cloner.clone(texture);
+    }
+
+    @Override
     public void write(JmeExporter ex) throws IOException {
         super.write(ex);
         OutputCapsule oc = ex.getCapsule(this);
         oc.write(0, "texture_unit", -1);
         oc.write(texture, "texture", null); // For backwards compatibility
-
         oc.write(colorSpace, "colorSpace", null);
     }
 
@@ -104,6 +111,6 @@ public class MatParamTexture extends MatParam {
         super.read(im);
         InputCapsule ic = im.getCapsule(this);
         texture = (Texture) value;
-        colorSpace = (ColorSpace) ic.readEnum("colorSpace", ColorSpace.class, null);
+        colorSpace = ic.readEnum("colorSpace", ColorSpace.class, null);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/material/Material.java
+++ b/jme3-core/src/main/java/com/jme3/material/Material.java
@@ -85,7 +85,7 @@ public class Material implements CloneableSmartAsset, JmeCloneable, Savable {
     private MaterialDef def;
     private ListMap<String, MatParam> paramValues = new ListMap<String, MatParam>();
     private Technique technique;
-    private HashMap<String, Technique> techniques = new HashMap<String, Technique>();
+    private HashMap<String, Technique> techniques = new HashMap<>();
     private RenderState additionalState = null;
     private RenderState mergedRenderState = new RenderState();
     private boolean transparent = false;
@@ -192,16 +192,19 @@ public class Material implements CloneableSmartAsset, JmeCloneable, Savable {
 
     @Override
     public Material clone() {
-        try {
-            return (Material) super.clone();
-        } catch (CloneNotSupportedException e) {
-            throw new RuntimeException(e);
-        }
+        final Cloner cloner = new Cloner();
+        final Material clone = jmeClone();
+        clone.cloneFields(cloner, this);
+        return clone;
     }
 
     @Override
     public Material jmeClone() {
-        return clone();
+        try {
+            return (Material) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
@@ -218,6 +221,7 @@ public class Material implements CloneableSmartAsset, JmeCloneable, Savable {
             paramValues.put(entry.getKey(), cloner.clone(entry.getValue()));
         }
 
+        techniques = new HashMap<>();
         technique = null;
         sortingId = -1;
     }
@@ -1068,7 +1072,7 @@ public class Material implements CloneableSmartAsset, JmeCloneable, Savable {
         }
 
         if (defName != null) {
-            def = im.getAssetManager().loadAsset(new AssetKey<>(defName));
+            def = (MaterialDef) im.getAssetManager().loadAsset(new AssetKey<>(defName));
         } else {
             def = (MaterialDef) ic.readSavable("material_def_embedded", null);
         }

--- a/jme3-core/src/main/java/com/jme3/material/MaterialDef.java
+++ b/jme3-core/src/main/java/com/jme3/material/MaterialDef.java
@@ -34,7 +34,6 @@ package com.jme3.material;
 import com.jme3.asset.AssetManager;
 import com.jme3.export.*;
 import com.jme3.shader.VarType;
-import com.jme3.system.Annotations;
 import com.jme3.texture.image.ColorSpace;
 import com.jme3.util.clone.Cloner;
 import com.jme3.util.clone.JmeCloneable;
@@ -49,7 +48,7 @@ import java.util.logging.Logger;
  * 
  * @author Kirill Vainer
  */
-public class MaterialDef{
+public class MaterialDef implements Savable, JmeCloneable {
 
     private static final Logger logger = Logger.getLogger(MaterialDef.class.getName());
 

--- a/jme3-core/src/main/java/com/jme3/material/ShaderGenerationInfo.java
+++ b/jme3-core/src/main/java/com/jme3/material/ShaderGenerationInfo.java
@@ -37,6 +37,9 @@ import com.jme3.export.JmeImporter;
 import com.jme3.export.OutputCapsule;
 import com.jme3.export.Savable;
 import com.jme3.shader.ShaderNodeVariable;
+import com.jme3.util.clone.Cloner;
+import com.jme3.util.clone.JmeCloneable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,7 +51,7 @@ import java.util.List;
  *
  * @author Nehon
  */
-public class ShaderGenerationInfo implements Savable, Cloneable {
+public class ShaderGenerationInfo implements Savable, JmeCloneable {
 
     /**
      * the list of attributes of the vertex shader
@@ -162,8 +165,24 @@ public class ShaderGenerationInfo implements Savable, Cloneable {
         return "ShaderGenerationInfo{" + "attributes=" + attributes + ", vertexUniforms=" + vertexUniforms + ", vertexGlobal=" + vertexGlobal + ", varyings=" + varyings + ", fragmentUniforms=" + fragmentUniforms + ", fragmentGlobals=" + fragmentGlobals + '}';
     }
 
-    
-    
+    @Override
+    public ShaderGenerationInfo jmeClone() {
+        try {
+            return (ShaderGenerationInfo) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void cloneFields(final Cloner cloner, final Object original) {
+        attributes = cloner.clone(attributes);
+        vertexUniforms = cloner.clone(vertexUniforms);
+        varyings = cloner.clone(varyings);
+        fragmentGlobals = cloner.clone(fragmentGlobals);
+        fragmentUniforms = cloner.clone(fragmentUniforms);
+        vertexGlobal = cloner.clone(vertexGlobal);
+    }
 
     @Override
     public void write(JmeExporter ex) throws IOException {
@@ -185,43 +204,5 @@ public class ShaderGenerationInfo implements Savable, Cloneable {
         fragmentUniforms = ic.readSavableArrayList("fragmentUniforms", new ArrayList<ShaderNodeVariable>());
         fragmentGlobals = ic.readSavableArrayList("fragmentGlobals", new ArrayList<ShaderNodeVariable>());
         vertexGlobal = (ShaderNodeVariable) ic.readSavable("vertexGlobal", null);
-
-    }
-
-    @Override
-    protected ShaderGenerationInfo clone() throws CloneNotSupportedException {
-        final ShaderGenerationInfo clone = (ShaderGenerationInfo) super.clone();
-        clone.attributes = new ArrayList<>();
-        clone.vertexUniforms = new ArrayList<>();
-        clone.fragmentUniforms = new ArrayList<>();
-        clone.fragmentGlobals = new ArrayList<>();
-        clone.unusedNodes = new ArrayList<>();
-        clone.varyings = new ArrayList<>();
-
-        for (ShaderNodeVariable attribute : attributes) {
-            clone.attributes.add(attribute.clone());
-        }
-
-        for (ShaderNodeVariable uniform : vertexUniforms) {
-            clone.vertexUniforms.add(uniform.clone());
-        }
-
-        clone.vertexGlobal = vertexGlobal.clone();
-
-        for (ShaderNodeVariable varying : varyings) {
-            clone.varyings.add(varying.clone());
-        }
-
-        for (ShaderNodeVariable uniform : fragmentUniforms) {
-            clone.fragmentUniforms.add(uniform.clone());
-        }
-
-        for (ShaderNodeVariable globals : fragmentGlobals) {
-            clone.fragmentGlobals.add(globals.clone());
-        }
-
-        clone.unusedNodes.addAll(unusedNodes);
-
-        return clone;
     }
 }

--- a/jme3-core/src/main/java/com/jme3/material/TechniqueDef.java
+++ b/jme3-core/src/main/java/com/jme3/material/TechniqueDef.java
@@ -452,9 +452,15 @@ public class TechniqueDef implements Savable, JmeCloneable {
             throw new IllegalStateException("Cannot have more than " + 
                     DefineList.MAX_DEFINES + " defines on a technique.");
         }
-        
-        defineNames.add(defineName);
-        defineTypes.add(defineType);
+
+        if (!defineNames.contains(defineName)) {
+            defineNames.add(defineName);
+        }
+
+        if (!defineTypes.contains(defineType)) {
+            defineTypes.add(defineType);
+        }
+
         return defineId;
     }
 
@@ -687,13 +693,25 @@ public class TechniqueDef implements Savable, JmeCloneable {
         shaderGenerationInfo = cloner.clone(shaderGenerationInfo);
 
         final ArrayList<UniformBinding> oldWorldBinds = this.worldBinds;
-        worldBinds = new ArrayList<>(oldWorldBinds == null ? Collections.<UniformBinding>emptyList() : oldWorldBinds);
+        worldBinds = new ArrayList<>();
+
+        if (oldWorldBinds != null) {
+            worldBinds.addAll(oldWorldBinds);
+        }
 
         final ArrayList<VarType> oldDefineTypes = this.defineTypes;
-        defineTypes = new ArrayList<>(oldDefineTypes == null ? Collections.<VarType>emptyList() : oldDefineTypes);
+        defineTypes = new ArrayList<>();
+
+        if (oldDefineTypes != null) {
+            defineTypes.addAll(oldDefineTypes);
+        }
 
         final ArrayList<String> oldDefineNames = this.defineNames;
-        defineNames = new ArrayList<>(oldDefineNames == null ? Collections.<String>emptyList() : oldDefineNames);
+        defineNames = new ArrayList<>();
+
+        if (oldDefineNames != null) {
+            defineNames.addAll(oldDefineNames);
+        }
 
         final EnumSet<Caps> oldRequiredCaps = this.requiredCaps;
         requiredCaps = EnumSet.noneOf(Caps.class);

--- a/jme3-core/src/main/java/com/jme3/renderer/Caps.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Caps.java
@@ -38,6 +38,7 @@ import com.jme3.texture.FrameBuffer.RenderBuffer;
 import com.jme3.texture.Image;
 import com.jme3.texture.Image.Format;
 import com.jme3.texture.Texture;
+
 import java.util.Collection;
 
 /**
@@ -395,6 +396,15 @@ public enum Caps {
      * GPU can provide and accept binary shaders.
      */
     BinaryShader;
+
+    private static final Caps[] VALUES = values();
+
+    public static Caps valueOf(final int ordinal) {
+        if (ordinal < 0 || ordinal >= VALUES.length) {
+            throw new IllegalArgumentException("The ordinal is out of values range.");
+        }
+        return VALUES[ordinal];
+    }
 
     /**
      * Returns true if given the renderer capabilities, the texture

--- a/jme3-core/src/main/java/com/jme3/scene/Spatial.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Spatial.java
@@ -38,6 +38,7 @@ import com.jme3.collision.Collidable;
 import com.jme3.export.*;
 import com.jme3.light.Light;
 import com.jme3.light.LightList;
+import com.jme3.material.MatParam;
 import com.jme3.material.MatParamOverride;
 import com.jme3.material.Material;
 import com.jme3.math.*;
@@ -48,11 +49,12 @@ import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.renderer.queue.RenderQueue.Bucket;
 import com.jme3.renderer.queue.RenderQueue.ShadowMode;
 import com.jme3.scene.control.Control;
+import com.jme3.util.SafeArrayList;
+import com.jme3.util.TempVars;
 import com.jme3.util.clone.Cloner;
 import com.jme3.util.clone.IdentityCloneFunction;
 import com.jme3.util.clone.JmeCloneable;
-import com.jme3.util.SafeArrayList;
-import com.jme3.util.TempVars;
+
 import java.io.IOException;
 import java.util.*;
 import java.util.logging.Logger;
@@ -1385,8 +1387,12 @@ public abstract class Spatial implements Savable, Cloneable, Collidable, Cloneab
             clone.worldOverrides = new SafeArrayList<>(MatParamOverride.class);
             clone.localOverrides = new SafeArrayList<>(MatParamOverride.class);
 
+            final Cloner cloner = new Cloner();
+
             for (MatParamOverride override : localOverrides) {
-                clone.localOverrides.add((MatParamOverride) override.clone());
+                final MatParam clonedParam = override.jmeClone();
+                clonedParam.cloneFields(cloner, override);
+                clone.localOverrides.add((MatParamOverride) clonedParam);
             }
 
             // No need to force cloned to update.

--- a/jme3-core/src/main/java/com/jme3/shader/ShaderNode.java
+++ b/jme3-core/src/main/java/com/jme3/shader/ShaderNode.java
@@ -36,6 +36,9 @@ import com.jme3.export.JmeExporter;
 import com.jme3.export.JmeImporter;
 import com.jme3.export.OutputCapsule;
 import com.jme3.export.Savable;
+import com.jme3.util.clone.Cloner;
+import com.jme3.util.clone.JmeCloneable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +57,7 @@ import java.util.List;
  *
  * @author Nehon
  */
-public class ShaderNode implements Savable, Cloneable {
+public class ShaderNode implements Savable, JmeCloneable {
 
     private String name;
     private ShaderNodeDefinition definition;
@@ -171,6 +174,22 @@ public class ShaderNode implements Savable, Cloneable {
         this.outputMapping = outputMapping;
     }
 
+    @Override
+    public ShaderNode jmeClone() {
+        try {
+            return (ShaderNode) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void cloneFields(final Cloner cloner, final Object original) {
+        definition = cloner.clone(definition);
+        inputMapping = cloner.clone(inputMapping);
+        outputMapping = cloner.clone(outputMapping);
+    }
+
     /**
      * jme serialization
      *
@@ -211,25 +230,5 @@ public class ShaderNode implements Savable, Cloneable {
     @Override
     public String toString() {
         return "\nShaderNode{" + "\nname=" + name + ", \ndefinition=" + definition.getName() + ", \ncondition=" + condition + ", \ninputMapping=" + inputMapping + ", \noutputMapping=" + outputMapping + '}';
-    }
-
-    @Override
-    public ShaderNode clone() throws CloneNotSupportedException {
-        ShaderNode clone = (ShaderNode) super.clone();
-
-        //No need to clone the definition.
-        clone.definition = definition;
-
-        clone.inputMapping = new ArrayList<>();
-        for (VariableMapping variableMapping : inputMapping) {
-            clone.inputMapping.add((VariableMapping) variableMapping.clone());
-        }
-
-        clone.outputMapping = new ArrayList<>();
-        for (VariableMapping variableMapping : outputMapping) {
-            clone.outputMapping.add((VariableMapping) variableMapping.clone());
-        }
-
-        return clone;
     }
 }

--- a/jme3-core/src/main/java/com/jme3/shader/ShaderNodeDefinition.java
+++ b/jme3-core/src/main/java/com/jme3/shader/ShaderNodeDefinition.java
@@ -31,12 +31,11 @@
  */
 package com.jme3.shader;
 
-import com.jme3.export.InputCapsule;
-import com.jme3.export.JmeExporter;
-import com.jme3.export.JmeImporter;
-import com.jme3.export.OutputCapsule;
-import com.jme3.export.Savable;
+import com.jme3.export.*;
 import com.jme3.shader.Shader.ShaderType;
+import com.jme3.util.clone.Cloner;
+import com.jme3.util.clone.JmeCloneable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,7 +47,7 @@ import java.util.List;
  *
  * @author Nehon
  */
-public class ShaderNodeDefinition implements Savable {
+public class ShaderNodeDefinition implements Savable, JmeCloneable {
 
     private String name;
     private Shader.ShaderType type;
@@ -183,8 +182,23 @@ public class ShaderNodeDefinition implements Savable {
     public void setPath(String path) {
         this.path = path;
     }
-    
-    
+
+    @Override
+    public ShaderNodeDefinition jmeClone() {
+        try {
+            return (ShaderNodeDefinition) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void cloneFields(final Cloner cloner, final Object original) {
+        shadersLanguage = new ArrayList<>(shadersLanguage);
+        shadersPath = new ArrayList<>(shadersPath);
+        inputs = cloner.clone(inputs);
+        outputs = cloner.clone(outputs);
+    }
 
     /**
      * jme serialization (not used)
@@ -194,14 +208,14 @@ public class ShaderNodeDefinition implements Savable {
      */
     @Override
     public void write(JmeExporter ex) throws IOException {
-        OutputCapsule oc = (OutputCapsule) ex.getCapsule(this);
+        OutputCapsule oc = ex.getCapsule(this);
         oc.write(name, "name", "");
         String[] str = new String[shadersLanguage.size()];
         oc.write(shadersLanguage.toArray(str), "shadersLanguage", null);
         oc.write(shadersPath.toArray(str), "shadersPath", null);
         oc.write(type, "type", null);
         oc.writeSavableArrayList((ArrayList) inputs, "inputs", new ArrayList<ShaderNodeVariable>());
-        oc.writeSavableArrayList((ArrayList) outputs, "inputs", new ArrayList<ShaderNodeVariable>());
+        oc.writeSavableArrayList((ArrayList) outputs, "outputs", new ArrayList<ShaderNodeVariable>());
     }
 
     public List<String> getShadersLanguage() {
@@ -230,7 +244,7 @@ public class ShaderNodeDefinition implements Savable {
      */
     @Override
     public void read(JmeImporter im) throws IOException {
-        InputCapsule ic = (InputCapsule) im.getCapsule(this);
+        InputCapsule ic = im.getCapsule(this);
         name = ic.readString("name", "");
 
         String[] str = ic.readStringArray("shadersLanguage", null);

--- a/jme3-core/src/main/java/com/jme3/shader/ShaderNodeVariable.java
+++ b/jme3-core/src/main/java/com/jme3/shader/ShaderNodeVariable.java
@@ -36,6 +36,9 @@ import com.jme3.export.JmeExporter;
 import com.jme3.export.JmeImporter;
 import com.jme3.export.OutputCapsule;
 import com.jme3.export.Savable;
+import com.jme3.util.clone.Cloner;
+import com.jme3.util.clone.JmeCloneable;
+
 import java.io.IOException;
 
 /**
@@ -43,7 +46,7 @@ import java.io.IOException;
  *
  * @author Nehon
  */
-public class ShaderNodeVariable implements Savable, Cloneable {
+public class ShaderNodeVariable implements Savable, JmeCloneable {
 
     private String prefix = "";
     private String name;
@@ -52,6 +55,9 @@ public class ShaderNodeVariable implements Savable, Cloneable {
     private String condition;
     private boolean shaderOutput = false;
     private String multiplicity;
+
+    public ShaderNodeVariable() {
+    }
 
     /**
      * creates a ShaderNodeVariable
@@ -222,6 +228,19 @@ public class ShaderNodeVariable implements Savable, Cloneable {
         return true;
     }
 
+    @Override
+    public ShaderNodeVariable jmeClone() {
+        try {
+            return (ShaderNodeVariable) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void cloneFields(final Cloner cloner, final Object original) {
+    }
+
     /**
      * jme serialization (not used)
      *
@@ -230,7 +249,7 @@ public class ShaderNodeVariable implements Savable, Cloneable {
      */
     @Override
     public void write(JmeExporter ex) throws IOException {
-        OutputCapsule oc = (OutputCapsule) ex.getCapsule(this);
+        OutputCapsule oc = ex.getCapsule(this);
         oc.write(name, "name", "");
         oc.write(type, "type", "");
         oc.write(prefix, "prefix", "");
@@ -249,12 +268,12 @@ public class ShaderNodeVariable implements Savable, Cloneable {
      */
     @Override
     public void read(JmeImporter im) throws IOException {
-        InputCapsule ic = (InputCapsule) im.getCapsule(this);
+        InputCapsule ic = im.getCapsule(this);
         name = ic.readString("name", "");
         type = ic.readString("type", "");
-        prefix = ic.readString("pefix", "");
+        prefix = ic.readString("prefix", "");
         nameSpace = ic.readString("nameSpace", "");
-        condition = ic.readString("condition", null);        
+        condition = ic.readString("condition", null);
         shaderOutput = ic.readBoolean("shaderOutput", false);
         multiplicity = ic.readString("multiplicity", null);
     }
@@ -313,10 +332,5 @@ public class ShaderNodeVariable implements Savable, Cloneable {
      */
     public void setMultiplicity(String multiplicity) {
         this.multiplicity = multiplicity;
-    }
-
-    @Override
-    public ShaderNodeVariable clone() throws CloneNotSupportedException {
-        return (ShaderNodeVariable) super.clone();
     }
 }

--- a/jme3-core/src/main/java/com/jme3/shader/UniformBinding.java
+++ b/jme3-core/src/main/java/com/jme3/shader/UniformBinding.java
@@ -196,19 +196,26 @@ public enum UniformBinding {
      * Type: vec4
      */
     LightColor("vec4");
-    
-    String glslType;
 
-    private UniformBinding() {
+    private static final UniformBinding[] VALUES = values();
+
+    public static UniformBinding valueOf(final int ordinal) {
+        if (ordinal < 0 || ordinal >= VALUES.length) {
+            throw new IllegalArgumentException("The ordinal is out of values range.");
+        }
+        return VALUES[ordinal];
     }
 
-    private UniformBinding(String glslType) {
+    String glslType;
+
+    UniformBinding() {
+    }
+
+    UniformBinding(String glslType) {
         this.glslType = glslType;
     }
 
     public String getGlslType() {
         return glslType;
     }
-    
-    
 }

--- a/jme3-core/src/main/java/com/jme3/shader/VarType.java
+++ b/jme3-core/src/main/java/com/jme3/shader/VarType.java
@@ -59,16 +59,24 @@ public enum VarType {
     TextureCubeMap(false,true,"samplerCube"),
     Int("int");
 
+    private static final VarType[] VALUES = values();
+
+    public static VarType valueOf(final int ordinal) {
+        if (ordinal < 0 || ordinal >= VALUES.length) {
+            throw new IllegalArgumentException("The ordinal is out of values range.");
+        }
+        return VALUES[ordinal];
+    }
+
     private boolean usesMultiData = false;
     private boolean textureType = false;
     private String glslType;
 
-    
-    VarType(String glslType){
+    VarType(String glslType) {
         this.glslType = glslType;
     }
 
-    VarType(boolean multiData, boolean textureType,String glslType){
+    VarType(boolean multiData, boolean textureType, String glslType) {
         usesMultiData = multiData;
         this.textureType = textureType;
         this.glslType = glslType;
@@ -84,6 +92,5 @@ public enum VarType {
 
     public String getGlslType() {
         return glslType;
-    }    
-
+    }
 }

--- a/jme3-core/src/main/java/com/jme3/shader/VariableMapping.java
+++ b/jme3-core/src/main/java/com/jme3/shader/VariableMapping.java
@@ -36,6 +36,9 @@ import com.jme3.export.JmeExporter;
 import com.jme3.export.JmeImporter;
 import com.jme3.export.OutputCapsule;
 import com.jme3.export.Savable;
+import com.jme3.util.clone.Cloner;
+import com.jme3.util.clone.JmeCloneable;
+
 import java.io.IOException;
 
 /**
@@ -43,7 +46,7 @@ import java.io.IOException;
  *
  * @author Nehon
  */
-public class VariableMapping implements Savable, Cloneable {
+public class VariableMapping implements Savable, JmeCloneable {
 
     private ShaderNodeVariable leftVariable;
     private ShaderNodeVariable rightVariable;
@@ -159,6 +162,21 @@ public class VariableMapping implements Savable, Cloneable {
         this.rightSwizzling = rightSwizzling;
     }
 
+    @Override
+    public VariableMapping jmeClone() {
+        try {
+            return (VariableMapping) super.clone();
+        } catch (final CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void cloneFields(final Cloner cloner, final Object original) {
+        leftVariable = cloner.clone(leftVariable);
+        rightVariable = cloner.clone(rightVariable);
+    }
+
     /**
      * jme serialization (not used)
      *
@@ -167,7 +185,7 @@ public class VariableMapping implements Savable, Cloneable {
      */
     @Override
     public void write(JmeExporter ex) throws IOException {
-        OutputCapsule oc = (OutputCapsule) ex.getCapsule(this);
+        OutputCapsule oc = ex.getCapsule(this);
         oc.write(leftVariable, "leftVariable", null);
         oc.write(rightVariable, "rightVariable", null);
         oc.write(condition, "condition", "");
@@ -183,7 +201,7 @@ public class VariableMapping implements Savable, Cloneable {
      */
     @Override
     public void read(JmeImporter im) throws IOException {
-        InputCapsule ic = (InputCapsule) im.getCapsule(this);
+        InputCapsule ic = im.getCapsule(this);
         leftVariable = (ShaderNodeVariable) ic.readSavable("leftVariable", null);
         rightVariable = (ShaderNodeVariable) ic.readSavable("rightVariable", null);
         condition = ic.readString("condition", "");
@@ -194,15 +212,5 @@ public class VariableMapping implements Savable, Cloneable {
     @Override
     public String toString() {
         return "\n{" + leftVariable.toString() + (leftSwizzling.length() > 0 ? ("." + leftSwizzling) : "") + " = " + rightVariable.getType() + " " + rightVariable.getNameSpace() + "." + rightVariable.getName() + (rightSwizzling.length() > 0 ? ("." + rightSwizzling) : "") + " : " + condition + "}";
-    }
-
-    @Override
-    protected VariableMapping clone() throws CloneNotSupportedException {
-        VariableMapping clone = (VariableMapping) super.clone();
-
-        clone.leftVariable = leftVariable.clone();
-        clone.rightVariable = rightVariable.clone();
-
-        return clone;
     }
 }


### PR DESCRIPTION
I like Jme clone system and savable objects system and I like to use it with all jME objects, but I saw that MaterialDef's things don't implement it. So I have migrated these things to use JmeClonable system and implemented JmeClonable/Savable interfaces for all these things.