### PR TITLE
avoid JDK10 so Travis CI can succeed on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
   - os: linux
     jdk: openjdk7
   - os: osx
+    osx_image: xcode9.3
     env: UPLOAD_NATIVE=true
 
 addons:


### PR DESCRIPTION
Currently the default OS X Build Environment at Travis has JDK10. However, it's tricky to make our build work with both JDK7 and JDK10 because 'javah' was replaced by 'javac -h'. Specifying "osx_image: xcode9.3" bypasses this issue for now.