### PR TITLE
fix for JME issue #887 (debug mesh ignores scaling)

### DIFF
--- a/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletCharacterDebugControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletCharacterDebugControl.java
@@ -68,6 +68,11 @@ public class BulletCharacterDebugControl extends AbstractPhysicsDebugControl {
      */
     protected Spatial geom;
     /**
+     * physics scale for which geom was generated
+     */
+    final private Vector3f oldScale = new Vector3f();
+
+    /**
      * Instantiate an enabled control to visualize the specified character.
      *
      * @param debugAppState which app state (not null, alias created)
@@ -78,7 +83,10 @@ public class BulletCharacterDebugControl extends AbstractPhysicsDebugControl {
         super(debugAppState);
         this.body = body;
         myShape = body.getCollisionShape();
-        this.geom = DebugShapeFactory.getDebugShape(body.getCollisionShape());
+        oldScale.set(myShape.getScale());
+
+        this.geom = DebugShapeFactory.getDebugShape(myShape);
+        this.geom.setName(body.toString());
         geom.setMaterial(debugAppState.DEBUG_PINK);
     }
 
@@ -110,15 +118,24 @@ public class BulletCharacterDebugControl extends AbstractPhysicsDebugControl {
      */
     @Override
     protected void controlUpdate(float tpf) {
-        if(myShape != body.getCollisionShape()){
-            Node node = (Node) this.spatial;
+        CollisionShape newShape = body.getCollisionShape();
+        Vector3f newScale = newShape.getScale();
+        if (myShape != newShape || !oldScale.equals(newScale)) {
+            myShape = newShape;
+            oldScale.set(newScale);
+
+            Node node = (Node) spatial;
             node.detachChild(geom);
-            geom = DebugShapeFactory.getDebugShape(body.getCollisionShape());
-            geom.setMaterial(debugAppState.DEBUG_PINK);
+
+            geom = DebugShapeFactory.getDebugShape(myShape);
+            geom.setName(body.toString());
+
             node.attachChild(geom);
         }
-        applyPhysicsTransform(body.getPhysicsLocation(location), Quaternion.IDENTITY);
-        geom.setLocalScale(body.getCollisionShape().getScale());
+        geom.setMaterial(debugAppState.DEBUG_PINK);
+
+        body.getPhysicsLocation(location);
+        applyPhysicsTransform(location, Quaternion.IDENTITY);
     }
 
     /**

--- a/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletGhostObjectDebugControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletGhostObjectDebugControl.java
@@ -70,7 +70,10 @@ public class BulletGhostObjectDebugControl extends AbstractPhysicsDebugControl {
      * geometry to visualize myShape (not null)
      */
     protected Spatial geom;
-
+    /**
+     * physics scale for which geom was generated
+     */
+    final private Vector3f oldScale = new Vector3f();
     /**
      * Instantiate an enabled control to visualize the specified ghost object.
      *
@@ -81,8 +84,9 @@ public class BulletGhostObjectDebugControl extends AbstractPhysicsDebugControl {
         super(debugAppState);
         this.body = body;
         myShape = body.getCollisionShape();
-        this.geom = DebugShapeFactory.getDebugShape(body.getCollisionShape());
-        this.geom.setName(body.toString());
+        oldScale.set(myShape.getScale());
+        
+        this.geom = DebugShapeFactory.getDebugShape(myShape);
         this.geom.setName(body.toString());
         geom.setMaterial(debugAppState.DEBUG_YELLOW);
     }
@@ -115,15 +119,25 @@ public class BulletGhostObjectDebugControl extends AbstractPhysicsDebugControl {
      */
     @Override
     protected void controlUpdate(float tpf) {
-        if (myShape != body.getCollisionShape()) {
-            Node node = (Node) this.spatial;
+        CollisionShape newShape = body.getCollisionShape();
+        Vector3f newScale = newShape.getScale();
+        if (myShape != newShape || !oldScale.equals(newScale)) {
+            myShape = newShape;
+            oldScale.set(newScale);
+
+            Node node = (Node) spatial;
             node.detachChild(geom);
-            geom = DebugShapeFactory.getDebugShape(body.getCollisionShape());
-            geom.setMaterial(debugAppState.DEBUG_YELLOW);
+
+            geom = DebugShapeFactory.getDebugShape(myShape);
+            geom.setName(body.toString());
+
             node.attachChild(geom);
         }
-        applyPhysicsTransform(body.getPhysicsLocation(location), body.getPhysicsRotation(rotation));
-        geom.setLocalScale(body.getCollisionShape().getScale());
+        geom.setMaterial(debugAppState.DEBUG_YELLOW);
+
+        body.getPhysicsLocation(location);
+        body.getPhysicsRotation(rotation);
+        applyPhysicsTransform(location, rotation);
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/util/DebugShapeFactory.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/util/DebugShapeFactory.java
@@ -35,7 +35,6 @@ import com.jme3.bullet.collision.shapes.CollisionShape;
 import com.jme3.bullet.collision.shapes.CompoundCollisionShape;
 import com.jme3.bullet.collision.shapes.infos.ChildCollisionShape;
 import com.jme3.math.Matrix3f;
-import com.jme3.math.Vector3f;
 import com.jme3.scene.Geometry;
 import com.jme3.scene.Mesh;
 import com.jme3.scene.Node;
@@ -46,6 +45,7 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
+ * A utility class to generate debug spatials from Bullet collision shapes.
  *
  * @author CJ Hare, normenhansen
  */
@@ -128,14 +128,8 @@ public class DebugShapeFactory {
     public static Mesh getDebugMesh(CollisionShape shape) {
         Mesh mesh = new Mesh();
         DebugMeshCallback callback = new DebugMeshCallback();
-        /*
-         * Populate the mesh based on an unscaled shape;
-         * the shape's scale will be applied later, to the geometry.
-         */
-        Vector3f savedScale = shape.getScale().clone();
-        shape.setScale(Vector3f.UNIT_XYZ);
-        getVertices(shape.getObjectId(), callback);
-        shape.setScale(savedScale);
+        long id = shape.getObjectId();
+        getVertices(id, callback);
 
         mesh.setBuffer(Type.Position, 3, callback.getVertices());
         mesh.getFloatBuffer(Type.Position).clear();


### PR DESCRIPTION
The trick is to re-generate the debug mesh each time the scale of the collision shape changes.