### PR TITLE
fixed asset linked node to reuse shared data between loaded models.

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/AssetLinkNode.java
+++ b/jme3-core/src/main/java/com/jme3/scene/AssetLinkNode.java
@@ -31,16 +31,15 @@
  */
 package com.jme3.scene;
 
-import com.jme3.asset.AssetInfo;
 import com.jme3.asset.AssetManager;
 import com.jme3.asset.ModelKey;
 import com.jme3.export.InputCapsule;
 import com.jme3.export.JmeExporter;
 import com.jme3.export.JmeImporter;
 import com.jme3.export.OutputCapsule;
-import com.jme3.export.binary.BinaryImporter;
-import com.jme3.util.clone.Cloner;
 import com.jme3.util.SafeArrayList;
+import com.jme3.util.clone.Cloner;
+
 import java.io.IOException;
 import java.util.*;
 import java.util.Map.Entry;
@@ -164,25 +163,24 @@ public class AssetLinkNode extends Node {
     @Override
     public void read(JmeImporter e) throws IOException {
         super.read(e);
-        InputCapsule capsule = e.getCapsule(this);
-        BinaryImporter importer = BinaryImporter.getInstance();
-        AssetManager loaderManager = e.getAssetManager();
+
+        final InputCapsule capsule = e.getCapsule(this);
+        final AssetManager assetManager = e.getAssetManager();
 
         assetLoaderKeys = (ArrayList<ModelKey>) capsule.readSavableArrayList("assetLoaderKeyList", new ArrayList<ModelKey>());
-        for (Iterator<ModelKey> it = assetLoaderKeys.iterator(); it.hasNext();) {
-            ModelKey modelKey = it.next();
-            AssetInfo info = loaderManager.locateAsset(modelKey);
-            Spatial child = null;
-            if (info != null) {
-                child = (Spatial) importer.load(info);
-            }
+
+        for (final Iterator<ModelKey> iterator = assetLoaderKeys.iterator(); iterator.hasNext(); ) {
+
+            final ModelKey modelKey = iterator.next();
+            final Spatial child = assetManager.loadAsset(modelKey);
+
             if (child != null) {
                 child.parent = this;
                 children.add(child);
                 assetChildren.put(modelKey, child);
             } else {
-                Logger.getLogger(this.getClass().getName()).log(Level.WARNING, "Cannot locate {0} for asset link node {1}",
-                                                                    new Object[]{ modelKey, key });
+                Logger.getLogger(this.getClass().getName()).log(Level.WARNING,
+                        "Cannot locate {0} for asset link node {1}", new Object[]{modelKey, key});
             }
         }
     }
@@ -190,7 +188,7 @@ public class AssetLinkNode extends Node {
     @Override
     public void write(JmeExporter e) throws IOException {
         SafeArrayList<Spatial> childs = children;
-        children = new SafeArrayList<Spatial>(Spatial.class);
+        children = new SafeArrayList<>(Spatial.class);
         super.write(e);
         OutputCapsule capsule = e.getCapsule(this);
         capsule.writeSavableArrayList(assetLoaderKeys, "assetLoaderKeyList", null);

--- a/jme3-core/src/main/resources/com/jme3/asset/General.cfg
+++ b/jme3-core/src/main/resources/com/jme3/asset/General.cfg
@@ -12,8 +12,8 @@ LOADER com.jme3.texture.plugins.DDSLoader : dds
 LOADER com.jme3.texture.plugins.PFMLoader : pfm
 LOADER com.jme3.texture.plugins.HDRLoader : hdr
 LOADER com.jme3.texture.plugins.TGALoader : tga
-LOADER com.jme3.export.binary.BinaryImporter : j3o
-LOADER com.jme3.export.binary.BinaryImporter : j3f
+LOADER com.jme3.export.binary.BinaryLoader : j3o
+LOADER com.jme3.export.binary.BinaryLoader : j3f
 LOADER com.jme3.scene.plugins.OBJLoader : obj
 LOADER com.jme3.scene.plugins.MTLLoader : mtl
 LOADER com.jme3.scene.plugins.ogre.MeshLoader : meshxml, mesh.xml

--- a/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryLoader.java
@@ -1,10 +1,7 @@
 package com.jme3.export.binary;
 
 import com.jme3.asset.AssetInfo;
-import com.jme3.asset.AssetManager;
-import com.jme3.export.InputCapsule;
-import com.jme3.export.JmeImporter;
-import com.jme3.export.Savable;
+import com.jme3.asset.AssetLoader;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -15,64 +12,30 @@ import java.util.Deque;
  *
  * @author JavaSaBr
  */
-public class BinaryLoader implements JmeImporter {
+public class BinaryLoader implements AssetLoader {
 
     /**
-     * The thread local importers.
+     * The importers queue.
      */
-    private final ThreadLocal<Deque<BinaryImporter>> threadLocalImporters;
-
-    /**
-     * The current importer.
-     */
-    private final ThreadLocal<BinaryImporter> currentImporter;
+    private final Deque<BinaryImporter> importers;
 
     public BinaryLoader() {
-        currentImporter = new ThreadLocal<>();
-        threadLocalImporters = new ThreadLocal<Deque<BinaryImporter>>() {
-
-            @Override
-            protected Deque<BinaryImporter> initialValue() {
-                return new ArrayDeque<>();
-            }
-        };
-    }
-
-    @Override
-    public InputCapsule getCapsule(final Savable id) {
-        final BinaryImporter importer = currentImporter.get();
-        return importer.getCapsule(id);
-    }
-
-    @Override
-    public AssetManager getAssetManager() {
-        final BinaryImporter importer = currentImporter.get();
-        return importer.getAssetManager();
-    }
-
-    @Override
-    public int getFormatVersion() {
-        final BinaryImporter importer = currentImporter.get();
-        return importer.getFormatVersion();
+        importers = new ArrayDeque<>();
     }
 
     @Override
     public Object load(final AssetInfo assetInfo) throws IOException {
 
-        final Deque<BinaryImporter> importers = threadLocalImporters.get();
         BinaryImporter importer = importers.pollLast();
 
         if (importer == null) {
             importer = new BinaryImporter();
         }
 
-        final BinaryImporter prev = currentImporter.get();
-        currentImporter.set(importer);
         try {
             return importer.load(assetInfo);
         } finally {
             importers.addLast(importer);
-            currentImporter.set(prev);
         }
     }
 }

--- a/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryLoader.java
@@ -1,0 +1,78 @@
+package com.jme3.export.binary;
+
+import com.jme3.asset.AssetInfo;
+import com.jme3.asset.AssetManager;
+import com.jme3.export.InputCapsule;
+import com.jme3.export.JmeImporter;
+import com.jme3.export.Savable;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * The default loader to load binaries files.
+ *
+ * @author JavaSaBr
+ */
+public class BinaryLoader implements JmeImporter {
+
+    /**
+     * The thread local importers.
+     */
+    private final ThreadLocal<Deque<BinaryImporter>> threadLocalImporters;
+
+    /**
+     * The current importer.
+     */
+    private final ThreadLocal<BinaryImporter> currentImporter;
+
+    public BinaryLoader() {
+        currentImporter = new ThreadLocal<>();
+        threadLocalImporters = new ThreadLocal<Deque<BinaryImporter>>() {
+
+            @Override
+            protected Deque<BinaryImporter> initialValue() {
+                return new ArrayDeque<>();
+            }
+        };
+    }
+
+    @Override
+    public InputCapsule getCapsule(final Savable id) {
+        final BinaryImporter importer = currentImporter.get();
+        return importer.getCapsule(id);
+    }
+
+    @Override
+    public AssetManager getAssetManager() {
+        final BinaryImporter importer = currentImporter.get();
+        return importer.getAssetManager();
+    }
+
+    @Override
+    public int getFormatVersion() {
+        final BinaryImporter importer = currentImporter.get();
+        return importer.getFormatVersion();
+    }
+
+    @Override
+    public Object load(final AssetInfo assetInfo) throws IOException {
+
+        final Deque<BinaryImporter> importers = threadLocalImporters.get();
+        BinaryImporter importer = importers.pollLast();
+
+        if (importer == null) {
+            importer = new BinaryImporter();
+        }
+
+        final BinaryImporter prev = currentImporter.get();
+        currentImporter.set(importer);
+        try {
+            return importer.load(assetInfo);
+        } finally {
+            importers.addLast(importer);
+            currentImporter.set(prev);
+        }
+    }
+}


### PR DESCRIPTION
I looked at the problem more deeply which was described by @NemesisMate here:
https://hub.jmonkeyengine.org/t/linkedassets-arent-sharing-meshes-when-imported/38494?u=nemesismate
So I think we need to use asset manager to load children of the asset linked node, but at this moment, BinaryImporter doesn't process correctly recursive loading models in this case, because the importer has a state which was inconsistent in my tests. I offer one of some solutions of this problem, of course, core team can have more correctly vision of this.