### PR TITLE
add getters to shadow renderers/filters for number of maps and sizes

### DIFF
--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
@@ -311,6 +311,24 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
         return shadowRenderer.getEdgeFilteringMode();
     }
 
+    /**
+     * Read the number of shadow maps rendered by this filter.
+     *
+     * @return count
+     */
+    public int getNumShadowMaps() {
+        return shadowRenderer.getNumShadowMaps();
+    }
+
+    /**
+     * Read the size of each shadow map rendered by this filter.
+     *
+     * @return a map's height (which is also its width, in pixels)
+     */
+    public int getShadowMapSize() {
+        return shadowRenderer.getShadowMapSize();
+    }
+
     @Override
     public AbstractShadowFilter<T> jmeClone() {
         try {

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
@@ -726,6 +726,24 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable,
     }
 
     /**
+     * Read the number of shadow maps rendered by this renderer.
+     *
+     * @return count
+     */
+    public int getNumShadowMaps() {
+        return nbShadowMaps;
+    }
+
+    /**
+     * Read the size of each shadow map rendered by this renderer.
+     *
+     * @return a map's height (which is also its width, in pixels)
+     */
+    public int getShadowMapSize() {
+        return (int) shadowMapSize;
+    }
+
+    /**
      * Sets the shadow edges thickness. default is 10, setting it to lower values
      * can help to reduce the jagged effect of the shadow edges
      *


### PR DESCRIPTION
This is added functionality for convenience, not a bug fix.