### PR TITLE
GImpactShape Test Added

### DIFF
--- a/jme3-examples/src/main/java/jme3test/bullet/PhysicsTestHelper.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/PhysicsTestHelper.java
@@ -332,12 +332,13 @@ public class PhysicsTestHelper {
     }
 
     private static float getY(float x, float z, float max) {
-        float yMaxHeight = 2;
-        float xv = FastMath.unInterpolateLinear(x, 0, max) * FastMath.TWO_PI;
-        float zv = FastMath.unInterpolateLinear(z, 0, max) * FastMath.TWO_PI;
+        float yMaxHeight = 8;
+        float xv = FastMath.unInterpolateLinear(FastMath.abs(x - (max / 2)), 0, max) * FastMath.TWO_PI;
+        float zv = FastMath.unInterpolateLinear(FastMath.abs(z - (max / 2)), 0, max) * FastMath.TWO_PI;
 
-        float xComp = (FastMath.cos(xv) + 1) * 0.5f;
-        float zComp = (FastMath.cos(zv) + 1) * 0.5f;
-        return yMaxHeight * xComp * zComp;
+        float xComp = (FastMath.sin(xv) + 1) * 0.5f;
+        float zComp = (FastMath.sin(zv) + 1) * 0.5f;
+
+        return -yMaxHeight * xComp * zComp;
     }
 }

