### PR TITLE
fixed NPE.

### DIFF
--- a/jme3-core/src/main/java/com/jme3/material/MatParam.java
+++ b/jme3-core/src/main/java/com/jme3/material/MatParam.java
@@ -37,6 +37,7 @@ import com.jme3.math.*;
 import com.jme3.shader.VarType;
 import com.jme3.texture.Texture;
 import com.jme3.texture.Texture.WrapMode;
+
 import java.io.IOException;
 
 /**
@@ -301,20 +302,17 @@ When arrays can be inserted in J3M files
         OutputCapsule oc = ex.getCapsule(this);
         oc.write(type, "varType", null);
         oc.write(name, "name", null);
-        if (value instanceof Savable) {
-            Savable s = (Savable) value;
-            oc.write(s, "value_savable", null);
+        if (value == null) {
+        } else if (value instanceof Savable) {
+            oc.write((Savable) value, "value_savable", null);
         } else if (value instanceof Float) {
-            Float f = (Float) value;
-            oc.write(f.floatValue(), "value_float", 0f);
+            oc.write((Float) value, "value_float", 0f);
         } else if (value instanceof Integer) {
-            Integer i = (Integer) value;
-            oc.write(i.intValue(), "value_int", 0);
+            oc.write((Integer) value, "value_int", 0);
         } else if (value instanceof Boolean) {
-            Boolean b = (Boolean) value;
-            oc.write(b.booleanValue(), "value_bool", false);
+            oc.write((Boolean) value, "value_bool", false);
         } else if (value.getClass().isArray() && value instanceof Savable[]) {
-            oc.write((Savable[])value, "value_savable_array", null);
+            oc.write((Savable[]) value, "value_savable_array", null);
         }
     }
 

--- a/jme3-core/src/main/java/com/jme3/material/MatParam.java
+++ b/jme3-core/src/main/java/com/jme3/material/MatParam.java
@@ -302,8 +302,12 @@ When arrays can be inserted in J3M files
         OutputCapsule oc = ex.getCapsule(this);
         oc.write(type, "varType", null);
         oc.write(name, "name", null);
+
         if (value == null) {
-        } else if (value instanceof Savable) {
+            return;
+        }
+
+        if (value instanceof Savable) {
             oc.write((Savable) value, "value_savable", null);
         } else if (value instanceof Float) {
             oc.write((Float) value, "value_float", 0f);


### PR DESCRIPTION
Fixed NPE during saving MatParamOverride. I found that MatParamOverride can have a null value in some cases. For example, if you look at the constructor of SkeletonControl, you can see that this control creates two MPO with null values by default.
```

        this.numberOfBonesParam = new MatParamOverride(VarType.Int, "NumberOfBones", null);
        this.boneMatricesParam = new MatParamOverride(VarType.Matrix4Array, "BoneMatrices", null);
```