### PR TITLE
Build Bullet for Linux ARM (Raspberry Pi)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,50 +14,48 @@ matrix:
     jdk: oraclejdk8
     dist: trusty
     env: UPLOAD=true UPLOAD_NATIVE=true
-    addons:
-        apt:
-            packages:
-                #- lib32gcc-7-dev
-                #- gcc-7-multilib
-                #- g++-7-multilib
-                #- gcc-7-arm-linux-gnueabihf
-                #- gcc-7-arm-linux-gnueabi
-                #- gcc-8-aarch64-linux-gnu
-                #- g++-7-arm-linux-gnueabihf
-                #- g++-7-arm-linux-gnueabi
-                #- g++-8-aarch64-linux-gnu
-                #- libc6-i386
-                #- libc6-dev-i386
-                #- libstdc++-7-dev-i386
-                #- libstdc++6-i386-cross
-                #- lib32stdc++-7-dev
-                #- libx32stdc++-7-dev
-                #- linux-libc-dev-arm64-cross
-                #- libubsan1-arm64-cross
-                #- libstdc++6-arm64-cross
-                #- libstdc++-8-dev-arm64-cross
-                #- libgcc1-arm64-cross
-                #- libgcc-8-dev-arm64-cross 
-                #- libc6-x32 
-                #- libc6-dev-arm64-cross
-                #- libatomic1-arm64-cross
-                #- libasan5-arm64-cross
-                #- binutils-common:amd64
-                - gcc-multilib
-                - g++-multilib
+    apt:
+        packages:
+            #- lib32gcc-7-dev
+            #- gcc-7-multilib
+            #- g++-7-multilib
+            #- gcc-7-arm-linux-gnueabihf
+            #- gcc-7-arm-linux-gnueabi
+            #- gcc-8-aarch64-linux-gnu
+            #- g++-7-arm-linux-gnueabihf
+            #- g++-7-arm-linux-gnueabi
+            #- g++-8-aarch64-linux-gnu
+            #- libc6-i386
+            #- libc6-dev-i386
+            #- libstdc++-7-dev-i386
+            #- libstdc++6-i386-cross
+            #- lib32stdc++-7-dev
+            #- libx32stdc++-7-dev
+            #- linux-libc-dev-arm64-cross
+            #- libubsan1-arm64-cross
+            #- libstdc++6-arm64-cross
+            #- libstdc++-8-dev-arm64-cross
+            #- libgcc1-arm64-cross
+            #- libgcc-8-dev-arm64-cross 
+            #- libc6-x32 
+            #- libc6-dev-arm64-cross
+            #- libatomic1-arm64-cross
+            #- libasan5-arm64-cross
+            #- binutils-common:amd64
+            - gcc-multilib
+            - g++-multilib
   - os: linux
     jdk: openjdk11
     dist: bionic
     env: UPLOAD=true
-    addons:
-        apt:
-            packages:
-                - gcc-7-arm-linux-gnueabihf
-                - gcc-7-arm-linux-gnueabi
-                - gcc-8-aarch64-linux-gnu
-                - g++-7-arm-linux-gnueabihf
-                - g++-7-arm-linux-gnueabi
-                - g++-8-aarch64-linux-gnu
+    apt:
+        packages:
+            - gcc-7-arm-linux-gnueabihf
+            - gcc-7-arm-linux-gnueabi
+            - gcc-8-aarch64-linux-gnu
+            - g++-7-arm-linux-gnueabihf
+            - g++-7-arm-linux-gnueabi
+            - g++-8-aarch64-linux-gnu
     install:
         - gradle -PbuildNativeProjects=true assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble -xjme3-bullet-native:compileBulletjmeLinux32SharedLibraryBulletjmeCpp -xjme3-bullet-native:compileBulletjmeLinux64SharedLibraryBulletjmeCpp
   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,7 @@ addons:
     - gcc-multilib
     - g++-multilib
     - g++-7-arm-linux-gnueabihf
-    - arm-linux-gnueabi-g++
-    #- gcc-8-aarch64-linux-gnu
+    - g++-7-arm-linux-gnueabi
     - g++-8-aarch64-linux-gnu
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ cache:
     - $HOME/.gradle/wrapper/
 
 install:
-  - '[ -n "$UPLOAD_NATIVE" ] && gradle -PbuildNativeProjects=true jme3-bullet-native:assembleDependentsBulletjmeLinuxArm64SharedLibrary -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble || ./gradlew assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble'
+  - '[ -n "$UPLOAD_NATIVE" ] && gradle -PbuildNativeProjects=true assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble || ./gradlew assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble'
 
 script:
   - ./gradlew check

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
         packages:
             #- gcc-multilib
             #- g++-multilib
+            - lib32gcc-7-dev
             - gcc
             - g++
             - gcc-7-arm-linux-gnueabihf
@@ -71,7 +72,6 @@ install:
   - '[ -n "$UPLOAD_NATIVE" ] && gradle -PbuildNativeProjects=true assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble || ./gradlew assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble'
 
 script:
-  - cat /home/travis/build/MeFisto94/jmonkeyengine/jme3-bullet-native/build/tmp/compileBulletjmeLinux32SharedLibraryBulletjmeCpp/options.txt
   - ./gradlew check
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
   - os: linux
     jdk: oraclejdk8
-    dist: precise
+    dist: bionic
     env: UPLOAD=true UPLOAD_NATIVE=true
   - os: linux
     jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,34 +14,39 @@ matrix:
     jdk: openjdk9
     dist: bionic
     env: UPLOAD=true UPLOAD_NATIVE=true
+    sudo: true
     apt:
         packages:
