### PR TITLE
J3MLoader Fix for default textures for j3md

### DIFF
--- a/jme3-core/src/main/java/com/jme3/material/MaterialDef.java
+++ b/jme3-core/src/main/java/com/jme3/material/MaterialDef.java
@@ -38,6 +38,7 @@ import com.jme3.texture.image.ColorSpace;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import com.jme3.texture.Texture;
 
 /**
  * Describes a J3MD (Material definition).
@@ -129,10 +130,11 @@ public class MaterialDef{
      * @param type Type of the parameter
      * @param name Name of the parameter
      * @param colorSpace the color space of the texture required by this texture param
+     * @param value Default value of the parameter
      * @see ColorSpace
      */
-    public void addMaterialParamTexture(VarType type, String name, ColorSpace colorSpace) {
-        matParams.put(name, new MatParamTexture(type, name, null, colorSpace));
+    public void addMaterialParamTexture(VarType type, String name, ColorSpace colorSpace,Texture value) {
+        matParams.put(name, new MatParamTexture(type, name, value, colorSpace));
     }
     
     /**

--- a/jme3-core/src/plugins/java/com/jme3/material/plugins/J3MLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/material/plugins/J3MLoader.java
@@ -295,8 +295,7 @@ public class J3MLoader implements AssetLoader {
             for (final TextureOptionValue textureOptionValue : textureOptionValues) {
                 textureOptionValue.applyToTexture(texture);
             }
-        }
-
+        }        
         return texture;
     }
 
@@ -402,7 +401,7 @@ public class J3MLoader implements AssetLoader {
             defaultValObj = readValue(type, defaultVal);
         }
         if(type.isTextureType()){
-            materialDef.addMaterialParamTexture(type, name, colorSpace);
+            materialDef.addMaterialParamTexture(type, name, colorSpace,(Texture)defaultValObj);
         }else{
             materialDef.addMaterialParam(type, name, defaultValObj);
         }


### PR DESCRIPTION
In j3md you should be allowed to define default textures like this
```        
Texture2D Texture -LINEAR: MinTrilinear MagBilinear /path/to/my/texture.dds
```
But the j3md loaded actually didn't set the default value for texture params. 
This pr fixes that.