--- a/jme3-examples/src/main/java/jme3test/bullet/PhysicsTestHelper.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/PhysicsTestHelper.java
@@ -262,7 +262,7 @@ public class PhysicsTestHelper {
      * @return
      */
     public static Geometry createGImpactTestFloor(AssetManager assetManager, float floorDimensions, Vector3f position) {
-        Geometry floor = createTestFloor(assetManager, floorDimensions, position);
+        Geometry floor = createTestFloor(assetManager, floorDimensions, position, ColorRGBA.Red);
         RigidBodyControl floorControl = new RigidBodyControl(new GImpactCollisionShape(floor.getMesh()), 0);
         floor.addControl(floorControl);
         return floor;
@@ -279,16 +279,17 @@ public class PhysicsTestHelper {
      * @return
      */
     public static Geometry createMeshTestFloor(AssetManager assetManager, float floorDimensions, Vector3f position) {
-        Geometry floor = createTestFloor(assetManager, floorDimensions, position);
+        Geometry floor = createTestFloor(assetManager, floorDimensions, position, new ColorRGBA(0.5f, 0.5f, 0.9f, 1));
         RigidBodyControl floorControl = new RigidBodyControl(new MeshCollisionShape(floor.getMesh()), 0);
         floor.addControl(floorControl);
         return floor;
     }
 
-    private static Geometry createTestFloor(AssetManager assetManager, float floorDimensions, Vector3f position) {
+    private static Geometry createTestFloor(AssetManager assetManager, float floorDimensions, Vector3f position, ColorRGBA color) {
         Geometry floor = new Geometry("floor", createFloorMesh(20, floorDimensions));
         Material material = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
         material.getAdditionalRenderState().setWireframe(true);
+        material.setColor("Color", color);
         floor.setMaterial(material);
         floor.setLocalTranslation(position);
         return floor;

--- a/jme3-examples/src/main/java/jme3test/bullet/PhysicsTestHelper.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/PhysicsTestHelper.java
@@ -36,6 +36,7 @@ import com.jme3.asset.AssetManager;
 import com.jme3.asset.TextureKey;
 import com.jme3.bullet.PhysicsSpace;
 import com.jme3.bullet.collision.shapes.CollisionShape;
+import com.jme3.bullet.collision.shapes.GImpactCollisionShape;
 import com.jme3.bullet.collision.shapes.MeshCollisionShape;
 import com.jme3.bullet.control.RigidBodyControl;
 import com.jme3.input.MouseInput;
@@ -44,13 +45,18 @@ import com.jme3.input.controls.MouseButtonTrigger;
 import com.jme3.light.AmbientLight;
 import com.jme3.material.Material;
 import com.jme3.math.ColorRGBA;
+import com.jme3.math.FastMath;
+import com.jme3.math.Vector3f;
 import com.jme3.renderer.queue.RenderQueue.ShadowMode;
 import com.jme3.scene.Geometry;
+import com.jme3.scene.Mesh;
 import com.jme3.scene.Node;
+import com.jme3.scene.VertexBuffer;
 import com.jme3.scene.shape.Box;
 import com.jme3.scene.shape.Sphere;
 import com.jme3.scene.shape.Sphere.TextureMode;
 import com.jme3.texture.Texture;
+import com.jme3.util.BufferUtils;
 
 /**
  *
@@ -59,8 +65,7 @@ import com.jme3.texture.Texture;
 public class PhysicsTestHelper {
 
     /**
-     * creates a simple physics test world with a floor, an obstacle and some
-     * test boxes
+     * creates a simple physics test world with a floor, an obstacle and some test boxes
      *
      * @param rootNode where lights and geometries should be added
      * @param assetManager for loading assets
@@ -107,7 +112,7 @@ public class PhysicsTestHelper {
         space.add(sphereGeometry);
 
     }
-    
+
     public static void createPhysicsTestWorldSoccer(Node rootNode, AssetManager assetManager, PhysicsSpace space) {
         AmbientLight light = new AmbientLight();
         light.setColor(ColorRGBA.LightGray);
@@ -140,24 +145,24 @@ public class PhysicsTestHelper {
             space.add(ballGeometry);
         }
         {
-        //immovable Box with mesh collision shape
-        Box box = new Box(1, 1, 1);
-        Geometry boxGeometry = new Geometry("Box", box);
-        boxGeometry.setMaterial(material);
-        boxGeometry.setLocalTranslation(4, 1, 2);
-        boxGeometry.addControl(new RigidBodyControl(new MeshCollisionShape(box), 0));
-        rootNode.attachChild(boxGeometry);
-        space.add(boxGeometry);
+            //immovable Box with mesh collision shape
+            Box box = new Box(1, 1, 1);
+            Geometry boxGeometry = new Geometry("Box", box);
+            boxGeometry.setMaterial(material);
+            boxGeometry.setLocalTranslation(4, 1, 2);
+            boxGeometry.addControl(new RigidBodyControl(new MeshCollisionShape(box), 0));
+            rootNode.attachChild(boxGeometry);
+            space.add(boxGeometry);
         }
         {
-        //immovable Box with mesh collision shape
-        Box box = new Box(1, 1, 1);
-        Geometry boxGeometry = new Geometry("Box", box);
-        boxGeometry.setMaterial(material);
-        boxGeometry.setLocalTranslation(4, 3, 4);
-        boxGeometry.addControl(new RigidBodyControl(new MeshCollisionShape(box), 0));
-        rootNode.attachChild(boxGeometry);
-        space.add(boxGeometry);
+            //immovable Box with mesh collision shape
+            Box box = new Box(1, 1, 1);
+            Geometry boxGeometry = new Geometry("Box", box);
+            boxGeometry.setMaterial(material);
+            boxGeometry.setLocalTranslation(4, 3, 4);
+            boxGeometry.addControl(new RigidBodyControl(new MeshCollisionShape(box), 0));
+            rootNode.attachChild(boxGeometry);
+            space.add(boxGeometry);
         }
     }
 
@@ -211,8 +216,7 @@ public class PhysicsTestHelper {
     }
 
     /**
-     * creates the necessary inputlistener and action to shoot balls from the
-     * camera
+     * creates the necessary inputlistener and action to shoot balls from the camera
      *
      * @param app the application that's running
      * @param rootNode where ball geometries should be added
@@ -245,5 +249,95 @@ public class PhysicsTestHelper {
         };
         app.getInputManager().addMapping("shoot", new MouseButtonTrigger(MouseInput.BUTTON_LEFT));
         app.getInputManager().addListener(actionListener, "shoot");
+    }
+
+    public static Geometry createGImpactTestFloor(AssetManager assetManager, float floorDimensions, Vector3f position) {
+        Geometry floor = createTestFloor(assetManager, floorDimensions, position);
+        RigidBodyControl floorControl = new RigidBodyControl(new GImpactCollisionShape(floor.getMesh()), 0);
+        floor.addControl(floorControl);
+        return floor;
+    }
+
+    public static Geometry createMeshTestFloor(AssetManager assetManager, float floorDimensions, Vector3f position) {
+        Geometry floor = createTestFloor(assetManager, floorDimensions, position);
+        RigidBodyControl floorControl = new RigidBodyControl(new MeshCollisionShape(floor.getMesh()), 0);
+        floor.addControl(floorControl);
+        return floor;
+    }
+
+    private static Geometry createTestFloor(AssetManager assetManager, float floorDimensions, Vector3f position) {
+        Geometry floor = new Geometry("floor", createFloorMesh(20, floorDimensions));
+        Material material = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+        material.getAdditionalRenderState().setWireframe(true);
+        floor.setMaterial(material);
+        floor.setLocalTranslation(position);
+        return floor;
+    }
+
+    private static Mesh createFloorMesh(int meshDetail, float floorDimensions) {
+        if (meshDetail < 10) {
+            meshDetail = 10;
+        }
+        int numVertices = meshDetail * meshDetail * 2 * 3;//width * depth * two tris * 3 verts per tri
+
+        int[] indexBuf = new int[numVertices];
+        int i = 0;
+        for (int x = 0; x < meshDetail; x++) {
+            for (int z = 0; z < meshDetail; z++) {
+                indexBuf[i] = i++;
+                indexBuf[i] = i++;
+                indexBuf[i] = i++;
+                indexBuf[i] = i++;
+                indexBuf[i] = i++;
+                indexBuf[i] = i++;
+            }
+        }
+
+        float[] vertBuf = new float[numVertices * 3];
+        float xIncrement = floorDimensions / meshDetail;
+        float zIncrement = floorDimensions / meshDetail;
+        int j = 0;
+        for (int x = 0; x < meshDetail; x++) {
+            float xPos = x * xIncrement;
+            for (int z = 0; z < meshDetail; z++) {
+                float zPos = z * zIncrement;
+                //First tri
+                vertBuf[j++] = xPos;
+                vertBuf[j++] = getY(xPos, zPos, floorDimensions);
+                vertBuf[j++] = zPos;
+                vertBuf[j++] = xPos;
+                vertBuf[j++] = getY(xPos, zPos + zIncrement, floorDimensions);
+                vertBuf[j++] = zPos + zIncrement;
+                vertBuf[j++] = xPos + xIncrement;
+                vertBuf[j++] = getY(xPos + xIncrement, zPos, floorDimensions);
+                vertBuf[j++] = zPos;
+                //Second tri
+                vertBuf[j++] = xPos;
+                vertBuf[j++] = getY(xPos, zPos + zIncrement, floorDimensions);
+                vertBuf[j++] = zPos + zIncrement;
+                vertBuf[j++] = xPos + xIncrement;
+                vertBuf[j++] = getY(xPos + xIncrement, zPos + zIncrement, floorDimensions);
+                vertBuf[j++] = zPos + zIncrement;
+                vertBuf[j++] = xPos + xIncrement;
+                vertBuf[j++] = getY(xPos + xIncrement, zPos, floorDimensions);
+                vertBuf[j++] = zPos;
+            }
+        }
+
+        Mesh m = new Mesh();
+        m.setBuffer(VertexBuffer.Type.Index, 1, BufferUtils.createIntBuffer(indexBuf));
+        m.setBuffer(VertexBuffer.Type.Position, 3, BufferUtils.createFloatBuffer(vertBuf));
+        m.updateBound();
+        return m;
+    }
+
+    private static float getY(float x, float z, float max) {
+        float yMaxHeight = 2;
+        float xv = FastMath.unInterpolateLinear(x, 0, max) * FastMath.TWO_PI;
+        float zv = FastMath.unInterpolateLinear(z, 0, max) * FastMath.TWO_PI;
+
+        float xComp = (FastMath.cos(xv) + 1) * 0.5f;
+        float zComp = (FastMath.cos(zv) + 1) * 0.5f;
+        return yMaxHeight * xComp * zComp;
     }
 }

--- a/jme3-examples/src/main/java/jme3test/bullet/PhysicsTestHelper.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/PhysicsTestHelper.java
@@ -251,6 +251,16 @@ public class PhysicsTestHelper {
         app.getInputManager().addListener(actionListener, "shoot");
     }
 
+    /**
+     * Creates a curved "floor" with a GImpactCollisionShape provided as the RigidBodyControl's collision
+     * shape. Surface has four slightly concave corners to allow for multiple tests and minimize falling off
+     * the edge of the floor.
+     *
+     * @param assetManager for loading assets
+     * @param floorDimensions width/depth of the "floor" (X/Z)
+     * @param position sets the floor's local translation
+     * @return
+     */
     public static Geometry createGImpactTestFloor(AssetManager assetManager, float floorDimensions, Vector3f position) {
         Geometry floor = createTestFloor(assetManager, floorDimensions, position);
         RigidBodyControl floorControl = new RigidBodyControl(new GImpactCollisionShape(floor.getMesh()), 0);
@@ -258,6 +268,16 @@ public class PhysicsTestHelper {
         return floor;
     }
 
+    /**
+     * Creates a curved "floor" with a MeshCollisionShape provided as the RigidBodyControl's collision shape.
+     * Surface has four slightly concave corners to allow for multiple tests and minimize falling off the edge
+     * of the floor.
+     *
+     * @param assetManager for loading assets
+     * @param floorDimensions width/depth of the "floor" (X/Z)
+     * @param position sets the floor's local translation
+     * @return
+     */
     public static Geometry createMeshTestFloor(AssetManager assetManager, float floorDimensions, Vector3f position) {
         Geometry floor = createTestFloor(assetManager, floorDimensions, position);
         RigidBodyControl floorControl = new RigidBodyControl(new MeshCollisionShape(floor.getMesh()), 0);

--- a/jme3-examples/src/main/java/jme3test/bullet/shape/TestGimpactShape.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/shape/TestGimpactShape.java
@@ -197,7 +197,7 @@ public class TestGimpactShape extends SimpleApplication {
     }
 
     private void initializeNewTest() {
-        testScale.setText("Object scale: " + scaleMod);
+        testScale.setText("Object scale: " + String.format("%.1f", scaleMod));
         solverNumIterationsTxt.setText("Solver Iterations: " + solverNumIterations);
 
         bulletAppState = new BulletAppState();
@@ -321,7 +321,7 @@ public class TestGimpactShape extends SimpleApplication {
 
     @Override
     public void simpleUpdate(float tpf) {
-        testTimer += tpf;
+        testTimer += tpf * bulletAppState.getSpeed();
 
         if (restart) {
             cleanup();
@@ -329,7 +329,7 @@ public class TestGimpactShape extends SimpleApplication {
             restart = false;
             testTimer = 0;
         }
-        timeElapsedTxt.setText("Time Elapsed: " + testTimer);
+        timeElapsedTxt.setText("Time Elapsed: " + String.format("%.3f", testTimer));
     }
 
     private void cleanup() {

--- a/jme3-examples/src/main/java/jme3test/bullet/shape/TestGimpactShape.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/shape/TestGimpactShape.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2009-2019 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package jme3test.bullet.shape;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.bullet.BulletAppState;
+import com.jme3.bullet.PhysicsSpace;
+import com.jme3.bullet.collision.shapes.GImpactCollisionShape;
+import com.jme3.bullet.control.RigidBodyControl;
+import com.jme3.bullet.debug.BulletDebugAppState;
+import com.jme3.font.BitmapFont;
+import com.jme3.font.BitmapText;
+import com.jme3.light.DirectionalLight;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.FastMath;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Mesh;
+import com.jme3.scene.Node;
+import com.jme3.scene.Spatial;
+import com.jme3.scene.shape.Box;
+import com.jme3.scene.shape.Cylinder;
+import com.jme3.scene.shape.Sphere;
+import java.util.ArrayList;
+import java.util.List;
+import jme3test.bullet.PhysicsTestHelper;
+
+/**
+ * 1st Test: 10 solver iterations, large pot<br>
+ * 2nd Test: 20 solver iterations, large pot<br>
+ * 3rd Test: 30 solver iterations, large pot<br>
+ * 4th Test: 10 solver iterations, small pot<br>
+ * 5th Test: 20 solver iterations, small pot<br>
+ * 6th Test: 30 solver iterations, small pot
+ *
+ * @author lou
+ */
+public class TestGimpactShape extends SimpleApplication {
+
+    private BulletAppState bulletAppState;
+    private final boolean physicsDebug = true;
+    private int solverNumIterations = 10;
+    protected BitmapFont font;
+    protected BitmapText timeElapsedTxt;
+    protected BitmapText solverNumIterationsTxt;
+    private final List<Spatial> testObjects = new ArrayList<>();
+    private float testTimer = 0;
+    private final float TIME_PER_TEST = 10;
+    private float teapotScale = 1;
+
+    public static void main(String[] args) {
+        TestGimpactShape a = new TestGimpactShape();
+        a.start();
+    }
+
+    @Override
+    public void simpleInitApp() {
+        getCamera().setLocation(new Vector3f(0, 10, 25));
+        getCamera().lookAt(new Vector3f(0, -5, 0), Vector3f.UNIT_Y);
+        getFlyByCamera().setMoveSpeed(25);
+
+        DirectionalLight dl = new DirectionalLight();
+        dl.setDirection(new Vector3f(-1, -1, -1).normalizeLocal());
+        dl.setColor(ColorRGBA.Green);
+        rootNode.addLight(dl);
+
+        guiNode = getGuiNode();
+        font = assetManager.loadFont("Interface/Fonts/Default.fnt");
+        timeElapsedTxt = new BitmapText(font, false);
+        solverNumIterationsTxt = new BitmapText(font, false);
+        float lineHeight = timeElapsedTxt.getLineHeight();
+
+        timeElapsedTxt.setLocalTranslation(202, lineHeight * 1, 0);
+        guiNode.attachChild(timeElapsedTxt);
+        solverNumIterationsTxt.setLocalTranslation(202, lineHeight * 2, 0);
+        guiNode.attachChild(solverNumIterationsTxt);
+
+        init();
+    }
+
+    private void init() {
+        solverNumIterationsTxt.setText("Solver Iterations: " + solverNumIterations);
+
+        bulletAppState = new BulletAppState();
+        bulletAppState.setDebugEnabled(physicsDebug);
+        stateManager.attach(bulletAppState);
+        bulletAppState.getPhysicsSpace().setSolverNumIterations(solverNumIterations);
+
+        //Left side test - GImpact objects collide with MeshCollisionShape floor
+        dropTest(-5, 2, 0);
+        dropTest2(-11, 7, 3);
+
+        Geometry leftFloor = PhysicsTestHelper.createMeshTestFloor(assetManager, 20, new Vector3f(-21, -5, -10));
+        addObject(leftFloor);
+
+        //Right side test - GImpact objects collide with GImpact floor
+        dropTest(10, 2, 0);
+        dropTest2(9, 7, 3);
+
+        Geometry rightFloor = PhysicsTestHelper.createGImpactTestFloor(assetManager, 20, new Vector3f(0, -5, -10));
+        addObject(rightFloor);
+
+        //Hide physics debug visualization for floors
+        if (physicsDebug) {
+            BulletDebugAppState bulletDebugAppState = stateManager.getState(BulletDebugAppState.class);
+            bulletDebugAppState.setFilter((Object obj) -> {
+                return !(obj.equals(rightFloor.getControl(RigidBodyControl.class))
+                    || obj.equals(leftFloor.getControl(RigidBodyControl.class)));
+            });
+        }
+    }
+
+    private void addObject(Spatial s) {
+        testObjects.add(s);
+        rootNode.attachChild(s);
+        physicsSpace().add(s);
+    }
+
+    private void dropTest(float x, float y, float z) {
+        Vector3f offset = new Vector3f(x, y, z);
+        attachTestObject(new Sphere(16, 16, 0.5f), new Vector3f(-4f, 2f, 2f).add(offset), 1);
+        attachTestObject(new Sphere(16, 16, 0.5f), new Vector3f(-5f, 2f, 0f).add(offset), 1);
+        attachTestObject(new Sphere(16, 16, 0.5f), new Vector3f(-6f, 2f, -2f).add(offset), 1);
+        attachTestObject(new Box(0.5f, 0.5f, 0.5f), new Vector3f(-8f, 2f, -1f).add(offset), 10);
+        attachTestObject(new Box(0.5f, 0.5f, 0.5f), new Vector3f(0f, 2f, -6f).add(offset), 10);
+        attachTestObject(new Box(0.5f, 0.5f, 0.5f), new Vector3f(0f, 2f, -3f).add(offset), 10);
+        attachTestObject(new Cylinder(2, 16, 0.2f, 2f), new Vector3f(0f, 2f, -5f).add(offset), 2);
+        attachTestObject(new Cylinder(2, 16, 0.2f, 2f), new Vector3f(-1f, 2f, -5f).add(offset), 2);
+        attachTestObject(new Cylinder(2, 16, 0.2f, 2f), new Vector3f(-2f, 2f, -5f).add(offset), 2);
+        attachTestObject(new Cylinder(2, 16, 0.2f, 2f), new Vector3f(-3f, 2f, -5f).add(offset), 2);
+    }
+
+    private void dropTest2(float x, float y, float z) {
+        Node n = (Node) assetManager.loadModel("Models/Teapot/Teapot.mesh.xml");
+        n.setLocalTranslation(x, y, z);
+        n.rotate(0, 0, -FastMath.HALF_PI);
+        n.scale(teapotScale);
+
+        Geometry tp = ((Geometry) n.getChild(0));
+        Material mat = new Material(assetManager, "Common/MatDefs/Light/Lighting.j3md");
+        tp.setMaterial(mat);
+
+        Mesh mesh = tp.getMesh();
+        GImpactCollisionShape shape = new GImpactCollisionShape(mesh);
+        shape.setScale(new Vector3f(teapotScale, teapotScale, teapotScale));
+
+        RigidBodyControl control = new RigidBodyControl(shape, 2);
+        n.addControl(control);
+        addObject(n);
+    }
+
+    private void attachTestObject(Mesh mesh, Vector3f position, float mass) {
+        Material material = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+        material.setTexture("ColorMap", assetManager.loadTexture("Interface/Logo/Monkey.jpg"));
+        Geometry g = new Geometry("mesh", mesh);
+        g.setLocalTranslation(position);
+        g.setMaterial(material);
+
+        RigidBodyControl control = new RigidBodyControl(new GImpactCollisionShape(mesh), mass);
+        g.addControl(control);
+        addObject(g);
+    }
+
+    private PhysicsSpace physicsSpace() {
+        return bulletAppState.getPhysicsSpace();
+    }
+
+    @Override
+    public void simpleUpdate(float tpf) {
+        testTimer += tpf;
+
+        if (testTimer / TIME_PER_TEST > 1) {
+            testTimer = 0;
+            switch (solverNumIterations) {
+                case 10:
+                    solverNumIterations = 20;
+                    cleanup();
+                    init();
+                    break;
+                case 20:
+                    solverNumIterations = 30;
+                    cleanup();
+                    init();
+                    break;
+                case 30:
+                    solverNumIterations = 10;
+                    teapotScale = teapotScale > 0.9f ? 0.5f : 1;
+                    cleanup();
+                    init();
+                    break;
+            }
+        }
+        timeElapsedTxt.setText("Time Elapsed: " + testTimer);
+    }
+
+    private void cleanup() {
+        stateManager.detach(bulletAppState);
+        stateManager.detach(stateManager.getState(BulletDebugAppState.class));
+        for (Spatial s : testObjects) {
+            rootNode.detachChild(s);
+        }
+    }
+}

--- a/jme3-examples/src/main/java/jme3test/bullet/shape/TestGimpactShape.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/shape/TestGimpactShape.java
@@ -69,12 +69,11 @@ public class TestGimpactShape extends SimpleApplication {
     private BulletAppState bulletAppState;
     private int solverNumIterations = 10;
     private BitmapFont font;
-    private BitmapText testInfo;
+    private final BitmapText[] testInfo = new BitmapText[2];
     private BitmapText timeElapsedTxt;
     private BitmapText solverNumIterationsTxt;
     private BitmapText testScale;
     private final List<Spatial> testObjects = new ArrayList<>();
-    private final float TIME_PER_TEST = 20;
     private float testTimer = 0;
     private float scaleMod = 1;
     private boolean restart = true;
@@ -99,15 +98,20 @@ public class TestGimpactShape extends SimpleApplication {
 
         guiNode = getGuiNode();
         font = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        testInfo = new BitmapText(font);
+        testInfo[0] = new BitmapText(font);
+        testInfo[1] = new BitmapText(font);
         timeElapsedTxt = new BitmapText(font);
         solverNumIterationsTxt = new BitmapText(font);
         testScale = new BitmapText(font);
 
-        float lineHeight = testInfo.getLineHeight();
-        testInfo.setText("Camera move keys:W/A/S/D/Q/Z      Solver iterations: 1=10, 2=20, 3=30      Inc/Dec object scale: +-");
-        testInfo.setLocalTranslation(10, test.settings.getHeight(), 0);
-        guiNode.attachChild(testInfo);
+        float lineHeight = testInfo[0].getLineHeight();
+        testInfo[0].setText("Camera move:W/A/S/D/Q/Z   Solver iterations: 1=10, 2=20, 3=30");
+        testInfo[0].setLocalTranslation(5, test.settings.getHeight(), 0);
+        guiNode.attachChild(testInfo[0]);
+        testInfo[1].setText("P: Toggle pause   Increase/Decrease object scale: +, -");
+        testInfo[1].setLocalTranslation(5, test.settings.getHeight() - lineHeight, 0);
+        guiNode.attachChild(testInfo[1]);
+
         timeElapsedTxt.setLocalTranslation(202, lineHeight * 1, 0);
         guiNode.attachChild(timeElapsedTxt);
         solverNumIterationsTxt.setLocalTranslation(202, lineHeight * 2, 0);
@@ -115,15 +119,24 @@ public class TestGimpactShape extends SimpleApplication {
         testScale.setLocalTranslation(202, lineHeight * 3, 0);
         guiNode.attachChild(testScale);
 
-        inputManager.addMapping("next", new KeyTrigger(KeyInput.KEY_SPACE));
+        inputManager.addMapping("restart", new KeyTrigger(KeyInput.KEY_SPACE));
         inputManager.addListener((ActionListener) (String name, boolean isPressed, float tpf) -> {
             restart = true;
-        }, "next");
+        }, "restart");
+        
+        inputManager.addMapping("pause", new KeyTrigger(KeyInput.KEY_P));
+        inputManager.addListener((ActionListener) (String name, boolean isPressed, float tpf) -> {
+            if (!isPressed) {
+                return;
+            }
+            bulletAppState.setSpeed(bulletAppState.getSpeed() > 0.1 ? 0 : 1);
+        }, "pause");
+        
         inputManager.addMapping("1", new KeyTrigger(KeyInput.KEY_1));
         inputManager.addMapping("2", new KeyTrigger(KeyInput.KEY_2));
         inputManager.addMapping("3", new KeyTrigger(KeyInput.KEY_3));
-        inputManager.addMapping("+", new KeyTrigger(KeyInput.KEY_ADD));
-        inputManager.addMapping("-", new KeyTrigger(KeyInput.KEY_SUBTRACT));
+        inputManager.addMapping("+", new KeyTrigger(KeyInput.KEY_ADD), new KeyTrigger(KeyInput.KEY_EQUALS));
+        inputManager.addMapping("-", new KeyTrigger(KeyInput.KEY_SUBTRACT), new KeyTrigger(KeyInput.KEY_MINUS));
         inputManager.addListener((ActionListener) (String name, boolean isPressed, float tpf) -> {
             switch (name) {
                 case "1":
@@ -274,13 +287,6 @@ public class TestGimpactShape extends SimpleApplication {
     @Override
     public void simpleUpdate(float tpf) {
         testTimer += tpf;
-
-        if (testTimer / TIME_PER_TEST > 1) {
-            restart = true;
-
-            solverNumIterations += 10;
-            solverNumIterations = solverNumIterations > 30 ? 10 : solverNumIterations;
-        }
 
         if (restart) {
             cleanup();


### PR DESCRIPTION
As requested, here's a physics test using GImpactShapes. For the left side "floor" I used a MeshCollisionShape, the right side is a GImpactCollisionShape. All the dropping objects are GImpact. 

What's interesting is how different the floors behave. The mesh shape sometimes allows objects to fall through. For me it's _always_ on the 1st, 2nd, and 5th tests, and it's always the same objects at the same places. The GImpact floor never drops anything, and things seem to settle a little better. :neutral_face: 

It's actually 6 slightly different tests which repeat: 
 * 1st Test: 10 solver iterations, large pot
 * 2nd Test: 20 solver iterations, large pot
 * 3rd Test: 30 solver iterations, large pot
 * 4th Test: 10 solver iterations, small pot
 * 5th Test: 20 solver iterations, small pot
 * 6th Test: 30 solver iterations, small pot

I may add some additional documentation & description later but this should be enough for feedback and such now. Planning to follow up with more tests like this as time allows (open to suggestions also).