### PR TITLE
Remove JVM arguments for OSX when running examples

### DIFF
--- a/jme3-examples/build.gradle
+++ b/jme3-examples/build.gradle
@@ -7,10 +7,6 @@ if (!hasProperty('mainClass')) {
 task run(dependsOn: 'build', type:JavaExec) {
     main = mainClass
     classpath = sourceSets.main.runtimeClasspath
-    if (System.properties['os.name'].toLowerCase().contains('mac')) {
-        jvmArgs "-XstartOnFirstThread"
-        jvmArgs "-Djava.awt.headless=true"
-    }
 
     if (System.properties['java.util.logging.config.file'] != null) {
         systemProperty "java.util.logging.config.file", System.properties['java.util.logging.config.file']


### PR DESCRIPTION
The examples won't run on OSX with `-Djava.awt.headless=true` added as a JVM argument.

```
> Task :jme3-examples:run FAILED
Exception in thread "main" java.awt.HeadlessException
        at java.awt.GraphicsEnvironment.checkHeadless(GraphicsEnvironment.java:204)
        at java.awt.Window.<init>(Window.java:536)
        at java.awt.Frame.<init>(Frame.java:420)
        at java.awt.Frame.<init>(Frame.java:385)
        at javax.swing.SwingUtilities$SharedOwnerFrame.<init>(SwingUtilities.java:1758)
        at javax.swing.SwingUtilities.getSharedOwnerFrame(SwingUtilities.java:1833)
        at javax.swing.JDialog.<init>(JDialog.java:272)
        at javax.swing.JDialog.<init>(JDialog.java:233)
        at jme3test.TestChooser.<init>(TestChooser.java:86)
        at jme3test.TestChooser.main(TestChooser.java:451)

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':jme3-examples:run'.
> Process 'command '/Library/Java/JavaVirtualMachines/jdk1.8.0_102.jdk/Contents/Home/bin/java'' finished with non-zero exit value 1```