### PR TITLE
Fix #456

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply from: file('version.gradle')
 subprojects {
     if(!project.name.equals('jme3-android-examples')) {
         apply from: rootProject.file('common.gradle')
-        if (!['jme3-testdata', 'sdk'].contains(project.name)) {
+        if (!project.name.equals('jme3-testdata')) {
             apply from: rootProject.file('bintray.gradle')
         }
     } else {
@@ -66,9 +66,9 @@ task createZipDistribution(type:Zip,dependsOn:["dist","libDist"], description:"P
     archiveName "jME" + jmeFullVersion + ".zip"
     into("/") {
          from {"./dist"}
-    }            
+    }
     into("/sources") {
-        from {"$buildDir/libDist/sources"}     
+        from {"$buildDir/libDist/sources"}
     }
 }
 
@@ -88,14 +88,14 @@ task dist(dependsOn: [':jme3-examples:dist', 'mergedJavadoc']){
 task mergedJavadoc(type: Javadoc, description: 'Creates Javadoc from all the projects.') {
     title = 'jMonkeyEngine3'
     destinationDir = mkdir("dist/javadoc")
-    
+
     options.encoding = 'UTF-8'
 
     // Allows Javadoc to be generated on Java 8 despite doclint errors.
     if (JavaVersion.current().isJava8Compatible()) {
         options.addStringOption('Xdoclint:none', '-quiet')
     }
-    
+
     options.overview = file("javadoc-overview.html")
     // Note: The closures below are executed lazily.
     source subprojects.collect {project ->
@@ -137,7 +137,7 @@ task configureAndroidNDK {
     if (System.env.ANDROID_NDK != null) {
         ndkBuildPath = System.env.ANDROID_NDK + File.separator + ndkBuildFile
     }
-    
+
     if (new File(ndkBuildPath).exists()) {
         ndkExists = true
         ndkCommandPath = ndkBuildPath

--- a/common.gradle
+++ b/common.gradle
@@ -16,6 +16,9 @@ repositories {
     maven {
         url "http://nifty-gui.sourceforge.net/nifty-maven-repo"
     }
+    flatDir {
+        dirs rootProject.file('lib')
+    }
 }
 
 dependencies {

--- a/jme3-android/build.gradle
+++ b/jme3-android/build.gradle
@@ -5,5 +5,5 @@ if (!hasProperty('mainClass')) {
 dependencies {
     compile project(':jme3-core')
     compile project(':jme3-plugins')
-    compile files('../lib/android.jar')
+    compileOnly 'android:android'
 }

--- a/jme3-jbullet/build.gradle
+++ b/jme3-jbullet/build.gradle
@@ -12,9 +12,9 @@ sourceSets {
 }
 
 dependencies {
-    compile ('java3d:vecmath:1.3.1')
-    compile files('../lib/jbullet.jar', '../lib/stack-alloc.jar')
+    compile 'java3d:vecmath:1.3.1'
+    compile 'jbullet:jbullet'
+    compile 'stack-alloc:stack-alloc'
     compile project(':jme3-core')
     compile project(':jme3-terrain')
-//    compile project(':jme3-bullet')
 }


### PR DESCRIPTION
When using a `flatDir` repository Gradle is able to copy the dependencies correctly