### PR TITLE
Update the link of the "Lightspeed Frontier".

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The engine is used by several commercial game studios and computer-science cours
  - [PirateHell](http://www.desura.com/games/piratehell)
  - [3089 (on steam)](http://store.steampowered.com/app/263360/)
  - [3079 (on steam)](http://store.steampowered.com/app/259620/)
- - [Lightspeed Frontier](http://www.lightspeedfrontier.com/)
+ - [Lightspeed Frontier](https://store.steampowered.com/app/548650/Lightspeed_Frontier/)
  - [Skullstone](http://www.skullstonegame.com/)
  - [Spoxel](https://store.steampowered.com/app/746880/Spoxel/)
 


### PR DESCRIPTION
The old link leads to the site for adults.