### PR TITLE
FlyByCamera rise/fall behaviour (issue #617)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
+++ b/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
@@ -412,7 +412,7 @@ public class FlyByCamera implements AnalogListener, ActionListener {
      * @param value translation amount
      */
     protected void riseCamera(float value){
-        Vector3f vel = new Vector3f(0, value * moveSpeed, 0);
+        Vector3f vel = initialUpVec.mult(value * moveSpeed);
         Vector3f pos = cam.getLocation().clone();
 
         if (motionAllowed != null)


### PR DESCRIPTION
Changed riseCamera to use the up vector set with 'setUpVector(Vector3f upVec)' when pressing Q and Z which should make it go up/down.

Previously it was still travelling along the default up vector when pressing Q or W, despite rotating around the new up vector.

jMonkeyEngine/jmonkeyengine#617