### PR TITLE
Some fixes in jme-vr

### DIFF
--- a/jme3-vr/build.gradle
+++ b/jme3-vr/build.gradle
@@ -2,7 +2,7 @@ if (!hasProperty('mainClass')) {
     ext.mainClass = ''
 }
 
-def lwjglVersion = '3.2.0'
+def lwjglVersion = '3.2.1'
 
 sourceCompatibility = '1.8'
 

--- a/jme3-vr/src/main/java/com/jme3/app/VREnvironment.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VREnvironment.java
@@ -433,9 +433,14 @@ public class VREnvironment {
         // we are going to use OpenVR now, not the Oculus Rift
         // OpenVR does support the Rift
         String OS     = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
-        vrSupportedOS = !OS.contains("nux") && System.getProperty("sun.arch.data.model").equalsIgnoreCase("64"); //for the moment, linux/unix causes crashes, 64-bit only
-        compositorOS  = OS.contains("indows");
-        
+        vrSupportedOS = System.getProperty("sun.arch.data.model").equalsIgnoreCase("64"); //64-bit only
+        compositorOS  = OS.contains("indows") || OS.contains("nux");
+
+        if (OS.contains("nux") && vrBinding != VRConstants.SETTING_VRAPI_OPENVR_LWJGL_VALUE){
+        	logger.severe("Only LWJGL VR backend is currently (partially) supported on Linux.");
+        	vrSupportedOS = false;
+        }
+
         if( vrSupportedOS) {
         	if( vrBinding == VRConstants.SETTING_VRAPI_OSVR_VALUE ) {
         		

--- a/jme3-vr/src/main/java/com/jme3/input/vr/HmdType.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/HmdType.java
@@ -13,7 +13,7 @@ public enum HmdType {
     HTC_VIVE,
 
     /**
-     * <a href="">Valve Index</a> Head Mounted Device (HMD).
+     * <a href="https://www.valvesoftware.com/en/index">Valve Index</a> Head Mounted Device (HMD).
      */
     VALVE_INDEX,
 

--- a/jme3-vr/src/main/java/com/jme3/input/vr/HmdType.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/HmdType.java
@@ -10,8 +10,13 @@ public enum HmdType {
 	/**
 	 * <a href="https://www.vive.com/fr/">HTC vive</a> Head Mounted Device (HMD).
 	 */
-    HTC_VIVE, 
-    
+    HTC_VIVE,
+
+    /**
+     * <a href="">Valve Index</a> Head Mounted Device (HMD).
+     */
+    VALVE_INDEX,
+
     /**
      * <a href="https://www3.oculus.com/en-us/rift/">Occulus Rift</a> Head Mounted Device (HMD).
      */

--- a/jme3-vr/src/main/java/com/jme3/input/vr/lwjgl_openvr/LWJGLOpenVR.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/lwjgl_openvr/LWJGLOpenVR.java
@@ -421,6 +421,8 @@ public class LWJGLOpenVR implements VRAPI {
                 completeName = completeName.toLowerCase(Locale.ENGLISH).trim();
                 if( completeName.contains("htc") || completeName.contains("vive") ) {
                     return HmdType.HTC_VIVE;
+                } else if ( completeName.contains("index") ) {
+                    return HmdType.VALVE_INDEX;
                 } else if( completeName.contains("osvr") ) {
                     return HmdType.OSVR;
                 } else if( completeName.contains("oculus") || completeName.contains("rift") ||

--- a/jme3-vr/src/main/java/com/jme3/input/vr/openvr/OpenVR.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/openvr/OpenVR.java
@@ -556,6 +556,8 @@ public class OpenVR implements VRAPI {
                 completeName = completeName.toLowerCase(Locale.ENGLISH).trim();
                 if( completeName.contains("htc") || completeName.contains("vive") ) {
                     return HmdType.HTC_VIVE;
+                } else if ( completeName.contains("index") ) {
+                    return HmdType.VALVE_INDEX;
                 } else if( completeName.contains("osvr") ) {
                     return HmdType.OSVR;
                 } else if( completeName.contains("oculus") || completeName.contains("rift") ||


### PR DESCRIPTION
This PR:

- Adds Valve Index to the list of recognized HMDs
- Brings the overall lwjgl version of the jme-vr module up to speed with the rest of the engine. This fixes OpenVR lwjgl backend.
- Removes Linux from the list of blacklisted OSes when lwjgl backend is used. In my testing, I got a picture inside the HMD on Linux, but it's cropped to be only the top half of the rendered view for some reason. Debugging this issue led me to believe that the version of OpenVR lwjgl 3.2.1 ships with is bugged on Linux, so this is unlikely to be fixed until we update lwjgl. On Windows it works fine.

_Also, is it just me or does git really think I deleted the whole files and then created them again?_