### PR TITLE
Improve support for subimage copying.

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/Caps.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Caps.java
@@ -438,10 +438,11 @@ public enum Caps {
     /**
      * Explicit support of depth 24 textures
      */
-    Depth24;
+    Depth24,     
 
-      
-
+    
+    UnpackRowLength
+    ;
 
     /**
      * Returns true if given the renderer capabilities, the texture

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GL.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GL.java
@@ -194,6 +194,7 @@ public interface GL {
     public static final int GL_VERSION = 0x1F02;
     public static final int GL_VERTEX_SHADER = 0x8B31;
     public static final int GL_ZERO = 0x0;
+    public static final int GL_UNPACK_ROW_LENGTH = 0x0CF2;
 
     public void resetStats();
 

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -52,6 +52,7 @@ import com.jme3.texture.FrameBuffer;
 import com.jme3.texture.FrameBuffer.RenderBuffer;
 import com.jme3.texture.Image;
 import com.jme3.texture.Texture;
+import com.jme3.texture.Texture2D;
 import com.jme3.texture.Texture.ShadowCompareMode;
 import com.jme3.texture.Texture.WrapAxis;
 import com.jme3.texture.image.LastTextureState;
@@ -527,6 +528,10 @@ public final class GLRenderer implements Renderer {
 
         if (hasExtension("GL_OES_tessellation_shader") || hasExtension("GL_EXT_tessellation_shader")) {
             caps.add(Caps.TesselationShader);
+        }
+         
+        if(caps.contains(Caps.OpenGL20)){
+            caps.add(Caps.UnpackRowLength);
         }
 
         // Print context information
@@ -2537,12 +2542,34 @@ public final class GLRenderer implements Renderer {
         setupTextureParams(unit, tex);
     }
 
+
+    /**
+     * @deprecated Use modifyTexture(Texture2D dest, Image src, int destX, int destY, int srcX, int srcY, int areaW, int areaH)
+     */
+    @Deprecated
     public void modifyTexture(Texture tex, Image pixels, int x, int y) {
         setTexture(0, tex);
         int target = convertTextureType(tex.getType(), pixels.getMultiSamples(), -1);
-        texUtil.uploadSubTexture(pixels, target, 0, x, y, linearizeSrgbImages);
+        texUtil.uploadSubTexture(target,pixels, 0, x, y,0,0,pixels.getWidth(),pixels.getHeight(), linearizeSrgbImages);     
     }
 
+     /**
+     * Copy a part of an image to a texture 2d.
+     * @param dest The destination image, where the source will be copied
+     * @param src The source image that contains the data to copy
+     * @param destX First pixel of the destination image from where the src image will be drawn (x component)
+     * @param destY First pixel of the destination image from where the src image will be drawn (y component)
+     * @param srcX  First pixel to copy (x component)
+     * @param srcY  First pixel to copy (y component)
+     * @param areaW Width of the area to copy
+     * @param areaH Height of the area to copy
+     */
+    public void modifyTexture(Texture2D dest, Image src, int destX, int destY, int srcX, int srcY, int areaW, int areaH) {
+        setTexture(0, dest);
+        int target = convertTextureType(dest.getType(), src.getMultiSamples(), -1);
+        texUtil.uploadSubTexture(target, src, 0, destX, destY, srcX, srcY, areaW, areaH, linearizeSrgbImages);
+    }
+  
     public void deleteImage(Image image) {
         int texId = image.getId();
         if (texId != -1) {


### PR DESCRIPTION
This pr overrides modifyTexture with a new method that allows to specify which part to copy from the source image. A workaround is implemented for gles, that doesn't provide GL_UNPACK_ROW_LENGTH.
The old method is kept for backward compatibility but deprecated in favor of the new one.