### PR TITLE
Particle tile number/UV calculation change

### DIFF
--- a/jme3-core/src/main/java/com/jme3/effect/ParticlePointMesh.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticlePointMesh.java
@@ -144,7 +144,7 @@ public class ParticlePointMesh extends ParticleMesh {
             colors.putInt(p.color.asIntABGR());
 
             int imgX = p.imageIndex % imagesX;
-            int imgY = (p.imageIndex - imgX) / imagesY;
+            int imgY = p.imageIndex/imagesX;
 
             float startX = ((float) imgX) / imagesX;
             float startY = ((float) imgY) / imagesY;

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleTriMesh.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleTriMesh.java
@@ -251,7 +251,7 @@ public class ParticleTriMesh extends ParticleMesh {
 
             if (uniqueTexCoords){
                 int imgX = p.imageIndex % imagesX;
-                int imgY = (p.imageIndex - imgX) / imagesY;
+                int imgY = p.imageIndex / imagesX;
 
                 float startX = ((float) imgX) / imagesX;
                 float startY = ((float) imgY) / imagesY;


### PR DESCRIPTION
Particles with a non random animation set currently only work for image sets with rows and columns equal, though you can set them separately and make them unequal. 3x4, 8x2 and so on give incorrect values for imgY. 

Forum link: https://hub.jmonkeyengine.org/t/particle-emitter-possible-bug/40971/2

Small change means you can have any number of rows and columns.