### PR TITLE
#1107-Fix Javadoc warnings in OpenJDK 9+ (jme3-core)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/bounding/BoundingBox.java
+++ b/jme3-core/src/main/java/com/jme3/bounding/BoundingBox.java
@@ -79,9 +79,9 @@ public class BoundingBox extends BoundingVolume {
      * Instantiate a <code>BoundingBox</code> with given center and extents.
      *
      * @param c the coordinates of the center of the box (not null, not altered)
-     * @param x the X-extent of the box (>=0, may be +Infinity)
-     * @param y the Y-extent of the box (>=0, may be +Infinity)
-     * @param z the Z-extent of the box (>=0, may be +Infinity)
+     * @param x the X-extent of the box (0 or greater, may be +Infinity)
+     * @param y the Y-extent of the box (0 or greater, may be +Infinity)
+     * @param z the Z-extent of the box (0 or greater, may be +Infinity)
      */
     public BoundingBox(Vector3f c, float x, float y, float z) {
         this.center.set(c);

--- a/jme3-core/src/main/java/com/jme3/bounding/BoundingSphere.java
+++ b/jme3-core/src/main/java/com/jme3/bounding/BoundingSphere.java
@@ -173,11 +173,11 @@ public class BoundingSphere extends BoundingVolume {
 
     /**
      * Calculates a minimum bounding sphere for the set of points. The algorithm
-     * was originally found in C++ at
-     * <p><a href="http://www.flipcode.com/cgi-bin/msg.cgi?showThread=COTD-SmallestEnclosingSpheres&forum=cotd&id=-1">
-     * http://www.flipcode.com/cgi-bin/msg.cgi?showThread=COTD-SmallestEnclosingSpheres&forum=cotd&id=-1</a><br><strong>broken link</strong></p>
-     * <p>and translated to java by Cep21</p>
-     *
+     * was originally found in C++ at <br>
+     * <a href="http://flipcode.com/archives/Smallest_Enclosing_Spheres.shtml">
+     * http://flipcode.com/archives/Smallest_Enclosing_Spheres.shtml</a> <br> 
+     * and translated to java by Cep21
+     *  
      * @param points
      *            The points to calculate the minimum bounds from.
      */

--- a/jme3-core/src/main/java/com/jme3/cinematic/events/CameraEvent.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/events/CameraEvent.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 
 /**
  *
- * @author Rickard <neph1 @ github>
+ * @author Rickard (neph1 @ github)
  */
 public class CameraEvent extends AbstractCinematicEvent{
 

--- a/jme3-core/src/main/java/com/jme3/light/LightProbe.java
+++ b/jme3-core/src/main/java/com/jme3/light/LightProbe.java
@@ -120,7 +120,7 @@ public class LightProbe extends Light implements Savable {
      // 1 | ay by cy | py | probe position
      // 2 | az bz cz | pz | )
      // --|----------|
-     // 3 | sx sy sz   sp | -> 1/probe radius + nbMipMaps
+     // 3 | sx sy sz   sp |    1/probe radius + nbMipMaps
      //    --scale--
      * <p>
      * (ax, ay, az) is the pitch rotation axis

--- a/jme3-core/src/main/java/com/jme3/material/RenderState.java
+++ b/jme3-core/src/main/java/com/jme3/material/RenderState.java
@@ -272,27 +272,27 @@ public class RenderState implements Cloneable, Savable {
         /**
          * Additive blending. For use with glows and particle emitters.
          * <p>
-         * Result = Source Color + Destination Color -> (GL_ONE, GL_ONE)
+         * Result = Source Color + Destination Color -&gt; (GL_ONE, GL_ONE)
          */
         Additive,
         /**
          * Premultiplied alpha blending, for use with premult alpha textures.
          * <p>
-         * Result = Source Color + (Dest Color * (1 - Source Alpha) ) -> (GL_ONE, GL_ONE_MINUS_SRC_ALPHA)
+         * Result = Source Color + (Dest Color * (1 - Source Alpha) ) -&gt; (GL_ONE, GL_ONE_MINUS_SRC_ALPHA)
          */
         PremultAlpha,
         /**
          * Additive blending that is multiplied with source alpha.
          * For use with glows and particle emitters.
          * <p>
-         * Result = (Source Alpha * Source Color) + Dest Color -> (GL_SRC_ALPHA, GL_ONE)
+         * Result = (Source Alpha * Source Color) + Dest Color -&gt; (GL_SRC_ALPHA, GL_ONE)
          */
         AlphaAdditive,
         /**
          * Color blending, blends in color from dest color
          * using source color.
          * <p>
-         * Result = Source Color + (1 - Source Color) * Dest Color -> (GL_ONE, GL_ONE_MINUS_SRC_COLOR)
+         * Result = Source Color + (1 - Source Color) * Dest Color -&gt; (GL_ONE, GL_ONE_MINUS_SRC_COLOR)
          */
         Color,
         /**
@@ -300,7 +300,7 @@ public class RenderState implements Cloneable, Savable {
          * using source alpha.
          * <p>
          * Result = Source Alpha * Source Color +
-         *          (1 - Source Alpha) * Dest Color -> (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+         *          (1 - Source Alpha) * Dest Color -&gt; (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
          */
         Alpha,
          /**
@@ -309,28 +309,28 @@ public class RenderState implements Cloneable, Savable {
          * The resulting alpha is the sum between the source alpha and the destination alpha.
          * <p>
          * Result.rgb = Source Alpha * Source Color +
-         *          (1 - Source Alpha) * Dest Color -> (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-         * Result.a = 1 * Source Alpha + 1 * Dest Alpha -> (GL_ONE, GL_ONE)
+         *          (1 - Source Alpha) * Dest Color -&gt; (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+         * Result.a = 1 * Source Alpha + 1 * Dest Alpha -&gt; (GL_ONE, GL_ONE)
          * 
          */
         AlphaSumA,
         /**
          * Multiplies the source and dest colors.
          * <p>
-         * Result = Source Color * Dest Color -> (GL_DST_COLOR, GL_ZERO)
+         * Result = Source Color * Dest Color -&gt; (GL_DST_COLOR, GL_ZERO)
          */
         Modulate,
         /**
          * Multiplies the source and dest colors then doubles the result.
          * <p>
-         * Result = 2 * Source Color * Dest Color -> (GL_DST_COLOR, GL_SRC_COLOR)
+         * Result = 2 * Source Color * Dest Color -&gt; (GL_DST_COLOR, GL_SRC_COLOR)
          */
         ModulateX2,
         /**
          * Opposite effect of Modulate/Multiply. Invert both colors, multiply and
          * then invert the result.
          * <p>
-         * Result = 1 - (1 - Source Color) * (1 - Dest Color) -> (GL_ONE, GL_ONE_MINUS_SRC_COLOR)
+         * Result = 1 - (1 - Source Color) * (1 - Dest Color) -&gt; (GL_ONE, GL_ONE_MINUS_SRC_COLOR)
          */
         Screen,
         /**
@@ -338,7 +338,7 @@ public class RenderState implements Cloneable, Savable {
          * operation.  This is directly equivalent to Photoshop's "Exclusion" blend.
          * <p>
          * Result = (Source Color * (1 - Dest Color)) + (Dest Color * (1 - Source Color))
-         *  -> (GL_ONE_MINUS_DST_COLOR, GL_ONE_MINUS_SRC_COLOR) 
+         *  -&gt; (GL_ONE_MINUS_DST_COLOR, GL_ONE_MINUS_SRC_COLOR) 
          */
         Exclusion,
         /**

--- a/jme3-core/src/main/java/com/jme3/material/Technique.java
+++ b/jme3-core/src/main/java/com/jme3/material/Technique.java
@@ -169,7 +169,7 @@ public final class Technique {
     /**
      * Get the {@link DefineList} for dynamic defines.
      * 
-     * Dynamic defines are used to implement material parameter -> define
+     * Dynamic defines are used to implement material parameter -- define
      * bindings as well as {@link TechniqueDefLogic} specific functionality.
      * 
      * @return all dynamic defines.

--- a/jme3-core/src/main/java/com/jme3/math/FastMath.java
+++ b/jme3-core/src/main/java/com/jme3/math/FastMath.java
@@ -91,7 +91,7 @@ final public class FastMath {
      * Get the next power of two of the given number.
      * 
      * E.g. for an input 100, this returns 128.
-     * Returns 1 for all numbers <= 1.
+     * Returns 1 for all numbers less than or equal to 1.
      * 
      * @param number The number to obtain the POT for.
      * @return The next power of two.
@@ -942,7 +942,8 @@ final public class FastMath {
      * Converts a single precision (32 bit) floating point value
      * into half precision (16 bit).
      *
-     * <p>Source: <a href="ftp://www.fox-toolkit.org/pub/fasthalffloatconversion.pdf</a>
+     * <p>Source: <a href="ftp://www.fox-toolkit.org/pub/fasthalffloatconversion.pdf">
+     * ftp://www.fox-toolkit.org/pub/fasthalffloatconversion.pdf</a>
      *
      * @param half The half floating point value as a short.
      * @return floating point value of the half.

--- a/jme3-core/src/main/java/com/jme3/math/Ray.java
+++ b/jme3-core/src/main/java/com/jme3/math/Ray.java
@@ -43,8 +43,9 @@ import java.io.IOException;
 /**
  * <code>Ray</code> defines a line segment which has an origin and a direction.
  * That is, a point and an infinite ray is cast from this point. The ray is
- * defined by the following equation: R(t) = origin + t*direction for t >= 0.
- * 
+ * defined by the following equation: {@literal
+ * R(t) = origin + t*direction for t >= 0.
+ * }
  * @author Mark Powell
  * @author Joshua Slack
  */

--- a/jme3-core/src/main/java/com/jme3/renderer/Caps.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Caps.java
@@ -238,7 +238,7 @@ public enum Caps {
     TextureBuffer,
 
     /**
-     * Supports floating point & half textures (Format.RGB16F)
+     * Supports floating point and half textures (Format.RGB16F)
      */
     FloatTexture,
     

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GL.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GL.java
@@ -991,7 +991,7 @@ public interface GL {
      * <p>
      * Defines the scissor rectangle for all viewports. The scissor test is enabled or disabled for all viewports using {@link #glEnable Enable} or {@link #glDisable Disable}
      * with the symbolic constant {@link #GL_SCISSOR_TEST SCISSOR_TEST}. When disabled, it is as if the scissor test always passes. When enabled, if
-     * <code>left <= x<sub>w</sub> < left + width</code> and <code>bottom <= y<sub>w</sub> < bottom + height</code> for the scissor rectangle, then the scissor
+     * left &lt;= x<sub>w</sub> &lt; left + width and bottom &lt;= y<sub>w</sub> &lt; bottom + height for the scissor rectangle, then the scissor
      * test passes. Otherwise, the test fails and the fragment is discarded.
      *
      * @param x      the left scissor rectangle coordinate.

--- a/jme3-core/src/main/java/com/jme3/system/SystemListener.java
+++ b/jme3-core/src/main/java/com/jme3/system/SystemListener.java
@@ -32,7 +32,7 @@
 package com.jme3.system;
 
 /**
- * The <code>ContextListener> provides a means for an application
+ * The {@code SystemListener} provides a means for an application
  * to receive events relating to a context.
  */
 public interface SystemListener {

--- a/jme3-core/src/main/java/com/jme3/texture/Texture.java
+++ b/jme3-core/src/main/java/com/jme3/texture/Texture.java
@@ -278,21 +278,23 @@ public abstract class Texture implements CloneableSmartAsset, Savable, Cloneable
          */
         Off,
 
-        /**
+        /** 
+         * {@code
          * Compares the 3rd texture coordinate R to the value
          * in this depth texture. If R <= texture value then result is 1.0,
          * otherwise, result is 0.0. If filtering is set to bilinear or trilinear
          * the implementation may sample the texture multiple times to provide
-         * smoother results in the range [0, 1].
+         * smoother results in the range [0, 1].}
          */
         LessOrEqual,
 
         /**
+         * {@code
          * Compares the 3rd texture coordinate R to the value
          * in this depth texture. If R >= texture value then result is 1.0,
          * otherwise, result is 0.0. If filtering is set to bilinear or trilinear
          * the implementation may sample the texture multiple times to provide
-         * smoother results in the range [0, 1].
+         * smoother results in the range [0, 1].}
          */
         GreaterOrEqual
     }

--- a/jme3-core/src/main/java/com/jme3/texture/TextureCubeMap.java
+++ b/jme3-core/src/main/java/com/jme3/texture/TextureCubeMap.java
@@ -44,14 +44,14 @@ import java.util.ArrayList;
  * Describes a cubemap texture.
  * The image specified by setImage must contain 6 data units,
  * each data contains a 2D image representing a cube's face.
- * The slices are specified in this order:<br/>
- * <br/>
- * 0 => Positive X (+x)<br/>
- * 1 => Negative X (-x)<br/>
- * 2 => Positive Y (+y)<br/>
- * 3 => Negative Y (-y)<br/>
- * 4 => Positive Z (+z)<br/>
- * 5 => Negative Z (-z)<br/>
+ * The slices are specified in this order:<br>
+ * <br>
+ * 0 -- Positive X (+x)<br>
+ * 1 -- Negative X (-x)<br>
+ * 2 -- Positive Y (+y)<br>
+ * 3 -- Negative Y (-y)<br>
+ * 4 -- Positive Z (+z)<br>
+ * 5 -- Negative Z (-z)<br>
  *
  * @author Joshua Slack
  */

--- a/jme3-core/src/main/java/com/jme3/util/ListSort.java
+++ b/jme3-core/src/main/java/com/jme3/util/ListSort.java
@@ -52,12 +52,13 @@ import java.util.Comparator;
  * for optimal performance, but can be called several times if the length of the
  * list changes
  *
+ * {@code
  * Disclaimer : I was intrigued by the use of val >>> 1 in java 7 Timsort class
  * instead of val / 2 (integer division). Micro benching revealed that val >>> 1
  * is twice faster than val / 2 in java 6 and has similar perf in java 7. The
  * following code uses val >>> 1 when ever a value needs to be divided by 2 and
  * rounded to its floor
- *
+ * }
  *
  * @author Nehon
  */
@@ -66,7 +67,7 @@ public class ListSort<T> {
     /**
      * Threshold for binary sort vs merge. Original algorithm use 64, java7
      * TimSort uses 32 and I used 128, see this post for explanations :
-     * http://hub.jmonkeyengine.org/groups/development-discussion-jme3/forum/topic/i-got-that-sorted-out-huhuhu/
+     * https://hub.jmonkeyengine.org/t/i-got-that-sorted-out-huhuhu/24478
      */
     private static final int MIN_SIZE = 128;
     private T[] array;

--- a/jme3-core/src/main/java/com/jme3/util/SortUtil.java
+++ b/jme3-core/src/main/java/com/jme3/util/SortUtil.java
@@ -47,7 +47,7 @@ public class SortUtil {
     private static final int INSERTION_SORT_THRESHOLD = 7;
     
     
-    /**
+    /*
  procedure optimizedGnomeSort(a[])
     pos := 1
     last := 0

--- a/jme3-core/src/plugins/java/com/jme3/export/binary/ByteUtils.java
+++ b/jme3-core/src/plugins/java/com/jme3/export/binary/ByteUtils.java
@@ -452,7 +452,7 @@ public class ByteUtils {
      * of bytes have been read.
      * 
      * @param store
-     *            the byte array to store in. Should have a length > bytes
+     *            the byte array to store in. Array length must be greater than bytes param.
      * @param bytes
      *            the number of bytes to read.
      * @param is

--- a/jme3-core/src/plugins/java/com/jme3/material/plugins/ConditionParser.java
+++ b/jme3-core/src/plugins/java/com/jme3/material/plugins/ConditionParser.java
@@ -79,13 +79,11 @@ public class ConditionParser {
      * additionally this methods updates the formattedExpression with uppercased
      * defines names
      *
-     * supported expression syntax example:
-     * <code>
-     * "(LightMap && SeparateTexCoord) || !ColorMap"
-     * "#if (defined(LightMap) && defined(SeparateTexCoord)) || !defined(ColorMap)"
-     * "#ifdef LightMap"
-     * "#ifdef (LightMap && SeparateTexCoord) || !ColorMap"
-     * </code>
+     * supported expression syntax example:<br><br>
+     * {@code "(LightMap && SeparateTexCoord) || !ColorMap"}<br><br>
+     * {@code "#if (defined(LightMap) && defined(SeparateTexCoord)) || !defined(ColorMap)"}<br><br>
+     * {@code "#ifdef LightMap"}<br><br>
+     * {@code "#ifdef (LightMap && SeparateTexCoord) || !ColorMap"}<br>
      *
      * @param expression the expression to parse
      * @return the list of defines

--- a/jme3-core/src/plugins/java/com/jme3/material/plugins/ShaderNodeLoaderDelegate.java
+++ b/jme3-core/src/plugins/java/com/jme3/material/plugins/ShaderNodeLoaderDelegate.java
@@ -1058,11 +1058,11 @@ public class ShaderNodeLoaderDelegate {
     }
 
     /**
-     * merges 2 condition with the given operator
+     * Merges 2 conditions with the given operator
      *
      * @param condition1 the first condition
      * @param condition2 the second condition
-     * @param operator the operator ("&&" or "||&)
+     * @param operator the operator {@literal ("&&" or "||&)}
      * @return the merged condition
      */
     public String mergeConditions(String condition1, String condition2, String operator) {

--- a/jme3-networking/src/main/java/com/jme3/network/serializing/Serializer.java
+++ b/jme3-networking/src/main/java/com/jme3/network/serializing/Serializer.java
@@ -153,7 +153,7 @@ public abstract class Serializer {
     
     /**
      *  When set to true, classes that do not have intrinsic IDs in their
-     *  @Serializable will not be auto-registered during write.  Defaults
+     *  {@code @Serializable } will not be auto-registered during write.  Defaults
      *  to true since this is almost never desired behavior with the way
      *  this code works.  Set to false to get the old permissive behavior.
      */


### PR DESCRIPTION
Took way longer than I thought it would for "core" so I didn't get to "vr" yet, but OpenJDK 11 builds produce far fewer warnings after this cleanup. (OpenJDK 8 also tested to make sure new warnings don't appear...) I took the time to understand & preserve comment _intent_ as best I could, and test JavaDoc rendering in NB 11 to ensure doc is readable (before fixes some comments were showing completely misleading text in autocomplete help!). Also fixed a few broken links. 

Also here "ContextListener" was changed to SystemListener - I can't find any "ContextListener" other than in some comments (possibly also outdated), so I think this was a typo/mistake? 
If not and there is some "ContextListener" concept I'm unaware of, let me know and I'll correct. 
```java
/**
 * The <code>ContextListener> provides a means for an application  (-)
 * The {@code SystemListener} provides a means for an application  (+)
 * to receive events relating to a context.
 */
public interface SystemListener {
```
