### PR TITLE
Fix waitFor not being implemented in lwjgl3

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -87,6 +87,7 @@ import java.util.logging.Logger;
 public abstract class LwjglContext implements JmeContext {
 
     private static final Logger logger = Logger.getLogger(LwjglContext.class.getName());
+    protected static final String THREAD_NAME = "jME3 Main";
 
     static {
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -425,7 +425,9 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
                 waitFor(true);
             }
         } else {
+            //Fix for OS X, OpenGL must be run on main thread.
             mainThread = Thread.currentThread();
+            run();
         }
     }
 
@@ -637,6 +639,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         needClose.set(true);
 
         if (mainThread == Thread.currentThread()) {
+            //If on main thread, no reason to wait.
             return;
         }
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -29,7 +29,6 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package com.jme3.system.lwjgl;
 
 import com.jme3.input.JoyInput;
@@ -118,8 +117,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
     private GLFWErrorCallback errorCallback;
     private GLFWWindowSizeCallback windowSizeCallback;
     private GLFWWindowFocusCallback windowFocusCallback;
-
-    private Thread mainThread;
 
     private double frameSleepTime;
     private long window = NULL;
@@ -303,7 +300,9 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
     protected void setWindowIcon(final AppSettings settings) {
 
         final Object[] icons = settings.getIcons();
-        if (icons == null) return;
+        if (icons == null) {
+            return;
+        }
 
         final GLFWImage[] images = imagesToGLFWImages(icons);
 
@@ -418,9 +417,10 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             return;
         }
 
-        // NOTE: this is required for Mac OS X!
-        mainThread = Thread.currentThread();
-        run();
+        new Thread(this, THREAD_NAME).start();
+        if (waitFor) {
+            waitFor(true);
+        }
     }
 
     /**
@@ -629,11 +629,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
     @Override
     public void destroy(boolean waitFor) {
         needClose.set(true);
-
-        if (mainThread == Thread.currentThread()) {
-            // Ignore waitFor.
-            return;
-        }
 
         if (waitFor) {
             waitFor(false);

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -418,12 +418,10 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             LOGGER.warning("create() called when display is already created!");
             return;
         }
-        if (waitFor) {
+        if (!waitFor) {
             mainThread = new Thread(this, THREAD_NAME);
             mainThread.start();
-            if (waitFor) {
-                waitFor(true);
-            }
+            waitFor(false);
         } else {
             //Fix for OS X, OpenGL must be run on main thread.
             mainThread = Thread.currentThread();

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -421,7 +421,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         if (!waitFor) {
             mainThread = new Thread(this, THREAD_NAME);
             mainThread.start();
-            waitFor(false);
         } else {
             //Fix for OS X, OpenGL must be run on main thread.
             mainThread = Thread.currentThread();

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -118,6 +118,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
     private GLFWWindowSizeCallback windowSizeCallback;
     private GLFWWindowFocusCallback windowFocusCallback;
 
+    private Thread mainThread;
+
     private double frameSleepTime;
     private long window = NULL;
     private int frameRateLimit = -1;
@@ -416,10 +418,14 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             LOGGER.warning("create() called when display is already created!");
             return;
         }
-
-        new Thread(this, THREAD_NAME).start();
         if (waitFor) {
-            waitFor(true);
+            mainThread = new Thread(this, THREAD_NAME);
+            mainThread.start();
+            if (waitFor) {
+                waitFor(true);
+            }
+        } else {
+            mainThread = Thread.currentThread();
         }
     }
 
@@ -629,6 +635,10 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
     @Override
     public void destroy(boolean waitFor) {
         needClose.set(true);
+
+        if (mainThread == Thread.currentThread()) {
+            return;
+        }
 
         if (waitFor) {
             waitFor(false);


### PR DESCRIPTION
So this seems like a big bug to me. I noticed that for some reason for the lwjgl 3 display context, the wait for was being ignored. There was a comment about a OSX fix, but with no information to go with it. 

It seems to me that it is important for the waitFor to work, as it broke one of my applications that I was swapping from lwjgl2 to lwjgl3. 

Does anyone know about this, or can provide insight into this? 
This PR adds support for the waitFor in the same way that it was implemented in lwjgl2.
Also, if someone can confirm that this still works for them, that would be great. 

PS: I hope I opened this PR correctly. If not I'm sorry in advance, every project has their preferred way of doing things. 

Thank you,
Trevor Flynn