### PR TITLE
Issue 1113. Allow for Particle emitters that constantly have their pa…

### DIFF
--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -783,7 +783,7 @@ public class ParticleEmitter extends Geometry {
      */
     public void setParticlesPerSec(float particlesPerSec) {
         this.particlesPerSec = particlesPerSec;
-        timeDifference = 0;
+        timeDifference = Math.min(timeDifference,1f / particlesPerSec); //prevent large accumulated timeDifference from causing a huge number of particles to be emitted
     }
 
     /**


### PR DESCRIPTION
…rticlesPerSec set to still emit

Previously if particlesPerSec was constantly set timeDifference could never grow large enough to emit a particle as timeDifference was reset to zero each time. This fixes that problem while still ensuring that timeDifference can't have grown very very large (leading to huge numbers of particles being emitted) by capping the timeDifference at the point where its just about to emit a particle.

Discussed at https://hub.jmonkeyengine.org/t/particle-emitter-cannot-emit-particles-if-its-emissions-per-second-is-updated-every-frame/41930/2