### PR TITLE
fix JME issue 843 - Update MaterialDebugAppState.java

### DIFF
--- a/jme3-core/src/main/java/com/jme3/util/MaterialDebugAppState.java
+++ b/jme3-core/src/main/java/com/jme3/util/MaterialDebugAppState.java
@@ -200,7 +200,8 @@ public class MaterialDebugAppState extends AbstractAppState {
         assetManager.clearCache();
 
         //creating a dummy mat with the mat def of the mat to reload
-        Material dummy = new Material(mat.getMaterialDef());
+        // Force the reloading of the asset, otherwise the new shader code will not be applied.
+        Material dummy = new Material(assetManager, mat.getMaterialDef().getAssetName());
 
         for (MatParam matParam : mat.getParams()) {
             dummy.setParam(matParam.getName(), matParam.getVarType(), matParam.getValue());


### PR DESCRIPTION
Reason:
If a shader-file has changed the application recognizes correctly the change, but the reload of the material actually reloads the old shader code instead of loading the new code. This is caused by the TechniqueDefault deep in the MaterialDefiniton.

Solution:
Instead of reuse the old MaterialDefinition let the AssetManager reload the MaterialDefinition.
