### PR TITLE
Added an easy way to add sub steps to the profiler

### DIFF
--- a/jme3-android/src/main/java/com/jme3/app/DefaultAndroidProfiler.java
+++ b/jme3-android/src/main/java/com/jme3/app/DefaultAndroidProfiler.java
@@ -135,6 +135,11 @@ public class DefaultAndroidProfiler implements AppProfiler {
         }
     }
 
+    @Override
+    public void appSubStep(String... additionalInfo) {
+        
+    }
+
     public void vpStep(VpStep vpStep, ViewPort vp, RenderQueue.Bucket bucket) {
         if (androidApiLevel >= 18) {
             switch (vpStep) {

--- a/jme3-android/src/main/java/com/jme3/app/DefaultAndroidProfiler.java
+++ b/jme3-android/src/main/java/com/jme3/app/DefaultAndroidProfiler.java
@@ -137,7 +137,7 @@ public class DefaultAndroidProfiler implements AppProfiler {
 
     @Override
     public void appSubStep(String... additionalInfo) {
-        
+
     }
 
     public void vpStep(VpStep vpStep, ViewPort vp, RenderQueue.Bucket bucket) {

--- a/jme3-core/src/main/java/com/jme3/app/BasicProfiler.java
+++ b/jme3-core/src/main/java/com/jme3/app/BasicProfiler.java
@@ -188,6 +188,10 @@ public class BasicProfiler implements AppProfiler {
     }
     
     @Override
+    public void appSubStep(String... additionalInfo) {
+    }
+    
+    @Override
     public void vpStep( VpStep step, ViewPort vp, Bucket bucket ) {
     }
 

--- a/jme3-core/src/main/java/com/jme3/app/DetailedProfiler.java
+++ b/jme3-core/src/main/java/com/jme3/app/DetailedProfiler.java
@@ -87,6 +87,17 @@ public class DetailedProfiler implements AppProfiler {
             closeFrame();
         }
     }
+    
+    
+    @Override
+    public void appSubStep(String... additionalInfo) {
+        if (data != null) {
+            String pathStep = getPath("", additionalInfo);
+            path.setLength(0);
+            path.append(curAppPath).append(pathStep);
+            addStep(path.toString(), System.nanoTime());
+        }
+    }
 
     private void closeFrame() {
         //close frame

--- a/jme3-core/src/main/java/com/jme3/app/state/AppStateManager.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/AppStateManager.java
@@ -32,6 +32,7 @@
 package com.jme3.app.state;
  
 import com.jme3.app.Application;
+import com.jme3.profile.AppProfiler;
 import com.jme3.renderer.RenderManager;
 import com.jme3.util.SafeArrayList;
 import java.util.Arrays;
@@ -284,6 +285,9 @@ public class AppStateManager {
         AppState[] array = getStates();
         for (AppState state : array){
             if (state.isEnabled()) {
+                if (app.getAppProfiler() != null) {
+                    app.getAppProfiler().appSubStep(state.getClass().getSimpleName());
+                }
                 state.update(tpf);
             }
         }

--- a/jme3-core/src/main/java/com/jme3/profile/AppProfiler.java
+++ b/jme3-core/src/main/java/com/jme3/profile/AppProfiler.java
@@ -52,6 +52,11 @@ public interface AppProfiler {
     public void appStep(AppStep step);
     
     /**
+     * Called as a substep of the previous AppStep
+     */
+    public void appSubStep(String... additionalInfo);
+    
+    /**
      *  Called at the beginning of the specified VpStep during
      *  the rendering of the specified ViewPort.  For bucket-specific
      *  steps the Bucket parameter will be non-null.

--- a/jme3-examples/src/main/java/jme3test/stress/TestShaderNodesStress.java
+++ b/jme3-examples/src/main/java/jme3test/stress/TestShaderNodesStress.java
@@ -92,6 +92,11 @@ public class TestShaderNodesStress extends SimpleApplication {
         }
 
         @Override
+        public void appSubStep(String... additionalInfo) {
+
+        }
+
+        @Override
         public void vpStep(VpStep step, ViewPort vp, RenderQueue.Bucket bucket) {
 
         }


### PR DESCRIPTION
This is the implementation I use in spoxel to dig into performance within app states. The default profiler only gives timings for the App State Manager, but this code automatically profiles each of the app states added to the App State Manager. You can set further breakpoints within the update methods of an app state by calling:

`profiler.appSubStep("EffectState", "Run Client Effects");`

In this case "EffectState" is an app state and "Run Client Effects" is one of the profiling points i've set.