-            - lib32gcc-7-dev
-            - gcc-7-multilib
-            - g++-7-multilib
-            - gcc-7-arm-linux-gnueabihf
-            - gcc-7-arm-linux-gnueabi
-            - gcc-8-aarch64-linux-gnu
-            - g++-7-arm-linux-gnueabihf
-            - g++-7-arm-linux-gnueabi
-            - g++-8-aarch64-linux-gnu
-            - libc6-i386
-            - libc6-dev-i386
-            - libstdc++-7-dev-i386
-            - libstdc++6-i386-cross
-            - lib32stdc++-7-dev
-            - libx32stdc++-7-dev
-            - linux-libc-dev-arm64-cross
-            - libubsan1-arm64-cross
-            - libstdc++6-arm64-cross
-            - libstdc++-8-dev-arm64-cross
-            - libgcc1-arm64-cross
-            - libgcc-8-dev-arm64-cross 
-            - libc6-x32 
-            - libc6-dev-arm64-cross
-            - libatomic1-arm64-cross
-            - libasan5-arm64-cross
-            - binutils-common:amd64
+            #- lib32gcc-7-dev
+            #- gcc-7-multilib
+            #- g++-7-multilib
+            #- gcc-7-arm-linux-gnueabihf
+            #- gcc-7-arm-linux-gnueabi
+            #- gcc-8-aarch64-linux-gnu
+            #- g++-7-arm-linux-gnueabihf
+            #- g++-7-arm-linux-gnueabi
+            #- g++-8-aarch64-linux-gnu
+            #- libc6-i386
+            #- libc6-dev-i386
+            #- libstdc++-7-dev-i386
+            #- libstdc++6-i386-cross
+            #- lib32stdc++-7-dev
+            #- libx32stdc++-7-dev
+            #- linux-libc-dev-arm64-cross
+            #- libubsan1-arm64-cross
+            #- libstdc++6-arm64-cross
+            #- libstdc++-8-dev-arm64-cross
+            #- libgcc1-arm64-cross
+            #- libgcc-8-dev-arm64-cross 
+            #- libc6-x32 
+            #- libc6-dev-arm64-cross
+            #- libatomic1-arm64-cross
+            #- libasan5-arm64-cross
+            #- binutils-common:amd64
+            - gcc-multilib
+            - g++-multilib
+    before_install:
+        - sudo apt install -y gcc-7-arm-linux-gnueabihf gcc-7-arm-linux-gnueabi gcc-8-aarch64-linux-gnu g++-7-arm-linux-gnueabihf g++-7-arm-linux-gnueabi g++-8-aarch64-linux-gnu
   - os: linux
     jdk: openjdk11
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ cache:
     - $HOME/.gradle/wrapper/
 
 install:
-  - '[ -n "$UPLOAD_NATIVE" ] && gradle -PbuildNativeProjects=true assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble || ./gradlew assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble'
+  - '[ -n "$UPLOAD_NATIVE" ] && ./gradlew -PbuildNativeProjects=true assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble || ./gradlew assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble'
 
 script:
   - ./gradlew check

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,9 @@ addons:
     packages:
     - gcc-multilib
     - g++-multilib
-    # - arm-linux-gnueabi-gcc
-    - gcc-8-aarch64-linux-gnu
+    - g++-7-arm-linux-gnueabihf
+    - arm-linux-gnueabi-g++
+    #- gcc-8-aarch64-linux-gnu
     - g++-8-aarch64-linux-gnu
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,23 @@ matrix:
     jdk: openjdk9
     dist: bionic
     env: UPLOAD=true UPLOAD_NATIVE=true
+    apt:
+        packages:
+            #- gcc-multilib
+            #- g++-multilib
+            - gcc
+            - g++
+            - gcc-7-arm-linux-gnueabihf
+            - gcc-7-arm-linux-gnueabi
+            - gcc-8-aarch64-linux-gnu
+            - g++-7-arm-linux-gnueabihf
+            - g++-7-arm-linux-gnueabi
+            - g++-8-aarch64-linux-gnu
+            - libc6-dev:i386
+            - libstdc++-7-dev:i386
   - os: linux
     jdk: openjdk11
-    dist: xenial
+    dist: bionic
   - os: osx
     osx_image: xcode9.3
     env: UPLOAD_NATIVE=true
@@ -40,19 +54,6 @@ addons:
   hosts:
     - travisci
   hostname: travisci
-  apt:
-    packages:
-    #- gcc-multilib
-    #- g++-multilib
-    - gcc
-    - g++
-    - gcc-7-arm-linux-gnueabihf
-    - gcc-7-arm-linux-gnueabi
-    - gcc-8-aarch64-linux-gnu
-    - g++-7-arm-linux-gnueabihf
-    - g++-7-arm-linux-gnueabi
-    - g++-8-aarch64-linux-gnu
-    - 
 
 before_install:
   - '[ -n "$UPLOAD" ] && git fetch --unshallow || :'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ branches:
 matrix:
   include:
   - os: linux
-    jdk: openjdk8
-    dist: trusty
+    jdk: oraclejdk8
+    dist: precise
     env: UPLOAD=true
   - os: linux
     jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
   - os: linux
     jdk: openjdk8
-    dist: bionic
+    dist: xenial
     env: UPLOAD=true UPLOAD_NATIVE=true
   - os: linux
     jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ cache:
 
 install:
   - '[ -n "$UPLOAD_NATIVE" ] && gradle -PbuildNativeProjects=true assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble || ./gradlew assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble'
+  - cat /home/travis/build/MeFisto94/jmonkeyengine/jme3-bullet-native/build/tmp/compileBulletjmeLinux32SharedLibraryBulletjmeCpp/options.txt
 
 script:
   - ./gradlew check

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ addons:
     packages:
     - gcc-multilib
     - g++-multilib
