### PR TITLE
Fix issue #1176: mergedJavadoc task fails on java 11 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,8 +102,8 @@ task mergedJavadoc(type: Javadoc, description: 'Creates Javadoc from all the pro
     source subprojects.collect {project ->
         project.sourceSets*.allJava
     }
-//    classpath = files(subprojects.collect {project ->
-//            project.sourceSets*.compileClasspath})
+    classpath = files(subprojects.collect {project ->
+            project.sourceSets*.compileClasspath})
     //    source {
     //        subprojects*.sourceSets*.main*.allSource
     //    }

--- a/common.gradle
+++ b/common.gradle
@@ -25,7 +25,7 @@ repositories {
 dependencies {
     // Adding dependencies here will add the dependencies to each subproject.
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '3.0.0'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'
     testCompile 'org.codehaus.groovy:groovy-all:2.5.8'
 }


### PR DESCRIPTION
I also updated the "mockito-core" version for better compatibility with java11. 
The older version had some issues with java 11 and was preventing the "mergedJavadoc" task to succeed.

For anyone curious, here is the error with older mockito-core version:

```
mockito-core-1.10.19.jar(/org/mockito/internal/stubbing/answers/ThrowsExceptionClass.java):11: error: package org.objenesis does not exist
import org.objenesis.ObjenesisHelper;
1 error

> Task :mergedJavadoc FAILED
```