### PR TITLE
jme-core: IndexBuffer fixes & API improvements

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/mesh/IndexBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/mesh/IndexBuffer.java
@@ -31,11 +31,13 @@
  */
 package com.jme3.scene.mesh;
 
-import com.jme3.util.BufferUtils;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
+
+import com.jme3.scene.VertexBuffer.Format;
+import com.jme3.util.BufferUtils;
 
 /**
  * <code>IndexBuffer</code> is an abstraction for integer index buffers,
@@ -59,21 +61,22 @@ public abstract class IndexBuffer {
     }
     
     /**
-     * Creates an index buffer that can contain the given amount
-     * of vertices.
-     * Returns {@link IndexShortBuffer}
+     * Creates an index buffer that can contain the given amount of vertices. 
+     * <br/>
+     * Returns either {@link IndexByteBuffer}, {@link IndexShortBuffer} or 
+     * {@link IndexIntBuffer}
      * 
      * @param vertexCount The amount of vertices to contain
-     * @param indexCount The amount of indices
-     * to contain.
-     * @return A new index buffer
+     * @param indexCount The amount of indices to contain
+     * @return A new, apropriately sized index buffer
      */
     public static IndexBuffer createIndexBuffer(int vertexCount, int indexCount){
-        if (vertexCount > 65535){
-            return new IndexIntBuffer(BufferUtils.createIntBuffer(indexCount));
-        }else{
+        if (vertexCount < 128)
+            return new IndexByteBuffer(BufferUtils.createByteBuffer (indexCount));
+        else if (vertexCount < 65536)
             return new IndexShortBuffer(BufferUtils.createShortBuffer(indexCount));
-        }
+        else
+            return new IndexIntBuffer(BufferUtils.createIntBuffer(indexCount));
     }
 
     /**
@@ -107,12 +110,31 @@ public abstract class IndexBuffer {
     public abstract int get(int i);
     
     /**
-     * Puts the vertex index at the index buffer's index.
+     * Absolute put method.
+     * 
+     * <p>Puts the vertex index at the index buffer's index.
      * Implementations may throw an {@link UnsupportedOperationException}
      * if modifying the IndexBuffer is not supported (e.g. virtual index
-     * buffers).
+     * buffers).</p>
+     * 
+     * @param i The buffer index
+     * @param value The vertex index
+     * @return This buffer
      */
-    public abstract void put(int i, int value);
+    public abstract IndexBuffer put(int i, int value);
+    
+    /**
+     * Relative put method.
+     * 
+     * <p>Puts the vertex index at the current position, then increments the
+     * position. Implementations may throw an 
+     * {@link UnsupportedOperationException} if modifying the IndexBuffer is not
+     * supported (e.g. virtual index buffers).</p>
+     * 
+     * @param value The vertex index
+     * @return This buffer
+     */
+    public abstract IndexBuffer put(int value);
     
     /**
      * Returns the size of the index buffer.
@@ -129,4 +151,17 @@ public abstract class IndexBuffer {
      * @return the underlying {@link Buffer}.
      */
     public abstract Buffer getBuffer();
+    
+    /**
+     * Returns the format of the data stored in this buffer.
+     * 
+     * <p>This method can be used to set an {@link IndexBuffer} to a 
+     * {@link com.jme3.scene.Mesh Mesh}:</p>
+     * <pre>
+     * mesh.setBuffer(Type.Index, 3, 
+     *     indexBuffer.getFormat(), indexBuffer);
+     * </pre>
+     * @return
+     */
+    public abstract Format getFormat();
 }

