### PR TITLE
Prevent double-updating the main scene in VR

### DIFF
--- a/jme3-vr/src/main/java/com/jme3/app/VRAppState.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VRAppState.java
@@ -398,24 +398,12 @@ public class VRAppState extends AbstractAppState {
         } else if( environment.getObserver() != null ) {
             environment.getCamera().setFrame(((Spatial)environment.getObserver()).getWorldTranslation(), ((Spatial)environment.getObserver()).getWorldRotation());
         }
-        
-        //FIXME: check if this code is necessary.
-        // Updates scene and gui states.
-        Iterator<Spatial> spatialIter = getLeftViewPort().getScenes().iterator();
-        Spatial spatial = null;
-        while(spatialIter.hasNext()){
-        	spatial = spatialIter.next();
-        	spatial.updateLogicalState(tpf);
-        	spatial.updateGeometricState();
-        }
 
         if( environment.isInVR() == false || environment.getVRGUIManager().getPositioningMode() == VRGUIPositioningMode.MANUAL ) {
             // only update geometric state here if GUI is in manual mode, or not in VR
             // it will get updated automatically in the viewmanager update otherwise
-        	spatialIter = application.getGuiViewPort().getScenes().iterator();
-            spatial = null;
-            while(spatialIter.hasNext()){
-            	spatial = spatialIter.next();
+            // TODO isn't this done by SimpleApplication?
+            for (Spatial spatial : application.getGuiViewPort().getScenes()) {
             	spatial.updateGeometricState();
             }    
         }


### PR DESCRIPTION
Currently, due to some changes I made while getting the GUI to work on the Rift, the main scene is being updated twice per frame while in VR, both on the Rift and SteamVR.

The loop used to iterate over `application.getViewPort().getScenes()`, and reverting to this fixed the issue on SteamVR.

On SteamVR, the main viewport is always empty while in VR, so removing the original version of the loop does not change anything. However, the main scene remained in the appliation viewport on the Rift, and as such removing the loop entirely fixes the issue.

See: [jME Forum post](https://hub.jmonkeyengine.org/t/jme3-vr-duplicate-calls-to-update/39479).