### PR TITLE
Fixed detecting varyings during loading shader nodes.

### DIFF
--- a/jme3-core/src/plugins/java/com/jme3/material/plugins/ShaderNodeLoaderDelegate.java
+++ b/jme3-core/src/plugins/java/com/jme3/material/plugins/ShaderNodeLoaderDelegate.java
@@ -70,10 +70,10 @@ public class ShaderNodeLoaderDelegate {
     protected ShaderNodeDefinition shaderNodeDefinition;
     protected ShaderNode shaderNode;
     protected TechniqueDef techniqueDef;
-    protected Map<String, DeclaredVariable> attributes = new HashMap<String, DeclaredVariable>();
-    protected Map<String, DeclaredVariable> vertexDeclaredUniforms = new HashMap<String, DeclaredVariable>();
-    protected Map<String, DeclaredVariable> fragmentDeclaredUniforms = new HashMap<String, DeclaredVariable>();
-    protected Map<String, DeclaredVariable> varyings = new HashMap<String, DeclaredVariable>();
+    protected Map<String, DeclaredVariable> attributes = new HashMap<>();
+    protected Map<String, DeclaredVariable> vertexDeclaredUniforms = new HashMap<>();
+    protected Map<String, DeclaredVariable> fragmentDeclaredUniforms = new HashMap<>();
+    protected Map<String, DeclaredVariable> varyings = new HashMap<>();
     protected MaterialDef materialDef;
     protected String shaderLanguage;
     protected String shaderName;
@@ -553,13 +553,13 @@ public class ShaderNodeLoaderDelegate {
                 //the right variable must have the same multiplicity and the same condition.
                 right.setMultiplicity(multiplicity);
                 right.setCondition(mapping.getLeftVariable().getCondition());
-            }       
+            }
             dv = new DeclaredVariable(right);
             map.put(right.getName(), dv);
-            dv.addNode(shaderNode);  
+            dv.addNode(shaderNode);
             mapping.setRightVariable(right);
             return true;
-        }      
+        }
         dv.addNode(shaderNode);
         mapping.setRightVariable(dv.var);
         return false;
@@ -943,21 +943,33 @@ public class ShaderNodeLoaderDelegate {
      */
     public void storeVaryings(ShaderNode node, ShaderNodeVariable variable) {
         variable.setShaderOutput(true);
-        if (node.getDefinition().getType() == Shader.ShaderType.Vertex && shaderNode.getDefinition().getType() == Shader.ShaderType.Fragment) {
-            DeclaredVariable dv = varyings.get(variable.getName());
-            if (dv == null) {
-                techniqueDef.getShaderGenerationInfo().getVaryings().add(variable);
-                dv = new DeclaredVariable(variable);
 
-                varyings.put(variable.getName(), dv);
-            }
-            dv.addNode(shaderNode);
-            //if a variable is declared with the same name as an input and an output and is a varying, set it as a shader output so it's declared as a varying only once.
-            for (VariableMapping variableMapping : node.getInputMapping()) {
-                final ShaderNodeVariable leftVariable = variableMapping.getLeftVariable();
-                if (leftVariable.getName().equals(variable.getName())) {
-                    leftVariable.setShaderOutput(true);
-                }
+        final ShaderNodeDefinition nodeDefinition = node.getDefinition();
+        final ShaderNodeDefinition currentDefinition = shaderNode.getDefinition();
+
+        if (nodeDefinition.getType() != Shader.ShaderType.Vertex ||
+                currentDefinition.getType() != Shader.ShaderType.Fragment) {
+            return;
+        }
+
+        final String fullName = node.getName() + "." + variable.getName();
+
+        DeclaredVariable declaredVar = varyings.get(fullName);
+
+        if (declaredVar == null) {
+            techniqueDef.getShaderGenerationInfo().getVaryings().add(variable);
+            declaredVar = new DeclaredVariable(variable);
+            varyings.put(fullName, declaredVar);
+        }
+
+        declaredVar.addNode(shaderNode);
+
+        // if a variable is declared with the same name as an input and an output and is a varying,
+        // set it as a shader output so it's declared as a varying only once.
+        for (final VariableMapping variableMapping : node.getInputMapping()) {
+            final ShaderNodeVariable leftVariable = variableMapping.getLeftVariable();
+            if (leftVariable.getName().equals(variable.getName())) {
+                leftVariable.setShaderOutput(true);
             }
         }
     }
@@ -1022,7 +1034,7 @@ public class ShaderNodeLoaderDelegate {
 
     private Map<String, ShaderNodeDefinition> getNodeDefinitions() {
         if (nodeDefinitions == null) {
-            nodeDefinitions = new HashMap<String, ShaderNodeDefinition>();
+            nodeDefinitions = new HashMap<>();
         }
         return nodeDefinitions;
     }


### PR DESCRIPTION
Fixed detecting varyings during loading shader nodes in the case, when we have several output parameters with the same name but with different namespaces.