### PR TITLE
Add .glsl extension to be used as a replacement for glsllib. 

### DIFF
--- a/jme3-core/src/plugins/java/com/jme3/shader/plugins/GLSLLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/shader/plugins/GLSLLoader.java
@@ -191,7 +191,7 @@ public class GLSLLoader implements AssetLoader {
         if (info.getKey() instanceof ShaderAssetKey) {
             injectDependencies = ((ShaderAssetKey) info.getKey()).isInjectDependencies();
         }
-        if (info.getKey().getExtension().equals("glsllib")) {
+        if (info.getKey().getExtension().equals("glsllib")||info.getKey().getExtension().equals("glsl")) {
             // NOTE: Loopback, GLSLLIB is loaded by this loader
             // and needs data as InputStream
             return reader;

--- a/jme3-core/src/test/java/com/jme3/asset/LoadShaderSourceTest.java
+++ b/jme3-core/src/test/java/com/jme3/asset/LoadShaderSourceTest.java
@@ -46,6 +46,7 @@ public class LoadShaderSourceTest {
         assetManager.registerLocator(null, ClasspathLocator.class);
         assetManager.registerLoader(GLSLLoader.class, "frag");
         assetManager.registerLoader(GLSLLoader.class, "glsllib");
+        assetManager.registerLoader(GLSLLoader.class, "glsl");
         String showNormals = (String) assetManager.loadAsset("Common/MatDefs/Misc/ShowNormals.frag");
         System.out.println(showNormals);
     }

--- a/jme3-core/src/tools/java/jme3tools/shadercheck/ShaderCheck.java
+++ b/jme3-core/src/tools/java/jme3tools/shadercheck/ShaderCheck.java
@@ -31,7 +31,7 @@ public class ShaderCheck {
         assetManager.registerLocator("/", ClasspathLocator.class);
         assetManager.registerLoader(J3MLoader.class, "j3m");
         assetManager.registerLoader(J3MLoader.class, "j3md");
-        assetManager.registerLoader(GLSLLoader.class, "vert", "frag","geom","tsctrl","tseval","glsllib");
+        assetManager.registerLoader(GLSLLoader.class, "vert", "frag","geom","tsctrl","tseval","glsllib","glsl");
     }
     
     private static void checkMatDef(String matdefName) {


### PR DESCRIPTION
glsllib is generally not recognized as proper glsl extension by editors.