### PR TITLE
Fixed the problem with LightControl.

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
@@ -42,8 +42,9 @@ import com.jme3.light.SpotLight;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.ViewPort;
-import com.jme3.scene.Spatial;
 import com.jme3.util.TempVars;
+import com.jme3.util.clone.Cloner;
+
 import java.io.IOException;
 
 /**
@@ -54,7 +55,10 @@ import java.io.IOException;
  */
 public class LightControl extends AbstractControl {
 
-    public static enum ControlDirection {
+    private static final String CONTROL_DIR_NAME = "controlDir";
+    private static final String LIGHT_NAME = "light";
+
+    public enum ControlDirection {
 
         /**
          * Means, that the Light's transform is "copied"
@@ -67,6 +71,7 @@ public class LightControl extends AbstractControl {
          */
         SpatialToLight;
     }
+
     private Light light;
     private ControlDirection controlDir = ControlDirection.SpatialToLight;
 
@@ -113,7 +118,7 @@ public class LightControl extends AbstractControl {
         if (spatial != null && light != null) {
             switch (controlDir) {
                 case SpatialToLight:
-                    spatialTolight(light);
+                    spatialToLight(light);
                     break;
                 case LightToSpatial:
                     lightToSpatial(light);
@@ -122,22 +127,29 @@ public class LightControl extends AbstractControl {
         }
     }
 
-    private void spatialTolight(Light light) {
+    private void spatialToLight(Light light) {
+
+        final Vector3f worldTranslation = spatial.getWorldTranslation();
+
         if (light instanceof PointLight) {
-            ((PointLight) light).setPosition(spatial.getWorldTranslation());
+            ((PointLight) light).setPosition(worldTranslation);
+            return;
         }
-        TempVars vars = TempVars.get();
+
+        final TempVars vars = TempVars.get();
+        final Vector3f vec = vars.vect1;
 
         if (light instanceof DirectionalLight) {
-            ((DirectionalLight) light).setDirection(vars.vect1.set(spatial.getWorldTranslation()).multLocal(-1.0f));
+            ((DirectionalLight) light).setDirection(vec.set(worldTranslation).multLocal(-1.0f));
         }
 
         if (light instanceof SpotLight) {
-            ((SpotLight) light).setPosition(spatial.getWorldTranslation());            
-            ((SpotLight) light).setDirection(spatial.getWorldRotation().multLocal(vars.vect1.set(Vector3f.UNIT_Y).multLocal(-1)));
+            final SpotLight spotLight = (SpotLight) light;
+            spotLight.setPosition(worldTranslation);
+            spotLight.setDirection(spatial.getWorldRotation().multLocal(vec.set(Vector3f.UNIT_Y).multLocal(-1)));
         }
-        vars.release();
 
+        vars.release();
     }
 
     private void lightToSpatial(Light light) {
@@ -158,8 +170,6 @@ public class LightControl extends AbstractControl {
         }
         vars.release();
         //TODO add code for Spot light here when it's done
-
-
     }
 
     @Override
@@ -167,23 +177,18 @@ public class LightControl extends AbstractControl {
         // nothing to do
     }
 
-    // default implementation from AbstractControl is equivalent
-    //@Override
-    //public Control cloneForSpatial(Spatial newSpatial) {
-    //    LightControl control = new LightControl(light, controlDir);
-    //    control.setSpatial(newSpatial);
-    //    control.setEnabled(isEnabled());
-    //    return control;
-    //}
-    private static final String CONTROL_DIR_NAME = "controlDir";
-    private static final String LIGHT_NAME = "light";
-    
+    @Override
+    public void cloneFields(final Cloner cloner, final Object original) {
+        super.cloneFields(cloner, original);
+        light = cloner.clone(light);
+    }
+
     @Override
     public void read(JmeImporter im) throws IOException {
         super.read(im);
         InputCapsule ic = im.getCapsule(this);
         controlDir = ic.readEnum(CONTROL_DIR_NAME, ControlDirection.class, ControlDirection.SpatialToLight);
-        light = (Light)ic.readSavable(LIGHT_NAME, null);
+        light = (Light) ic.readSavable(LIGHT_NAME, null);
     }
 
     @Override


### PR DESCRIPTION
Fixed the problem with the reference to light, when we had incorrect reference to the light after loading/cloning spatial of this control.

Example:
I have a node with a point light and a light control with the reference to the light. When I load the node late, I have a cloned version of the node with a cloned version of the light and a cloned version of the light control, but the cloned control related to original light.