### PR TITLE
Geometry: set worldTransform to identity if ignoreTranform is true

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Geometry.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Geometry.java
@@ -138,6 +138,20 @@ public class Geometry extends Spatial {
     }
 
     /**
+     * Update the world transform of this Geometry and clear the
+     * TRANSFORM refresh flag.
+     */
+    @Override
+    void checkDoTransformUpdate() {
+        if (ignoreTransform) {
+            worldTransform.loadIdentity();
+            refreshFlags &= ~RF_TRANSFORM;
+        } else {
+            super.checkDoTransformUpdate();
+        }    
+    }
+    
+    /**
      * @return If ignoreTransform mode is set.
      *
      * @see Geometry#setIgnoreTransform(boolean)
@@ -151,6 +165,7 @@ public class Geometry extends Spatial {
      */
     public void setIgnoreTransform(boolean ignoreTransform) {
         this.ignoreTransform = ignoreTransform;
+        setTransformRefresh();
     }
 
     /**
@@ -398,9 +413,6 @@ public class Geometry extends Spatial {
 
         // Compute the cached world matrix
         cachedWorldMat.loadIdentity();
-        if (ignoreTransform) {
-            return;
-        }
         cachedWorldMat.setRotationQuaternion(worldTransform.getRotation());
         cachedWorldMat.setTranslation(worldTransform.getTranslation());
 


### PR DESCRIPTION
This PR changes the semantics of localToWorld() and worldToLocal() to identities in the case that ignoreTransform is set to true on the Geometry. I think this is more useful than applying a transform that isn't actually used in visualization. Also getWorldRotation(), getWorldScale(), getWorldTransform() and getWorldRotation() will return identities if ignoreTransform is set, which is consistent with localToWorld() if not perfectly intuitive.

I've confirmed that this change doesn't break CollideIgnoreTransformTest.  By itself, it doesn't fix issue #742 nor issue #743, though it should make both those issues slightly easier to fix.