+    - gcc-7-arm-linux-gnueabihf
+    - gcc-7-arm-linux-gnueabi
+    - gcc-8-aarch64-linux-gnu
     - g++-7-arm-linux-gnueabihf
     - g++-7-arm-linux-gnueabi
     - g++-8-aarch64-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,17 @@ matrix:
             - libstdc++6-i386-cross
             - lib32stdc++-7-dev
             - libx32stdc++-7-dev
+            - linux-libc-dev-arm64-cross
+            - libubsan1-arm64-cross
+            - libstdc++6-arm64-cross
+            - libstdc++-8-dev-arm64-cross
+            - libgcc1-arm64-cross
+            - libgcc-8-dev-arm64-cross 
+            - libc6-x32 
+            - libc6-dev-arm64-cross
+            - libatomic1-arm64-cross
+            - libasan5-arm64-cross
+            - binutils-common:amd64
   - os: linux
     jdk: openjdk11
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ branches:
 matrix:
   include:
   - os: linux
-    jdk: oraclejdk8
+    jdk: openjdk8
     dist: bionic
     env: UPLOAD=true UPLOAD_NATIVE=true
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ matrix:
             - libc6-i386
             - libc6-dev-i386
             - libstdc++-7-dev-i386
+            - libstdc++6-i386-cross
+            - lib32stdc++-7-dev
+            - libx32stdc++-7-dev
   - os: linux
     jdk: openjdk11
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,47 +11,21 @@ branches:
 matrix:
   include:
   - os: linux
-    jdk: openjdk9
+    jdk: openjdk8
+    dist: trusty
+    env: UPLOAD=true
+  - os: linux
+    jdk: openjdk11
     dist: bionic
     env: UPLOAD=true UPLOAD_NATIVE=true
     sudo: true
     addons:
         apt:
             packages:
-                #- lib32gcc-7-dev
-                #- gcc-7-multilib
-                #- g++-7-multilib
-                #- gcc-7-arm-linux-gnueabihf
-                #- gcc-7-arm-linux-gnueabi
-                #- gcc-8-aarch64-linux-gnu
-                #- g++-7-arm-linux-gnueabihf
-                #- g++-7-arm-linux-gnueabi
-                #- g++-8-aarch64-linux-gnu
-                #- libc6-i386
-                #- libc6-dev-i386
-                #- libstdc++-7-dev-i386
-                #- libstdc++6-i386-cross
-                #- lib32stdc++-7-dev
-                #- libx32stdc++-7-dev
-                #- linux-libc-dev-arm64-cross
-                #- libubsan1-arm64-cross
-                #- libstdc++6-arm64-cross
-                #- libstdc++-8-dev-arm64-cross
-                #- libgcc1-arm64-cross
-                #- libgcc-8-dev-arm64-cross 
-                #- libc6-x32 
-                #- libc6-dev-arm64-cross
-                #- libatomic1-arm64-cross
-                #- libasan5-arm64-cross
-                #- binutils-common:amd64
-                #- openjdk-11-jdk
                 - gcc-multilib
                 - g++-multilib
     before_install:
         - sudo apt update && sudo apt install -fy gcc-7-arm-linux-gnueabihf gcc-7-arm-linux-gnueabi gcc-8-aarch64-linux-gnu g++-7-arm-linux-gnueabihf g++-7-arm-linux-gnueabi g++-8-aarch64-linux-gnu
-  - os: linux
-    jdk: openjdk11
-    dist: bionic
   - os: osx
     osx_image: xcode9.3
     env: UPLOAD_NATIVE=true
@@ -95,7 +69,6 @@ script:
   - ./gradlew check
 
 after_success:
