### PR TITLE
Fix #324. Blender importer now respects the lightNode pos in the graph

### DIFF
--- a/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/BlenderLoader.java
+++ b/jme3-blender/src/main/java/com/jme3/scene/plugins/blender/BlenderLoader.java
@@ -245,15 +245,17 @@ public class BlenderLoader implements AssetLoader {
                 Structure objectStructure = pObject.fetchData().get(0);
 
                 Object object = objectHelper.toObject(objectStructure, blenderContext);
-                if (object instanceof LightNode) {
-                    result.addLight(((LightNode) object).getLight());// FIXME: check if this is needed !!!
-                    result.attachChild((LightNode) object);
-                } else if (object instanceof Node) {
+                if (object instanceof Node) {
                     if (LOGGER.isLoggable(Level.FINE)) {
                         LOGGER.log(Level.FINE, "{0}: {1}--> {2}", new Object[] { ((Node) object).getName(), ((Node) object).getLocalTranslation().toString(), ((Node) object).getParent() == null ? "null" : ((Node) object).getParent().getName() });
                     }
+
                     if (((Node) object).getParent() == null) {
                         result.attachChild((Spatial) object);
+                    }
+
+                    if(object instanceof LightNode) {
+                        result.addLight(((LightNode) object).getLight());
                     }
                 }
             }


### PR DESCRIPTION
The light is still being added, however, to the scene root node as this is the blender behavior and a wysiwyg is desired.