### PR TITLE
Add MavenLocal() to version.gradle

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -4,7 +4,7 @@ import org.ajoberstar.grgit.*
 
 buildscript {
     repositories {
-		mavenLocal()
+        mavenLocal()
         mavenCentral()
     }
     dependencies {

--- a/version.gradle
+++ b/version.gradle
@@ -4,6 +4,7 @@ import org.ajoberstar.grgit.*
 
 buildscript {
     repositories {
+		mavenLocal()
         mavenCentral()
     }
     dependencies {


### PR DESCRIPTION
This is a PR to add the `MavenLocal()` command to the `version.gradle` file. 
This enables builds to be stored in the local `.m2` repo.

This is one of the first things I do when I clone jme, and I am going to guess that I am not the only one. Is there any reason this is not already (or should not be) in the `version.gradle`?

Thanks,
Trevor