### PR TITLE
roll back PR 746 (worldTransform to identity) in master branch

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Geometry.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Geometry.java
@@ -138,20 +138,6 @@ public class Geometry extends Spatial {
     }
 
     /**
-     * Update the world transform of this Geometry and clear the
-     * TRANSFORM refresh flag.
-     */
-    @Override
-    void checkDoTransformUpdate() {
-        if (ignoreTransform) {
-            worldTransform.loadIdentity();
-            refreshFlags &= ~RF_TRANSFORM;
-        } else {
-            super.checkDoTransformUpdate();
-        }    
-    }
-    
-    /**
      * @return If ignoreTransform mode is set.
      *
      * @see Geometry#setIgnoreTransform(boolean)
@@ -165,7 +151,6 @@ public class Geometry extends Spatial {
      */
     public void setIgnoreTransform(boolean ignoreTransform) {
         this.ignoreTransform = ignoreTransform;
-        setTransformRefresh();
     }
 
     /**
@@ -413,6 +398,9 @@ public class Geometry extends Spatial {
 
         // Compute the cached world matrix
         cachedWorldMat.loadIdentity();
+        if (ignoreTransform) {
+            return;
+        }
         cachedWorldMat.setRotationQuaternion(worldTransform.getRotation());
         cachedWorldMat.setTranslation(worldTransform.getTranslation());
 


### PR DESCRIPTION
Based on recent forum discussion at 

https://hub.jmonkeyengine.org/t/3-2-0-alpha-phase/39711/36

I'm rolling back PR 746. With this change, the emitter in TestMovingParticle appears to move again. I'm optimistic that this will also resolve glh3586's issue. 