### PR TITLE
define 2 new Platform values for Linux ARM, register BulletJme lib paths

### DIFF
--- a/jme3-core/src/main/java/com/jme3/system/JmeSystemDelegate.java
+++ b/jme3-core/src/main/java/com/jme3/system/JmeSystemDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -169,8 +169,13 @@ public abstract class JmeSystemDelegate {
         boolean is64 = is64Bit(arch);
         if (os.contains("windows")) {
             return is64 ? Platform.Windows64 : Platform.Windows32;
-        } else if (os.contains("linux") || os.contains("freebsd") || os.contains("sunos")) {
-            return is64 ? Platform.Linux64 : Platform.Linux32;
+        } else if (os.contains("linux") || os.contains("freebsd") 
+                || os.contains("sunos") || os.contains("unix")) {
+            if (arch.startsWith("arm")) {
+                return is64 ? Platform.Linux_ARM64 : Platform.Linux_ARM32;
+            } else {
+                return is64 ? Platform.Linux64 : Platform.Linux32;
+            }
         } else if (os.contains("mac os x") || os.contains("darwin")) {
             if (arch.startsWith("ppc")) {
                 return is64 ? Platform.MacOSX_PPC64 : Platform.MacOSX_PPC32;

--- a/jme3-core/src/main/java/com/jme3/system/Platform.java
+++ b/jme3-core/src/main/java/com/jme3/system/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,22 +44,32 @@ public enum Platform {
     Windows64(true),
     
     /**
-     * Linux 32 bit
+     * Linux 32-bit Intel
      */
     Linux32,
     
     /**
-     * Linux 64 bit
+     * Linux 64-bit Intel
      */
     Linux64(true),
     
     /**
-     * Apple Mac OS X 32 bit
+     * Linux 32-bit ARM
+     */
+    Linux_ARM32,
+    
+    /**
+     * Linux 64-bit ARM
+     */
+    Linux_ARM64(true),
+    
+    /**
+     * Apple Mac OS X 32-bit Intel
      */
     MacOSX32,
     
     /**
-     * Apple Mac OS X 64 bit
+     * Apple Mac OS X 64-bit Intel
      */
     MacOSX64(true),
     

--- a/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -175,6 +175,8 @@ public final class NativeLibraryLoader {
         registerNativeLibrary("bulletjme", Platform.Windows64, "native/windows/x86_64/bulletjme.dll");
         registerNativeLibrary("bulletjme", Platform.Linux32,   "native/linux/x86/libbulletjme.so");
         registerNativeLibrary("bulletjme", Platform.Linux64,   "native/linux/x86_64/libbulletjme.so");
+        registerNativeLibrary("bulletjme", Platform.Linux_ARM32, "native/linux/arm32/libbulletjme.so");
+        registerNativeLibrary("bulletjme", Platform.Linux_ARM64, "native/linux/arm64/libbulletjme.so");
         registerNativeLibrary("bulletjme", Platform.MacOSX32,  "native/osx/x86/libbulletjme.dylib");
         registerNativeLibrary("bulletjme", Platform.MacOSX64,  "native/osx/x86_64/libbulletjme.dylib");
         


### PR DESCRIPTION
Add 2 new values to the `com.jme3.system.Platform` enum (and logic to `com.jme3.system.JmeSystemDelegate`) in order to distinguish Linux-on-ARM platforms. (LWJGL3 already supports such platforms.) Define paths to hypothetical BulletJme native libraries built for such platforms.

This is just a first step toward supporting Linux-on-ARM.