### PR TITLE
OrientedBoxProbeArea copy constructor fixed

### DIFF
--- a/jme3-core/src/main/java/com/jme3/light/OrientedBoxProbeArea.java
+++ b/jme3-core/src/main/java/com/jme3/light/OrientedBoxProbeArea.java
@@ -23,7 +23,7 @@ public class OrientedBoxProbeArea implements ProbeArea {
     }
 
     public OrientedBoxProbeArea(Transform transform) {
-        transform.set(transform);
+        this.transform.set(transform);
         updateMatrix();
     }
 


### PR DESCRIPTION
The copy constructor of the OrientedBoxProbeArea wouldn't take the given transform into account. Now it does.