### PR TITLE
initialize InputManager.cursorPos to fix issue #792 (if using LWJGL)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/input/InputManager.java
+++ b/jme3-core/src/main/java/com/jme3/input/InputManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2018 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -423,15 +423,22 @@ public class InputManager implements RawInputListener {
 
     /**
      * Callback from RawInputListener. Do not use.
+     *
+     * @param evt event to add to the input queue (not null)
      */
     @Override
     public void onMouseMotionEvent(MouseMotionEvent evt) {
-        if (!eventsPermitted) {
-            throw new UnsupportedOperationException("MouseInput has raised an event at an illegal time.");
-        }
-
+        /*
+         * If events aren't allowed, the event may be a "first mouse event"
+         * triggered by the constructor setting the the mouse listener.
+         * In that case, use the event to initialize the cursor position,
+         * but don't queue it for futher processing.
+         * This is part of the fix for issue #792.
+         */
         cursorPos.set(evt.getX(), evt.getY());
-        inputQueue.add(evt);
+        if (eventsPermitted) {
+            inputQueue.add(evt);
+        }
     }
 
     private void onMouseButtonEventQueued(MouseButtonEvent evt) {

--- a/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/LwjglMouseInput.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/LwjglMouseInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2018 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -85,6 +85,10 @@ public class LwjglMouseInput implements MouseInput {
         } catch (LWJGLException ex) {
             logger.log(Level.SEVERE, "Error while creating mouse", ex);
         }
+
+        if (listener != null) {
+            sendFirstMouseEvent();
+        }
     }
 
     public boolean isInitialized(){
@@ -158,8 +162,32 @@ public class LwjglMouseInput implements MouseInput {
         Mouse.setGrabbed(!visible);
     }
 
+    @Override
     public void setInputListener(RawInputListener listener) {
         this.listener = listener;
+        if (listener != null && Mouse.isCreated()) {
+            sendFirstMouseEvent();
+        }
+    }
+
+    /**
+     * Send the input listener a special mouse-motion event with zero deltas in
+     * order to initialize the listener's cursor position.
+     */
+    private void sendFirstMouseEvent() {
+        assert listener != null;
+        assert Mouse.isCreated();
+
+        int x = Mouse.getX();
+        int y = Mouse.getY();
+        int xDelta = 0;
+        int yDelta = 0;
+        int wheelDelta = 0;
+        MouseMotionEvent evt = new MouseMotionEvent(x, y, xDelta, yDelta,
+                curWheel, wheelDelta);
+        evt.setTime(Mouse.getEventNanoseconds());
+
+        listener.onMouseMotionEvent(evt);
     }
 
     public long getInputTimeNanos() {


### PR DESCRIPTION
It's not pretty code, but it improves the behavior of InputManager when LWJGL is in use and shouldn't break anything (that isn't already broken) when it isn't.

For the longer term, a cleaner solution might be to modify MouseInput.setInputListener() so that it returns the current mouse position.

Let me know what you think!