-  - ls -lsh jme3-bullet-native/build/libs/bulletjme/shared/*
   - '[ "$TRAVIS_PULL_REQUEST" == "false" ] && [ -n "$UPLOAD_NATIVE" ] && ./private/upload_native.sh || :'
   - '[ -n "$TRAVIS_TAG" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ -n "$UPLOAD" ] && ./gradlew bintrayUpload || :'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,48 +14,50 @@ matrix:
     jdk: oraclejdk8
     dist: trusty
     env: UPLOAD=true UPLOAD_NATIVE=true
-    apt:
-        packages:
-            #- lib32gcc-7-dev
-            #- gcc-7-multilib
-            #- g++-7-multilib
-            #- gcc-7-arm-linux-gnueabihf
-            #- gcc-7-arm-linux-gnueabi
-            #- gcc-8-aarch64-linux-gnu
-            #- g++-7-arm-linux-gnueabihf
-            #- g++-7-arm-linux-gnueabi
-            #- g++-8-aarch64-linux-gnu
-            #- libc6-i386
-            #- libc6-dev-i386
-            #- libstdc++-7-dev-i386
-            #- libstdc++6-i386-cross
-            #- lib32stdc++-7-dev
-            #- libx32stdc++-7-dev
-            #- linux-libc-dev-arm64-cross
-            #- libubsan1-arm64-cross
-            #- libstdc++6-arm64-cross
-            #- libstdc++-8-dev-arm64-cross
-            #- libgcc1-arm64-cross
-            #- libgcc-8-dev-arm64-cross 
-            #- libc6-x32 
-            #- libc6-dev-arm64-cross
-            #- libatomic1-arm64-cross
-            #- libasan5-arm64-cross
-            #- binutils-common:amd64
-            - gcc-multilib
-            - g++-multilib
+    addons:
+        apt:
+            packages:
+                #- lib32gcc-7-dev
+                #- gcc-7-multilib
+                #- g++-7-multilib
+                #- gcc-7-arm-linux-gnueabihf
+                #- gcc-7-arm-linux-gnueabi
+                #- gcc-8-aarch64-linux-gnu
+                #- g++-7-arm-linux-gnueabihf
+                #- g++-7-arm-linux-gnueabi
+                #- g++-8-aarch64-linux-gnu
+                #- libc6-i386
+                #- libc6-dev-i386
+                #- libstdc++-7-dev-i386
+                #- libstdc++6-i386-cross
+                #- lib32stdc++-7-dev
+                #- libx32stdc++-7-dev
+                #- linux-libc-dev-arm64-cross
+                #- libubsan1-arm64-cross
+                #- libstdc++6-arm64-cross
+                #- libstdc++-8-dev-arm64-cross
+                #- libgcc1-arm64-cross
+                #- libgcc-8-dev-arm64-cross 
+                #- libc6-x32 
+                #- libc6-dev-arm64-cross
+                #- libatomic1-arm64-cross
+                #- libasan5-arm64-cross
+                #- binutils-common:amd64
+                - gcc-multilib
+                - g++-multilib
   - os: linux
     jdk: openjdk11
     dist: bionic
     env: UPLOAD=true
-    apt:
-        packages:
-            - gcc-7-arm-linux-gnueabihf
-            - gcc-7-arm-linux-gnueabi
-            - gcc-8-aarch64-linux-gnu
-            - g++-7-arm-linux-gnueabihf
-            - g++-7-arm-linux-gnueabi
-            - g++-8-aarch64-linux-gnu
+    addons:
+        apt:
+            packages:
+                - gcc-7-arm-linux-gnueabihf
+                - gcc-7-arm-linux-gnueabi
+                - gcc-8-aarch64-linux-gnu
+                - g++-7-arm-linux-gnueabihf
+                - g++-7-arm-linux-gnueabi
+                - g++-8-aarch64-linux-gnu
     install:
         - gradle -PbuildNativeProjects=true assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble -xjme3-bullet-native:compileBulletjmeLinux32SharedLibraryBulletjmeCpp -xjme3-bullet-native:compileBulletjmeLinux64SharedLibraryBulletjmeCpp
   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ script:
   - ./gradlew check
 
 after_success:
+  - ls -lsh jme3-bullet-native/build/libs/bulletjme/shared/*
   - '[ "$TRAVIS_PULL_REQUEST" == "false" ] && [ -n "$UPLOAD_NATIVE" ] && ./private/upload_native.sh || :'
   - '[ -n "$TRAVIS_TAG" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ -n "$UPLOAD" ] && ./gradlew bintrayUpload || :'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,12 @@ addons:
     packages:
     - gcc-multilib
     - g++-multilib
-    - gcc-7-arm-linux-gnueabihf
-    - gcc-7-arm-linux-gnueabi
-    - gcc-8-aarch64-linux-gnu
-    - g++-7-arm-linux-gnueabihf
-    - g++-7-arm-linux-gnueabi
-    - g++-8-aarch64-linux-gnu
+    #- gcc-7-arm-linux-gnueabihf
+    #- gcc-7-arm-linux-gnueabi
+    #- gcc-8-aarch64-linux-gnu
+    #- g++-7-arm-linux-gnueabihf
+    #- g++-7-arm-linux-gnueabi
+    #- g++-8-aarch64-linux-gnu
 
 before_install:
   - '[ -n "$UPLOAD" ] && git fetch --unshallow || :'

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
             - gcc-multilib
             - g++-multilib
     before_install:
-        - sudo apt install -y gcc-7-arm-linux-gnueabihf gcc-7-arm-linux-gnueabi gcc-8-aarch64-linux-gnu g++-7-arm-linux-gnueabihf g++-7-arm-linux-gnueabi g++-8-aarch64-linux-gnu libstdc++-7-dev-armel-cross libstdc++-7-dev-armhf-cross libstdc++-8-dev-arm64-cross libgcc-7-dev-armel-cross libgcc-7-dev-armhf-cross libgcc-8-dev-arm64-cross
+        - sudo apt update && sudo apt install -fy gcc-7-arm-linux-gnueabihf gcc-7-arm-linux-gnueabi gcc-8-aarch64-linux-gnu g++-7-arm-linux-gnueabihf g++-7-arm-linux-gnueabi g++-8-aarch64-linux-gnu
   - os: linux
     jdk: openjdk11
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,9 @@ cache:
 
 install:
   - '[ -n "$UPLOAD_NATIVE" ] && gradle -PbuildNativeProjects=true assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble || ./gradlew assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble'
-  - cat /home/travis/build/MeFisto94/jmonkeyengine/jme3-bullet-native/build/tmp/compileBulletjmeLinux32SharedLibraryBulletjmeCpp/options.txt
 
 script:
+  - cat /home/travis/build/MeFisto94/jmonkeyengine/jme3-bullet-native/build/tmp/compileBulletjmeLinux32SharedLibraryBulletjmeCpp/options.txt
   - ./gradlew check
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,17 @@ addons:
   hostname: travisci
   apt:
     packages:
-    - gcc-multilib
-    - g++-multilib
-    #- gcc-7-arm-linux-gnueabihf
-    #- gcc-7-arm-linux-gnueabi
-    #- gcc-8-aarch64-linux-gnu
-    #- g++-7-arm-linux-gnueabihf
-    #- g++-7-arm-linux-gnueabi
-    #- g++-8-aarch64-linux-gnu
+    #- gcc-multilib
+    #- g++-multilib
+    - gcc
+    - g++
+    - gcc-7-arm-linux-gnueabihf
+    - gcc-7-arm-linux-gnueabi
+    - gcc-8-aarch64-linux-gnu
+    - g++-7-arm-linux-gnueabihf
+    - g++-7-arm-linux-gnueabi
+    - g++-8-aarch64-linux-gnu
+    - 
 
 before_install:
   - '[ -n "$UPLOAD" ] && git fetch --unshallow || :'

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
   - os: linux
     jdk: openjdk11
     dist: bionic
-    env: UPLOAD=true
+    env: UPLOAD=true UPLOAD_NATIVE=true
     apt:
         packages:
             - gcc-7-arm-linux-gnueabihf
@@ -56,8 +56,6 @@ matrix:
             - g++-7-arm-linux-gnueabihf
             - g++-7-arm-linux-gnueabi
             - g++-8-aarch64-linux-gnu
-    install:
-        - gradle -PbuildNativeProjects=true assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble -xjme3-bullet-native:compileBulletjmeLinux32SharedLibraryBulletjmeCpp -xjme3-bullet-native:compileBulletjmeLinux64SharedLibraryBulletjmeCpp
   - os: osx
     osx_image: xcode9.3
     env: UPLOAD_NATIVE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,37 +15,38 @@ matrix:
     dist: bionic
     env: UPLOAD=true UPLOAD_NATIVE=true
     sudo: true
-    apt:
-        packages:
-            #- lib32gcc-7-dev
-            #- gcc-7-multilib
-            #- g++-7-multilib
-            #- gcc-7-arm-linux-gnueabihf
-            #- gcc-7-arm-linux-gnueabi
-            #- gcc-8-aarch64-linux-gnu
-            #- g++-7-arm-linux-gnueabihf
-            #- g++-7-arm-linux-gnueabi
-            #- g++-8-aarch64-linux-gnu
-            #- libc6-i386
-            #- libc6-dev-i386
-            #- libstdc++-7-dev-i386
-            #- libstdc++6-i386-cross
-            #- lib32stdc++-7-dev
-            #- libx32stdc++-7-dev
-            #- linux-libc-dev-arm64-cross
-            #- libubsan1-arm64-cross
-            #- libstdc++6-arm64-cross
-            #- libstdc++-8-dev-arm64-cross
-            #- libgcc1-arm64-cross
-            #- libgcc-8-dev-arm64-cross 
-            #- libc6-x32 
-            #- libc6-dev-arm64-cross
-            #- libatomic1-arm64-cross
-            #- libasan5-arm64-cross
-            #- binutils-common:amd64
-            - openjdk-11-jdk
-            - gcc-multilib
-            - g++-multilib
+    addons:
+        apt:
+            packages:
+                #- lib32gcc-7-dev
+                #- gcc-7-multilib
+                #- g++-7-multilib
+                #- gcc-7-arm-linux-gnueabihf
+                #- gcc-7-arm-linux-gnueabi
+                #- gcc-8-aarch64-linux-gnu
+                #- g++-7-arm-linux-gnueabihf
+                #- g++-7-arm-linux-gnueabi
+                #- g++-8-aarch64-linux-gnu
+                #- libc6-i386
+                #- libc6-dev-i386
+                #- libstdc++-7-dev-i386
+                #- libstdc++6-i386-cross
+                #- lib32stdc++-7-dev
+                #- libx32stdc++-7-dev
+                #- linux-libc-dev-arm64-cross
+                #- libubsan1-arm64-cross
+                #- libstdc++6-arm64-cross
+                #- libstdc++-8-dev-arm64-cross
+                #- libgcc1-arm64-cross
+                #- libgcc-8-dev-arm64-cross 
+                #- libc6-x32 
+                #- libc6-dev-arm64-cross
+                #- libatomic1-arm64-cross
+                #- libasan5-arm64-cross
+                #- binutils-common:amd64
+                - openjdk-11-jdk
+                - gcc-multilib
+                - g++-multilib
     before_install:
         - sudo apt update && sudo apt install -fy gcc-7-arm-linux-gnueabihf gcc-7-arm-linux-gnueabi gcc-8-aarch64-linux-gnu g++-7-arm-linux-gnueabihf g++-7-arm-linux-gnueabi g++-8-aarch64-linux-gnu
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
                 #- libatomic1-arm64-cross
                 #- libasan5-arm64-cross
                 #- binutils-common:amd64
-                - openjdk-11-jdk
+                #- openjdk-11-jdk
                 - gcc-multilib
                 - g++-multilib
     before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ branches:
 matrix:
   include:
   - os: linux
-    jdk: oraclejdk8
-    dist: trusty
+    jdk: openjdk9
+    dist: bionic
     env: UPLOAD=true UPLOAD_NATIVE=true
+    sudo: true
     apt:
         packages:
             #- lib32gcc-7-dev
@@ -42,22 +43,14 @@ matrix:
             #- libatomic1-arm64-cross
             #- libasan5-arm64-cross
             #- binutils-common:amd64
+            - openjdk-11-jdk
             - gcc-multilib
             - g++-multilib
     before_install:
-        - sudo apt update && sudo apt install -fy 
+        - sudo apt update && sudo apt install -fy gcc-7-arm-linux-gnueabihf gcc-7-arm-linux-gnueabi gcc-8-aarch64-linux-gnu g++-7-arm-linux-gnueabihf g++-7-arm-linux-gnueabi g++-8-aarch64-linux-gnu
   - os: linux
     jdk: openjdk11
     dist: bionic
-    env: UPLOAD=true UPLOAD_NATIVE=true
-    apt:
-        packages:
-            - gcc-7-arm-linux-gnueabihf
-            - gcc-7-arm-linux-gnueabi
-            - gcc-8-aarch64-linux-gnu
-            - g++-7-arm-linux-gnueabihf
-            - g++-7-arm-linux-gnueabi
-            - g++-8-aarch64-linux-gnu
   - os: osx
     osx_image: xcode9.3
     env: UPLOAD_NATIVE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ matrix:
             - g++-7-arm-linux-gnueabihf
             - g++-7-arm-linux-gnueabi
             - g++-8-aarch64-linux-gnu
-            - libc6-dev:i386
-            - libstdc++-7-dev:i386
+            - libc6-dev-i386
+            - libstdc++-7-dev-i386
   - os: linux
     jdk: openjdk11
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ matrix:
             #- libatomic1-arm64-cross
             #- libasan5-arm64-cross
             #- binutils-common:amd64
+            - openjdk-11-jdk
             - gcc-multilib
             - g++-multilib
     before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,9 @@ branches:
 matrix:
   include:
   - os: linux
-    jdk: openjdk9
-    dist: bionic
+    jdk: oraclejdk8
+    dist: trusty
     env: UPLOAD=true UPLOAD_NATIVE=true
-    sudo: true
     apt:
         packages:
             #- lib32gcc-7-dev
@@ -43,14 +42,22 @@ matrix:
             #- libatomic1-arm64-cross
             #- libasan5-arm64-cross
             #- binutils-common:amd64
-            - openjdk-11-jdk
             - gcc-multilib
             - g++-multilib
     before_install:
-        - sudo apt update && sudo apt install -fy gcc-7-arm-linux-gnueabihf gcc-7-arm-linux-gnueabi gcc-8-aarch64-linux-gnu g++-7-arm-linux-gnueabihf g++-7-arm-linux-gnueabi g++-8-aarch64-linux-gnu
+        - sudo apt update && sudo apt install -fy 
   - os: linux
     jdk: openjdk11
     dist: bionic
+    env: UPLOAD=true UPLOAD_NATIVE=true
+    apt:
+        packages:
+            - gcc-7-arm-linux-gnueabihf
+            - gcc-7-arm-linux-gnueabi
+            - gcc-8-aarch64-linux-gnu
+            - g++-7-arm-linux-gnueabihf
+            - g++-7-arm-linux-gnueabi
+            - g++-8-aarch64-linux-gnu
   - os: osx
     osx_image: xcode9.3
     env: UPLOAD_NATIVE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ addons:
     - gcc-multilib
     - g++-multilib
     # - arm-linux-gnueabi-gcc
-    - gcc-8-aarch64-linux-gnu
-    - g++-8-aarch64-linux-gnu
+    - gcc-7-aarch64-linux-gnu
+    - g++-7-aarch64-linux-gnu
 
 before_install:
   - '[ -n "$UPLOAD" ] && git fetch --unshallow || :'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,9 @@ matrix:
     env: UPLOAD=true UPLOAD_NATIVE=true
     apt:
         packages:
-            #- gcc-multilib
-            #- g++-multilib
             - lib32gcc-7-dev
-            - gcc
-            - g++
+            - gcc-7-multilib
+            - g++-7-multilib
             - gcc-7-arm-linux-gnueabihf
             - gcc-7-arm-linux-gnueabi
             - gcc-8-aarch64-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
             - g++-7-arm-linux-gnueabihf
             - g++-7-arm-linux-gnueabi
             - g++-8-aarch64-linux-gnu
+            - libc6-i386
             - libc6-dev-i386
             - libstdc++-7-dev-i386
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
             - gcc-multilib
             - g++-multilib
     before_install:
-        - sudo apt install -y gcc-7-arm-linux-gnueabihf gcc-7-arm-linux-gnueabi gcc-8-aarch64-linux-gnu g++-7-arm-linux-gnueabihf g++-7-arm-linux-gnueabi g++-8-aarch64-linux-gnu
+        - sudo apt install -y gcc-7-arm-linux-gnueabihf gcc-7-arm-linux-gnueabi gcc-8-aarch64-linux-gnu g++-7-arm-linux-gnueabihf g++-7-arm-linux-gnueabi g++-8-aarch64-linux-gnu libstdc++-7-dev-armel-cross libstdc++-7-dev-armhf-cross libstdc++-8-dev-arm64-cross libgcc-7-dev-armel-cross libgcc-7-dev-armhf-cross libgcc-8-dev-arm64-cross
   - os: linux
     jdk: openjdk11
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
   - os: linux
     jdk: openjdk11
     dist: bionic
-    env: UPLOAD=true UPLOAD_NATIVE=true
+    env: UPLOAD=true
     apt:
         packages:
             - gcc-7-arm-linux-gnueabihf
@@ -56,6 +56,8 @@ matrix:
             - g++-7-arm-linux-gnueabihf
             - g++-7-arm-linux-gnueabi
             - g++-8-aarch64-linux-gnu
+    install:
+        - gradle -PbuildNativeProjects=true assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble -xjme3-bullet-native:compileBulletjmeLinux32SharedLibraryBulletjmeCpp -xjme3-bullet-native:compileBulletjmeLinux64SharedLibraryBulletjmeCpp
   - os: osx
     osx_image: xcode9.3
     env: UPLOAD_NATIVE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,9 @@ addons:
     packages:
     - gcc-multilib
     - g++-multilib
-    - arm-linux-gnueabi-gcc
+    # - arm-linux-gnueabi-gcc
+    - gcc-8-aarch64-linux-gnu
+    - g++-8-aarch64-linux-gnu
 
 before_install:
   - '[ -n "$UPLOAD" ] && git fetch --unshallow || :'
@@ -59,7 +61,7 @@ cache:
     - $HOME/.gradle/wrapper/
 
 install:
-  - '[ -n "$UPLOAD_NATIVE" ] && ./gradlew -PbuildNativeProjects=true assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble || ./gradlew assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble'
+  - '[ -n "$UPLOAD_NATIVE" ] && gradle -PbuildNativeProjects=true jme3-bullet-native:assembleDependentsBulletjmeLinuxArm64SharedLibrary -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble || ./gradlew assemble -xjme3-android-native:assemble -xjme3-bullet-native-android:assemble'
 
 script:
   - ./gradlew check

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ matrix:
             #- binutils-common:amd64
             - gcc-multilib
             - g++-multilib
+    before_install:
+        - sudo apt update && sudo apt install -fy 
   - os: linux
     jdk: openjdk11
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ branches:
 matrix:
   include:
   - os: linux
-    jdk: openjdk8
-    dist: xenial
+    jdk: openjdk9
+    dist: bionic
     env: UPLOAD=true UPLOAD_NATIVE=true
   - os: linux
     jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ addons:
     - gcc-multilib
     - g++-multilib
     # - arm-linux-gnueabi-gcc
-    - gcc-7-aarch64-linux-gnu
-    - g++-7-aarch64-linux-gnu
+    - gcc-8-aarch64-linux-gnu
+    - g++-8-aarch64-linux-gnu
 
 before_install:
   - '[ -n "$UPLOAD" ] && git fetch --unshallow || :'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
   - /^v3.3.*$/
   - v3.2
   - /^v3.2.*$/
+  - feature/bullet-arm
 
 matrix:
   include:
@@ -43,6 +44,7 @@ addons:
     packages:
     - gcc-multilib
     - g++-multilib
+    - arm-linux-gnueabi-gcc
 
 before_install:
   - '[ -n "$UPLOAD" ] && git fetch --unshallow || :'

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,6 @@ matrix:
             #- binutils-common:amd64
             - gcc-multilib
             - g++-multilib
-    before_install:
-        - sudo apt update && sudo apt install -fy 
   - os: linux
     jdk: openjdk11
     dist: bionic

--- a/jme3-bullet-native/build.gradle
+++ b/jme3-bullet-native/build.gradle
@@ -71,9 +71,9 @@ model {
             // Fun Fact: Gradle uses gcc as linker frontend, so we don't specify ld directly here
             target("LinuxArm"){
                 path "/usr/bin"
-                cCompiler.executable = "arm-linux-gnueabi-gcc"
-                cppCompiler.executable = "arm-linux-gnueabi-gcc"
-                linker.executable = "arm-linux-gnueabi-gcc"
+                cCompiler.executable = "arm-linux-gnueabi-gcc-7"
+                cppCompiler.executable = "arm-linux-gnueabi-g++-7"
+                linker.executable = "arm-linux-gnueabi-gcc-7"
                 assembler.executable = "arm-linux-gnueabi-as"
             }
             
@@ -88,7 +88,7 @@ model {
             target("LinuxArm64"){
                 path "/usr/bin"
                 cCompiler.executable = "aarch64-linux-gnu-gcc-8"
-                cppCompiler.executable = "aarch64-linux-gnu-gcc-8"
+                cppCompiler.executable = "aarch64-linux-gnu-g++-8"
                 linker.executable = "aarch64-linux-gnu-gcc-8"
                 assembler.executable = "aarch64-linux-gnu-as"
             }

--- a/jme3-bullet-native/build.gradle
+++ b/jme3-bullet-native/build.gradle
@@ -36,6 +36,7 @@ model {
             targetPlatform 'Linux64'
             targetPlatform 'Linux32'
             targetPlatform 'LinuxArm'
+            targetPlatform 'LinuxArmHF'
             targetPlatform 'LinuxArm64'
 
             sources {
@@ -67,26 +68,28 @@ model {
     
     toolChains {
         gccArm(Gcc) {
-            /*target("LinuxArm"){
+            // Fun Fact: Gradle uses gcc as linker frontend, so we don't specify ld directly here
+            target("LinuxArm"){
                 path "/usr/bin"
                 cCompiler.executable = "arm-linux-gnueabi-gcc"
-                cppCompiler.executable = "arm-linux-gnueabi-cpp"
-                linker.executable = "arm-linux-gnueabi-ld"
+                cppCompiler.executable = "arm-linux-gnueabi-gcc"
+                linker.executable = "arm-linux-gnueabi-gcc"
                 assembler.executable = "arm-linux-gnueabi-as"
-                
-                cppCompiler.withArguments { args ->
-                    args << "-m32"
-                }
-                linker.withArguments { args ->
-                    args << "-m32"
-                }
-            }*/
+            }
+            
+            target("LinuxArmHF"){
+                path "/usr/bin"
+                cCompiler.executable = "arm-linux-gnueabihf-gcc-7"
+                cppCompiler.executable = "arm-linux-gnueabihf-g++-7"
+                linker.executable = "arm-linux-gnueabihf-gcc-7"
+                assembler.executable = "arm-linux-gnueabihf-as"
+            }
             
             target("LinuxArm64"){
                 path "/usr/bin"
                 cCompiler.executable = "aarch64-linux-gnu-gcc-8"
                 cppCompiler.executable = "aarch64-linux-gnu-gcc-8"
-                linker.executable = "aarch64-linux-gnu-ld"
+                linker.executable = "aarch64-linux-gnu-gcc-8"
                 assembler.executable = "aarch64-linux-gnu-as"
             }
         }
