### PR TITLE
Fix forced colorspace in matdefs working only once.

### DIFF
--- a/jme3-core/src/main/java/com/jme3/material/Material.java
+++ b/jme3-core/src/main/java/com/jme3/material/Material.java
@@ -539,6 +539,7 @@ public class Material implements CloneableSmartAsset, Cloneable, Savable {
             checkTextureParamColorSpace(name, value);
             paramValues.put(name, new MatParamTexture(type, name, value, value.getImage() != null ? value.getImage().getColorSpace() : null));
         } else {
+            checkTextureParamColorSpace(name, value);
             val.setTextureValue(value);
             val.setColorSpace(value.getImage() != null ? value.getImage().getColorSpace() : null);
         }

--- a/jme3-core/src/test/java/com/jme3/material/MaterialTest.java
+++ b/jme3-core/src/test/java/com/jme3/material/MaterialTest.java
@@ -36,8 +36,15 @@ import com.jme3.renderer.Caps;
 import com.jme3.renderer.RenderManager;
 import com.jme3.scene.Geometry;
 import com.jme3.scene.shape.Box;
+import com.jme3.shader.VarType;
 import com.jme3.system.NullRenderer;
 import com.jme3.system.TestUtil;
+import com.jme3.texture.Image;
+import com.jme3.texture.Texture2D;
+import com.jme3.texture.Image.Format;
+import com.jme3.texture.image.ColorSpace;
+import com.jme3.util.BufferUtils;
+
 import java.util.Arrays;
 import java.util.EnumSet;
 import static org.junit.Assert.*;
@@ -118,6 +125,30 @@ public class MaterialTest {
         material.selectTechnique("PostShadow", renderManager);
 
         checkRequiredCaps(Caps.GLSL150);
+    }
+
+    @Test
+    public void testForcedColorSpace(){
+       
+        Image img=new Image(Format.RGBA8,2,2,BufferUtils.createByteBuffer(16),null,ColorSpace.sRGB);
+        Image img2=new Image(Format.RGBA8,2,2,BufferUtils.createByteBuffer(16),null,ColorSpace.sRGB);
+        Texture2D tx=new Texture2D(img);
+        Texture2D tx2=new Texture2D(img2);
+
+        assertTrue(tx2.getImage().getColorSpace()==ColorSpace.sRGB);
+        assertTrue(tx2.getImage().getColorSpace()==ColorSpace.sRGB);
+
+        AssetManager assetManager = TestUtil.createAssetManager();
+        MaterialDef def=new MaterialDef(assetManager,"test");
+        def.addMaterialParamTexture(VarType.Texture2D, "ColorMap",ColorSpace.Linear, null);
+        Material mat=new Material(def);
+        
+        mat.setTexture("ColorMap",tx);          
+        assertTrue(tx.getImage().getColorSpace()==ColorSpace.Linear);
+        
+        mat.setTexture("ColorMap",tx2);  
+        assertTrue(tx2.getImage().getColorSpace()==ColorSpace.Linear);       
+    
     }
 
     @Test


### PR DESCRIPTION
When you have forced colorspace (-LINEAR) in the matdef and you set a texture param, it will work as expected, but if the value of the matparam is replaced with a different texture, the code that takes care of the colorspace switching will be skipped all together.

The unit test shows the issue in detail.
