### PR TITLE
Added ambient light support in PBR shader

### DIFF
--- a/jme3-core/src/main/java/com/jme3/material/logic/SinglePassAndImageBasedLightingLogic.java
+++ b/jme3-core/src/main/java/com/jme3/material/logic/SinglePassAndImageBasedLightingLogic.java
@@ -48,8 +48,10 @@ public final class SinglePassAndImageBasedLightingLogic extends DefaultTechnique
     private static final String DEFINE_SINGLE_PASS_LIGHTING = "SINGLE_PASS_LIGHTING";
     private static final String DEFINE_NB_LIGHTS = "NB_LIGHTS";
     private static final String DEFINE_NB_PROBES = "NB_PROBES";
+    private static final String DEFINE_USE_AMBIENT_LIGHT = "USE_AMBIENT_LIGHT";
     private static final RenderState ADDITIVE_LIGHT = new RenderState();
 
+    private boolean useAmbientLight;
     private final ColorRGBA ambientLightColor = new ColorRGBA(0, 0, 0, 1);
     private List<LightProbe> lightProbes = new ArrayList<>(3);
 
@@ -61,12 +63,14 @@ public final class SinglePassAndImageBasedLightingLogic extends DefaultTechnique
     private final int singlePassLightingDefineId;
     private final int nbLightsDefineId;
     private final int nbProbesDefineId;
+    private final int useAmbientLightDefineId;
 
     public SinglePassAndImageBasedLightingLogic(TechniqueDef techniqueDef) {
         super(techniqueDef);
         singlePassLightingDefineId = techniqueDef.addShaderUnmappedDefine(DEFINE_SINGLE_PASS_LIGHTING, VarType.Boolean);
         nbLightsDefineId = techniqueDef.addShaderUnmappedDefine(DEFINE_NB_LIGHTS, VarType.Int);
         nbProbesDefineId = techniqueDef.addShaderUnmappedDefine(DEFINE_NB_PROBES, VarType.Int);
+        useAmbientLightDefineId = techniqueDef.addShaderUnmappedDefine(DEFINE_USE_AMBIENT_LIGHT, VarType.Boolean);
     }
 
     @Override
@@ -83,6 +87,7 @@ public final class SinglePassAndImageBasedLightingLogic extends DefaultTechnique
             lightProbes.clear();
             extractIndirectLights(lights, false);
             defines.set(nbProbesDefineId, lightProbes.size());
+            defines.set(useAmbientLightDefineId, useAmbientLight);
         }
 
         return super.makeCurrent(assetManager, renderManager, rendererCaps, lights, defines);
@@ -127,7 +132,7 @@ public final class SinglePassAndImageBasedLightingLogic extends DefaultTechnique
             // apply additive blending for 2nd and future passes
             rm.getRenderer().applyRenderState(ADDITIVE_LIGHT);
             ambientColor.setValue(VarType.Vector4, ColorRGBA.Black);
-        }else{
+        } else{
             extractIndirectLights(lightList,true);
             ambientColor.setValue(VarType.Vector4, ambientLightColor);
         }
