### PR TITLE
upgrade native Bullet to v2.87, which should fix issue #877

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 /jme3-core/src/main/resources/com/jme3/system/version.properties
 /jme3-*/build/
 /jme3-bullet-native/bullet3.zip
-/jme3-bullet-native/bullet3-2.86.1/
+/jme3-bullet-native/bullet3-2.87/
 /jme3-bullet-native/src/native/cpp/com_jme3_bullet_*.h
 /jme3-android-native/openal-soft/
 /jme3-android-native/OpenALSoft.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ build_script:
 cache:
 - C:\Users\appveyor\.gradle\caches
 - C:\Users\appveyor\.gradle\wrapper
-- jme3-bullet-native\bullet3.zip
+- jme3-bullet-native\bullet3.zip -> gradle.properties
 
 test: off
 deploy: off

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,8 +19,8 @@ buildAndroidExamples = false
 ndkPath = /opt/android-ndk-r16b
 
 # Path for downloading native Bullet
-bulletUrl = https://github.com/bulletphysics/bullet3/archive/2.86.1.zip
-bulletFolder = bullet3-2.86.1
+bulletUrl = https://github.com/bulletphysics/bullet3/archive/2.87.zip
+bulletFolder = bullet3-2.87
 bulletZipFile = bullet3.zip
 
 # POM settings

--- a/jme3-bullet-native/build.gradle
+++ b/jme3-bullet-native/build.gradle
@@ -21,6 +21,10 @@ task cleanHeaders(type: Delete) {
 task cleanUnzipped(type: Delete) {
     delete bulletFolder
 }
+// clean up the downloaded archive
+task cleanZipFile(type: Delete) {
+    delete bulletZipFile
+}
 
 model {
     components {
@@ -37,13 +41,21 @@ model {
                     source {
                         srcDir 'src/native/cpp'
                         srcDir bulletSrcPath
+                        exclude 'Bullet3Collision/**'
+                        exclude 'Bullet3Dynamics/**'
+                        exclude 'Bullet3Geometry/**'
                         exclude 'Bullet3OpenCL/**'
+                        exclude 'Bullet3Serialize/**'
                         include '**/*.cpp'
                     }
                     exportedHeaders {
                         srcDir 'src/native/cpp'
                         srcDir bulletSrcPath
+                        exclude 'Bullet3Collision/**'
+                        exclude 'Bullet3Dynamics/**'
+                        exclude 'Bullet3Geometry/**'
                         exclude 'Bullet3OpenCL/**'
+                        exclude 'Bullet3Serialize/**'
                         include '**/*.h'
                     }
                 }

--- a/jme3-bullet-native/src/native/cpp/com_jme3_bullet_joints_HingeJoint.cpp
+++ b/jme3-bullet-native/src/native/cpp/com_jme3_bullet_joints_HingeJoint.cpp
@@ -85,7 +85,7 @@ extern "C" {
             env->ThrowNew(newExc, "The native object does not exist.");
             return 0;
         }
-        return joint->getMotorTargetVelosity();
+        return joint->getMotorTargetVelocity();
     }
 
     /*


### PR DESCRIPTION
Found one incompatibility between v2.86.1 and v2.87: `btHingeConstraint::getMotorTargetVelosity()` was renamed to `getMotorTargetVelocity`.

Excluded 4 Bullet3 folders from the C++ compile. These are not needed for 2.87; excluding them should result in smaller libraries.

Added a `cleanZipFile` task to `jme3-bullet-native/build.gradle`. Unsure what should depend on it, but it'll be useful when someone wants to rebuild after changing Bullet versions, as I just did.