@@ -146,7 +149,7 @@ model {
                 cppCompiler.args "-O3"
                 cppCompiler.args "-U_FORTIFY_SOURCE"
                 cppCompiler.args "-fpermissive"
-                linker.args "-fvisibility=hidden"
+                linker.args "-fvisibility=hidden"                
             } else if (os == "windows") {
                 if (toolChain in Gcc) {
                     if (toolChain.name.startsWith('mingw')) {
@@ -221,7 +224,10 @@ model {
             architecture "arm"
             operatingSystem "linux"
         }
-        
+        LinuxArmHF {
+            architecture "armhf"
+            operatingSystem "linux"        
+        }
         LinuxArm64 {
             architecture "aarch64"
             operatingSystem "linux"

--- a/jme3-bullet-native/build.gradle
+++ b/jme3-bullet-native/build.gradle
@@ -149,7 +149,12 @@ model {
                 cppCompiler.args "-O3"
                 cppCompiler.args "-U_FORTIFY_SOURCE"
                 cppCompiler.args "-fpermissive"
-                linker.args "-fvisibility=hidden"                
+                
+                if (arch == "x86_64") {
+                    cppCompiler.args "-m32"
+                }
+                
+                linker.args "-fvisibility=hidden"
             } else if (os == "windows") {
                 if (toolChain in Gcc) {
                     if (toolChain.name.startsWith('mingw')) {

--- a/jme3-bullet-native/build.gradle
+++ b/jme3-bullet-native/build.gradle
@@ -149,7 +149,6 @@ model {
                 cppCompiler.args "-O3"
                 cppCompiler.args "-U_FORTIFY_SOURCE"
                 cppCompiler.args "-fpermissive"
-                
                 linker.args "-fvisibility=hidden"
             } else if (os == "windows") {
                 if (toolChain in Gcc) {

--- a/jme3-bullet-native/build.gradle
+++ b/jme3-bullet-native/build.gradle
@@ -35,6 +35,8 @@ model {
             targetPlatform 'Mac32'
             targetPlatform 'Linux64'
             targetPlatform 'Linux32'
+            targetPlatform 'LinuxArm'
+            targetPlatform 'LinuxArm64'
 
             sources {
                 cpp {
@@ -58,6 +60,25 @@ model {
                         exclude 'Bullet3Serialize/**'
                         include '**/*.h'
                     }
+                }
+            }
+        }
+    }
+    
+    toolChains {
+        gccArm(Gcc) {
+            target("LinuxArm"){
+                path "/usr/bin"
+                cCompiler.executable = "arm-linux-gnueabi-gcc"
+                cppCompiler.executable = "arm-linux-gnueabi-gcc"
+                linker.executable = "arm-linux-gnueabi-ld"
+                assembler.executable = "arm-linux-gnueabi-as"
+                
+                cppCompiler.withArguments { args ->
+                    args << "-m32"
+                }
+                linker.withArguments { args ->
+                    args << "-m32"
                 }
             }
         }
@@ -186,6 +207,15 @@ model {
         }
         Linux64 {
             architecture "x86_64"
+            operatingSystem "linux"
+        }
+        LinuxArm {
+            architecture "arm"
+            operatingSystem "linux"
+        }
+        
+        LinuxArm64 {
+            architecture "arm64"
             operatingSystem "linux"
         }
     }

--- a/jme3-bullet-native/build.gradle
+++ b/jme3-bullet-native/build.gradle
@@ -150,10 +150,6 @@ model {
                 cppCompiler.args "-U_FORTIFY_SOURCE"
                 cppCompiler.args "-fpermissive"
                 
-                if (arch == "x86_64") {
-                    cppCompiler.args "-m32"
-                }
-                
                 linker.args "-fvisibility=hidden"
             } else if (os == "windows") {
                 if (toolChain in Gcc) {

--- a/jme3-bullet-native/build.gradle
+++ b/jme3-bullet-native/build.gradle
@@ -67,10 +67,10 @@ model {
     
     toolChains {
         gccArm(Gcc) {
-            target("LinuxArm"){
+            /*target("LinuxArm"){
                 path "/usr/bin"
                 cCompiler.executable = "arm-linux-gnueabi-gcc"
-                cppCompiler.executable = "arm-linux-gnueabi-gcc"
+                cppCompiler.executable = "arm-linux-gnueabi-cpp"
                 linker.executable = "arm-linux-gnueabi-ld"
                 assembler.executable = "arm-linux-gnueabi-as"
                 
@@ -80,6 +80,14 @@ model {
                 linker.withArguments { args ->
                     args << "-m32"
                 }
+            }*/
+            
+            target("LinuxArm64"){
+                path "/usr/bin"
+                cCompiler.executable = "aarch64-linux-gnu-gcc-8"
+                cppCompiler.executable = "aarch64-linux-gnu-gcc-8"
+                linker.executable = "aarch64-linux-gnu-ld"
+                assembler.executable = "aarch64-linux-gnu-as"
             }
         }
     }
@@ -215,7 +223,7 @@ model {
         }
         
         LinuxArm64 {
-            architecture "arm64"
+            architecture "aarch64"
             operatingSystem "linux"
         }
     }


### PR DESCRIPTION
Fixes #1183 
This PR needs to have it's 32bit linux build tested and unfortunately requires sudo (for now), as the packages need to be installed in a two step progress, which is what travis wouldn't do.

I also move the native build to our more new openjdk11 environment and also updated the dist to be the newest available. This is just because otherwise the compiler versions would be 4 instead of 7. Also precise is in the process of being decomissioned and basically this PR has to be redone whenever the dist is upgraded, as the packages might change (have a higher version number).

So the second part of this PR is like: Move the build towards bionic and keep java 8 for testing / things not ready for java 11.

Also note the draft state of this PR, the binaries first have to be tested, some changes might need to be reverted (branchers: feature/bullet-arm).
Also the gradle wrapper couldn't be used locally as it lead to a NullPointerException. So we use the installed gradle here, we might consider upping the wrapper version a bit.