### PR TITLE
Basic support for Transform Feedback

### DIFF
--- a/jme3-android/src/main/java/com/jme3/renderer/android/AndroidGL.java
+++ b/jme3-android/src/main/java/com/jme3/renderer/android/AndroidGL.java
@@ -296,7 +296,9 @@ public class AndroidGL implements GL, GLExt, GLFbo {
     @Override
     public int glGetQueryObjectiv(int query, int pname) {
         IntBuffer buff = IntBuffer.allocate(1);
-        GLES30.glGetQueryiv(query, pname, buff);
+        //bug? wrong method call
+        //GLES30.glGetQueryiv(query, pname, buff);
+        GLES30.glGetQueryObjectuiv(query, pname, buff);
         return buff.get(0);
     }
 
@@ -565,5 +567,15 @@ public class AndroidGL implements GL, GLExt, GLFbo {
     @Override
     public void glFramebufferTextureLayerEXT(int target, int attachment, int texture, int level, int layer) {
         throw new UnsupportedOperationException("OpenGL ES 2 does not support texture arrays");
+    }
+
+    @Override
+    public void glGetQuery(int target, int pname, IntBuffer params) {
+        GLES30.glGetQueryiv(pname, pname, params);
+    }
+
+    @Override
+    public void glDeleteQueries(IntBuffer ib) {
+        GLES30.glDeleteQueries(ib.limit(), ib);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/app/DetailedProfiler.java
+++ b/jme3-core/src/main/java/com/jme3/app/DetailedProfiler.java
@@ -57,6 +57,9 @@ public class DetailedProfiler implements AppProfiler {
             for (StatLine statLine : data.values()) {
                 for (Iterator<Integer> i = statLine.taskIds.iterator(); i.hasNext(); ) {
                     int id = i.next();
+                    //FixMe
+                    //throws with app.settings.putBoolean("GraphicsDebug", true);
+                    //reason: query has not started/ended or is already running
                     if (renderer.isTaskResultAvailable(id)) {
                         long val = renderer.getProfilingTime(id);
                         statLine.setValueGpu(val);

--- a/jme3-core/src/main/java/com/jme3/material/Material.java
+++ b/jme3-core/src/main/java/com/jme3/material/Material.java
@@ -673,8 +673,8 @@ public class Material implements CloneableSmartAsset, Cloneable, Savable {
      * @param name  the name of the buffer object defined in the material definition (j3md).
      * @param value the buffer object.
      */
-    public void setUniformBufferObject(final String name, final BufferObject value) {
-        value.setBufferType(BufferObject.BufferType.UniformBufferObject);
+    public void setUniformBufferObject(final String name, final UniformBufferObject value) {
+        value.setBufferType(UniformBufferObject.BufferType.UniformBufferObject);
         setParam(name, VarType.BufferObject, value);
     }
 
@@ -684,8 +684,8 @@ public class Material implements CloneableSmartAsset, Cloneable, Savable {
      * @param name  the name of the buffer object defined in the material definition (j3md).
      * @param value the buffer object.
      */
-    public void setShaderStorageBufferObject(final String name, final BufferObject value) {
-        value.setBufferType(BufferObject.BufferType.ShaderStorageBufferObject);
+    public void setShaderStorageBufferObject(final String name, final UniformBufferObject value) {
+        value.setBufferType(UniformBufferObject.BufferType.ShaderStorageBufferObject);
         setParam(name, VarType.BufferObject, value);
     }
 
@@ -830,7 +830,7 @@ public class Material implements CloneableSmartAsset, Cloneable, Savable {
             if (isBO(type)) {
 
                 final ShaderBufferBlock bufferBlock = shader.getBufferBlock(param.getPrefixedName());
-                bufferBlock.setBufferObject((BufferObject) param.getValue());
+                bufferBlock.setBufferObject((UniformBufferObject) param.getValue());
 
             } else {
 

--- a/jme3-core/src/main/java/com/jme3/renderer/Caps.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Caps.java
@@ -31,6 +31,7 @@
  */
 package com.jme3.renderer;
 
+import com.jme3.material.TechniqueDef;
 import com.jme3.shader.Shader;
 import com.jme3.shader.Shader.ShaderSource;
 import com.jme3.texture.FrameBuffer;
@@ -403,7 +404,44 @@ public enum Caps {
     /**
      * Supporting working with ShaderStorageBufferObjects.
      */
-    ShaderStorageBufferObject;
+    ShaderStorageBufferObject,
+    /**
+     * Supports TimerQueries
+     * GL3.3 is available or (GL_ARB_timer_query) or (GL_EXT_timer_query)
+     * 
+     * TODO
+     * GLES: add support for (EXT_disjoint_timer_query)
+     */
+    TimerQuery,
+    /**
+     * Supports for GL_ANY_SAMPLES_PASSED query.
+     * GL3.3 is available or (GL_ARB_occlusion_query2)
+     * 
+     */
+    OcclusionQuery2,
+    /**
+     * Supports for GL_ANY_SAMPLES_PASSED_CONSERVATIVE query.
+     * GL4.3 is available or (GL_ARB_ES3_compatibility)
+     * 
+     */
+    OcclusionQueryConservative,
+    /**
+     * Support for transform feedback, primitives_generated que
+     * GL3.0 is available or (GL_EXT_transform_feedback)
+     */
+    TransformFeedback,
+    /**
+     * Support for additional transform feedback operations
+     * GL4.0 is available or (GL_ARB_transform_feedback2)
+     */
+    TransformFeedback2,
+     /**
+     * Support for additional transform feedback operations
+     * GL4.0 is available or (GL_ARB_transform_feedback3)
+     */
+    TransformFeedback3
+    
+    ;
 
     /**
      * Returns true if given the renderer capabilities, the texture
@@ -552,7 +590,37 @@ public enum Caps {
                 }
             }
         }
+        if(shader.getBoundTransformFeedbackMode() != null &&
+           shader.getBoundTransformFeedbackMode() != TechniqueDef.TransformFeedbackMode.Off &&
+           !caps.contains(Caps.TransformFeedback)) return false;
+            
         return true;
     }
-
+    /**
+     * Returns true if given the renderer capabilities, the query object
+     * can be supported by the renderer.
+     * 
+     * @param caps The collection of renderer capabilities {@link Renderer#getCaps() }.
+     * @param query The query object to check
+     * @return True if it is supported, false otherwise.
+     */
+    public static boolean supports(Collection<Caps> caps, QueryObject query) {
+        switch(query.getType()) {
+            case SamplesPassed:
+                //GL1.5 is available or (GL_ARB_occlusion_query)
+                return true;
+            case AnySamplesPassed: 
+                return caps.contains(Caps.OcclusionQuery2);
+            case TimeElapsed: 
+                return caps.contains(Caps.TimerQuery);
+            case TransformFeedbackPrimitivesGenerated:
+                return caps.contains(Caps.TransformFeedback);
+            case PrimitivesGenerated: 
+                return caps.contains(Caps.TransformFeedback);
+            case AnySamplesPassedConservative: 
+                return caps.contains(Caps.OcclusionQueryConservative);
+            default:
+                throw new UnsupportedOperationException("Unrecognized query object type: " + query.getType());
+        }
+    }
 }

--- a/jme3-core/src/main/java/com/jme3/renderer/Limits.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Limits.java
@@ -78,4 +78,22 @@ public enum Limits {
     ShaderStorageBufferObjectMaxTessEvaluationBlocks,
     ShaderStorageBufferObjectMaxComputeBlocks,
     ShaderStorageBufferObjectMaxCombineBlocks,
+    
+    //Transform feedback
+    TransformFeedbackMaxSeparateAttribs,
+    TransformFeedbackMaxSeparateComponents,
+    TransformFeedbackMaxInterleavedComponents,
+    TransformFeedbackMaxFeedbackBuffers,
+    MaxVertexStreams,
+    
+    //Query objects
+    QuerySamplesPassedCounterBits,
+    QueryAnySamplesCounterBits,
+    QueryAnySamplesConservativeCounterBits,
+    QueryPrimitivesGeneratedCounterBits,
+    QueryTransformFeedbackPrimitivesWrittenCounterBits,
+    QueryTimeElapsedCounterBits,
+    QueryTimestampCounterBits
+    
+    
 }

--- a/jme3-core/src/main/java/com/jme3/renderer/QueryObject.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/QueryObject.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2009-2019 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.renderer;
+
+import com.jme3.util.NativeObject;
+import java.util.EnumMap;
+
+/**
+ * Query Objects are OpenGL Objects that are used for asynchronous queries of certain kinds of information.
+ * https://www.khronos.org/opengl/wiki/Query_Object
+ * 
+ * @author Riccardo Balbo, Juraj Papp
+ */
+public class QueryObject extends NativeObject {
+    /**
+     * The type of queries.
+     */
+    public enum Type {
+        AnySamplesPassed,
+        AnySamplesPassedConservative,
+        PrimitivesGenerated,
+        SamplesPassed,
+        TimeElapsed,
+        TransformFeedbackPrimitivesGenerated
+    }
+    /**
+     * State of query. The state limits what can be done with a query.
+     */
+    public enum State {
+        /**
+         * New query can start by calling the begin method.
+         */
+        New,
+        /**
+         * The result of the query can be retrived wether by waiting
+         * or by checking if it is available.
+         * The query can start by calling the begin method.
+         */
+        CanBegin,
+        /**
+         * A started query can only end.
+         */
+        CanEnd
+    }
+    
+    protected State state = State.New;
+    protected Type type;
+    protected Renderer renderer;
+    protected int index = 0;
+
+    /**
+     * Creates a new query object with the given type
+     * @param renderer
+     * @param type 
+     */
+    public QueryObject(Renderer renderer, Type type) {
+        this(renderer, type, 0);
+    }
+    
+    /**
+     * Creates a new query object with the given type and index
+     * 
+     * @param renderer
+     * @param type PrimitivesGenerated or TransformFeedbackPrimitivesGenerated
+     * @param index vertex stream index
+     */
+    public QueryObject(Renderer renderer, Type type, int index) {
+        if(index != 0) {
+            //only PrimitivesGenerated and TransformFeedbackPrimitivesGenerated
+            //support indexed mode
+            if(type != Type.PrimitivesGenerated && type != Type.TransformFeedbackPrimitivesGenerated)
+                throw new IllegalArgumentException("Type of query " + type + " supports index 0 only.");
+            //index must be less than GL_MAX_VERTEX_STREAMS
+            //delegate caps checking to renderer
+            //optionally could check caps now, but the user is not using the query yet
+        }       
+        this.renderer = renderer;
+        this.type = type;
+        this.index = index;
+    }
+    
+    /**
+     * Checks is the renderer is capable of rendering this query.
+     * 
+     * However, since "An implementation may support 0 bits in its counter, in which case query results are always undefined and essentially useless."
+     * checking just the capabilities and extensions may not be sufficient
+     * to determine if query is usable.
+     * 
+     * Thus, if true is returned check the result of getQueryCounterBits().
+     * 
+     * @return true is query is supported
+     */
+    public boolean isQuerySupported() {
+        return Caps.supports(renderer.getCaps(), this);
+    }
+    
+    /**
+     * Returns the number of counter bits or zero if not supported.
+     * @return number of bits
+     */
+    public int getQueryCounterBits() {
+        Limits limit = null;
+        switch(type) {
+            case AnySamplesPassed: limit = Limits.QueryAnySamplesCounterBits; break;
+            case AnySamplesPassedConservative: limit = Limits.QueryAnySamplesConservativeCounterBits; break;
+            case PrimitivesGenerated: limit = Limits.QueryPrimitivesGeneratedCounterBits; break;
+            case SamplesPassed: limit = Limits.QuerySamplesPassedCounterBits; break;
+            case TimeElapsed: limit = Limits.QueryTimeElapsedCounterBits; break;
+            case TransformFeedbackPrimitivesGenerated: limit = Limits.QueryTransformFeedbackPrimitivesWrittenCounterBits; break;
+            default: throw new IllegalArgumentException("Unknown type " + type);
+        }
+        Integer i = renderer.getLimits().get(limit);
+        if(i == null) return 0;
+        return i;
+    }
+    
+    /**
+     * Start the query.
+     * 
+     * @throws IllegalArgumentException if this query is already started
+     * @throws IllegalArgumentException if a query with given
+     * type and index is already started.
+     */
+    public void begin() {
+        if(state == State.CanEnd) throw new IllegalArgumentException("The query is already started");
+        renderer.beginQuery(this);
+    }
+    
+    /**
+     * End the query.
+     * 
+     * @throws IllegalArgumentException if this query is not started
+     */
+    public void end() {
+        if(state != State.CanEnd) throw new IllegalArgumentException("The query is not running and thus cannot end.");
+        renderer.endQuery(this);
+    }
+    
+    /**
+     * Returns the query result or -1 if it is not yet available.
+     * @return the query result or -1 if not yet available.
+     * 
+     * @throws IllegalArgumentException if this query has not started and ended
+     */
+    public long getIfReady() {
+        if(state != State.CanBegin) throw new IllegalArgumentException("This query has not ended or didn't run at all.");
+        return renderer.isQueryResultReady(this)?renderer.getQueryResult(this):-1;
+    }
+    
+    /**
+     * Waits until the query result is available and retrieves it.
+     * @return 
+     * 
+     * @throws IllegalArgumentException if this query has not started and ended
+     */
+    public long getAndWait() {
+        if(state != State.CanBegin) throw new IllegalArgumentException("This query has not ended or didn't run at all.");
+        return renderer.getQueryResult(this);
+    }
+    
+    /**
+     * Checks if the query result is available.
+     * @return true is result is available. 
+     * 
+     * @throws IllegalArgumentException if this query has not started and ended
+     */
+    public boolean isResultReady() {
+        if(state != State.CanBegin) throw new IllegalArgumentException("This query has not ended or didn't run at all.");
+        return renderer.isQueryResultReady(this);
+    }
+
+    /**
+     * Returns the query type.
+     * @return type of query 
+     */
+    public Type getType() {
+        return type;
+    }
+
+    /**
+     * Returns the query index.
+     * Only queries with type PrimitivesGenerated and TransformFeedbackPrimitivesGenerated
+     * can specifiy index other than zero.
+     * 
+     * @return index 
+     */
+    public int getIndex() {
+        return index;
+    }
+
+    /**
+     * The state of this query.
+     * @return 
+     */
+    public State getState() {
+        return state;
+    }
+
+    /**
+     * Used internally by the renderer. Do not use.
+     * @param state 
+     */
+    public void setState(State state) {
+        this.state = state;
+    }
+    
+    
+    @Override
+    public void resetObject() {
+        this.id = -1;
+        state = State.New;
+        setUpdateNeeded();
+    }
+
+    @Override
+    public void deleteObject(Object rendererObject) {
+        ((Renderer)rendererObject).deleteQuery(this);
+    }
+
+    @Override
+    public NativeObject createDestructableClone() {
+        QueryObject q = new QueryObject(renderer, type);
+        q.state = state;
+        q.index = index;
+        q.setId(id);
+        return q;
+    }
+
+    @Override
+    public long getUniqueId() {
+        return ((long)OBJTYPE_QUERY << 32) | ((long)id);
+    }
+    
+}

--- a/jme3-core/src/main/java/com/jme3/renderer/QueryObject.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/QueryObject.java
@@ -178,7 +178,7 @@ public class QueryObject extends NativeObject {
     
     /**
      * Waits until the query result is available and retrieves it.
-     * @return 
+     * @return the result of the query
      * 
      * @throws IllegalArgumentException if this query has not started and ended
      */
@@ -219,7 +219,7 @@ public class QueryObject extends NativeObject {
 
     /**
      * The state of this query.
-     * @return 
+     * @return query state
      */
     public State getState() {
         return state;

--- a/jme3-core/src/main/java/com/jme3/renderer/RenderContext.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderContext.java
@@ -35,6 +35,7 @@ import com.jme3.material.RenderState;
 import com.jme3.material.RenderState.BlendFunc;
 import com.jme3.math.ColorRGBA;
 import com.jme3.scene.Mesh;
+import com.jme3.scene.TransformFeedbackOutput;
 import com.jme3.scene.VertexBuffer;
 import com.jme3.shader.Shader;
 import com.jme3.texture.FrameBuffer;
@@ -75,6 +76,21 @@ public class RenderContext {
      * @see RenderState#setPolyOffset(float, float) 
      */
     public boolean polyOffsetEnabled = false;
+    
+    /**
+     * Stores rasterized discard state.
+     */
+    public boolean rasterizerDiscard = false;
+    
+    /**
+     * Stores transform feedback state.
+     */
+    public int transformFeedbackEnabled = -1;
+    
+    /**
+     * Stored transform feedback output.
+     */
+    public TransformFeedbackOutput transformFeedbackOutput;
     
     /**
      * @see RenderState#setPolyOffset(float, float) 
@@ -281,6 +297,11 @@ public class RenderContext {
     public ColorRGBA clearColor = new ColorRGBA(0,0,0,0);
     
     /**
+     * Started queries.
+     */
+    public int[] startedQueries = new int[6/*QueryObject.Type.values().length*/];
+    
+    /**
      * Reset the RenderContext to default GL state
      */
     public void reset(){
@@ -317,6 +338,8 @@ public class RenderContext {
             boundBO[i] = 0;
         for (int i = 0; i < boundTextures.length; i++)
             boundTextures[i] = null;
+        for (int i = 0; i < startedQueries.length; i++)
+            startedQueries[i] = 0;
 
         textureIndexList.reset();
         boundTextureUnit = 0;
@@ -338,5 +361,9 @@ public class RenderContext {
         depthFunc = RenderState.TestFunction.LessOrEqual;    
         alphaFunc = RenderState.TestFunction.Greater;
         clearColor.set(0,0,0,0);
+        
+        rasterizerDiscard = false;
+        transformFeedbackEnabled = -1;
+        transformFeedbackOutput = null;
     }
 }

--- a/jme3-core/src/main/java/com/jme3/renderer/RenderContext.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderContext.java
@@ -189,24 +189,24 @@ public class RenderContext {
      */
     public int boundReadBuf = -1;
 
-    /**
-     * Currently bound element array vertex buffer.
-     * 
-     * @see Renderer#renderMesh(com.jme3.scene.Mesh, int, int, com.jme3.scene.VertexBuffer[]) 
-     */
-    public int boundElementArrayVBO;
+//    /**
+//     * Currently bound element array vertex buffer.
+//     * 
+//     * @see Renderer#renderMesh(com.jme3.scene.Mesh, int, int, com.jme3.scene.VertexBuffer[]) 
+//     */
+//    public int boundElementArrayVBO;
 
     /**
      * @see Renderer#renderMesh(com.jme3.scene.Mesh, int, int, com.jme3.scene.VertexBuffer[]) 
      */
     public int boundVertexArray;
 
-    /**
-     * Currently bound array vertex buffer.
-     * 
-     * @see Renderer#renderMesh(com.jme3.scene.Mesh, int, int, com.jme3.scene.VertexBuffer[]) 
-     */
-    public int boundArrayVBO;
+//    /**
+//     * Currently bound array vertex buffer.
+//     * 
+//     * @see Renderer#renderMesh(com.jme3.scene.Mesh, int, int, com.jme3.scene.VertexBuffer[]) 
+//     */
+//    public int boundArrayVBO;
     
     /**
      * Currently bound pixel pack pixel buffer.
@@ -214,6 +214,11 @@ public class RenderContext {
     public int boundPixelPackPBO;
 
     public int numTexturesSet = 0;
+    
+    /**
+     * Currently bound buffer objects.
+     */
+    public int[] boundBO = new int[14/*BufferObject.Target.values().length*/];
 
     /**
      * Current bound texture IDs for each texture unit.
@@ -303,11 +308,13 @@ public class RenderContext {
         boundRB = 0;
         boundDrawBuf = -1; 
         boundReadBuf = -1;
-        boundElementArrayVBO = 0;
+//        boundElementArrayVBO = 0;
         boundVertexArray = 0;
-        boundArrayVBO = 0;
+//        boundArrayVBO = 0;
         boundPixelPackPBO = 0;
         numTexturesSet = 0;
+        for (int i = 0; i < boundBO.length; i++)
+            boundBO[i] = 0;
         for (int i = 0; i < boundTextures.length; i++)
             boundTextures[i] = null;
 

--- a/jme3-core/src/main/java/com/jme3/renderer/Renderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Renderer.java
@@ -35,6 +35,7 @@ import com.jme3.material.RenderState;
 import com.jme3.math.ColorRGBA;
 import com.jme3.scene.BufferObject;
 import com.jme3.scene.Mesh;
+import com.jme3.scene.TransformFeedbackOutput;
 import com.jme3.scene.VertexBuffer;
 import com.jme3.shader.UniformBufferObject;
 import com.jme3.shader.Shader;
@@ -432,4 +433,46 @@ public interface Renderer {
      */
     public boolean isTaskResultAvailable(int taskId);
 
+    /**
+     * Enable transform feedback and set the output buffer.
+     * Multiple render commands can be exectured to fill the output buffer
+     * as long as they use the same compiled shader. (Materials can be different
+     * as long as only their uniforms are updated, and such action wont trigger
+     * shader recompilation.)
+     * If multiple materials are present a render exception will be thrown when
+     * rendering the first different material.
+     * 
+     * @param output transform feedback output to write to or null to disable
+     *          transform feedback
+     */
+    public void setTransformFeedbackOutput(TransformFeedbackOutput output);
+    
+    /**
+     * Returns true is query results is ready.
+     * @param q query object
+     * @return true is result is ready
+     */
+    public boolean isQueryResultReady(QueryObject q);
+    /**
+     * Retrieves the query result, blocking if query has
+     * not completed yet.
+     * @param q query object
+     * @return value of the query
+     */
+    public long getQueryResult(QueryObject q);
+    /**
+     * Start the query.
+     * @param q query object
+     */
+    public void beginQuery(QueryObject q);
+    /**
+     * Ends the query.
+     * @param q query object.
+     */
+    public void endQuery(QueryObject q);
+    /**
+     * Deletes the query.
+     * @param q query object.
+     */
+    public void deleteQuery(QueryObject q);
 }

--- a/jme3-core/src/main/java/com/jme3/renderer/Renderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Renderer.java
@@ -33,9 +33,10 @@ package com.jme3.renderer;
 
 import com.jme3.material.RenderState;
 import com.jme3.math.ColorRGBA;
+import com.jme3.scene.BufferObject;
 import com.jme3.scene.Mesh;
 import com.jme3.scene.VertexBuffer;
-import com.jme3.shader.BufferObject;
+import com.jme3.shader.UniformBufferObject;
 import com.jme3.shader.Shader;
 import com.jme3.shader.Shader.ShaderSource;
 import com.jme3.system.AppSettings;
@@ -262,25 +263,12 @@ public interface Renderer {
     public void deleteImage(Image image);
 
     /**
-     * Uploads a vertex buffer to the GPU.
+     * Uploads a buffer object to the GPU.
      * 
-     * @param vb The vertex buffer to upload
+     * @param vb The buffer object to upload
      */
-    public void updateBufferData(VertexBuffer vb);
-
-    /**
-     * Uploads data of the buffer object on the GPU.
-     *
-     * @param bo the buffer object to upload.
-     */
-    public void updateBufferData(BufferObject bo);
-
-    /**
-     * Deletes a vertex buffer from the GPU.
-     * @param vb The vertex buffer to delete
-     */
-    public void deleteBuffer(VertexBuffer vb);
-
+    public void updateBufferData(BufferObject vb);   
+    
     /**
      * Deletes the buffer object from the GPU.
      *

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GL.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GL.java
@@ -66,6 +66,7 @@ public interface GL {
     public static final int GL_DST_ALPHA = 0x0304;
     public static final int GL_DST_COLOR = 0x306;
     public static final int GL_DYNAMIC_DRAW = 0x88E8;
+    public static final int GL_DYNAMIC_READ = 0x88E9;
     public static final int GL_DYNAMIC_COPY = 0x88EA;
     public static final int GL_ELEMENT_ARRAY_BUFFER = 0x8893;
     public static final int GL_EQUAL = 0x202;
@@ -146,10 +147,13 @@ public interface GL {
     public static final int GL_SRC_ALPHA_SATURATE = 0x0308;
     public static final int GL_SRC_COLOR = 0x300;
     public static final int GL_STATIC_DRAW = 0x88E4;
+    public static final int GL_STATIC_READ = 0x88E5;
+    public static final int GL_STATIC_COPY = 0x88E6;
     public static final int GL_STENCIL_BUFFER_BIT = 0x400;
     public static final int GL_STENCIL_TEST = 0xB90;
     public static final int GL_STREAM_DRAW = 0x88E0;
     public static final int GL_STREAM_READ = 0x88E1;
+    public static final int GL_STREAM_COPY = 0x88E2;
     public static final int GL_TEXTURE = 0x1702;
     public static final int GL_TEXTURE0 = 0x84C0;
     public static final int GL_TEXTURE1 = 0x84C1;
@@ -194,7 +198,7 @@ public interface GL {
     public static final int GL_VERSION = 0x1F02;
     public static final int GL_VERTEX_SHADER = 0x8B31;
     public static final int GL_ZERO = 0x0;
-
+    
     public void resetStats();
 
     /**

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GL.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GL.java
@@ -199,6 +199,10 @@ public interface GL {
     public static final int GL_VERTEX_SHADER = 0x8B31;
     public static final int GL_ZERO = 0x0;
     
+    public static final int GL_SAMPLES_PASSED = 35092;
+	public static final int GL_QUERY_COUNTER_BITS = 34916;
+	public static final int GL_CURRENT_QUERY = 34917;
+    
     public void resetStats();
 
     /**
@@ -1303,4 +1307,19 @@ public interface GL {
      * @param height the viewport height.
      */
     public void glViewport(int x, int y, int width, int height);
+    /**
+     * <p><a target="_blank" href="http://docs.gl/gl4/glGetQueryiv">Reference Page</a></p>
+     * Returns parameters of a query object target
+     * 
+     * @param target query target
+     * @param pname GL_CURRENT_QUERY or GL_QUERY_COUNTER_BITS
+     * @param value pointer to buffer to store the result
+     */
+    public void glGetQuery(int target, int pname, IntBuffer value);
+    /**
+     * <p><a target="_blank" href="http://docs.gl/gl4/glDeleteQueries">Reference Page</a></p>
+     * Deletes named query objects.
+     * @param ib an array of query objects to be deleted.
+     */
+    public void glDeleteQueries(IntBuffer ib);
 }

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GL2.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GL2.java
@@ -74,6 +74,8 @@ public interface GL2 extends GL {
     public static final int GL_TEXTURE_WRAP_R = 0x8072;
     public static final int GL_VERTEX_PROGRAM_POINT_SIZE = 0x8642;
     public static final int GL_UNSIGNED_INT_8_8_8_8 = 0x8035;
+    public static final int GL_PIXEL_PACK_BUFFER = 0x88EB;
+    public static final int GL_PIXEL_UNPACK_BUFFER = 0x88EC;
 
     /**
      * <p><a target="_blank" href="http://docs.gl/gl3/glAlphaFunc">Reference Page</a> - <em>This function is deprecated and unavailable in the Core profile</em></p>

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GL3.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GL3.java
@@ -92,6 +92,13 @@ public interface GL3 extends GL2 {
     public static final int GL_COPY_READ_BUFFER = 0x8F36;
     public static final int GL_COPY_WRITE_BUFFER = 0x8F37;
     public static final int GL_TEXTURE_BUFFER = 0x8C2A;
+    
+    /**
+     * Query target (OpenGL 3.3+)
+     */
+    public static final int GL_ANY_SAMPLES_PASSED = 35887;
+    public static final int GL_TIMESTAMP = 36392;
+
 
     /**
      * Accepted by the {@code target} parameters of BindBuffer, BufferData, BufferSubData, MapBuffer, UnmapBuffer, GetBufferSubData, and GetBufferPointerv.
@@ -130,6 +137,20 @@ public interface GL3 extends GL2 {
      * BindBufferRange, BindBufferOffset and BindBufferBase.
      */
     public static final int GL_TRANSFORM_FEEDBACK_BUFFER = 0x8C8E;
+    public static final int GL_TRANSFORM_FEEDBACK_BUFFER_START = 35972;
+	public static final int GL_TRANSFORM_FEEDBACK_BUFFER_SIZE = 35973;
+	public static final int GL_TRANSFORM_FEEDBACK_BUFFER_BINDING = 35983;
+	public static final int GL_INTERLEAVED_ATTRIBS = 35980;
+	public static final int GL_SEPARATE_ATTRIBS = 35981;
+	public static final int GL_PRIMITIVES_GENERATED = 35975;
+	public static final int GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN = 35976;
+	public static final int GL_RASTERIZER_DISCARD = 35977;
+	public static final int GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS = 35978;
+	public static final int GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS = 35979;
+	public static final int GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS = 35968;
+	public static final int GL_TRANSFORM_FEEDBACK_VARYINGS = 35971;
+	public static final int GL_TRANSFORM_FEEDBACK_BUFFER_MODE = 35967;
+	public static final int GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH = 35958;
 
     /**
      * <p><a target="_blank" href="http://docs.gl/gl4/glBindFragDataLocation">Reference Page</a></p>
@@ -199,6 +220,8 @@ public interface GL3 extends GL2 {
      * @param buffer a buffer object to bind to the specified binding point
      */
     public void glBindBufferBase(int target, int index, int buffer);
+    
+    public void glBindBufferRange(int target, int index, int buffer, long offset, long size);
 
     /**
      * Binding points for active uniform blocks are assigned using glUniformBlockBinding. Each of a program's active
@@ -219,4 +242,13 @@ public interface GL3 extends GL2 {
      *                            uniformBlockIndex within program.
      */
     public void glUniformBlockBinding(int program, int uniformBlockIndex, int uniformBlockBinding);
+
+    public void glTransformFeedbackVaryings(int program, String[] varyings, int bufferMode);
+    
+    public void glBeginTransformFeedback(int primitiveMode);
+    
+    public void glEndTransformFeedback();
+    
+    
+
 }

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GL3.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GL3.java
@@ -88,6 +88,10 @@ public interface GL3 extends GL2 {
     public static final int GL_RGBA_INTEGER = 36249;
 
     public static final int GL_UNIFORM_OFFSET = 0x8A3B;
+    
+    public static final int GL_COPY_READ_BUFFER = 0x8F36;
+    public static final int GL_COPY_WRITE_BUFFER = 0x8F37;
+    public static final int GL_TEXTURE_BUFFER = 0x8C2A;
 
     /**
      * Accepted by the {@code target} parameters of BindBuffer, BufferData, BufferSubData, MapBuffer, UnmapBuffer, GetBufferSubData, and GetBufferPointerv.

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GL4.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GL4.java
@@ -52,6 +52,10 @@ public interface GL4 extends GL3 {
      */
     public static final int GL_SHADER_STORAGE_BUFFER = 0x90D2;
     public static final int GL_SHADER_STORAGE_BLOCK = 0x92E6;
+    
+    public static final int GL_DRAW_INDIRECT_BUFFER = 0x8F3F;
+    public static final int GL_DISPATCH_INDIRECT_BUFFER = 0x90EE;
+    public static final int GL_QUERY_BUFFER = 0x9192;
 
     /**
      *  Accepted by the &lt;pname&gt; parameter of GetIntegerv, GetBooleanv,

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GL4.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GL4.java
@@ -71,6 +71,20 @@ public interface GL4 extends GL3 {
     public static final int GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS = 0x90DD;
     public static final int GL_MAX_SHADER_STORAGE_BLOCK_SIZE = 0x90DE;
     public static final int GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT = 0x90DF;
+    
+    public static final int GL_TRANSFORM_FEEDBACK = 36386;
+    public static final int GL_TRANSFORM_FEEDBACK_PAUSED = 36387;
+    public static final int GL_TRANSFORM_FEEDBACK_ACTIVE = 36388;
+    public static final int GL_TRANSFORM_FEEDBACK_BUFFER_PAUSED = 36387;
+    public static final int GL_TRANSFORM_FEEDBACK_BUFFER_ACTIVE = 36388;
+    public static final int GL_TRANSFORM_FEEDBACK_BINDING = 36389;
+    public static final int GL_MAX_TRANSFORM_FEEDBACK_BUFFERS = 36464;
+    public static final int GL_MAX_VERTEX_STREAMS = 36465;
+
+    /**
+     * Query target (OpenGL 4.3+)
+     */
+    public static final int GL_ANY_SAMPLES_PASSED_CONSERVATIVE = 36202;
 
     /**
      * <p><a target="_blank" href="http://docs.gl/gl4/glPatchParameteri">Reference Page</a></p>
@@ -104,4 +118,26 @@ public interface GL4 extends GL3 {
      * @param storageBlockBinding The index storage block binding to associate with the specified storage block.
      */
     public void glShaderStorageBlockBinding(int program, int storageBlockIndex, int storageBlockBinding);
+
+    /**
+     * <p><a target="_blank" href="http://docs.gl/gl4/glBeginQueryIndexed">Reference Page</a></p>
+     * <p>
+     * Creates a query object and makes it active at indexed target.
+     *
+     * @param target the target type of query object established.
+     * @param index  target index
+     * @param id  id of query object
+     */
+    public void glBeginQueryIndexed(int target, int index, int id);
+    
+     /**
+     * <p><a target="_blank" href="http://docs.gl/gl4/glBeginQueryIndexed">Reference Page</a></p>
+     * <p>
+     * Marks the end of the sequence of commands to be tracked for the active query specified by {@code target}.
+     *
+     * @param target the query object target.
+     * @param index target index
+     */
+    public void glEndQueryIndexed(int target, int index);
+
 }

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLDebugDesktop.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLDebugDesktop.java
@@ -16,61 +16,73 @@ public class GLDebugDesktop extends GLDebugES implements GL2, GL3, GL4 {
         this.gl4 = gl instanceof GL4 ? (GL4) gl : null;
     }
     
+    @Override
     public void glAlphaFunc(int func, float ref) {
         gl2.glAlphaFunc(func, ref);
         checkError();
     }
 
+    @Override
     public void glPointSize(float size) {
         gl2.glPointSize(size);
         checkError();
     }
 
+    @Override
     public void glPolygonMode(int face, int mode) {
         gl2.glPolygonMode(face, mode);
         checkError();
     }
 
+    @Override
     public void glDrawBuffer(int mode) {
         gl2.glDrawBuffer(mode);
         checkError();
     }
 
+    @Override
     public void glReadBuffer(int mode) {
         gl2.glReadBuffer(mode);
         checkError();
     }
 
+    @Override
     public void glCompressedTexImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, ByteBuffer data) {
         gl2.glCompressedTexImage3D(target, level, internalformat, width, height, depth, border, data);
         checkError();
     }
 
+    @Override
     public void glCompressedTexSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int format, ByteBuffer data) {
         gl2.glCompressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, data);
         checkError();
     }
 
+    @Override
     public void glTexImage3D(int target, int level, int internalFormat, int width, int height, int depth, int border, int format, int type, ByteBuffer data) {
         gl2.glTexImage3D(target, level, internalFormat, width, height, depth, border, format, type, data);
         checkError();
     }
 
+    @Override
     public void glTexSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int format, int type, ByteBuffer data) {
         gl2.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data);
         checkError();
     }
 
+    @Override
     public void glBindFragDataLocation(int param1, int param2, String param3) {
         gl3.glBindFragDataLocation(param1, param2, param3);
         checkError();
     }
 
+    @Override
     public void glBindVertexArray(int param1) {
         gl3.glBindVertexArray(param1);
         checkError();
     }
 
+    @Override
     public void glGenVertexArrays(IntBuffer param1) {
         gl3.glGenVertexArrays(param1);
         checkError();
@@ -121,6 +133,7 @@ public class GLDebugDesktop extends GLDebugES implements GL2, GL3, GL4 {
         checkError();
     }
 
+    @Override
     public void glBlendEquationSeparate(int colorMode, int alphaMode) {
         gl.glBlendEquationSeparate(colorMode, alphaMode);
         checkError();
@@ -131,4 +144,41 @@ public class GLDebugDesktop extends GLDebugES implements GL2, GL3, GL4 {
         gl3.glUniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
         checkError();
     }
+
+    @Override
+    public void glBindBufferRange(int target, int index, int buffer, long offset, long size) {
+        gl3.glBindBufferRange(target, index, buffer, offset, size);
+        checkError();
+    }
+
+    @Override
+    public void glBeginTransformFeedback(int primitiveMode) {
+        gl3.glBeginTransformFeedback(primitiveMode);
+        checkError();
+    }
+
+    @Override
+    public void glEndTransformFeedback() {
+        gl3.glEndTransformFeedback();
+        checkError();
+    }
+
+    @Override
+    public void glTransformFeedbackVaryings(int program, String[] varyings, int bufferMode) {
+        gl3.glTransformFeedbackVaryings(program, varyings, bufferMode);
+        checkError();
+    }
+
+    @Override
+    public void glBeginQueryIndexed(int target, int index, int id) {
+        gl4.glBeginQueryIndexed(target, index, id);
+        checkError();
+    }
+
+    @Override
+    public void glEndQueryIndexed(int target, int index) {
+        gl4.glEndQueryIndexed(target, index);
+        checkError();
+    }
+
 }

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLDebugES.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLDebugES.java
@@ -51,8 +51,7 @@ public class GLDebugES extends GLDebug implements GL, GLFbo, GLExt {
         checkError();
     }
     
-    public void glBlendFuncSeparate(int sfactorRGB, int dfactorRGB, int sfactorAlpha, int dFactorAlpha)
-    {
+    public void glBlendFuncSeparate(int sfactorRGB, int dfactorRGB, int sfactorAlpha, int dFactorAlpha) {
        gl.glBlendFuncSeparate(sfactorRGB, dfactorRGB, sfactorAlpha, dFactorAlpha);
        checkError();
     }
@@ -206,6 +205,7 @@ public class GLDebugES extends GLDebug implements GL, GLFbo, GLExt {
 
     @Override
     public void glEndQuery(int target) {
+        gl.glEndQuery(target);
         checkError();
     }
 
@@ -221,7 +221,7 @@ public class GLDebugES extends GLDebug implements GL, GLFbo, GLExt {
 
     @Override
     public void glGenQueries(int num, IntBuffer ids) {
-        glGenQueries(num, ids);
+        gl.glGenQueries(num, ids);
         checkError();
     }
 
@@ -607,6 +607,18 @@ public class GLDebugES extends GLDebug implements GL, GLFbo, GLExt {
     @Override
     public void glFramebufferTextureLayerEXT(int param1, int param2, int param3, int param4, int param5) {
         glfbo.glFramebufferTextureLayerEXT(param1, param2, param3, param4, param5);
+        checkError();
+    }
+
+    @Override
+    public void glGetQuery(int target, int pname, IntBuffer params) {
+        gl.glGetQuery(target, pname, params);
+        checkError();
+    }
+
+    @Override
+    public void glDeleteQueries(IntBuffer ib) {
+        gl.glDeleteQueries(ib);
         checkError();
     }
 }

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -698,10 +698,6 @@ public final class GLRenderer implements Renderer {
 
     public void setBackgroundColor(ColorRGBA color) {
         if (!context.clearColor.equals(color)) {
-            if(context.rasterizerDiscard) {
-                gl.glDisable(GL3.GL_RASTERIZER_DISCARD);
-                context.rasterizerDiscard = false;
-            }
             gl.glClearColor(color.r, color.g, color.b, color.a);
             context.clearColor.set(color);
         }

--- a/jme3-core/src/main/java/com/jme3/scene/BufferObject.java
+++ b/jme3-core/src/main/java/com/jme3/scene/BufferObject.java
@@ -272,9 +272,10 @@ public class BufferObject extends NativeObject implements Savable, Cloneable {
      * information.
      */
     public void setTarget(Target target) {
-        if (getId() != -1) 
-            throw new IllegalStateException("Can't change buffer's target after the buffer is initialized.");
+//        if (getId() != -1) 
+//            throw new IllegalStateException("Can't change buffer's target after the buffer is initialized.");
         this.target = target;
+        this.setUpdateNeeded();
     }
     
     
@@ -821,6 +822,7 @@ public class BufferObject extends NativeObject implements Savable, Cloneable {
         OutputCapsule oc = ex.getCapsule(this);
         oc.write(components, "components", 0);
         oc.write(usage, "usage", Usage.Dynamic);
+        oc.write(target, "target", null);
 //        oc.write(bufType, "buffer_type", null);
         oc.write(format, "format", Format.Float);
 //        oc.write(normalized, "normalized", false);
@@ -857,6 +859,7 @@ public class BufferObject extends NativeObject implements Savable, Cloneable {
         InputCapsule ic = im.getCapsule(this);
         components = ic.readInt("components", 0);
         usage = ic.readEnum("usage", Usage.class, Usage.Dynamic);
+        target = ic.readEnum("target", Target.class, null);
 //        bufType = ic.readEnum("buffer_type", Type.class, null);
         format = ic.readEnum("format", Format.class, Format.Float);
 //        normalized = ic.readBoolean("normalized", false);

--- a/jme3-core/src/main/java/com/jme3/scene/BufferObject.java
+++ b/jme3-core/src/main/java/com/jme3/scene/BufferObject.java
@@ -1,0 +1,891 @@
+/*
+ * Copyright (c) 2009-2012 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.scene;
+
+import com.jme3.export.*;
+import com.jme3.math.FastMath;
+import com.jme3.renderer.Renderer;
+import com.jme3.scene.VertexBuffer.*;
+import com.jme3.util.BufferUtils;
+import com.jme3.util.NativeObject;
+import java.io.IOException;
+import java.nio.*;
+
+/**
+ * Buffer objects stores memory to be uploaded/downloaded to/from renderer.
+ * 
+ */
+public class BufferObject extends NativeObject implements Savable, Cloneable {
+  
+    /**
+     * Represents a buffer binding target for this object.
+     * Subclasses of BufferObject may set an appropriate target.
+     */
+    public static enum Target {
+        /**
+         * Vertex attributes
+         */
+        Array,
+        /**
+         * Atomic counter storage
+         */
+        AtomicCounter,
+        /**
+         * Buffer copy source
+         */
+        CopyRead,
+        /**
+         * Buffer copy destination
+         */
+        CopyWrite,
+        /**
+         * Indirect compute dispatch commands
+         */
+        DispatchIndirect,
+        /**
+         * Indirect command arguments
+         */
+        DrawIndirect,
+        /**
+         * Vertex array indices
+         */
+        ElementArray,
+        /**
+         * Pixel read target
+         */
+        PixelPack,
+        /**
+         * Texture data source
+         */
+        PixelUnpack,
+        /**
+         * Query result buffer
+         */
+        Query,
+        /**
+         * Read-write storage for shaders
+         */
+        ShaderStorage,
+        /**
+         * Texture data buffer
+         */
+        Texture,
+        /**
+         * Transform feedback buffer
+         */
+        TransformFeedback,
+        /**
+         * Uniform block storage
+         */
+        Uniform;
+    }
+
+    protected int lastLimit = 0;
+    protected int components = 0;
+
+    /**
+     * derived from components * format.getComponentSize()
+     */
+    protected transient int componentsLength = 0;
+    protected Buffer data = null;
+    
+    protected Target target;
+    protected Usage usage;
+    protected Format format;
+
+    protected transient boolean dataSizeChanged = false;
+
+    /**
+     * Serialization only. Do not use.
+     */
+    public BufferObject() {
+        super();
+    }
+
+    /**
+     * Creates an empty, uninitialized buffer.
+     * Must call setupData() to initialize.
+     * @param target
+     */
+    public BufferObject(Target target){
+        super();
+        this.target = target;
+    }
+
+   
+    protected BufferObject(int id){
+        super(id);
+    }
+
+    public boolean invariant() {
+        // Does the VB hold any data?
+        if (data == null) {
+            throw new AssertionError();
+        }
+        // Position must be 0.
+        if (data.position() != 0) {
+            throw new AssertionError();
+        }
+        // Is the size of the VB == 0?
+        if (data.limit() == 0) {
+            throw new AssertionError();
+        }
+        
+//        // Does offset exceed buffer limit or negative?
+//        if (offset > data.limit() || offset < 0) {
+//            throw new AssertionError();
+//        }
+//        // Are components between 1 and 4?
+//        
+//        // Are components between 1 and 4 and not InstanceData?
+//        if (bufType != Type.InstanceData) {
+//            if (components < 1 || components > 4) {
+//                throw new AssertionError();
+//            }
+//        }
+
+        // Does usage comply with buffer directness?
+        //if (usage == Usage.CpuOnly && data.isDirect()) {
+        //    throw new AssertionError();
+        /*} else*/ if (usage != Usage.CpuOnly && !data.isDirect()) {
+            throw new AssertionError();
+        }
+
+        // Double/Char/Long buffers are not supported for VertexBuffers.
+        // For the rest, ensure they comply with the "Format" value.
+        if (data instanceof DoubleBuffer) {
+            throw new AssertionError();
+        } else if (data instanceof CharBuffer) {
+            throw new AssertionError();
+        } else if (data instanceof LongBuffer) {
+            throw new AssertionError();
+        } else if (data instanceof FloatBuffer && format != Format.Float) {
+            throw new AssertionError();
+        } else if (data instanceof IntBuffer && format != Format.Int && format != Format.UnsignedInt) {
+            throw new AssertionError();
+        } else if (data instanceof ShortBuffer && format != Format.Short && format != Format.UnsignedShort) {
+            throw new AssertionError();
+        } else if (data instanceof ByteBuffer && format != Format.Byte && format != Format.UnsignedByte) {
+            throw new AssertionError();
+        }
+        return true;
+    }
+    
+   
+
+    /**
+     * Returns the raw internal data buffer used by this VertexBuffer.
+     * This buffer is not safe to call from multiple threads since buffers
+     * have their own internal position state that cannot be shared.
+     * Call getData().duplicate(), getData().asReadOnlyBuffer(), or 
+     * the more convenient getDataReadOnly() if the buffer may be accessed 
+     * from multiple threads.
+     * 
+     * @return A native buffer, in the specified {@link Format format}.
+     */
+    public Buffer getData(){
+        return data;
+    }
+    
+    /** 
+     * Returns a safe read-only version of this VertexBuffer's data.  The
+     * contents of the buffer will reflect whatever changes are made on
+     * other threads (eventually) but these should not be used in that way.
+     * This method provides a read-only buffer that is safe to _read_ from
+     * a separate thread since it has its own book-keeping state (position, limit, etc.)
+     *
+     * @return A rewound native buffer in the specified {@link Format format}
+     *         that is safe to read from a separate thread from other readers. 
+     */
+    public Buffer getDataReadOnly() {
+    
+        if (data == null) {
+            return null;
+        }
+        
+        // Create a read-only duplicate().  Note: this does not copy
+        // the underlying memory, it just creates a new read-only wrapper
+        // with its own buffer position state.
+        
+        // Unfortunately, this is not 100% straight forward since Buffer
+        // does not have an asReadOnlyBuffer() method.
+        Buffer result;
+        if( data instanceof ByteBuffer ) {
+            result = ((ByteBuffer)data).asReadOnlyBuffer();
+        } else if( data instanceof FloatBuffer ) {
+            result = ((FloatBuffer)data).asReadOnlyBuffer();
+        } else if( data instanceof ShortBuffer ) {
+            result = ((ShortBuffer)data).asReadOnlyBuffer();
+        } else if( data instanceof IntBuffer ) {
+            result = ((IntBuffer)data).asReadOnlyBuffer();
+        } else {
+            throw new UnsupportedOperationException( "Cannot get read-only view of buffer type:" + data );
+        }
+        
+        // Make sure the caller gets a consistent view since we may
+        // have grabbed this buffer while another thread was reading
+        // the raw data.
+        result.rewind();
+        
+        return result;
+    }
+
+    /**
+     * @return The target of this buffer. See {@link Target} for more
+     * information.
+     */
+    public Target getTarget() {
+        return target;
+    }
+
+    /**
+     * @param target The target of this buffer. See {@link Target} for more
+     * information.
+     */
+    public void setTarget(Target target) {
+        if (getId() != -1) 
+            throw new IllegalStateException("Can't change buffer's target after the buffer is initialized.");
+        this.target = target;
+    }
+    
+    
+
+    /**
+     * @return The usage of this buffer. See {@link Usage} for more
+     * information.
+     */
+    public Usage getUsage(){
+        return usage;
+    }
+
+    /**
+     * @param usage The usage of this buffer. See {@link Usage} for more
+     * information.
+     */
+    public void setUsage(Usage usage){
+//        if (id != -1)
+//            throw new UnsupportedOperationException("Data has already been sent. Cannot set usage.");
+
+        this.usage = usage;
+        this.setUpdateNeeded();
+    }
+
+
+
+    /**
+     * @return The {@link Format format}, or data type of the data.
+     */
+    public Format getFormat(){
+        return format;
+    }
+
+    /**
+     * @return The number of components of the given {@link Format format} per
+     * element.
+     */
+    public int getNumComponents(){
+        return components;
+    }
+
+    /**
+     * @return The total number of data elements in the data buffer.
+     */
+    public int getNumElements(){
+        if( data == null ) {
+            return 0;
+        }
+        int elements = data.limit() / components;
+        if (format == Format.Half) {
+            elements /= 2;
+        }
+        return elements;
+    }
+
+   /**
+     * Called to initialize the data in the <code>BufferObject</code>. 
+     * 
+     * @param usage The usage for the data, or how often will the data
+     * be updated per frame. See the {@link Usage} enum.
+     * @param components The number of components per element.
+     * @param format The {@link Format format}, or data-type of a single
+     * component.
+    */
+    public void setupData(Usage usage, int components, Format format){
+        if (id != -1) {
+            throw new UnsupportedOperationException("Data has already been sent. Cannot setupData again.");
+        }
+
+        if (usage == null || format == null) {
+            throw new IllegalArgumentException("None of the arguments can be null");
+        }
+
+
+//        if (bufType != Type.InstanceData) {
+//            if (components < 1 || components > 4) {
+//                throw new IllegalArgumentException("components must be between 1 and 4");
+//            }
+//        }
+        
+//        this.data = buf;
+        this.components = components;
+        this.usage = usage;
+        this.format = format;
+        this.componentsLength = components * format.getComponentSize();
+//        this.lastLimit = buf.limit();
+        setUpdateNeeded();
+    }
+    
+    /**
+     * Called to initialize the data in the <code>BufferObject</code>. Must only
+     * be called once.
+     * 
+     * @param usage The usage for the data, or how often will the data
+     * be updated per frame. See the {@link Usage} enum.
+     * @param components The number of components per element.
+     * @param format The {@link Format format}, or data-type of a single
+     * component.
+     * @param data A native buffer, the format of which matches the {@link Format}
+     * argument.
+     */
+    public void setupData(Usage usage, int components, Format format, Buffer data){
+        if (id != -1) {
+            throw new UnsupportedOperationException("Data has already been sent. Cannot setupData again.");
+        }
+
+        if (usage == null || format == null || data == null) {
+            throw new IllegalArgumentException("None of the arguments can be null");
+        }
+
+        if (data.isReadOnly()) {
+            throw new IllegalArgumentException("VertexBuffer data cannot be read-only.");
+        }
+
+//        if (bufType != Type.InstanceData) {
+//            if (components < 1 || components > 4) {
+//                throw new IllegalArgumentException("components must be between 1 and 4");
+//            }
+//        }
+        
+        this.data = data;
+        this.components = components;
+        this.usage = usage;
+        this.format = format;
+        this.componentsLength = components * format.getComponentSize();
+        this.lastLimit = data.limit();
+        setUpdateNeeded();
+    }
+
+    /**
+     * Called to update the data in the buffer with new data. Can only
+     * be called after {@link VertexBuffer#setupData(com.jme3.scene.VertexBuffer.Usage, int, com.jme3.scene.VertexBuffer.Format, java.nio.Buffer) }
+     * has been called. Note that it is fine to call this method on the
+     * data already set, e.g. vb.updateData(vb.getData()), this will just
+     * set the proper update flag indicating the data should be sent to the GPU
+     * again.
+     * <p>
+     * It is allowed to specify a buffer with different capacity than the
+     * originally set buffer, HOWEVER, if you do so, you must
+     * call Mesh.updateCounts() otherwise bizarre errors can occur.
+     * 
+     * @param data The data buffer to set
+     */
+    public void updateData(Buffer data){
+        if (id != -1){
+            // request to update data is okay
+        }
+
+        // Check if the data buffer is read-only which is a sign
+        // of a bug on the part of the caller
+        if (data != null && data.isReadOnly()) {
+            throw new IllegalArgumentException( "VertexBuffer data cannot be read-only." );
+        }
+
+        // will force renderer to call glBufferData again
+        if (data != null && (this.data.getClass() != data.getClass() || data.limit() != lastLimit)){
+            dataSizeChanged = true;
+            lastLimit = data.limit();
+        }
+        
+        this.data = data;
+        setUpdateNeeded();
+    }
+
+    /**
+     * Returns true if the data size of the VertexBuffer has changed.
+     * Internal use only.
+     * @return true if the data size has changed
+     */
+    public boolean hasDataSizeChanged() {
+        return dataSizeChanged;
+    }
+
+    @Override
+    public void clearUpdateNeeded(){
+        super.clearUpdateNeeded();
+        dataSizeChanged = false;
+    }
+
+    /**
+     * Converts single floating-point data to {@link Format#Half half} floating-point data.
+     */
+    public void convertToHalf(){
+        if (id != -1) {
+            throw new UnsupportedOperationException("Data has already been sent.");
+        }
+
+        if (format != Format.Float) {
+            throw new IllegalStateException("Format must be float!");
+        }
+
+        int numElements = data.limit() / components;
+        format = Format.Half;
+        this.componentsLength = components * format.getComponentSize();
+        
+        ByteBuffer halfData = BufferUtils.createByteBuffer(componentsLength * numElements);
+        halfData.rewind();
+
+        FloatBuffer floatData = (FloatBuffer) data;
+        floatData.rewind();
+
+        for (int i = 0; i < floatData.limit(); i++){
+            float f = floatData.get(i);
+            short half = FastMath.convertFloatToHalf(f);
+            halfData.putShort(half);
+        }
+        this.data = halfData;
+        setUpdateNeeded();
+        dataSizeChanged = true;
+    }
+
+    /**
+     * Reduces the capacity of the buffer to the given amount
+     * of elements, any elements at the end of the buffer are truncated
+     * as necessary.
+     *
+     * @param numElements The number of elements to reduce to.
+     */
+    public void compact(int numElements){
+        int total = components * numElements;
+        data.clear();
+        switch (format){
+            case Byte:
+            case UnsignedByte:
+            case Half:
+                ByteBuffer bbuf = (ByteBuffer) data;
+                bbuf.limit(total);
+                ByteBuffer bnewBuf = BufferUtils.createByteBuffer(total);
+                bnewBuf.put(bbuf);
+                data = bnewBuf;
+                break;
+            case Short:
+            case UnsignedShort:
+                ShortBuffer sbuf = (ShortBuffer) data;
+                sbuf.limit(total);
+                ShortBuffer snewBuf = BufferUtils.createShortBuffer(total);
+                snewBuf.put(sbuf);
+                data = snewBuf;
+                break;
+            case Int:
+            case UnsignedInt:
+                IntBuffer ibuf = (IntBuffer) data;
+                ibuf.limit(total);
+                IntBuffer inewBuf = BufferUtils.createIntBuffer(total);
+                inewBuf.put(ibuf);
+                data = inewBuf;
+                break;
+            case Float:
+                FloatBuffer fbuf = (FloatBuffer) data;
+                fbuf.limit(total);
+                FloatBuffer fnewBuf = BufferUtils.createFloatBuffer(total);
+                fnewBuf.put(fbuf);
+                data = fnewBuf;
+                break;
+            default:
+                throw new UnsupportedOperationException("Unrecognized buffer format: "+format);
+        }
+        data.clear();
+        setUpdateNeeded();
+        dataSizeChanged = true;
+    }
+
+    /**
+     * Modify a component inside an element.
+     * The <code>val</code> parameter must be in the buffer's format:
+     * {@link Format}.
+     * 
+     * @param elementIndex The element index to modify
+     * @param componentIndex The component index to modify
+     * @param val The value to set, either byte, short, int or float depending
+     * on the {@link Format}.
+     */
+    public void setElementComponent(int elementIndex, int componentIndex, Object val){
+        int inPos = elementIndex * components;
+        int elementPos = componentIndex;
+
+        if (format == Format.Half){
+            inPos *= 2;
+            elementPos *= 2;
+        }
+
+        data.clear();
+
+        switch (format){
+            case Byte:
+            case UnsignedByte:
+            case Half:
+                ByteBuffer bin = (ByteBuffer) data;
+                bin.put(inPos + elementPos, (Byte)val);
+                break;
+            case Short:
+            case UnsignedShort:
+                ShortBuffer sin = (ShortBuffer) data;
+                sin.put(inPos + elementPos, (Short)val);
+                break;
+            case Int:
+            case UnsignedInt:
+                IntBuffer iin = (IntBuffer) data;
+                iin.put(inPos + elementPos, (Integer)val);
+                break;
+            case Float:
+                FloatBuffer fin = (FloatBuffer) data;
+                fin.put(inPos + elementPos, (Float)val);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unrecognized buffer format: "+format);
+        }
+    }
+
+    /**
+     * Get the component inside an element.
+     * 
+     * @param elementIndex The element index
+     * @param componentIndex The component index
+     * @return The component, as one of the primitive types, byte, short,
+     * int or float.
+     */
+    public Object getElementComponent(int elementIndex, int componentIndex){
+        int inPos = elementIndex * components;
+        int elementPos = componentIndex;
+
+        if (format == Format.Half){
+            inPos *= 2;
+            elementPos *= 2;
+        }
+
+        Buffer srcData = getDataReadOnly();
+
+        switch (format){
+            case Byte:
+            case UnsignedByte:
+            case Half:
+                ByteBuffer bin = (ByteBuffer) srcData;
+                return bin.get(inPos + elementPos);
+            case Short:
+            case UnsignedShort:
+                ShortBuffer sin = (ShortBuffer) srcData;
+                return sin.get(inPos + elementPos);
+            case Int:
+            case UnsignedInt:
+                IntBuffer iin = (IntBuffer) srcData;
+                return iin.get(inPos + elementPos);
+            case Float:
+                FloatBuffer fin = (FloatBuffer) srcData;
+                return fin.get(inPos + elementPos);
+            default:
+                throw new UnsupportedOperationException("Unrecognized buffer format: "+format);
+        }
+    }
+
+    /**
+     * Copies a single element of data from this <code>BufferObject</code>
+     * to the given output BufferObject.
+     * 
+     * @param inIndex The input element index
+     * @param outVb The buffer to copy to
+     * @param outIndex The output element index
+     * 
+     * @throws IllegalArgumentException If the formats of the buffers do not
+     * match.
+     */
+    public void copyElement(int inIndex, BufferObject outVb, int outIndex){
+        copyElements(inIndex, outVb, outIndex, 1);
+    }
+
+    /**
+     * Copies a sequence of elements of data from this <code>BufferObject</code>
+     * to the given output BufferObject.
+     * 
+     * @param inIndex The input element index
+     * @param outVb The buffer to copy to
+     * @param outIndex The output element index
+     * @param len The number of elements to copy
+     * 
+     * @throws IllegalArgumentException If the formats of the buffers do not
+     * match.
+     */
+    public void copyElements(int inIndex, BufferObject outVb, int outIndex, int len){
+        if (outVb.format != format || outVb.components != components) {
+            throw new IllegalArgumentException("Buffer format mismatch. Cannot copy");
+        }
+
+        int inPos  = inIndex  * components;
+        int outPos = outIndex * components;
+        int elementSz = components;
+        if (format == Format.Half){
+            // because half is stored as bytebuf but its 2 bytes long
+            inPos *= 2;
+            outPos *= 2;
+            elementSz *= 2;
+        }
+
+        // Make sure to grab a read-only copy in case some other
+        // thread is also accessing the buffer and messing with its
+        // position()
+        Buffer srcData = getDataReadOnly();
+        outVb.data.clear();
+
+        switch (format){
+            case Byte:
+            case UnsignedByte:
+            case Half:
+                ByteBuffer bin = (ByteBuffer) srcData;
+                ByteBuffer bout = (ByteBuffer) outVb.data;
+                bin.position(inPos).limit(inPos + elementSz * len);
+                bout.position(outPos).limit(outPos + elementSz * len);
+                bout.put(bin);                        
+                break;
+            case Short:
+            case UnsignedShort:
+                ShortBuffer sin = (ShortBuffer) srcData;
+                ShortBuffer sout = (ShortBuffer) outVb.data;
+                sin.position(inPos).limit(inPos + elementSz * len);
+                sout.position(outPos).limit(outPos + elementSz * len);
+                sout.put(sin);
+                break;
+            case Int:
+            case UnsignedInt:
+                IntBuffer iin = (IntBuffer) srcData;
+                IntBuffer iout = (IntBuffer) outVb.data;
+                iin.position(inPos).limit(inPos + elementSz * len);
+                iout.position(outPos).limit(outPos + elementSz * len);
+                iout.put(iin);
+                break;
+            case Float:
+                FloatBuffer fin = (FloatBuffer) srcData;
+                FloatBuffer fout = (FloatBuffer) outVb.data;
+                fin.position(inPos).limit(inPos + elementSz * len);
+                fout.position(outPos).limit(outPos + elementSz * len);
+                fout.put(fin);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unrecognized buffer format: "+format);
+        }
+
+        // Clear the output buffer to rewind it and reset its
+        // limit from where we shortened it above.
+        outVb.data.clear();
+    }
+
+    /**
+     * Creates a {@link Buffer} that satisfies the given type and size requirements
+     * of the parameters. The buffer will be of the type specified by
+     * {@link Format format} and would be able to contain the given number
+     * of elements with the given number of components in each element.
+     */
+    public static Buffer createBuffer(Format format, int components, int numElements){
+        if (components < 1 || components > 4) {
+            throw new IllegalArgumentException("Num components must be between 1 and 4");
+        }
+
+        int total = numElements * components;
+
+        switch (format){
+            case Byte:
+            case UnsignedByte:
+                return BufferUtils.createByteBuffer(total);
+            case Half:
+                return BufferUtils.createByteBuffer(total * 2);
+            case Short:
+            case UnsignedShort:
+                return BufferUtils.createShortBuffer(total);
+            case Int:
+            case UnsignedInt:
+                return BufferUtils.createIntBuffer(total);
+            case Float:
+                return BufferUtils.createFloatBuffer(total);
+            case Double:
+                return BufferUtils.createDoubleBuffer(total);
+            default:
+                throw new UnsupportedOperationException("Unrecoginized buffer format: "+format);
+        }
+    }
+
+    /**
+     * Creates a deep clone of the {@link VertexBuffer}.
+     * 
+     * @return Deep clone of this buffer
+     */
+    @Override
+    public BufferObject clone(){
+        // NOTE: Superclass GLObject automatically creates shallow clone
+        // e.g re-use ID.
+        BufferObject bo = (BufferObject) super.clone();
+        bo.handleRef = new Object();
+        bo.id = -1;
+        if (data != null) {
+            // Make sure to pass a read-only buffer to clone so that
+            // the position information doesn't get clobbered by another
+            // reading thread during cloning (and vice versa) since this is
+            // a purely read-only operation.
+            bo.updateData(BufferUtils.clone(getDataReadOnly()));
+        }
+        
+        return bo;
+    }
+
+    
+
+    @Override
+    public String toString(){
+        String dataTxt = null;
+        if (data != null){
+            dataTxt = ", elements="+data.limit();
+        }
+        return getClass().getSimpleName() + "[fmt="+format.name()
+//                                            +", type="+bufType.name()
+                                            +", usage="+usage.name()
+                                            +dataTxt+"]";
+    }
+
+    @Override
+    public void resetObject() {
+//        assert this.id != -1;
+        this.id = -1;
+        setUpdateNeeded();
+    }
+
+    @Override
+    public void deleteObject(Object rendererObject) {
+        ((Renderer)rendererObject).deleteBuffer(this);
+    }
+    
+    @Override
+    protected void deleteNativeBuffers() {
+        if (data != null) {
+            BufferUtils.destroyDirectBuffer(data);
+        }
+    }
+            
+    @Override
+    public NativeObject createDestructableClone(){
+        return new BufferObject(id);
+    }
+
+    @Override
+    public long getUniqueId() {
+        return ((long)OBJTYPE_BO << 32) | ((long)id);
+    }
+    
+    @Override
+    public void write(JmeExporter ex) throws IOException {
+        
+        OutputCapsule oc = ex.getCapsule(this);
+        oc.write(components, "components", 0);
+        oc.write(usage, "usage", Usage.Dynamic);
+//        oc.write(bufType, "buffer_type", null);
+        oc.write(format, "format", Format.Float);
+//        oc.write(normalized, "normalized", false);
+//        oc.write(offset, "offset", 0);
+//        oc.write(stride, "stride", 0);
+//        oc.write(instanceSpan, "instanceSpan", 0);
+
+        String dataName = "data" + format.name();
+        Buffer roData = getDataReadOnly();
+        switch (format){
+            case Float:
+                oc.write((FloatBuffer) roData, dataName, null);
+                break;
+            case Short:
+            case UnsignedShort:
+                oc.write((ShortBuffer) roData, dataName, null);
+                break;
+            case UnsignedByte:
+            case Byte:
+            case Half:
+                oc.write((ByteBuffer) roData, dataName, null);
+                break;
+            case Int:
+            case UnsignedInt:
+                oc.write((IntBuffer) roData, dataName, null);
+                break;
+            default:
+                throw new IOException("Unsupported export buffer format: "+format);
+        }
+    }
+
+    @Override
+    public void read(JmeImporter im) throws IOException {
+        InputCapsule ic = im.getCapsule(this);
+        components = ic.readInt("components", 0);
+        usage = ic.readEnum("usage", Usage.class, Usage.Dynamic);
+//        bufType = ic.readEnum("buffer_type", Type.class, null);
+        format = ic.readEnum("format", Format.class, Format.Float);
+//        normalized = ic.readBoolean("normalized", false);
+//        offset = ic.readInt("offset", 0);
+//        stride = ic.readInt("stride", 0);
+//        instanceSpan = ic.readInt("instanceSpan", 0);
+        componentsLength = components * format.getComponentSize();
+
+        String dataName = "data" + format.name();
+        switch (format){
+            case Float:
+                data = ic.readFloatBuffer(dataName, null);
+                break;
+            case Short:
+            case UnsignedShort:
+                data = ic.readShortBuffer(dataName, null);
+                break;
+            case UnsignedByte:
+            case Byte:
+            case Half:
+                data = ic.readByteBuffer(dataName, null);
+                break;
+            case Int:
+            case UnsignedInt:
+                data = ic.readIntBuffer(dataName, null);
+                break;
+            default:
+                throw new IOException("Unsupported import buffer format: "+format);
+        }
+    }
+
+}

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -896,6 +896,19 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
     }
 
     /**
+     * Set the number of instances that will be drawn.
+     * This method is optional, and useful if one does not want
+     * to draw all the instances.
+     * Otherwise updateCounts() will set instanceCount to the maximum
+     * number of instances.
+     * This value will be overwritten if updateCounts() is called.
+     * @param instanceCount number of instances
+     */
+    public void setInstanceCount(int instanceCount) {
+        this.instanceCount = instanceCount;
+    }
+    
+    /**
      * Gets the triangle vertex positions at the given triangle index
      * and stores them into the v1, v2, v3 arguments.
      *

--- a/jme3-core/src/main/java/com/jme3/scene/TransformFeedbackOutput.java
+++ b/jme3-core/src/main/java/com/jme3/scene/TransformFeedbackOutput.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2009-2019 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.scene;
+
+import java.util.ArrayList;
+
+/**
+ * This class defines a list of buffer objects which
+ * will be bound to ouput of transform feedback.
+ * 
+ * @author Juraj Papp
+ */
+public class TransformFeedbackOutput {
+    
+    protected Mesh.Mode mode;
+    protected boolean currentlyInUse = false;
+    protected ArrayList<OutputBuffer> buffers = new ArrayList<>();
+    
+    public class OutputBuffer {
+        public BufferObject buf;
+        public int slot;
+        public boolean range;
+        public long offset;
+        public long size;
+
+        public OutputBuffer(BufferObject b, int slot) {
+            this.buf = b;
+            this.slot = slot;
+            this.range = false;
+        }
+        public OutputBuffer(BufferObject b, int slot, long offset, long size) {
+            this.buf = b;
+            this.slot = slot;
+            this.range = true;
+            this.offset = offset;
+            this.size = size;
+        }
+    }
+
+    /**
+     * Create a new transform feedback output objects which
+     * stores output buffers and mode.
+     * 
+     * Allowed modes are: Points, Lines and Triangles.
+     * eg. if TriangleFan is specified the mode is converted to Triangles, etc...
+     * 
+     * @param mode POINTS, LINES or TRIANGLES
+     */
+    public TransformFeedbackOutput(Mesh.Mode mode) {
+        setMode(mode);
+    }
+    
+    /**
+     * Add output buffer.
+     * 
+     * @param b buffer object to capture into
+     */
+    public void add(BufferObject b) {
+        add(b, buffers.size());
+    }
+    
+    /**
+     * Add output buffer to the selected binding slot.
+     * If a buffer with the given slot index exists, an IllegalArgumentException is thrown.
+     * 
+     * @param b buffer object to capture into
+     * @param slot binding index
+     */
+    public void add(BufferObject b, int slot) {
+        if(isInUse()) throw new IllegalArgumentException("The output buffer is currently in use!");
+        for(int i = 0; i < buffers.size(); i++) {
+            OutputBuffer buf = buffers.get(i);
+            if(buf.slot == slot) 
+                throw new IllegalArgumentException("Buffer slot already specified.");
+        }
+        buffers.add(new OutputBuffer(b, slot));
+    }
+    /**
+     * Add output buffer to the selected binding slot and range.
+     * If a buffer with the given slot index exists, and their ranges overlap
+     * an IllegalArgumentException is thrown.
+     * 
+     * @param b buffer object to capture into
+     * @param offset 4 byte aligned offset, or 8 byte aligned if capturing doubles
+     * @param size amount of data that can be used from offset
+     */
+    public void add(BufferObject b, long offset, long size) {
+        add(b, buffers.size(), offset, size);
+    }
+    /**
+     * Add output buffer to the selected binding slot and range.
+     * If a buffer with the given slot index exists, and their ranges overlap
+     * an IllegalArgumentException is thrown.
+     * 
+     * @param b buffer object to capture into
+     * @param slot binding index
+     * @param offset 4 byte aligned offset, or 8 byte aligned if capturing doubles
+     * @param size amount of data that can be used from offset
+     */
+    public void add(BufferObject b, int slot, long offset, long size) {
+        if(isInUse()) throw new IllegalArgumentException("The output buffer is currently in use!");
+        if((offset&3) != 0) throw new IllegalArgumentException("The offset must by 4 byte aligned.");
+        for(int i = 0; i < buffers.size(); i++) {
+            OutputBuffer buf = buffers.get(i);
+            if(buf.slot == slot && 
+                (!buf.range ||
+                    Math.max(buf.offset, offset) <= Math.min(buf.offset+buf.size, offset+size)
+                    )
+                ) 
+                throw new IllegalArgumentException("Buffer slots overlap!");
+        }
+        buffers.add(new OutputBuffer(b, slot, offset, size));
+    }
+    
+    /**
+     * Used internally by renderer. Do not use.
+     * @param inUse
+     */
+    public void setInUse(boolean inUse) { currentlyInUse = inUse; }
+    
+    /**
+     * Returns true if this output buffer is currently in use.
+     * @return 
+     */
+    public boolean isInUse() { return currentlyInUse; }
+
+    /**
+     * Returns the binding at specified index.
+     * @param i
+     * @return binding at position i 
+     */
+    public OutputBuffer getOutputBinding(int i) {
+        return buffers.get(i);
+    }
+    
+    /**
+     * Removed the binding at specified index.
+     * @param i
+     * @return 
+     */
+    public OutputBuffer removeBinding(int i) {
+        if(isInUse()) throw new IllegalArgumentException("The output buffer is currently in use!");
+        return buffers.remove(i);
+    }
+    
+    /**
+     * Clears all bindings.
+     */
+    public void clear() {
+        if(isInUse()) throw new IllegalArgumentException("The output buffer is currently in use!");
+        buffers.clear();
+    }
+    
+    /**
+     * 
+     * @return the number of buffer bindings
+     */
+    public int getNumberOfBufferBindings() {
+        return buffers.size();
+    }
+
+    /**
+     * Returns the generated primitives which are produced by transform feedback.
+     * @return 
+     */
+    public Mesh.Mode getMode() {
+        return mode;
+    }
+
+    /**
+     * Set the type of primitives which are produced by transform feedback.
+     * Allowed modes are: Points, Lines and Triangles.
+     * 
+     * eg. if TriangleFan is specified the mode is converted to Triangles, etc...
+     * 
+     * @param mode POINTS, LINES or TRIANGLES
+     */
+    public void setMode(Mesh.Mode mode) {
+        if(isInUse()) throw new IllegalArgumentException("The output buffer is currently in use!");
+        if(mode == null) throw new IllegalArgumentException("Mode cannot be null");
+        this.mode = mode;
+    }
+    
+    
+    protected Mesh.Mode convertTFMode(Mesh.Mode mode) {
+        switch (mode) {
+            case Points:
+                return Mesh.Mode.Points;
+            case Lines:
+            case LineLoop:
+            case LineStrip:
+                return Mesh.Mode.Lines;
+            case Triangles:
+            case TriangleFan:
+            case TriangleStrip:
+                return Mesh.Mode.Triangles;
+            default:
+                throw new UnsupportedOperationException("Invalid transform feedback mode: " + mode);
+        }
+    }
+}

--- a/jme3-core/src/main/java/com/jme3/scene/TransformFeedbackOutput.java
+++ b/jme3-core/src/main/java/com/jme3/scene/TransformFeedbackOutput.java
@@ -149,7 +149,7 @@ public class TransformFeedbackOutput {
     
     /**
      * Returns true if this output buffer is currently in use.
-     * @return 
+     * @return true if in use
      */
     public boolean isInUse() { return currentlyInUse; }
 
@@ -165,7 +165,7 @@ public class TransformFeedbackOutput {
     /**
      * Removed the binding at specified index.
      * @param i
-     * @return 
+     * @return the binding removed
      */
     public OutputBuffer removeBinding(int i) {
         if(isInUse()) throw new IllegalArgumentException("The output buffer is currently in use!");
@@ -190,7 +190,7 @@ public class TransformFeedbackOutput {
 
     /**
      * Returns the generated primitives which are produced by transform feedback.
-     * @return 
+     * @return mode POINTS, LINES or TRIANGLES
      */
     public Mesh.Mode getMode() {
         return mode;

--- a/jme3-core/src/main/java/com/jme3/shader/Shader.java
+++ b/jme3-core/src/main/java/com/jme3/shader/Shader.java
@@ -31,6 +31,8 @@
  */
 package com.jme3.shader;
 
+import com.jme3.material.RenderState;
+import com.jme3.material.TechniqueDef;
 import com.jme3.renderer.Renderer;
 import com.jme3.scene.VertexBuffer;
 import com.jme3.util.IntMap;
@@ -68,6 +70,15 @@ public final class Shader extends NativeObject {
      * Maps attribute name to the location of the attribute in the shader.
      */
     private final IntMap<Attribute> attribs;
+    
+    /**
+     * Bound transform feedback mode.
+     */
+    private TechniqueDef.TransformFeedbackMode boundTransformFeedbackMode = null;
+    /**
+     * Bound output transform feedback varyings.
+     */
+    private String[] boundTransformFeedbackVaryings = null;
 
     /**
      * Type of shader. The shader will control the pipeline of its type.
@@ -361,12 +372,49 @@ public final class Shader extends NativeObject {
         return shaderSourceList;
     }
 
+    /**
+     * Set transform feedback by passing array of output variables
+     * or disable it by passing null.
+     * 
+     * Only if mode is set to <code>Interleaved</code> or <code>Separate</code> this function has any effect.
+     * 
+     * @param mode
+     *      mode determines how output is written to the transform feedback buffer
+     * 
+     * @param varying 
+     *  <pre>
+     *     An array of strings specifying the names of the varying variables to use for transform feedback. 
+     *     Or null to disable transform feedback.
+     *     
+     *     If mode is Interleaved, the array may contain the following special string:
+     * 
+     *     gl_NextBuffer
+     *         Subsequent captured varyings will be stored in the next transform feedback binding point.
+     *     gl_SkipComponents#
+     *         This specifies that there will be an empty place in the captured data, so the feedback operation will skip writing up to # components. # is a number 1-4. Memory skipped in this way will not be modified. These components still count towards the limitations on transform feedback components to be captured in a single buffer. 
+     * </pre>
+     * 
+     */
+    public void setTransformFeedbackBinding(TechniqueDef.TransformFeedbackMode mode, String[] varying) {
+        boundTransformFeedbackMode = mode;
+        boundTransformFeedbackVaryings = varying;
+        setUpdateNeeded();
+    }
+    public TechniqueDef.TransformFeedbackMode getBoundTransformFeedbackMode() {
+        return boundTransformFeedbackMode;
+    }
+
+    public String[] getBoundTransformFeedbackVaryings() {
+        return boundTransformFeedbackVaryings;
+    }    
+
     @Override
     public String toString() {
         return getClass().getSimpleName() + 
                 "[numSources=" + shaderSourceList.size() +
                 ", numUniforms=" + uniforms.size() +
                 ", numBufferBlocks=" + bufferBlocks.size() +
+                ", transformFeedbackMode=" + boundTransformFeedbackMode +
                 ", shaderSources=" + getSources() + "]";
     }
 

--- a/jme3-core/src/main/java/com/jme3/shader/ShaderBufferBlock.java
+++ b/jme3-core/src/main/java/com/jme3/shader/ShaderBufferBlock.java
@@ -41,14 +41,14 @@ public class ShaderBufferBlock extends ShaderVariable {
     /**
      * Current used buffer object.
      */
-    protected BufferObject bufferObject;
+    protected UniformBufferObject bufferObject;
 
     /**
      * Set the new buffer object.
      *
      * @param bufferObject the new buffer object.
      */
-    public void setBufferObject(final BufferObject bufferObject) {
+    public void setBufferObject(final UniformBufferObject bufferObject) {
 
         if (bufferObject == null) {
             throw new IllegalArgumentException("for storage block " + name + ": storageData cannot be null");
@@ -87,7 +87,7 @@ public class ShaderBufferBlock extends ShaderVariable {
      *
      * @return the current storage data.
      */
-    public BufferObject getBufferObject() {
+    public UniformBufferObject getBufferObject() {
         return bufferObject;
     }
 }

--- a/jme3-core/src/main/java/com/jme3/system/NullRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/system/NullRenderer.java
@@ -37,10 +37,12 @@ import com.jme3.math.ColorRGBA;
 import com.jme3.math.Matrix4f;
 import com.jme3.renderer.Caps;
 import com.jme3.renderer.Limits;
+import com.jme3.renderer.QueryObject;
 import com.jme3.renderer.Renderer;
 import com.jme3.renderer.Statistics;
 import com.jme3.scene.BufferObject;
 import com.jme3.scene.Mesh;
+import com.jme3.scene.TransformFeedbackOutput;
 import com.jme3.scene.VertexBuffer;
 import com.jme3.shader.UniformBufferObject;
 import com.jme3.shader.Shader;
@@ -204,5 +206,34 @@ public class NullRenderer implements Renderer {
 
     @Override
     public void setDefaultAnisotropicFilter(int level) {
+    }
+
+    @Override
+    public void setTransformFeedbackOutput(TransformFeedbackOutput output) {
+    }
+
+    @Override
+    public boolean isQueryResultReady(QueryObject q) {
+        return false;
+    }
+
+    @Override
+    public long getQueryResult(QueryObject q) {
+        return 0;
+    }
+
+    @Override
+    public void beginQuery(QueryObject q) {
+
+    }
+
+    @Override
+    public void endQuery(QueryObject q) {
+
+    }
+
+    @Override
+    public void deleteQuery(QueryObject q) {
+
     }
 }

--- a/jme3-core/src/main/java/com/jme3/system/NullRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/system/NullRenderer.java
@@ -39,9 +39,10 @@ import com.jme3.renderer.Caps;
 import com.jme3.renderer.Limits;
 import com.jme3.renderer.Renderer;
 import com.jme3.renderer.Statistics;
+import com.jme3.scene.BufferObject;
 import com.jme3.scene.Mesh;
 import com.jme3.scene.VertexBuffer;
-import com.jme3.shader.BufferObject;
+import com.jme3.shader.UniformBufferObject;
 import com.jme3.shader.Shader;
 import com.jme3.shader.Shader.ShaderSource;
 import com.jme3.texture.FrameBuffer;
@@ -146,18 +147,10 @@ public class NullRenderer implements Renderer {
     public void modifyTexture(Texture tex, Image pixels, int x, int y) {
     }
 
-    public void updateBufferData(VertexBuffer vb) {
+    public void updateBufferData(BufferObject vb) {
     }
 
-    @Override
-    public void updateBufferData(BufferObject bo) {
-    }
-    public void deleteBuffer(VertexBuffer vb) {
-    }
-
-    @Override
-    public void deleteBuffer(BufferObject bo) {
-
+    public void deleteBuffer(BufferObject vb) {
     }
 
     public void renderMesh(Mesh mesh, int lod, int count, VertexBuffer[] instanceData) {

--- a/jme3-core/src/main/java/com/jme3/util/NativeObject.java
+++ b/jme3-core/src/main/java/com/jme3/util/NativeObject.java
@@ -53,7 +53,8 @@ public abstract class NativeObject implements Cloneable {
                                OBJTYPE_AUDIOBUFFER  = 6,
                                OBJTYPE_AUDIOSTREAM  = 7,
                                OBJTYPE_FILTER       = 8,
-                               OBJTYPE_BO           = 9;
+                               OBJTYPE_BO           = 9,
+                               OBJTYPE_QUERY        = 10;
     
     /**
      * The object manager to which this NativeObject is registered to.

--- a/jme3-examples/src/main/java/jme3test/renderer/TestTransformFeedback.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestTransformFeedback.java
@@ -62,7 +62,7 @@ public class TestTransformFeedback extends SimpleApplication {
         app.settings = new AppSettings(true);
         app.settings.setWidth(800);
         app.settings.setWidth(600);
-        app.settings.putBoolean("GraphicsDebug", true);
+//        app.settings.putBoolean("GraphicsDebug", true);
         app.settings.setRenderer(AppSettings.LWJGL_OPENGL3);
         app.setShowSettings(false);
         app.start();

--- a/jme3-examples/src/main/java/jme3test/renderer/TestTransformFeedback.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestTransformFeedback.java
@@ -69,7 +69,7 @@ public class TestTransformFeedback extends SimpleApplication {
     }
    
     TransformFeedbackOutput tf; //transform feedback object
-    QueryObject query; //qieru to retrieve the number of visible instances
+    QueryObject query; //query to retrieve the number of visible instances
     Geometry cullGeometry; //geometry with location of instances
     
     Geometry instancedGeometry; //the actual instanced geometry

--- a/jme3-examples/src/main/java/jme3test/renderer/TestTransformFeedback.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestTransformFeedback.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright (c) 2009-2012 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package jme3test.renderer;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.bounding.BoundingBox;
+import com.jme3.font.BitmapText;
+import com.jme3.input.KeyInput;
+import com.jme3.input.controls.*;
+import com.jme3.material.Material;
+import com.jme3.math.*;
+import com.jme3.renderer.QueryObject;
+import com.jme3.scene.*;
+import com.jme3.scene.debug.Arrow;
+import com.jme3.scene.shape.Box;
+import com.jme3.system.AppSettings;
+import com.jme3.util.BufferUtils;
+import java.nio.FloatBuffer;
+
+/**
+ * Transform feedback test.
+ * Implements a simplified cone culling algorithm with the use of
+ * transform feedback, vertex and geometry shader.
+ * 
+ * @author Juraj Papp
+ */
+public class TestTransformFeedback extends SimpleApplication {
+
+
+    public static void main(String[] args){
+        TestTransformFeedback app = new TestTransformFeedback();
+        app.settings = new AppSettings(true);
+        app.settings.setWidth(800);
+        app.settings.setWidth(600);
+        app.settings.putBoolean("GraphicsDebug", true);
+        app.settings.setRenderer(AppSettings.LWJGL_OPENGL3);
+        app.setShowSettings(false);
+        app.start();
+    }
+   
+    TransformFeedbackOutput tf; //transform feedback object
+    QueryObject query; //qieru to retrieve the number of visible instances
+    Geometry cullGeometry; //geometry with location of instances
+    
+    Geometry instancedGeometry; //the actual instanced geometry
+    
+    BitmapText text;
+    boolean pauseCulling = false;
+    
+    //input here a large number of instances
+    int maxInstances = 1024*1024; //(1 048 576)    
+    
+    //size of space where random cubes are generated
+    int randomSize = 100;
+    
+
+    public void simpleInitApp() {
+        flyCam.setDragToRotate(true);
+        flyCam.setMoveSpeed(10);
+        cam.setFrustumPerspective(60f,cam.getWidth()/(float)cam.getHeight(), 0.1f, 300f);        
+        
+        //------------Cull Geometry----------------
+        
+        cullGeometry = createCullGeometry();
+        
+        //do not attach to rootnode
+        
+        //------------Instanced Geometry----------------
+        
+        instancedGeometry = createInstancedGeometry();
+        
+        //attach to root node
+        rootNode.attachChild(instancedGeometry);
+        
+        //Update state so that checkCulling doesn't throw an exception
+        instancedGeometry.updateGeometricState();
+        
+        //------------Query Object----------------
+        
+        //Create a query object to retrieve the number of primitives (in this case points) written
+        query = new QueryObject(renderer, QueryObject.Type.TransformFeedbackPrimitivesGenerated);        
+        
+        //------------Transform Feedback Output----------------
+        
+        //The output mode is points (single mat4 per instance)
+        //It will connect directly to InstancedData VertexBuffer
+        tf = new TransformFeedbackOutput(Mesh.Mode.Points);
+        tf.add(instancedGeometry.getMesh().getBuffer(VertexBuffer.Type.InstanceData));
+        
+        //------------etc----------------
+        
+        text = new BitmapText(guiFont);
+        text.setSize(guiFont.getPreferredSize());
+        text.setText("...");
+        text.setColor(ColorRGBA.White);
+        text.setLocalTranslation(0, cam.getHeight(), 0);
+        guiNode.attachChild(text);
+                
+        //add some coordinate axes
+        attachCoordinateAxes();
+        
+        //On key pressed paused/resume culling
+        key(KeyInput.KEY_P, new ActionListener() {
+            @Override
+            public void onAction(String name, boolean isPressed, float tpf) {
+                if(isPressed) {
+                    pauseCulling = !pauseCulling;
+                    if(pauseCulling) text.setText("paused");
+                    else text.setText("...");
+                }
+            }
+        });
+       
+    }
+    
+    public Geometry createCullGeometry() {
+        //Let's create the mesh with the positions of instances
+        //For simplicity pass whole matrix
+        Mesh pointMesh = new Mesh();
+        //Each instance has one mat4, so mode is points
+        pointMesh.setMode(Mesh.Mode.Points);
+        
+        //Create vertex buffer which will store the data
+        //Use type Position, so that we do not need to specify an index buffers
+        //The index buffer would contain [0,1,2,3,4...,maxInstance-1] numbers anyway.
+        VertexBuffer dataForCulling = new VertexBuffer(VertexBuffer.Type.Position);
+        
+        //Create FloatBuffer, matrix4 has 16 floats
+        //fill it with matrix4 with random positions
+        FloatBuffer fb = (FloatBuffer)BufferUtils.createFloatBuffer(16*maxInstances);
+        
+        fb.clear();
+        
+        Matrix4f mat4 = new Matrix4f();
+        for(int i = 0; i < maxInstances; i++) {
+            mat4.setTranslation(FastMath.nextRandomFloat()*randomSize,
+                    FastMath.nextRandomFloat()*randomSize,
+                    FastMath.nextRandomFloat()*randomSize);
+            mat4.fillFloatBuffer(fb, true);
+        }
+        fb.flip();
+        
+        //Setup the data, Usage static since here we do not modify it.
+        dataForCulling.setupData(VertexBuffer.Usage.Static, 16, VertexBuffer.Format.Float, fb);
+        pointMesh.setBuffer(dataForCulling);
+        
+        //Create cull geometry, and material
+        Geometry cullGeom = new Geometry("CullGeom", pointMesh);
+        Material cullTestMat = new Material(assetManager, "jme3test/renderer/TestTR.j3md");
+        cullGeom.setMaterial(cullTestMat);
+        return cullGeom;
+    }
+    
+    public Geometry createInstancedGeometry() {
+        VertexBuffer instanceData = new VertexBuffer(VertexBuffer.Type.InstanceData);
+        instanceData.setInstanced(true);
+//        FloatBuffer fb2 = (FloatBuffer)BufferUtils.createFloatBuffer(16*maxInstances); 
+//        fb2.clear();
+//        
+//         for(int i = 0; i < maxInstances; i++) {
+//            mat4.setTranslation(
+//                    FastMath.nextRandomFloat()*randomSize,
+//                    FastMath.nextRandomFloat()*randomSize,
+//                    FastMath.nextRandomFloat()*randomSize);
+//            mat4.fillFloatBuffer(fb2, true);
+//        }
+//        
+//        fb2.flip();
+
+        //No need to create another cpu buffer
+        //optimally just the size of the buffer should be passed here
+        //we already got a buffer with the same size
+        FloatBuffer dummy = (FloatBuffer)cullGeometry.getMesh().getBuffer(VertexBuffer.Type.Position).getData();
+        
+        instanceData.setupData(VertexBuffer.Usage.StreamCopy, 16,
+                VertexBuffer.Format.Float,
+                dummy
+//              fb2
+        );        
+        
+        //Setting a bounding box so that culling against camera works.
+        Geometry instancedGeom = new Geometry("geom", new Box(0.1f, 0.1f,0.1f));
+        instancedGeom.setModelBound(new BoundingBox(Vector3f.ZERO, new Vector3f(randomSize+1f,randomSize+1f,randomSize+1f)));
+        instancedGeom.getMesh().setBuffer(instanceData);
+        instancedGeom.getMesh().updateCounts();
+                
+        Material mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+        mat.setColor("Color", ColorRGBA.Orange);
+        mat.setBoolean("UseInstancing", true);
+                
+        instancedGeom.setMaterial(mat);
+        return instancedGeom;
+    }
+    
+    
+//    Vector3f lastCamPos = new Vector3f();
+//    Vector3f lastCamDir = new Vector3f();
+    public void testTransformFeedback() {
+        //This code is slightly convoluted
+        //due to the special case of 0 written instances 
+        
+        if(pauseCulling) return;
+        //No need to cull instances if completely outside camera frustrum
+        instancedGeometry.setCullHint(Spatial.CullHint.Inherit);
+        if(!instancedGeometry.checkCulling(cam) ) {
+            instancedGeometry.setCullHint(Spatial.CullHint.Always);
+            text.setText("outside of camera frustrum.");
+            return;
+        }
+        
+        //For static geom, don't need to cull again if cam & cam dir didn't change
+        //But let's be more strict for this test case and disable this optimization
+//        if(lastCamPos.equals(cam.getLocation()) && lastCamDir.equals(cam.getDirection()))
+//            return;
+//        lastCamPos.set(cam.getLocation());
+//        lastCamDir.set(cam.getDirection());
+        
+        //Why not use g_CameraPosition and g_CameraDirection?
+        //Since they don't work in update loop
+        cullGeometry.getMaterial().setVector3("CamPos", cam.getLocation());
+        cullGeometry.getMaterial().setVector3("CamDir", cam.getDirection());
+        
+        //------------Transform Feedback Start----------------
+        renderer.setTransformFeedbackOutput(tf);
+        query.begin();
+        renderManager.renderGeometry(cullGeometry);
+        query.end();
+        renderer.setTransformFeedbackOutput(null);
+        //------------Transform Feedback End----------------
+
+        //do some cpu work here
+        //otherwise would be waiting for gpu to finish
+        
+        //also a multi-buffer approach can be used
+        //where query from previous frame is used
+        //and buffers are swapped
+        
+//        long timeDelay = System.nanoTime();
+        long instancesWritten = query.getAndWait();
+//        timeDelay = System.nanoTime()-timeDelay;
+//        System.out.println("Delay " + timeDelay*0.000001f + " ms.");
+        
+        text.setText("(P) to pause. Instances Written " + instancesWritten);
+        
+        //Currently setting instanceCount to 0 will render the mesh as if uninstanced
+        //thus...
+        //things would be much simpler if the mesh wouldn't be rendered
+        if(instancesWritten == 0) {
+            instancedGeometry.setCullHint(Spatial.CullHint.Always);
+        }
+        else {
+            instancedGeometry.setCullHint(Spatial.CullHint.Inherit);
+            instancedGeometry.getMesh().setInstanceCount((int)instancesWritten);
+        }
+    }
+
+    @Override
+    public void simpleUpdate(float tpf) {
+        testTransformFeedback();
+        
+    }
+
+    
+    
+    
+    //some utility methods 
+    public Node attachCoordinateAxes() {
+        return attachCoordinateAxes(Vector3f.ZERO);
+    }
+    public Node attachCoordinateAxes(Vector3f pos) {
+        return attachCoordinateAxes(pos, rootNode);
+    }
+    public Node attachCoordinateAxes(Vector3f pos, Node node) {
+        Node coords = new Node("coords");
+        Arrow arrow = new Arrow(Vector3f.UNIT_X);
+        putShape(arrow, ColorRGBA.Red.mult(0.9f), coords).setLocalTranslation(pos);
+
+        arrow = new Arrow(Vector3f.UNIT_Y);
+        putShape(arrow, ColorRGBA.Green.mult(0.8f), coords).setLocalTranslation(pos);
+
+        arrow = new Arrow(Vector3f.UNIT_Z);
+        putShape(arrow, ColorRGBA.Blue.mult(0.9f), coords).setLocalTranslation(pos);
+        node.attachChild(coords);
+        return coords;
+    }
+    public Geometry putShape(Mesh shape, ColorRGBA color, Node node) {
+        Geometry g = new Geometry("coordinate axis", shape);
+        Material mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+//        mat.getAdditionalRenderState().setWireframe(true);
+        mat.setColor("Color", color);
+        g.setMaterial(mat);
+        node.attachChild(g);
+        return g;
+    }
+    private static int actionc = 0;
+    
+    public void trigger(Trigger t, InputListener a) {
+        trigger(t, a, "trigger_"+(++actionc));
+    }
+    public void trigger(Trigger t, InputListener a, String name) {
+        inputManager.addMapping(name, t);
+        inputManager.addListener(a, name);
+    }
+    public void key(int keyInput, InputListener a) {
+        key(keyInput, a, "trigger_"+(++actionc));
+    }
+    public void key(int keyInput, InputListener a, String name) {
+        trigger(new KeyTrigger(keyInput), a, name);
+    }
+}

--- a/jme3-examples/src/main/resources/jme3test/renderer/TestTR.geom
+++ b/jme3-examples/src/main/resources/jme3test/renderer/TestTR.geom
@@ -1,0 +1,18 @@
+layout(points) in;
+layout(points, max_vertices = 1) out;
+
+
+flat in mat4 instanceData[1];
+flat in float visible[1];
+
+//layout(xfb_offset = 0,xfb_buffer = 0)
+out mat4 TransformFeedback;
+
+void main() {
+   if(visible[0] == 1.0) {
+      TransformFeedback = instanceData[0];
+	 // gl_Position = gl_in[0].gl_Position; 
+      EmitVertex();
+      EndPrimitive();
+   }
+}

--- a/jme3-examples/src/main/resources/jme3test/renderer/TestTR.j3md
+++ b/jme3-examples/src/main/resources/jme3test/renderer/TestTR.j3md
@@ -1,0 +1,20 @@
+MaterialDef TestTR {
+
+    MaterialParameters {
+		Vector3 CamPos
+		Vector3 CamDir
+    }
+
+    Technique {
+        VertexShader GLSL130: jme3test/renderer/TestTR.vert
+		GeometryShader GLSL150: jme3test/renderer/TestTR.geom
+	
+		RenderState {
+			RasterizerDiscard On
+			FaceCull Off
+		}
+
+		TransformFeedback Interleaved TransformFeedback
+    }
+
+}

--- a/jme3-examples/src/main/resources/jme3test/renderer/TestTR.vert
+++ b/jme3-examples/src/main/resources/jme3test/renderer/TestTR.vert
@@ -1,0 +1,30 @@
+//uniform mat4 g_WorldViewProjectionMatrix;
+//out vec4 TransformFeedback;
+
+uniform vec3 m_CamPos;
+uniform vec3 m_CamDir;
+
+attribute mat4 inPosition; 
+
+flat out mat4 instanceData;
+flat out float visible;
+
+//cone pos, cone dir norm, rad at dist 1
+float coneInPoint(vec3 cP, vec3 dN, float rad, vec3 pos) {
+	float d = dot(pos-cP,dN);
+	float cRad = d * rad;
+	vec3 a2 = pos-(d*dN+cP);
+	float rSq = dot(a2,a2);
+	//0.0 <= d
+	//rSq <= cRad*cRad;
+	return step(0.0,d) * step(rSq, cRad*cRad);
+}
+
+void main() {
+	//simple cone, point frustrum checking
+	//not finished/polished, just for test case
+	visible = coneInPoint(m_CamPos, m_CamDir, 1.0, inPosition[3].xyz);
+	
+	instanceData = inPosition;
+	
+}

--- a/jme3-ios/src/main/java/com/jme3/renderer/ios/IosGL.java
+++ b/jme3-ios/src/main/java/com/jme3/renderer/ios/IosGL.java
@@ -616,4 +616,14 @@ public class IosGL implements GL, GLExt, GLFbo {
     public void glFramebufferTextureLayerEXT(int target, int attachment, int texture, int level, int layer) {
         throw new UnsupportedOperationException("OpenGL ES 2 does not support texture arrays");
     }
+
+    @Override
+    public void glGetQuery(int target, int pname, IntBuffer value) {
+        throw new UnsupportedOperationException("Not supported yet."); 
+    }
+
+    @Override
+    public void glDeleteQueries(IntBuffer ib) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }

--- a/jme3-jogl/src/main/java/com/jme3/renderer/jogl/JoglGL.java
+++ b/jme3-jogl/src/main/java/com/jme3/renderer/jogl/JoglGL.java
@@ -659,4 +659,44 @@ public class JoglGL implements GL, GL2, GL3, GL4 {
     public void glUniformBlockBinding(final int program, final int uniformBlockIndex, final int uniformBlockBinding) {
         GLContext.getCurrentGL().getGL3bc().glUniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
     }
+
+    @Override
+    public void glBindBufferRange(int target, int index, int buffer, long offset, long size) {
+        GLContext.getCurrentGL().getGL3().glBindBufferRange(target, index, buffer, offset, size);
+    }
+
+    @Override
+    public void glBeginTransformFeedback(int primitiveMode) {
+        GLContext.getCurrentGL().getGL3().glBeginTransformFeedback(primitiveMode);
+    }
+
+    @Override
+    public void glEndTransformFeedback() {
+        GLContext.getCurrentGL().getGL3().glEndTransformFeedback();
+    }
+
+    @Override
+    public void glTransformFeedbackVaryings(int program, String[] varyings, int bufferMode) {
+        GLContext.getCurrentGL().getGL3().glTransformFeedbackVaryings(program, varyings.length, varyings, bufferMode);
+    }
+
+    @Override
+    public void glGetQuery(int target, int pname, IntBuffer value) {
+        GLContext.getCurrentGL().getGL2().glGetQueryiv(target, pname, value);
+    }
+
+    @Override
+    public void glDeleteQueries(IntBuffer ib) {
+        GLContext.getCurrentGL().getGL2().glDeleteQueries(ib.limit(), ib);
+    }
+
+    @Override
+    public void glBeginQueryIndexed(int target, int index, int id) {
+        GLContext.getCurrentGL().getGL3().glBeginQueryIndexed(target, index, id);
+    }
+
+    @Override
+    public void glEndQueryIndexed(int target, int index) {
+        GLContext.getCurrentGL().getGL3().glEndQueryIndexed(target, index);
+    }
 }

--- a/jme3-lwjgl/src/main/java/com/jme3/renderer/lwjgl/LwjglGL.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/renderer/lwjgl/LwjglGL.java
@@ -514,4 +514,45 @@ public final class LwjglGL implements GL, GL2, GL3, GL4 {
     public void glUniformBlockBinding(final int program, final int uniformBlockIndex, final int uniformBlockBinding) {
         GL31.glUniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
     }
+
+    @Override
+    public void glBindBufferRange(int target, int index, int buffer, long offset, long size) {
+        GL30.glBindBufferRange(target, index, buffer, offset, size);
+    }
+
+    @Override
+    public void glBeginTransformFeedback(int primitiveMode) {
+        GL30.glBeginTransformFeedback(primitiveMode);
+    }
+
+    @Override
+    public void glEndTransformFeedback() {
+        GL30.glEndTransformFeedback();
+    }
+
+    @Override
+    public void glTransformFeedbackVaryings(int program, String[] varyings, int bufferMode) {
+        GL30.glTransformFeedbackVaryings(program, varyings, bufferMode);
+    }
+
+    @Override
+    public void glGetQuery(int target, int pname, IntBuffer params) {
+        GL15.glGetQuery(target, pname, params);
+    }
+
+    @Override
+    public void glDeleteQueries(IntBuffer ib) {
+        GL15.glDeleteQueries(ib);
+    }
+
+    @Override
+    public void glBeginQueryIndexed(int target, int index, int id) {
+        GL40.glBeginQueryIndexed(target, index, id);
+    }
+
+    @Override
+    public void glEndQueryIndexed(int target, int index) {
+        GL40.glEndQueryIndexed(target, index);
+    }
+    
 }

--- a/jme3-lwjgl3/src/main/java/com/jme3/renderer/lwjgl/LwjglGL.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/renderer/lwjgl/LwjglGL.java
@@ -646,4 +646,44 @@ public class LwjglGL extends LwjglRender implements GL, GL2, GL3, GL4 {
     public void glUniformBlockBinding(final int program, final int uniformBlockIndex, final int uniformBlockBinding) {
         GL31.glUniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
     }
+
+    @Override
+    public void glBindBufferRange(int target, int index, int buffer, long offset, long size) {
+        GL30.glBindBufferRange(target, index, buffer, offset, size);
+    }
+
+    @Override
+    public void glBeginTransformFeedback(int primitiveMode) {
+        GL30.glBeginTransformFeedback(primitiveMode);
+    }
+
+    @Override
+    public void glEndTransformFeedback() {
+        GL30.glEndTransformFeedback();
+    }
+
+    @Override
+    public void glTransformFeedbackVaryings(int program, String[] varyings, int bufferMode) {
+        GL30.glTransformFeedbackVaryings(program, varyings, bufferMode);
+    }
+
+    @Override
+    public void glGetQuery(int target, int pname, IntBuffer value) {
+        GL20.glGetQueryiv(target, pname, value);
+    }
+
+    @Override
+    public void glDeleteQueries(IntBuffer ib) {
+        GL20.glDeleteQueries(ib);
+    }
+
+    @Override
+    public void glBeginQueryIndexed(int target, int index, int id) {
+        GL40.glBeginQueryIndexed(target, index, id);
+    }
+
+    @Override
+    public void glEndQueryIndexed(int target, int index) {
+        GL40.glEndQueryIndexed(target, index);
+    }
 }


### PR DESCRIPTION
Adds basic support for Transform Feedback (TF).
As part of discussion on discord
- new class BufferObject was added which manages BufferObjects
- VertexBuffer now extends BufferObject
- jme3.shader.BufferObject was renamed to UniformBufferObject and now extends BufferObject

To support basic transform feedback.
- setTransformFeedbackOutput(TransformFeedbackOutput output) method was added to the Renderer interface

The use of this method is similar to how rendering of framebuffers is handled in jme. This method is called to enable transform feedback, after which rendered geometry's TF ouput will be captured to the specified output buffers. Calling it will null, disables transform feedback.

In order to use TF, a shader has to specify the output variables which will be outputted to TF. This is accomplished by specifying the output variables in Technique block of .j3md file. Syntax is:
```
TransformFeedback [Off | Interleaved | Separate | InShader] varying1 varying2 varying3 ...
```
For example a vertex/geometry shader contains the ouput:
```
out mat4 TransformFeedback;
```
A technique can be written as:
```
Technique {
    VertexShader GLSL130: jme3test/renderer/TestTR.vert
    GeometryShader GLSL150: jme3test/renderer/TestTR.geom
    RenderState {
        RasterizerDiscard On
    }
    TransformFeedback Interleaved TransformFeedback
}
```
- added Render State RasterizerDiscard - when enabled Fragment Processing stage is skipped, 
- added QueryObject, retrieve the number of written primitives for TF operation
- added TF testcase jme3test.renderer.TestTransformFeedback

Awaiting your feedback.