### PR TITLE
Parallel Builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,3 +39,6 @@ POM_INCEPTION_YEAR=2009
 bintray_user=
 bintray_api_key=
 
+#Speed up builds
+org.gradle.parallel=true
+


### PR DESCRIPTION
This allows for builds to be much faster, I always set this to true on my local builds when working with jmonkey. 

I do not see a reason to not enable parallel builds. Any thoughts?