### PR TITLE
fix issue #901 (collision margins initialized to 0)

### DIFF
--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/CollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/CollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,6 +50,11 @@ import java.util.logging.Logger;
 public abstract class CollisionShape implements Savable {
 
     /**
+     * default margin for new non-sphere/non-capsule shapes (in physics-space
+     * units, &gt;0, default=0.04)
+     */
+    private static float defaultMargin = 0.04f;
+    /**
      * unique identifier of the btCollisionShape
      * <p>
      * Constructors are responsible for setting this to a non-zero value. After
@@ -63,7 +68,7 @@ public abstract class CollisionShape implements Savable {
     /**
      * copy of collision margin (in physics-space units, &gt;0, default=0)
      */
-    protected float margin = 0.0f;
+    protected float margin = defaultMargin;
 
     public CollisionShape() {
     }
@@ -136,6 +141,17 @@ public abstract class CollisionShape implements Savable {
     private native float getMargin(long objectId);
 
     /**
+     * Alter the default margin for new shapes that are neither capsules nor
+     * spheres.
+     *
+     * @param margin the desired margin distance (in physics-space units, &gt;0,
+     * default=0.04)
+     */
+    public static void setDefaultMargin(float margin) {
+        defaultMargin = margin;
+    }
+
+    /**
      * Alter the collision margin of this shape. CAUTION: Margin is applied
      * differently, depending on the type of shape. Generally the collision
      * margin expands the object, creating a gap. Don't set the collision margin
@@ -145,7 +161,7 @@ public abstract class CollisionShape implements Savable {
      * compound shapes) changes can have unintended consequences.
      *
      * @param margin the desired margin distance (in physics-space units, &gt;0,
-     * default=0)
+     * default=0.04)
      */
     public void setMargin(float margin) {
         setMargin(objectId, margin);

--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/CollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/CollisionShape.java
@@ -152,6 +152,16 @@ public abstract class CollisionShape implements Savable {
     }
 
     /**
+     * Read the default margin for new shapes.
+     *
+     * @return margin the default margin distance (in physics-space units,
+     * &gt;0)
+     */
+    public static float getDefaultMargin() {
+        return defaultMargin;
+    }
+
+    /**
      * Alter the collision margin of this shape. CAUTION: Margin is applied
      * differently, depending on the type of shape. Generally the collision
      * margin expands the object, creating a gap. Don't set the collision margin

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/CollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/CollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,9 +44,17 @@ import java.io.IOException;
  */
 public abstract class CollisionShape implements Savable {
 
+    /**
+     * default margin for new shapes (in physics-space units, &gt;0,
+     * default=0.04)
+     */
+    private static float defaultMargin = 0.04f;
     protected com.bulletphysics.collision.shapes.CollisionShape cShape;
     protected Vector3f scale = new Vector3f(1, 1, 1);
-    protected float margin = 0.0f;
+    /**
+     * copy of collision margin (in physics-space units, &gt;0, default=0)
+     */
+    protected float margin = defaultMargin;
 
     public CollisionShape() {
     }
@@ -86,6 +94,16 @@ public abstract class CollisionShape implements Savable {
 
     public float getMargin() {
         return cShape.getMargin();
+    }
+
+    /**
+     * Alter the default margin for new shapes.
+     *
+     * @param margin the desired margin distance (in physics-space units, &gt;0,
+     * default=0.04)
+     */
+    public static void setDefaultMargin(float margin) {
+        defaultMargin = margin;
     }
 
     public void setMargin(float margin) {

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/CollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/CollisionShape.java
@@ -106,6 +106,16 @@ public abstract class CollisionShape implements Savable {
         defaultMargin = margin;
     }
 
+    /**
+     * Read the default margin for new shapes.
+     *
+     * @return margin the default margin distance (in physics-space units,
+     * &gt;0)
+     */
+    public static float getDefaultMargin() {
+        return defaultMargin;
+    }
+
     public void setMargin(float margin) {
         cShape.setMargin(margin);
         this.margin = margin;


### PR DESCRIPTION
This adds a new public static method to set the default collision margin.

I'm unsure whether `jme3-jbullet` has any issue with 0 collision margin. To maintain consistency between libraries I modified both `jme3-bullet` and `jme3-jbullet`.

I ran all the physics tests in `jme3-examples` with both physics libraries and didn't notice any changes, except that `TestCcd` now works with `jme3-bullet`. Refer to issue #1043 for details.