### PR TITLE
setUserObject called when cloning controls - bug fixed (issue #797)

### DIFF
--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/CharacterControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/CharacterControl.java
@@ -110,6 +110,7 @@ public class CharacterControl extends PhysicsCharacter implements PhysicsControl
         control.setUpAxis(getUpAxis());
         control.setApplyPhysicsLocal(isApplyPhysicsLocal());
         control.spatial = this.spatial;
+        control.setUserObject(this.getUserObject());
         control.setEnabled(isEnabled());
         return control;
     }     

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/GhostControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/GhostControl.java
@@ -112,6 +112,7 @@ public class GhostControl extends PhysicsGhostObject implements PhysicsControl, 
         control.setPhysicsRotation(getPhysicsRotationMatrix());
         control.setApplyPhysicsLocal(isApplyPhysicsLocal());
         control.spatial = this.spatial;
+        control.setUserObject(this.getUserObject());
         return control;
     }     
 

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/RigidBodyControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/RigidBodyControl.java
@@ -116,12 +116,14 @@ public class RigidBodyControl extends PhysicsRigidBody implements PhysicsControl
         control.setPhysicsRotation(getPhysicsRotationMatrix(null));
         control.setRestitution(getRestitution());
 
+
         if (mass > 0) {
             control.setAngularVelocity(getAngularVelocity());
             control.setLinearVelocity(getLinearVelocity());
         }
         control.setApplyPhysicsLocal(isApplyPhysicsLocal());
         control.spatial = this.spatial;
+        control.setUserObject(this.getUserObject());
         control.setEnabled(isEnabled());
 
         return control;

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/VehicleControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/VehicleControl.java
@@ -139,6 +139,7 @@ public class VehicleControl extends PhysicsVehicle implements PhysicsControl, Jm
         control.setSuspensionCompression(tuning.suspensionCompression);
         control.setSuspensionDamping(tuning.suspensionDamping);
         control.setMaxSuspensionForce(getMaxSuspensionForce());
+
     
         for (Iterator<VehicleWheel> it = wheels.iterator(); it.hasNext();) {
             VehicleWheel wheel = it.next();
@@ -158,6 +159,8 @@ public class VehicleControl extends PhysicsVehicle implements PhysicsControl, Jm
         control.setEnabled(isEnabled());
         
         control.spatial = spatial;
+        this.setUserObject(this.getUserObject());
+
         return control;
     }     
 


### PR DESCRIPTION
Hi, 
I think I corrected this problem, can you see if this is correct ?
 When testing with RigidBodyControl, the null value was placed in the setUserObject. The spatial (in the case of RigidBodyControl), was not copied.

Thanks