### PR TITLE
Blender ImageLoader: Support Loading of HDR Files and many other

### DIFF
--- a/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/textures/TextureHelper.java
+++ b/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/textures/TextureHelper.java
@@ -252,11 +252,8 @@ public class TextureHelper extends AbstractBlenderHelper {
                     blenderContext.getInputStream().setPosition(dataFileBlock.getBlockPosition());
 
                     // Should the texture be flipped? It works for sinbad ..
-                    Image img = new ImageLoader().loadImage(blenderContext.getInputStream(), dataFileBlock.getBlockPosition(), true);
-                    
-                    if (img != null) {
-                        result = new Texture2D(img);
-                    } else {
+                    result = new ImageLoader().loadTexture(blenderContext.getAssetManager(), blenderContext.getInputStream(), dataFileBlock.getBlockPosition(), true);
+                    if (result == null) {
                         result = new Texture2D(PlaceholderAssets.getPlaceholderImage(blenderContext.getAssetManager()));
                         LOGGER.fine("ImageLoader returned null. It probably failed to load the packed texture, using placeholder asset");
                     }


### PR DESCRIPTION
See jMonkeyEngine/jmonkeyengine#727

When a blender file contained a hdr image, for example, the engine is able to load that as a texture, however the blender importer didn't do so.
This was because it didn't rely on the AssetManager to load images but instead called some Loaders directly.

This pull request fixes this by using the AM, which means any (even user-) registered AssetLoader can be used to load textures from blender files now.

I've made an API Change though: ImageLoader is now more of a TextureLoader. The AssetManager can only hand back Texture objects and since there is no point in converting: Texture->Image->Texture, I added loadTexture() and deprecated loadImage.

Technically loadImage could be removed as well since it's never called, but I kept it in for now.