### PR TITLE
Fixed classes location while building natives (JDK11 Support)

### DIFF
--- a/jme3-android-native/decode.gradle
+++ b/jme3-android-native/decode.gradle
@@ -58,7 +58,7 @@ task generateJavahHeaders(type: Exec) {
     executable org.gradle.internal.jvm.Jvm.current().getExecutable('javac')
     args '-h', decodeSourceDir
     args "@$projectDir/java_classes.jtxt"
-	args '-d', decodeClassesBuildDir
+    args '-d', decodeClassesBuildDir
 }
 
 // Copy jME Android native files to jni directory

--- a/jme3-android-native/decode.gradle
+++ b/jme3-android-native/decode.gradle
@@ -3,6 +3,7 @@ String stbiUrl = 'https://raw.githubusercontent.com/nothings/stb/master/stb_imag
 
 // Working directories for the ndk build.
 String decodeBuildDir = "${buildDir}" + File.separator + 'decode'
+String decodeClassesBuildDir = "${buildDir}" + File.separator + 'decode_classes'
 String decodeBuildJniDir = decodeBuildDir + File.separator + 'jni'
 String decodeBuildLibsDir = decodeBuildDir + File.separator + 'libs'
 
@@ -57,6 +58,7 @@ task generateJavahHeaders(type: Exec) {
     executable org.gradle.internal.jvm.Jvm.current().getExecutable('javac')
     args '-h', decodeSourceDir
     args "@$projectDir/java_classes.jtxt"
+	args '-d', decodeClassesBuildDir
 }
 
 // Copy jME Android native files to jni directory

--- a/jme3-android-native/openalsoft.gradle
+++ b/jme3-android-native/openalsoft.gradle
@@ -9,6 +9,7 @@ String openALSoftFolder = 'openal-soft-e5016f8'
 
 //Working directories for the ndk build.
 String openalsoftBuildDir = "${buildDir}" + File.separator + 'openalsoft'
+String openalsoftClassesBuildDir = "${buildDir}" + File.separator + 'openalsoft_classes'
 String openalsoftBuildJniDir = openalsoftBuildDir + File.separator + 'jni'
 String openalsoftBuildLibsDir = openalsoftBuildDir + File.separator + 'libs'
 
@@ -84,6 +85,7 @@ task generateOpenAlSoftHeaders(type:Exec, dependsOn: copyJmeOpenALSoft) {
     executable org.gradle.internal.jvm.Jvm.current().getExecutable('javac')
     args '-h', openalsoftJmeAndroidPath
     args "@$projectDir/java_classes.jtxt"
+	args '-d', openalsoftClassesBuildDir
 }
 
 task buildOpenAlSoftNativeLib(type: Exec, dependsOn: generateOpenAlSoftHeaders) {

--- a/jme3-android-native/openalsoft.gradle
+++ b/jme3-android-native/openalsoft.gradle
@@ -85,7 +85,7 @@ task generateOpenAlSoftHeaders(type:Exec, dependsOn: copyJmeOpenALSoft) {
     executable org.gradle.internal.jvm.Jvm.current().getExecutable('javac')
     args '-h', openalsoftJmeAndroidPath
     args "@$projectDir/java_classes.jtxt"
-	args '-d', openalsoftClassesBuildDir
+    args '-d', openalsoftClassesBuildDir
 }
 
 task buildOpenAlSoftNativeLib(type: Exec, dependsOn: generateOpenAlSoftHeaders) {

--- a/jme3-bullet/build.gradle
+++ b/jme3-bullet/build.gradle
@@ -2,6 +2,8 @@ if (!hasProperty('mainClass')) {
     ext.mainClass = ''
 }
 
+String classBuildDir = "${buildDir}" + File.separator + 'classes'
+
 sourceSets {
     main {
         java {
@@ -27,13 +29,10 @@ task generateNativeHeaders(type: Exec, dependsOn: classes) {
     def nativeIncludes = new File(project(":jme3-bullet-native").projectDir, "src/native/cpp")
 	def filesList = "\"" + files0.join("\"\n\"") + "\"\n\"" + files1.join("\"\n\"") + "\"\n\"" + files2.join("\"\n\"") + "\"\n\"" + files3.join("\"\n\"") + "\"\n\"" + files4.join("\"\n\"") + "\"\n\"" + files5.join("\"\n\"") + "\""
 	new File("$projectDir/java_classes.jtxt").text = filesList.replaceAll(java.util.regex.Pattern.quote("\\"), java.util.regex.Matcher.quoteReplacement("/"))
-    //project.logger.lifecycle("Files: " + files0.size())
-    //project.logger.lifecycle("Files: " + files1.size())
     executable org.gradle.internal.jvm.Jvm.current().getExecutable('javac')
     args "-h", nativeIncludes
-    //args "-classpath", classpath
     args "@$projectDir/java_classes.jtxt"
-    //args classes.split(",").collect { it.trim() }
+    args '-d', classBuildDir
 }
 
 assemble.dependsOn(generateNativeHeaders)


### PR DESCRIPTION
This PR fixes the issue of class files being placed in the source tree during native binary builds. 
See #1072 for more info.