### PR TITLE
test case and fix for issue #889

### DIFF
--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/AbstractPhysicsControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/AbstractPhysicsControl.java
@@ -218,22 +218,31 @@ public abstract class AbstractPhysicsControl implements PhysicsControl, JmeClone
     public void render(RenderManager rm, ViewPort vp) {
     }
 
-    public void setPhysicsSpace(PhysicsSpace space) {
-        if (space == null) {
-            if (this.space != null) {
-                removePhysics(this.space);
-                added = false;
-            }
-        } else {
-            if (this.space == space) {
-                return;
-            } else if (this.space != null) {
-                removePhysics(this.space);
-            }
-            addPhysics(space);
+    /**
+     * If enabled, add this control's physics object to the specified physics
+     * space. If not enabled, alter where the object would be added. The object
+     * is removed from any other space it's currently in.
+     *
+     * @param newSpace where to add, or null to simply remove
+     */
+    @Override
+    public void setPhysicsSpace(PhysicsSpace newSpace) {
+        if (space == newSpace) {
+            return;
+        }
+        if (added) {
+            removePhysics(space);
+            added = false;
+        }
+        if (newSpace != null && isEnabled()) {
+            addPhysics(newSpace);
             added = true;
         }
-        this.space = space;
+        /*
+         * If this control isn't enabled, its physics object will be
+         * added to the new space when the control becomes enabled.
+         */
+        space = newSpace;
     }
 
     public PhysicsSpace getPhysicsSpace() {

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/CharacterControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/CharacterControl.java
@@ -190,21 +190,31 @@ public class CharacterControl extends PhysicsCharacter implements PhysicsControl
     public void render(RenderManager rm, ViewPort vp) {
     }
 
-    public void setPhysicsSpace(PhysicsSpace space) {
-        if (space == null) {
-            if (this.space != null) {
-                this.space.removeCollisionObject(this);
-                added = false;
-            }
-        } else {
-            if(this.space == space) return;
-            // if this object isn't enabled, it will be added when it will be enabled.
-            if (isEnabled()) {
-                space.addCollisionObject(this);
-                added = true;
-            }
+    /**
+     * If enabled, add this control's physics object to the specified physics
+     * space. If not enabled, alter where the object would be added. The object
+     * is removed from any other space it's currently in.
+     *
+     * @param newSpace where to add, or null to simply remove
+     */
+    @Override
+    public void setPhysicsSpace(PhysicsSpace newSpace) {
+        if (space == newSpace) {
+            return;
         }
-        this.space = space;
+        if (added) {
+            space.removeCollisionObject(this);
+            added = false;
+        }
+        if (newSpace != null && isEnabled()) {
+            newSpace.addCollisionObject(this);
+            added = true;
+        }
+        /*
+         * If this control isn't enabled, its physics object will be
+         * added to the new space when the control becomes enabled.
+         */
+        space = newSpace;
     }
 
     public PhysicsSpace getPhysicsSpace() {

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/GhostControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/GhostControl.java
@@ -162,20 +162,31 @@ public class GhostControl extends PhysicsGhostObject implements PhysicsControl, 
     public void render(RenderManager rm, ViewPort vp) {
     }
 
-    public void setPhysicsSpace(PhysicsSpace space) {
-        if (space == null) {
-            if (this.space != null) {
-                this.space.removeCollisionObject(this);
-                added = false;
-            }
-        } else {
-            if (this.space == space) {
-                return;
-            }
-            space.addCollisionObject(this);
+    /**
+     * If enabled, add this control's physics object to the specified physics
+     * space. If not enabled, alter where the object would be added. The object
+     * is removed from any other space it's currently in.
+     *
+     * @param newSpace where to add, or null to simply remove
+     */
+    @Override
+    public void setPhysicsSpace(PhysicsSpace newSpace) {
+        if (space == newSpace) {
+            return;
+        }
+        if (added) {
+            space.removeCollisionObject(this);
+            added = false;
+        }
+        if (newSpace != null && isEnabled()) {
+            newSpace.addCollisionObject(this);
             added = true;
         }
-        this.space = space;
+        /*
+         * If this control isn't enabled, its physics object will be
+         * added to the new space when the control becomes enabled.
+         */
+        space = newSpace;
     }
 
     public PhysicsSpace getPhysicsSpace() {

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/RigidBodyControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/RigidBodyControl.java
@@ -247,21 +247,31 @@ public class RigidBodyControl extends PhysicsRigidBody implements PhysicsControl
     public void render(RenderManager rm, ViewPort vp) {
     }
 
-    public void setPhysicsSpace(PhysicsSpace space) {
-        if (space == null) {
-            if (this.space != null) {
-                this.space.removeCollisionObject(this);
-                added = false;
-            }
-        } else {
-            if (this.space == space) return;
-            // if this object isn't enabled, it will be added when it will be enabled.
-            if (isEnabled()) {
-                space.addCollisionObject(this);
-                added = true;
-            }
+    /**
+     * If enabled, add this control's body to the specified physics space. In
+     * not enabled, alter where the body would be added. The body is removed
+     * from any other space it's currently in.
+     *
+     * @param newSpace where to add, or null to simply remove
+     */
+    @Override
+    public void setPhysicsSpace(PhysicsSpace newSpace) {
+        if (space == newSpace) {
+            return;
         }
-        this.space = space;
+        if (added) {
+            space.removeCollisionObject(this);
+            added = false;
+        }
+        if (newSpace != null && isEnabled()) {
+            newSpace.addCollisionObject(this);
+            added = true;
+        }
+        /*
+         * If this control isn't enabled, its body will be
+         * added to the new space when the control becomes enabled.
+         */
+        space = newSpace;
     }
 
     public PhysicsSpace getPhysicsSpace() {

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/VehicleControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/VehicleControl.java
@@ -216,22 +216,31 @@ public class VehicleControl extends PhysicsVehicle implements PhysicsControl, Jm
     public void render(RenderManager rm, ViewPort vp) {
     }
 
-    public void setPhysicsSpace(PhysicsSpace space) {
-        createVehicle(space);
-        if (space == null) {
-            if (this.space != null) {
-                this.space.removeCollisionObject(this);
-                added = false;
-            }
-        } else {
-            if(this.space == space) return;
-            // if this object isn't enabled, it will be added when it will be enabled.
-            if (isEnabled()) {
-                space.addCollisionObject(this);
-                added = true;
-            }
+    /**
+     * If enabled, add this control's physics object to the specified physics
+     * space. In not enabled, alter where the object would be added. The object
+     * is removed from any other space it's currently in.
+     *
+     * @param newSpace where to add, or null to simply remove
+     */
+    @Override
+    public void setPhysicsSpace(PhysicsSpace newSpace) {
+        if (space == newSpace) {
+            return;
         }
-        this.space = space;
+        if (added) {
+            space.removeCollisionObject(this);
+            added = false;
+        }
+        if (newSpace != null && isEnabled()) {
+            newSpace.addCollisionObject(this);
+            added = true;
+        }
+        /*
+         * If this control isn't enabled, its physics object will be
+         * added to the new space when the control becomes enabled.
+         */
+        space = newSpace;
     }
 
     public PhysicsSpace getPhysicsSpace() {

--- a/jme3-examples/src/main/java/jme3test/bullet/TestIssue889.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestIssue889.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2018 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package jme3test.bullet;
+
+/**
+ * Test case for JME issue #889: disabled physics control gets added to a
+ * physics space.
+ * <p>
+ * If successful, no debug meshes will be visible.
+ */
+import com.jme3.app.SimpleApplication;
+import com.jme3.bullet.BulletAppState;
+import com.jme3.bullet.PhysicsSpace;
+import com.jme3.bullet.collision.shapes.BoxCollisionShape;
+import com.jme3.bullet.collision.shapes.CollisionShape;
+import com.jme3.bullet.collision.shapes.SphereCollisionShape;
+import com.jme3.bullet.control.BetterCharacterControl;
+import com.jme3.bullet.control.GhostControl;
+import com.jme3.bullet.control.RigidBodyControl;
+import com.jme3.math.Vector3f;
+
+public class TestIssue889 extends SimpleApplication {
+
+    public static void main(String[] args) {
+        TestIssue889 app = new TestIssue889();
+        app.start();
+    }
+
+    @Override
+    public void simpleInitApp() {
+        flyCam.setEnabled(false);
+
+        BulletAppState bulletAppState = new BulletAppState();
+        bulletAppState.setDebugEnabled(true);
+        bulletAppState.setSpeed(0f);
+        stateManager.attach(bulletAppState);
+        PhysicsSpace space = bulletAppState.getPhysicsSpace();
+
+        float radius = 1f;
+        CollisionShape sphere = new SphereCollisionShape(radius);
+        CollisionShape box = new BoxCollisionShape(Vector3f.UNIT_XYZ);
+
+        RigidBodyControl rbc = new RigidBodyControl(box);
+        rbc.setEnabled(false);
+        rbc.setPhysicsSpace(space);
+        rootNode.addControl(rbc);
+
+        BetterCharacterControl bcc = new BetterCharacterControl(radius, 4f, 1f);
+        bcc.setEnabled(false);
+        bcc.setPhysicsSpace(space);
+        rootNode.addControl(bcc);
+
+        GhostControl gc = new GhostControl(sphere);
+        gc.setEnabled(false);
+        gc.setPhysicsSpace(space);
+        rootNode.addControl(gc);
+    }
+}


### PR DESCRIPTION
A cleaner setPhysicsSpace() method fixes the issue.

Applied the change to AbstractPhysicsControl, CharacterControl, GhostControl, RigidBodyControl, and VehicleControl (though only AbstractPhysicsControl and GhostControl were affected by the issue) in order to increase clarity and reduce the amount of unique code.

At some point in the past, the issue probably affected all physics controls. Whoever fixed RigidBodyControl somehow missed fixing AbstractPhysicsControl and GhostControl.

If all physics controls were based on AbstractPhysicsControl, there'd be a lot less cut-and-paste, and issues like this one would be easier to catch and fix globally. But such a change would break code that assumes certain physics controls are based on PhysicsCollisionObject.