### PR TITLE
avoid ClassCastException in Uniform.setValue()

### DIFF
--- a/jme3-core/src/main/java/com/jme3/shader/Uniform.java
+++ b/jme3-core/src/main/java/com/jme3/shader/Uniform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2017 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -348,21 +348,51 @@ public class Uniform extends ShaderVariable {
                 if (value.equals(this.value)) {
                     return;
                 }
-                if (value instanceof ColorRGBA) {
-                    if (this.value == null) {
-                        this.value = new ColorRGBA();
+                if (this.value instanceof ColorRGBA) {
+                    ColorRGBA thisValue = (ColorRGBA) this.value;
+                    if (value instanceof ColorRGBA) {
+                        thisValue.set((ColorRGBA) value);
+                    } else if (value instanceof Quaternion) {
+                        Quaternion q = (Quaternion) value;
+                        thisValue.set(q.getX(), q.getY(), q.getZ(), q.getW());
+                    } else if (value instanceof Vector4f) {
+                        Vector4f v = (Vector4f) value;
+                        thisValue.set(v.x, v.y, v.z, v.w);
                     }
-                    ((ColorRGBA) this.value).set((ColorRGBA) value);
-                } else if (value instanceof Vector4f) {
-                    if (this.value == null) {
-                        this.value = new Vector4f();
+                } else if (this.value instanceof Quaternion) {
+                    Quaternion thisValue = (Quaternion) this.value;
+                    if (value instanceof ColorRGBA) {
+                        ColorRGBA c = (ColorRGBA) value;
+                        thisValue.set(c.r, c.g, c.b, c.a);
+                    } else if (value instanceof Quaternion) {
+                        thisValue.set((Quaternion) value);
+                    } else if (value instanceof Vector4f) {
+                        Vector4f v = (Vector4f) value;
+                        thisValue.set(v.x, v.y, v.z, v.w);
                     }
-                    ((Vector4f) this.value).set((Vector4f) value);
+                } else if (this.value instanceof Vector4f) {
+                    Vector4f thisValue = (Vector4f) this.value;
+                    if (value instanceof ColorRGBA) {
+                        ColorRGBA c = (ColorRGBA) value;
+                        thisValue.set(c.r, c.g, c.b, c.a);
+                    } else if (value instanceof Quaternion) {
+                        Quaternion q = (Quaternion) value;
+                        thisValue.set(q.getX(), q.getY(), q.getZ(), q.getW());
+                    } else if (value instanceof Vector4f) {
+                        thisValue.set((Vector4f) value);
+                    }
                 } else {
-                    if (this.value == null) {
-                        this.value = new Quaternion();
+                    assert this.value == null;
+                    if (value instanceof ColorRGBA) {
+                        ColorRGBA c = (ColorRGBA) value;
+                        this.value = c.clone();
+                    } else if (value instanceof Quaternion) {
+                        Quaternion q = (Quaternion) value;
+                        this.value = q.clone();
+                    } else if (value instanceof Vector4f) {
+                        Vector4f v = (Vector4f) value;
+                        this.value = v.clone();
                     }
-                    ((Quaternion) this.value).set((Quaternion) value);
                 }
                 break;
                 // Only use check if equals optimization for primitive values

--- a/jme3-examples/src/main/java/jme3test/material/TestMatParamOverride.java
+++ b/jme3-examples/src/main/java/jme3test/material/TestMatParamOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2016 jMonkeyEngine
+ * Copyright (c) 2009-2017 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,6 +38,8 @@ import com.jme3.input.controls.KeyTrigger;
 import com.jme3.material.MatParamOverride;
 import com.jme3.material.Material;
 import com.jme3.math.ColorRGBA;
+import com.jme3.math.Quaternion;
+import com.jme3.math.Vector4f;
 import com.jme3.scene.Geometry;
 import com.jme3.scene.shape.Box;
 import com.jme3.shader.VarType;
@@ -50,7 +52,15 @@ import com.jme3.shader.VarType;
 public class TestMatParamOverride extends SimpleApplication {
 
     private Box box = new Box(1, 1, 1);
-    private MatParamOverride override = new MatParamOverride(VarType.Vector4, "Color", ColorRGBA.Yellow);
+    final MatParamOverride overrideYellow
+            = new MatParamOverride(VarType.Vector4, "Color",
+                    ColorRGBA.Yellow);
+    final MatParamOverride overrideWhite
+            = new MatParamOverride(VarType.Vector4, "Color",
+                    Vector4f.UNIT_XYZW);
+    final MatParamOverride overrideGray
+            = new MatParamOverride(VarType.Vector4, "Color",
+                    new Quaternion(0.5f, 0.5f, 0.5f, 1f));
 
     public static void main(String[] args) {
         TestMatParamOverride app = new TestMatParamOverride();
@@ -74,19 +84,30 @@ public class TestMatParamOverride extends SimpleApplication {
         createBox(0, ColorRGBA.Green);
         createBox(3, ColorRGBA.Blue);
 
-        inputManager.addMapping("override", new KeyTrigger(KeyInput.KEY_SPACE));
+        System.out.println("Press G, W, Y, or space bar ...");
+        inputManager.addMapping("overrideClear", new KeyTrigger(KeyInput.KEY_SPACE));
+        inputManager.addMapping("overrideGray", new KeyTrigger(KeyInput.KEY_G));
+        inputManager.addMapping("overrideWhite", new KeyTrigger(KeyInput.KEY_W));
+        inputManager.addMapping("overrideYellow", new KeyTrigger(KeyInput.KEY_Y));
         inputManager.addListener(new ActionListener() {
             @Override
             public void onAction(String name, boolean isPressed, float tpf) {
-                if (name.equals("override") && isPressed) {
-                    if (!rootNode.getLocalMatParamOverrides().isEmpty()) {
+                if (isPressed) {
+                    if (name.equals("overrideClear")) {
                         rootNode.clearMatParamOverrides();
-                    } else {
-                        rootNode.addMatParamOverride(override);
+                    } else if (name.equals("overrideGray")) {
+                        rootNode.clearMatParamOverrides();
+                        rootNode.addMatParamOverride(overrideGray);
+                    } else if (name.equals("overrideWhite")) {
+                        rootNode.clearMatParamOverrides();
+                        rootNode.addMatParamOverride(overrideWhite);
+                    } else if (name.equals("overrideYellow")) {
+                        rootNode.clearMatParamOverrides();
+                        rootNode.addMatParamOverride(overrideYellow);
                     }
                     System.out.println(rootNode.getLocalMatParamOverrides());
                 }
             }
-        }, "override");
+        }, "overrideClear", "overrideGray", "overrideWhite", "overrideYellow");
     }
 }


### PR DESCRIPTION
In 3.1, a delayed ClassCastException would occur com.jme3.shader.Uniform#setValue() whenever:
  1. a ColorRGBA material parameter was overridden by a Quaternion/Vector4f 
  2. a Quaternion material parameter was overridden by a ColorRGBA/Vector4f OR
  3. a Vector4f material parameter was overridden by a ColorRGBA/Quaternion .

To the shader, these all represent Vector4 values, but to Java they are incompatible objects.
 