--- a/jme3-core/src/main/java/com/jme3/scene/mesh/IndexByteBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/mesh/IndexByteBuffer.java
@@ -34,6 +34,8 @@ package com.jme3.scene.mesh;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
+import com.jme3.scene.VertexBuffer.Format;
+
 /**
  * IndexBuffer implementation for {@link ByteBuffer}s.
  * 
@@ -59,8 +61,15 @@ public class IndexByteBuffer extends IndexBuffer {
     }
 
     @Override
-    public void put(int i, int value) {
+    public IndexByteBuffer put(int i, int value) {
         buf.put(i, (byte) value);
+        return this;
+    }
+    
+    @Override
+    public IndexByteBuffer put(int value) {
+        buf.put((byte) value);
+        return this;
     }
 
     @Override
@@ -71,6 +80,11 @@ public class IndexByteBuffer extends IndexBuffer {
     @Override
     public Buffer getBuffer() {
         return buf;
+    }
+    
+    @Override
+    public Format getFormat () {
+        return Format.UnsignedByte;
     }
 
 }

--- a/jme3-core/src/main/java/com/jme3/scene/mesh/IndexIntBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/mesh/IndexIntBuffer.java
@@ -34,6 +34,8 @@ package com.jme3.scene.mesh;
 import java.nio.Buffer;
 import java.nio.IntBuffer;
 
+import com.jme3.scene.VertexBuffer.Format;
+
 /**
  * IndexBuffer implementation for {@link IntBuffer}s.
  * 
@@ -58,8 +60,15 @@ public class IndexIntBuffer extends IndexBuffer {
     }
 
     @Override
-    public void put(int i, int value) {
+    public IndexIntBuffer put(int i, int value) {
         buf.put(i, value);
+        return this;
+    }
+    
+    @Override
+    public IndexIntBuffer put(int value) {
+        buf.put(value);
+        return this;
     }
 
     @Override
@@ -70,5 +79,10 @@ public class IndexIntBuffer extends IndexBuffer {
     @Override
     public Buffer getBuffer() {
         return buf;
+    }
+    
+    @Override
+    public Format getFormat () {
+        return Format.UnsignedInt;
     }
 }

--- a/jme3-core/src/main/java/com/jme3/scene/mesh/IndexShortBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/mesh/IndexShortBuffer.java
@@ -34,6 +34,8 @@ package com.jme3.scene.mesh;
 import java.nio.Buffer;
 import java.nio.ShortBuffer;
 
+import com.jme3.scene.VertexBuffer.Format;
+
 /**
  * IndexBuffer implementation for {@link ShortBuffer}s.
  * 
@@ -58,8 +60,15 @@ public class IndexShortBuffer extends IndexBuffer {
     }
 
     @Override
-    public void put(int i, int value) {
+    public IndexShortBuffer put(int i, int value) {
         buf.put(i, (short) value);
+        return this;
+    }
+    
+    @Override
+    public IndexShortBuffer put(int value) {
+        buf.put((short) value);
+        return this;
     }
 
     @Override
@@ -70,5 +79,10 @@ public class IndexShortBuffer extends IndexBuffer {
     @Override
     public Buffer getBuffer() {
         return buf;
+    }
+    
+    @Override
+    public Format getFormat () {
+        return Format.UnsignedShort;
     }
 }

--- a/jme3-core/src/main/java/com/jme3/scene/mesh/VirtualIndexBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/mesh/VirtualIndexBuffer.java
@@ -32,6 +32,8 @@
 package com.jme3.scene.mesh;
 
 import com.jme3.scene.Mesh.Mode;
+import com.jme3.scene.VertexBuffer.Format;
+
 import java.nio.Buffer;
 
 /**
@@ -138,7 +140,7 @@ public class VirtualIndexBuffer extends IndexBuffer {
     }
 
     @Override
-    public void put(int i, int value) {
+    public IndexBuffer put(int i, int value) {
         throw new UnsupportedOperationException("Does not represent index buffer");
     }
 
@@ -151,5 +153,16 @@ public class VirtualIndexBuffer extends IndexBuffer {
     public Buffer getBuffer() {
         return null;
     }
+
+	@Override
+	public IndexBuffer put (int value) {
+		throw new UnsupportedOperationException("Does not represent index buffer");
+	}
+
+	@Override
+	public Format getFormat () {
+		// return largest size
+		return Format.UnsignedInt;
+	}
 
 }

--- a/jme3-core/src/main/java/com/jme3/scene/mesh/WrappedIndexBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/mesh/WrappedIndexBuffer.java
@@ -107,11 +107,7 @@ public class WrappedIndexBuffer extends VirtualIndexBuffer {
             default:
                 break;
         }
-        if (outBuf instanceof IndexIntBuffer){
-            mesh.setBuffer(Type.Index, 3, (IntBuffer)outBuf.getBuffer());
-        }else{
-            mesh.setBuffer(Type.Index, 3, (ShortBuffer)outBuf.getBuffer());
-        }
+        mesh.setBuffer(Type.Index, 3, outBuf.getFormat(), outBuf.getBuffer());
     }
     
 }


### PR DESCRIPTION
As discussed in:
https://hub.jmonkeyengine.org/t/indexbuffer-suggestions-improvements-consistency/42022/4

* [Fix] createIndexBuffer(int, int): return IndexByteBuffer as well for
	vertexCount < 128
* [Enhancement] Make put(int i, int value) fluid interface
* [Enhancement] Add relative put(int i) to allow easier chaining (parity
	with other buffer implementations)
* [Enhancement] Add getFormat() to allow setting an IndexBuffer to a
	Mesh directly without type inspection.
* [Fix] Fix WrappedIndexBuffer
	API changes make it possible that IndexByteBuffer is now a valid  type
for outBuf, leverage the new getFormat() method to set the buffer to the
mesh regardless of its type.