### PR TITLE
Update GLImageFormats to fix framebuffer exceptions in android

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLImageFormats.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLImageFormats.java
@@ -220,7 +220,7 @@ public final class GLImageFormats {
         
         // NOTE: OpenGL ES 2.0 does not support DEPTH_COMPONENT as internal format -- fallback to 16-bit depth.
         if (caps.contains(Caps.OpenGLES20)) {
-            format(formatToGL, Format.Depth, GL.GL_DEPTH_COMPONENT16, GL.GL_DEPTH_COMPONENT, GL.GL_UNSIGNED_BYTE);
+            format(formatToGL, Format.Depth, GL.GL_DEPTH_COMPONENT16, GL.GL_DEPTH_COMPONENT, GL.GL_UNSIGNED_SHORT);
         } else {
             format(formatToGL, Format.Depth, GL.GL_DEPTH_COMPONENT, GL.GL_DEPTH_COMPONENT, GL.GL_UNSIGNED_BYTE);
         }


### PR DESCRIPTION
As stated at forum topic https://hub.jmonkeyengine.org/t/illegalstateexception-framebuffer-has-erronous-attachment-if-using-filterpostprocessor-or-shadows/40463 there's an error in the depth format defined for opengl ES 2.0 which should be GL.GL_UNSIGNED_SHORT instead of GL.GL_UNSIGNED_BYTE solving "Framebuffer has erronous attachment" IllegalStateException