### PR TITLE
Add RGTC compressed formats

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GL3.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GL3.java
@@ -54,6 +54,10 @@ public interface GL3 extends GL2 {
     public static final int GL_TEXTURE_SWIZZLE_B = 0x8E44;
     public static final int GL_TEXTURE_SWIZZLE_G = 0x8E43;
     public static final int GL_TEXTURE_SWIZZLE_R = 0x8E42;
+    public static final int GL_COMPRESSED_RED_RGTC1 = 0x8DBB;
+    public static final int GL_COMPRESSED_SIGNED_RED_RGTC1 = 0x8DBC;
+    public static final int GL_COMPRESSED_RG_RGTC2 = 0x8DBD;
+    public static final int GL_COMPRESSED_SIGNED_RG_RGTC2 = 0x8DBE;
     public static final int GL_R8I = 33329;
     public static final int GL_R8UI = 33330;
     public static final int GL_R16I = 33331;

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLImageFormats.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLImageFormats.java
@@ -245,6 +245,13 @@ public final class GLImageFormats {
             formatComp(formatToGL, Format.DXT3,  GLExt.GL_COMPRESSED_RGBA_S3TC_DXT3_EXT, GL.GL_RGBA, GL.GL_UNSIGNED_BYTE);
             formatComp(formatToGL, Format.DXT5,  GLExt.GL_COMPRESSED_RGBA_S3TC_DXT5_EXT, GL.GL_RGBA, GL.GL_UNSIGNED_BYTE);
         }
+
+        if(caps.contains(Caps.OpenGL30)){
+            formatComp(formatToGL, Format.RGTC2,  GL3.GL_COMPRESSED_RG_RGTC2,  GL3.GL_RG,  GL.GL_UNSIGNED_BYTE);
+            formatComp(formatToGL, Format.SIGNED_RGTC2,  GL3.GL_COMPRESSED_SIGNED_RG_RGTC2,  GL3.GL_RG,  GL.GL_BYTE);
+            formatComp(formatToGL, Format.RGTC1,  GL3.GL_COMPRESSED_RED_RGTC1,  GL3.GL_RED,  GL.GL_UNSIGNED_BYTE);
+            formatComp(formatToGL, Format.SIGNED_RGTC1,  GL3.GL_COMPRESSED_SIGNED_RED_RGTC1,  GL3.GL_RED,  GL.GL_BYTE);
+        }
         
         if (caps.contains(Caps.TextureCompressionETC2)) {
             formatComp(formatToGL, Format.ETC1, GLExt.GL_COMPRESSED_RGB8_ETC2, GL.GL_RGB, GL.GL_UNSIGNED_BYTE);

--- a/jme3-core/src/main/java/com/jme3/texture/Image.java
+++ b/jme3-core/src/main/java/com/jme3/texture/Image.java
@@ -185,6 +185,14 @@ public class Image extends NativeObject implements Savable /*, Cloneable*/ {
          * 
          */
         DXT5(8,false,true, false),
+
+        RGTC2(8,false,true, false),
+
+        SIGNED_RGTC2(8,false,true, false),
+        
+        RGTC1(4,false,true, false),
+        
+        SIGNED_RGTC1(4,false,true, false),
         
         /**
          * Luminance-Alpha Texture Compression. 

--- a/jme3-core/src/plugins/java/com/jme3/texture/plugins/DDSLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/texture/plugins/DDSLoader.java
@@ -280,16 +280,14 @@ public class DDSLoader implements AssetLoader {
                         normal = true;
                     }
                     break;
-                /*
                 case PF_ATI1:
                     bpp = 4;
-                    pixelFormat = Image.Format.LTC;
+                    pixelFormat = Image.Format.RGTC1;
                     break;
                 case PF_ATI2:
                     bpp = 8;
-                    pixelFormat = Image.Format.LATC;
+                    pixelFormat = Image.Format.RGTC2;
                     break;
-                */
                 case PF_DX10:
                     compressed = false;
                     directx10 = true;

--- a/jme3-core/src/plugins/java/com/jme3/texture/plugins/DXTFlipper.java
+++ b/jme3-core/src/plugins/java/com/jme3/texture/plugins/DXTFlipper.java
@@ -213,14 +213,12 @@ public class DXTFlipper {
             case DXT5:
                 type = 3;
                 break;
-            /*
-            case LATC:
+            case RGTC2:
                 type = 4;
-                break;
-            case LTC:
+                break;                
+            case RGTC1:
                 type = 5;
                 break;
-            */
             default:
                 throw new IllegalArgumentException();
         }


### PR DESCRIPTION
From https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_compression_rgtc.txt

```
    These formats are designed to reduce the storage requirements
    and memory bandwidth required for red and red-green textures by
    a factor of 2-to-1 over conventional uncompressed luminance and
    luminance-alpha textures with 8-bit components (GL_LUMINANCE8 and
    GL_LUMINANCE8_ALPHA8).

    The compressed signed red-green format is reasonably suited for
    storing compressed normal maps.

```