### PR TITLE
Add `aimAtTarget` method to Ray (issue #859)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Ray.java
+++ b/jme3-core/src/main/java/com/jme3/math/Ray.java
@@ -77,7 +77,7 @@ public final class Ray implements Savable, Cloneable, Collidable, java.io.Serial
      * Constructor instantiates a new <code>Ray</code> object. The origin and
      * direction are given.
      * @param origin the origin of the ray.
-     * @param direction the direction the ray travels in.
+     * @param direction a unit vector for the relative direction from the origin the ray travels in.
      */
     public Ray(Vector3f origin, Vector3f direction) {
         setOrigin(origin);
@@ -473,11 +473,20 @@ public final class Ray implements Savable, Cloneable, Collidable, java.io.Serial
     /**
      *
      * <code>setDirection</code> sets the direction vector of the ray.
-     * @param direction the direction of the ray.
+     * @param direction a unit vector for the relative direction from the origin the ray travels in.
      */
     public void setDirection(Vector3f direction) {
         assert direction.isUnitVector();
         this.direction.set(direction);
+    }
+
+    /**
+     * Normalize the vector from your origin to your target and uses that to set the direction.
+     * @param target the coordinates that your vector should point towards.
+     */
+    public void aimAtTarget(Vector3f target) {
+        Vector3f relativeDirection = target.subtract(origin);
+        setDirection(relativeDirection.normalize());
     }
 
     /**

--- a/jme3-core/src/test/java/com/jme3/math/RayTest.java
+++ b/jme3-core/src/test/java/com/jme3/math/RayTest.java
@@ -1,0 +1,18 @@
+package com.jme3.math;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Ignore;
+
+public class RayTest {
+
+    @Test
+    public void testAimAtTarget() {
+        Ray ray = new Ray();
+        ray.setOrigin(new Vector3f(1, 2, 3));
+        ray.aimAtTarget(new Vector3f(2, 3, 4));
+        assertEquals(Vector3f.UNIT_XYZ.normalize(), ray.getDirection());
+    }
+
+}


### PR DESCRIPTION
Addressed issue 859.  Added a method to aim a ray at a given target location.  Additionally, updated some of the Javadocs to make it clear that the `setDirection` method takes in a relative vector for direction.