### PR TITLE
Fixed ClassCastException in RMI implementation.

### DIFF
--- a/jme3-networking/src/main/java/com/jme3/network/service/rmi/RmiRegistry.java
+++ b/jme3-networking/src/main/java/com/jme3/network/service/rmi/RmiRegistry.java
@@ -194,7 +194,7 @@ public class RmiRegistry {
     public <T> T getLocalObject( String name, Class<T> type ) {
         local.lock.readLock().lock();
         try {
-            return type.cast(local.byName.get(name));
+            return type.cast(local.byName.get(name).object);
         } finally {
             local.lock.readLock().unlock();
         }


### PR DESCRIPTION
jME's RMI registry uses an internal SharedObject class to track
metadata about objects that have been shared. The problem is that when
you retrieve the shared object, the RMI implementation mistakenly
attempts to cast the SharedObject holder to the class of the actual
shared object. This PR fixes that bug by casting the actual shared
object instead of the SharedObject holder.