### PR TITLE
partial revert PR #1059 (JDK 11 support) which duplicated .class files

### DIFF
--- a/jme3-android-native/decode.gradle
+++ b/jme3-android-native/decode.gradle
@@ -44,19 +44,13 @@ task copyTremorFiles(type: Copy) {
     into outputDir
 }
 
-// Generate headers via javac -h
+// Generate headers via javah
 task generateJavahHeaders(type: Exec) {
-    def files0 = fileTree("src/main/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files1 = fileTree("src/common/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files2 = fileTree("../jme3-core/src/main/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files3 = fileTree("../jme3-core/src/plugins/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files4 = fileTree("../jme3-core/src/tools/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files5 = fileTree("../jme3-terrain/src/main/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def filesList = "\"" + files0.join("\"\n\"") + "\"\n\"" + files1.join("\"\n\"") + "\"\n\"" + files2.join("\"\n\"") + "\"\n\"" + files3.join("\"\n\"") + "\"\n\"" + files4.join("\"\n\"") + "\"\n\"" + files5.join("\"\n\"") + "\""
-	new File("$projectDir/java_classes.jtxt").text = filesList.replaceAll(java.util.regex.Pattern.quote("\\"), java.util.regex.Matcher.quoteReplacement("/"))
-    executable org.gradle.internal.jvm.Jvm.current().getExecutable('javac')
-    args '-h', decodeSourceDir
-    args "@$projectDir/java_classes.jtxt"
+    executable org.gradle.internal.jvm.Jvm.current().getExecutable('javah')
+    args '-d', decodeSourceDir
+    args '-classpath', project.projectClassPath
+    args "com.jme3.audio.plugins.NativeVorbisFile"
+    args "com.jme3.texture.plugins.AndroidNativeImageLoader"
 }
 
 // Copy jME Android native files to jni directory

--- a/jme3-android-native/openalsoft.gradle
+++ b/jme3-android-native/openalsoft.gradle
@@ -73,17 +73,12 @@ task copyJmeOpenALSoft(type: Copy, dependsOn:copyOpenALSoft) {
 }
 
 task generateOpenAlSoftHeaders(type:Exec, dependsOn: copyJmeOpenALSoft) {
-    def files0 = fileTree("src/main/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files1 = fileTree("src/common/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files2 = fileTree("../jme3-core/src/main/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files3 = fileTree("../jme3-core/src/plugins/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files4 = fileTree("../jme3-core/src/tools/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files5 = fileTree("../jme3-terrain/src/main/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def filesList = "\"" + files0.join("\"\n\"") + "\"\n\"" + files1.join("\"\n\"") + "\"\n\"" + files2.join("\"\n\"") + "\"\n\"" + files3.join("\"\n\"") + "\"\n\"" + files4.join("\"\n\"") + "\"\n\"" + files5.join("\"\n\"") + "\""
-	new File("$projectDir/java_classes.jtxt").text = filesList.replaceAll(java.util.regex.Pattern.quote("\\"), java.util.regex.Matcher.quoteReplacement("/"))
-    executable org.gradle.internal.jvm.Jvm.current().getExecutable('javac')
-    args '-h', openalsoftJmeAndroidPath
-    args "@$projectDir/java_classes.jtxt"
+    executable org.gradle.internal.jvm.Jvm.current().getExecutable('javah')
+    args '-d', openalsoftJmeAndroidPath
+    args '-classpath', project.projectClassPath
+    args "com.jme3.audio.android.AndroidAL"
+    args "com.jme3.audio.android.AndroidALC"
+    args "com.jme3.audio.android.AndroidEFX"
 }
 
 task buildOpenAlSoftNativeLib(type: Exec, dependsOn: generateOpenAlSoftHeaders) {

--- a/jme3-bullet/build.gradle
+++ b/jme3-bullet/build.gradle
@@ -17,23 +17,52 @@ dependencies {
 }
 
 task generateNativeHeaders(type: Exec, dependsOn: classes) {
-    def files0 = fileTree("src/main/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files1 = fileTree("src/common/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files2 = fileTree("../jme3-core/src/main/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files3 = fileTree("../jme3-core/src/plugins/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files4 = fileTree("../jme3-core/src/tools/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
-    def files5 = fileTree("../jme3-terrain/src/main/java/").filter { it.isFile() && it.getName().endsWith(".java") }.files
+    def classes = " \
+        com.jme3.bullet.PhysicsSpace, \
+        \
+        com.jme3.bullet.collision.PhysicsCollisionEvent, \
+        com.jme3.bullet.collision.PhysicsCollisionObject,\
+        com.jme3.bullet.objects.PhysicsCharacter, \
+        com.jme3.bullet.objects.PhysicsGhostObject, \
+        com.jme3.bullet.objects.PhysicsRigidBody, \
+        com.jme3.bullet.objects.PhysicsVehicle, \
+        com.jme3.bullet.objects.VehicleWheel, \
+        com.jme3.bullet.objects.infos.RigidBodyMotionState, \
+        \
+        com.jme3.bullet.collision.shapes.CollisionShape, \
+        com.jme3.bullet.collision.shapes.BoxCollisionShape, \
+        com.jme3.bullet.collision.shapes.CapsuleCollisionShape, \
+        com.jme3.bullet.collision.shapes.CompoundCollisionShape, \
+        com.jme3.bullet.collision.shapes.ConeCollisionShape, \
+        com.jme3.bullet.collision.shapes.CylinderCollisionShape, \
+        com.jme3.bullet.collision.shapes.GImpactCollisionShape, \
+        com.jme3.bullet.collision.shapes.HeightfieldCollisionShape, \
+        com.jme3.bullet.collision.shapes.HullCollisionShape, \
+        com.jme3.bullet.collision.shapes.MeshCollisionShape, \
+        com.jme3.bullet.collision.shapes.PlaneCollisionShape, \
+        com.jme3.bullet.collision.shapes.SimplexCollisionShape, \
+        com.jme3.bullet.collision.shapes.SphereCollisionShape, \
+        \
+        com.jme3.bullet.joints.PhysicsJoint, \
+        com.jme3.bullet.joints.ConeJoint, \
+        com.jme3.bullet.joints.HingeJoint, \
+        com.jme3.bullet.joints.Point2PointJoint, \
+        com.jme3.bullet.joints.SixDofJoint, \
+        com.jme3.bullet.joints.SixDofSpringJoint, \
+        com.jme3.bullet.joints.SliderJoint, \
+        com.jme3.bullet.joints.motors.RotationalLimitMotor, \
+        com.jme3.bullet.joints.motors.TranslationalLimitMotor, \
+        \
+        com.jme3.bullet.util.NativeMeshUtil, \
+        com.jme3.bullet.util.DebugShapeFactory"
+
     def classpath = sourceSets.main.runtimeClasspath.asPath
     def nativeIncludes = new File(project(":jme3-bullet-native").projectDir, "src/native/cpp")
-	def filesList = "\"" + files0.join("\"\n\"") + "\"\n\"" + files1.join("\"\n\"") + "\"\n\"" + files2.join("\"\n\"") + "\"\n\"" + files3.join("\"\n\"") + "\"\n\"" + files4.join("\"\n\"") + "\"\n\"" + files5.join("\"\n\"") + "\""
-	new File("$projectDir/java_classes.jtxt").text = filesList.replaceAll(java.util.regex.Pattern.quote("\\"), java.util.regex.Matcher.quoteReplacement("/"))
-    //project.logger.lifecycle("Files: " + files0.size())
-    //project.logger.lifecycle("Files: " + files1.size())
-    executable org.gradle.internal.jvm.Jvm.current().getExecutable('javac')
-    args "-h", nativeIncludes
-    //args "-classpath", classpath
-    args "@$projectDir/java_classes.jtxt"
-    //args classes.split(",").collect { it.trim() }
+
+    executable org.gradle.internal.jvm.Jvm.current().getExecutable('javah')
+    args "-d", nativeIncludes
+    args "-classpath", classpath
+    args classes.split(",").collect { it.trim() }
 }
 
 assemble.dependsOn(generateNativeHeaders)


### PR DESCRIPTION
This PR proposes reverting the part of PR #1059 which caused class files to be stored in the source-code directories. This will break JDK10/11 builds, where `javah` no longer exists. However it will allow development on JDK7/8/9 to proceed while a cleaner solution for JDK10/11 builds is developed.