### PR TITLE
Fixed an issue with BlendableAction.setTransitionLength()...

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendableAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendableAction.java
@@ -74,6 +74,7 @@ public abstract class BlendableAction extends Action {
 
     public void setTransitionLength(double transitionLength) {
         this.transitionLength = transitionLength;
+        this.transition.setLength(transitionLength);
     }
 
     protected float getTransitionWeight() {


### PR DESCRIPTION
...which was not setting new length to "transition" tween and causing the new length to have no effect.