@@ -260,9 +265,11 @@ public final class SinglePassAndImageBasedLightingLogic extends DefaultTechnique
 
     protected void extractIndirectLights(LightList lightList, boolean removeLights) {
         ambientLightColor.set(0, 0, 0, 1);
+        useAmbientLight = false;
         for (int j = 0; j < lightList.size(); j++) {
             Light l = lightList.get(j);
             if (l instanceof AmbientLight) {
+                useAmbientLight = true;
                 ambientLightColor.addLocal(l.getColor());
                 if(removeLights){
                     lightList.remove(l);

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -296,7 +296,7 @@ void main(){
             weight3 /= weightSum;
         #endif
 
-        #ifdef AMBIENT_LIGHT_COLOR
+        #if USE_AMBIENT_LIGHT
             color1.rgb *= g_AmbientLightColor.rgb;
             color2.rgb *= g_AmbientLightColor.rgb;
             color3.rgb *= g_AmbientLightColor.rgb;

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -12,6 +12,7 @@ varying vec4 Color;
 
 uniform vec4 g_LightData[NB_LIGHTS];
 uniform vec3 g_CameraPosition;
+uniform vec4 g_AmbientLightColor;
 
 uniform float m_Roughness;
 uniform float m_Metallic;
@@ -40,7 +41,7 @@ varying vec3 wPosition;
 #endif
 
 #ifdef USE_PACKED_MR
-     uniform sampler2D m_MetallicRoughnessMap;
+  uniform sampler2D m_MetallicRoughnessMap;
 #else
     #ifdef METALLICMAP
       uniform sampler2D m_MetallicMap;
@@ -51,10 +52,10 @@ varying vec3 wPosition;
 #endif
 
 #ifdef EMISSIVE
-    uniform vec4 m_Emissive;
+  uniform vec4 m_Emissive;
 #endif
 #ifdef EMISSIVEMAP
-    uniform sampler2D m_EmissiveMap;
+  uniform sampler2D m_EmissiveMap;
 #endif
 #if defined(EMISSIVE) || defined(EMISSIVEMAP)
     uniform float m_EmissivePower;
@@ -91,7 +92,7 @@ varying vec3 wPosition;
 varying vec3 wNormal;
 
 #ifdef DISCARD_ALPHA
-uniform float m_AlphaDiscardThreshold;
+  uniform float m_AlphaDiscardThreshold;
 #endif
 
 void main(){
@@ -273,7 +274,7 @@ void main(){
             float ndf3 = renderProbe(viewDir, wPosition, normal, norm, Roughness, diffuseColor, specularColor, ndotv, ao, g_LightProbeData3, g_ShCoeffs3, g_PrefEnvMap3, color3);
         #endif
 
-         #if NB_PROBES >= 2
+        #if NB_PROBES >= 2
             float invNdf =  max(1.0 - ndf,0.0);
             float invNdf2 =  max(1.0 - ndf2,0.0);
             float sumNdf = ndf + ndf2;
@@ -293,6 +294,12 @@ void main(){
             weight1 /= weightSum;
             weight2 /= weightSum;
             weight3 /= weightSum;
+        #endif
+
+        #ifdef AMBIENT_LIGHT_COLOR
+            color1.rgb *= g_AmbientLightColor.rgb;
+            color2.rgb *= g_AmbientLightColor.rgb;
+            color3.rgb *= g_AmbientLightColor.rgb;
         #endif
         gl_FragColor.rgb += color1 * clamp(weight1,0.0,1.0) + color2 * clamp(weight2,0.0,1.0) + color3 * clamp(weight3,0.0,1.0);
 

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -53,7 +53,7 @@ MaterialDef PBR Lighting {
         // Parallax/height map
         Texture2D ParallaxMap -LINEAR
 
-        //Set to true is parallax map is stored in the alpha channel of the normal map
+        //Set to true if parallax map is stored in the alpha channel of the normal map
         Boolean PackedNormalParallax   
 
         //Sets the relief height for parallax mapping
@@ -111,13 +111,16 @@ MaterialDef PBR Lighting {
         Int NumberOfMorphTargets
         Int NumberOfTargetsBuffers
                 
-        //For instancing
+        // For instancing
         Boolean UseInstancing
 
-        //For Vertex Color
+        // For Vertex Color
         Boolean UseVertexColor
 
         Boolean BackfaceShadows : false
+
+        // Set to true to use AmbientLight
+        Boolean UseAmbientLightColor
     }
 
     Technique {
@@ -161,6 +164,7 @@ MaterialDef PBR Lighting {
             NUM_MORPH_TARGETS: NumberOfMorphTargets
             NUM_TARGETS_BUFFERS: NumberOfTargetsBuffers
             HORIZON_FADE: HorizonFade
+            AMBIENT_LIGHT_COLOR: UseAmbientLightColor
         }
     }
 

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -118,9 +118,6 @@ MaterialDef PBR Lighting {
         Boolean UseVertexColor
 
         Boolean BackfaceShadows : false
-
-        // Set to true to use AmbientLight
-        Boolean UseAmbientLightColor
     }
 
     Technique {
@@ -164,7 +161,6 @@ MaterialDef PBR Lighting {
             NUM_MORPH_TARGETS: NumberOfMorphTargets
             NUM_TARGETS_BUFFERS: NumberOfTargetsBuffers
             HORIZON_FADE: HorizonFade
-            AMBIENT_LIGHT_COLOR: UseAmbientLightColor
         }
     }
 


### PR DESCRIPTION
to control the brightness and color of the light probe. Very useful for simulating day/night light and any use case where you don't rebake the probes every time the ambient color needs to change. 

  