### PR TITLE
Fix Billboard ShaderNode cannot compile on Android

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/ShaderNodes/Common/Billboard.j3sn
+++ b/jme3-core/src/main/resources/Common/MatDefs/ShaderNodes/Common/Billboard.j3sn
@@ -24,7 +24,7 @@ ShaderNodeDefinitions{
             mat4 worldViewMatrix
             mat4 projectionMatrix
             vec3 modelPosition
-            float scale 1
+            float scale 1.0
         }
         Output {
             //all the node outputs


### PR DESCRIPTION
I encountered the problem when trying to use the ArmatureDebugger on Android.
The shader compilation fails with a `cannot convert from 'int' to 'highp float'` error and this fixes it.