### PR TITLE
Fix a typo which makes pbr shader fail to compile when glossiness is enabled

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -272,7 +272,7 @@ void main(){
                 vec4 specularColor = vec4(1.0);
             #endif
             #ifdef GLOSSINESSMAP
-                float glossiness = texture2D(m_GlossinesMap, newTexCoord).r * m_Glossiness;
+                float glossiness = texture2D(m_GlossinessMap, newTexCoord).r * m_Glossiness;
             #else
                 float glossiness = m_Glossiness;
             #endif


### PR DESCRIPTION
There was a singe s in glossiness which makes the whole shader not compile if you have a glossiness map set.