### PR TITLE
fix for issue #972 (TestModelExportingCloning fails)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/tween/AbstractTween.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/AbstractTween.java
@@ -36,10 +36,8 @@
 
 package com.jme3.anim.tween;
 
-
-import com.jme3.export.*;
-
-import java.io.IOException;
+import com.jme3.util.clone.Cloner;
+import com.jme3.util.clone.JmeCloneable;
 
 /**
  * Base implementation of the Tween interface that provides
@@ -50,7 +48,7 @@ import java.io.IOException;
  *
  * @author Paul Speed
  */
-public abstract class AbstractTween implements Tween {
+public abstract class AbstractTween implements JmeCloneable, Tween {
 
     private double length;
 
@@ -94,4 +92,32 @@ public abstract class AbstractTween implements Tween {
     }
 
     protected abstract void doInterpolate(double t);
+
+    /**
+     * Create a shallow clone for the JME cloner.
+     *
+     * @return a new tween (not null)
+     */
+    @Override
+    public AbstractTween jmeClone() {
+        try {
+            AbstractTween clone = (AbstractTween) super.clone();
+            return clone;
+        } catch (CloneNotSupportedException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    /**
+     * Callback from {@link com.jme3.util.clone.Cloner} to convert this
+     * shallow-cloned tween into a deep-cloned one, using the specified cloner
+     * and original to resolve copied fields.
+     *
+     * @param cloner the cloner that's cloning this tween (not null)
+     * @param original the tween from which this tween was shallow-cloned
+     * (unused)
+     */
+    @Override
+    public void cloneFields(Cloner cloner, Object original) {
+    }
 }

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/Action.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/Action.java
@@ -2,8 +2,10 @@ package com.jme3.anim.tween.action;
 
 import com.jme3.anim.AnimationMask;
 import com.jme3.anim.tween.Tween;
+import com.jme3.util.clone.Cloner;
+import com.jme3.util.clone.JmeCloneable;
 
-public abstract class Action implements Tween {
+public abstract class Action implements JmeCloneable, Tween {
 
     protected Action[] actions;
     private double length;
@@ -66,5 +68,35 @@ public abstract class Action implements Tween {
             action.setForward(forward);
         }
 
+    }
+
+    /**
+     * Create a shallow clone for the JME cloner.
+     *
+     * @return a new action (not null)
+     */
+    @Override
+    public Action jmeClone() {
+        try {
+            Action clone = (Action) super.clone();
+            return clone;
+        } catch (CloneNotSupportedException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    /**
+     * Callback from {@link com.jme3.util.clone.Cloner} to convert this
+     * shallow-cloned action into a deep-cloned one, using the specified cloner
+     * and original to resolve copied fields.
+     *
+     * @param cloner the cloner that's cloning this action (not null)
+     * @param original the action from which this action was shallow-cloned
+     * (unused)
+     */
+    @Override
+    public void cloneFields(Cloner cloner, Object original) {
+        actions = cloner.clone(actions);
+        mask = cloner.clone(mask);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendableAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendableAction.java
@@ -3,9 +3,8 @@ package com.jme3.anim.tween.action;
 import com.jme3.anim.tween.AbstractTween;
 import com.jme3.anim.tween.Tween;
 import com.jme3.anim.util.HasLocalTransform;
-import com.jme3.math.FastMath;
 import com.jme3.math.Transform;
-
+import com.jme3.util.clone.Cloner;
 import java.util.Collection;
 
 public abstract class BlendableAction extends Action {
@@ -79,6 +78,37 @@ public abstract class BlendableAction extends Action {
 
     protected float getTransitionWeight() {
         return transitionWeight;
+    }
+
+    /**
+     * Create a shallow clone for the JME cloner.
+     *
+     * @return a new action (not null)
+     */
+    @Override
+    public BlendableAction jmeClone() {
+        try {
+            BlendableAction clone = (BlendableAction) super.clone();
+            return clone;
+        } catch (CloneNotSupportedException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    /**
+     * Callback from {@link com.jme3.util.clone.Cloner} to convert this
+     * shallow-cloned action into a deep-cloned one, using the specified cloner
+     * and original to resolve copied fields.
+     *
+     * @param cloner the cloner that's cloning this action (not null)
+     * @param original the action from which this action was shallow-cloned
+     * (unused)
+     */
+    @Override
+    public void cloneFields(Cloner cloner, Object original) {
+        super.cloneFields(cloner, original);
+        collectTransformDelegate = cloner.clone(collectTransformDelegate);
+        transition = cloner.clone(transition);
     }
 
     private class TransitionTween extends AbstractTween {

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/ClipAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/ClipAction.java
@@ -1,11 +1,10 @@
 package com.jme3.anim.tween.action;
 
 import com.jme3.anim.*;
-import com.jme3.anim.tween.AbstractTween;
 import com.jme3.anim.util.HasLocalTransform;
 import com.jme3.math.Transform;
 import com.jme3.scene.Geometry;
-
+import com.jme3.util.clone.Cloner;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -90,5 +89,34 @@ public class ClipAction extends BlendableAction {
         }
     }
 
+    /**
+     * Create a shallow clone for the JME cloner.
+     *
+     * @return a new action (not null)
+     */
+    @Override
+    public ClipAction jmeClone() {
+        try {
+            ClipAction clone = (ClipAction) super.clone();
+            return clone;
+        } catch (CloneNotSupportedException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
 
+    /**
+     * Callback from {@link com.jme3.util.clone.Cloner} to convert this
+     * shallow-cloned action into a deep-cloned one, using the specified cloner
+     * and original to resolve copied fields.
+     *
+     * @param cloner the cloner that's cloning this action (not null)
+     * @param original the action from which this action was shallow-cloned
+     * (unused)
+     */
+    @Override
+    public void cloneFields(Cloner cloner, Object original) {
+        super.cloneFields(cloner, original);
+        clip = cloner.clone(clip);
+        transform = cloner.clone(transform);
+    }
 }


### PR DESCRIPTION
In addition to making `Action`, `BlendableAction`, and `ClipAction` into `JmeCloneable` classes, I also made `AbstractTween` into a `JmeCloneable` class.