### PR TITLE
Adds option to disable VR mouse cursor

### DIFF
--- a/jme3-vr/src/main/java/com/jme3/input/vr/AbstractVRMouseManager.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/AbstractVRMouseManager.java
@@ -9,7 +9,6 @@ import com.jme3.input.MouseInput;
 import com.jme3.input.lwjgl.GlfwMouseInputVR;
 import com.jme3.material.RenderState.BlendMode;
 import com.jme3.math.Vector2f;
-import com.jme3.scene.Node;
 import com.jme3.system.AppSettings;
 import com.jme3.system.lwjgl.LwjglWindow;
 import com.jme3.texture.Texture;
@@ -27,8 +26,8 @@ public abstract class AbstractVRMouseManager implements VRMouseManager {
 
 	private VREnvironment environment = null;
 	
-
-    
+    private boolean vrMouseEnabled = true;
+    private boolean mouseAttached = false;
     private Picture mouseImage;
     private int recentCenterCount = 0;
     
@@ -69,6 +68,11 @@ public abstract class AbstractVRMouseManager implements VRMouseManager {
     @Override
     public VREnvironment getVREnvironment() {
       return environment;
+    }
+
+    @Override
+    public void setVRMouseEnabled(boolean enabled) {
+        vrMouseEnabled = enabled;
     }
     
     @Override
@@ -185,10 +189,9 @@ public abstract class AbstractVRMouseManager implements VRMouseManager {
     @Override
     public void update(float tpf) {
         // if we are showing the cursor, add our picture as it
-
-        if( environment.getApplication().getInputManager().isCursorVisible() ) {
-            if( mouseImage.getParent() == null ) {
-            	
+        if( vrMouseEnabled && environment.getApplication().getInputManager().isCursorVisible() ) {
+            if(!mouseAttached) {
+                mouseAttached = true;
             	environment.getApplication().getGuiViewPort().attachScene(mouseImage);         
                 centerMouse();
                 // the "real" mouse pointer should stay hidden
@@ -216,13 +219,13 @@ public abstract class AbstractVRMouseManager implements VRMouseManager {
 		    
             mouseImage.updateGeometricState();
             
-        } else if( mouseImage.getParent() != null ) {
-        	Node n = mouseImage.getParent();
-            mouseImage.removeFromParent();
-            
-            if (n != null){
-              n.updateGeometricState();
-            }
+        } else if(mouseAttached) {
+            mouseAttached = false;
+            environment.getApplication().getGuiViewPort().detachScene(mouseImage);
+
+            // Use the setCursorVisible implementation to show the cursor again, depending on the state of cursorVisible
+            boolean cursorVisible = environment.getApplication().getInputManager().isCursorVisible();
+            environment.getApplication().getContext().getMouseInput().setCursorVisible(cursorVisible);
         }
     }  
 }

--- a/jme3-vr/src/main/java/com/jme3/input/vr/VRMouseManager.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/VRMouseManager.java
@@ -21,6 +21,12 @@ public interface VRMouseManager {
    * @return the {@link VREnvironment VR Environment} to which this manager is attached.
    */
   public VREnvironment getVREnvironment();
+
+  /**
+   * Set if the mouse cursor should be used in the VR view.
+   * @param enabled <code>true</code> if the mouse cursor should be displayed in VR and <code>false</code> otherwise.
+   */
+  public void setVRMouseEnabled(boolean enabled);
   
   /**
    * Set if the VR device controller is used within thumb stick mode.
@@ -29,7 +35,7 @@ public interface VRMouseManager {
   public void setThumbstickMode(boolean set);
   
   /**
-   * Get  if the VR device controller is used within thumb stick mode.
+   * Get if the VR device controller is used within thumb stick mode.
    * @return <code>true</code> if the VR device controller is used within thumb stick mode and <code>false</code> otherwise.
    */
   public boolean isThumbstickMode();


### PR DESCRIPTION
**Adds option to disable VR mouse cursor and thus enable the cursor on the desktop:**
Usecase: We need the cursor on the desktop because the application is operated by a different user who doesn't wear the VR goggles. Using the VRAppState would always disable the desktop-cursor. I added `VRMouseManager.setVRMouseEnabled()`. Default value for `vrMouseEnabled` is true, so it will behave the same by default.

**Fixes repeated attachment of mouseImage as scene to gui viewport (because its parent was always null):**
`AbstractVRMouseManager.update()` used `mouseImage.getParent()` to check if it's already attached. `mouseImage` is added as a scene to the gui viewport and will never have a parent, hence it was attached on every update call.