### PR TITLE
Blender Importer: Don't crash when a packed texture couldn't be loaded

### DIFF
--- a/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/textures/TextureHelper.java
+++ b/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/textures/TextureHelper.java
@@ -72,6 +72,7 @@ import com.jme3.texture.Texture.WrapMode;
 import com.jme3.texture.Texture2D;
 import com.jme3.texture.image.ColorSpace;
 import com.jme3.util.BufferUtils;
+import com.jme3.util.PlaceholderAssets;
 
 /**
  * A class that is used in texture calculations.
@@ -256,7 +257,8 @@ public class TextureHelper extends AbstractBlenderHelper {
                     if (img != null) {
                         result = new Texture2D(img);
                     } else {
-                        LOGGER.fine("ImageLoader returned null. It probably failed to load the packed texture");
+                        result = new Texture2D(PlaceholderAssets.getPlaceholderImage(blenderContext.getAssetManager()));
+                        LOGGER.fine("ImageLoader returned null. It probably failed to load the packed texture, using placeholder asset");
                     }
                 }
             }

--- a/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/textures/TextureHelper.java
+++ b/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/textures/TextureHelper.java
@@ -251,7 +251,13 @@ public class TextureHelper extends AbstractBlenderHelper {
                     blenderContext.getInputStream().setPosition(dataFileBlock.getBlockPosition());
 
                     // Should the texture be flipped? It works for sinbad ..
-                    result = new Texture2D(new ImageLoader().loadImage(blenderContext.getInputStream(), dataFileBlock.getBlockPosition(), true));
+                    Image img = new ImageLoader().loadImage(blenderContext.getInputStream(), dataFileBlock.getBlockPosition(), true);
+                    
+                    if (img != null) {
+                        result = new Texture2D(img);
+                    } else {
+                        LOGGER.fine("ImageLoader returned null. It probably failed to load the packed texture");
+                    }
                 }
             }
         //} else {


### PR DESCRIPTION
So there is a little bug in the blender importer:
When there is a texture which couldn't be loaded (in my case it was a hdr file which wasn't supported yet), the whole import procedure crashed with a NullPointerException (loadImage() returned null).

Judging by 0e340416fdf399aec25da9711b501f081232abd9 and the general intention it would be better to import a model without that texture then (The code was already prepared for result being null), so we just don't throw an Exception when the Texture Loading failed.