### PR TITLE
Fixed typo in PhysicSpace described in issue #538

### DIFF
--- a/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
@@ -235,7 +235,7 @@ public class PhysicsSpace {
 //                    collides = (bp1.collisionFilterGroup & bp.collisionFilterMask) != 0;
 //                }
 //                if (collides) {
-//                    assert (bp.clientObject instanceof com.bulletphysics.collision.dispatch.CollisionObject && bp.clientObject instanceof com.bulletphysics.collision.dispatch.CollisionObject);
+//                    assert (bp.clientObject instanceof com.bulletphysics.collision.dispatch.CollisionObject && bp1.clientObject instanceof com.bulletphysics.collision.dispatch.CollisionObject);
 //                    com.bulletphysics.collision.dispatch.CollisionObject colOb = (com.bulletphysics.collision.dispatch.CollisionObject) bp.clientObject;
 //                    com.bulletphysics.collision.dispatch.CollisionObject colOb1 = (com.bulletphysics.collision.dispatch.CollisionObject) bp1.clientObject;
 //                    assert (colOb.getUserPointer() != null && colOb1.getUserPointer() != null);

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
@@ -227,7 +227,7 @@ public class PhysicsSpace {
                     collides = (bp1.collisionFilterGroup & bp.collisionFilterMask) != 0;
                 }
                 if (collides) {
-                    assert (bp.clientObject instanceof com.bulletphysics.collision.dispatch.CollisionObject && bp.clientObject instanceof com.bulletphysics.collision.dispatch.CollisionObject);
+                    assert (bp.clientObject instanceof com.bulletphysics.collision.dispatch.CollisionObject && bp1.clientObject instanceof com.bulletphysics.collision.dispatch.CollisionObject);
                     com.bulletphysics.collision.dispatch.CollisionObject colOb = (com.bulletphysics.collision.dispatch.CollisionObject) bp.clientObject;
                     com.bulletphysics.collision.dispatch.CollisionObject colOb1 = (com.bulletphysics.collision.dispatch.CollisionObject) bp1.clientObject;
                     assert (colOb.getUserPointer() != null && colOb1.getUserPointer() != null);


### PR DESCRIPTION
This pull request fixes the typo in the assert statement in the class PhysicSpace.
The typo is contained in both packages: jme3-bullet and jme3-jbullet but note that in first the whole method is commented out anyway.