### PR TITLE
Fix macos build.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,14 +114,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04,windows-2019,macOS-10.14] 
+        os: [ubuntu-18.04,windows-2019,macOS-latest] 
         jdk: [8.x.x]
         include:
           - os: ubuntu-18.04
             osName: linux
           - os: windows-2019
             osName: windows
-          - os: macOS-10.14
+          - os: macOS-latest
             osName: mac
               
     name: Build natives for ${{ matrix.osName }}
@@ -147,19 +147,7 @@ jobs:
           # Install dependencies
           if [ "$OS_NAME" = "mac" ];
           then
-            echo "Prepare mac"
-            # We need this older version to compile for 32bit...
-            sudo xcode-select -switch  /Applications/Xcode_9.4.1.app
-
-            # ghetto fix for expired certificate (still safer than -allowUntrusted) 
-            cdate=`date +%m%d%H%M%y`
-            sudo date -u 1020000019
-            
-
-            sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
-          
-            # restore real date
-            sudo date -u "$cdate"
+            echo "Prepare mac"        
           
           elif [ "$OS_NAME" = "linux" ];
           then
@@ -191,7 +179,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04,windows-2019,macOS-10.14]
+        os: [ubuntu-18.04,windows-2019,macOS-latest]
         jdk: [8.x.x,11.x.x]
         include:
           - os: ubuntu-18.04
@@ -199,7 +187,7 @@ jobs:
             deploy: true
           - os: windows-2019
             osName: windows
-          - os: macOS-10.14
+          - os: macOS-latest
             osName: mac 
           - jdk: 11.x.x
             deploy: false 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ buildJavaDoc = true
 buildNativeProjects = false
 buildAndroidExamples = false
 
-buildForPlatforms = Linux64,Linux32,Windows64,Windows32,Mac64,Mac32
+buildForPlatforms = Linux64,Linux32,Windows64,Windows32,Mac64
 # Forcefully ignore prebuilt libraries
 skipPrebuildLibraries=false
 # Path to android NDK for building native libraries
@@ -22,8 +22,9 @@ skipPrebuildLibraries=false
 ndkPath = /opt/android-ndk-r16b
 
 # Path for downloading native Bullet
-bulletUrl = https://github.com/bulletphysics/bullet3/archive/2.87.zip
-bulletFolder = bullet3-2.87
+# 2.88+
+bulletUrl = https://github.com/bulletphysics/bullet3/archive/28039903b14c2aec28beff5b3609c9308b17e76a.zip
+bulletFolder = bullet3-28039903b14c2aec28beff5b3609c9308b17e76a
 bulletZipFile = bullet3.zip
 
 # POM settings

--- a/jme3-bullet-native-android/src/native/android/Android.mk
+++ b/jme3-bullet-native-android/src/native/android/Android.mk
@@ -71,6 +71,7 @@ FILE_LIST := $(wildcard $(LOCAL_PATH)/*.cpp)
 FILE_LIST += $(wildcard $(LOCAL_PATH)/**/*.cpp)
 FILE_LIST += $(wildcard $(LOCAL_PATH)/**/**/*.cpp)
 FILE_LIST := $(filter-out $(wildcard $(LOCAL_PATH)/Bullet3OpenCL/**/*.cpp), $(FILE_LIST))
+FILE_LIST := $(filter-out $(wildcard $(LOCAL_PATH)/*All.cpp), $(FILE_LIST))
 LOCAL_SRC_FILES := $(FILE_LIST:$(LOCAL_PATH)/%=%)
 
 include $(BUILD_SHARED_LIBRARY)

--- a/jme3-bullet-native/build.gradle
+++ b/jme3-bullet-native/build.gradle
@@ -37,7 +37,6 @@ model {
                 "Windows64",
                 "Windows32",
                 "Mac64",
-                "Mac32",
                 "Linux64",
                 "Linux32",
                 "LinuxArm",
@@ -71,6 +70,7 @@ model {
                         exclude 'Bullet3OpenCL/**'
                         exclude 'Bullet3Serialize/**'
                         include '**/*.cpp'
+                        exclude '**/*All.cpp'
                     }
                     exportedHeaders {
                         srcDir 'src/native/cpp'
@@ -196,10 +196,6 @@ model {
         Windows64 {
             architecture "x86_64"
             operatingSystem "windows"
-        }
-        Mac32 {
-            architecture "x86"
-            operatingSystem "osx"
         }
         Mac64 {
             architecture "x86_64"


### PR DESCRIPTION
Update MacOS build: removed 32 bit support (since deprecated by apple). Update bullet library to the current master branch (needed for compatibility patch with recent clang).