### PR TITLE
protect 47 no-arg constructors in the jme3-core library

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/AnimClip.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AnimClip.java
@@ -16,7 +16,7 @@ public class AnimClip implements JmeCloneable, Savable {
 
     private AnimTrack[] tracks;
 
-    public AnimClip() {
+    protected AnimClip() {
     }
 
     public AnimClip(String name) {

--- a/jme3-core/src/main/java/com/jme3/anim/Armature.java
+++ b/jme3-core/src/main/java/com/jme3/anim/Armature.java
@@ -28,7 +28,7 @@ public class Armature implements JmeCloneable, Savable {
     /**
      * Serialization only
      */
-    public Armature() {
+    protected Armature() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -59,7 +59,7 @@ public class MorphTrack implements AnimTrack<float[]> {
     /**
      * Serialization-only. Do not use.
      */
-    public MorphTrack() {
+    protected MorphTrack() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/anim/SkinningControl.java
+++ b/jme3-core/src/main/java/com/jme3/anim/SkinningControl.java
@@ -115,7 +115,7 @@ public class SkinningControl extends AbstractControl implements Cloneable, JmeCl
     /**
      * Serialization only. Do not use.
      */
-    public SkinningControl() {
+    protected SkinningControl() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/animation/Animation.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Animation.java
@@ -65,7 +65,7 @@ public class Animation implements Savable, Cloneable, JmeCloneable {
     /**
      * Serialization-only. Do not use.
      */
-    public Animation() {
+    protected Animation() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/animation/AudioTrack.java
+++ b/jme3-core/src/main/java/com/jme3/animation/AudioTrack.java
@@ -82,9 +82,9 @@ public class AudioTrack implements ClonableTrack {
     }
 
     /**
-     * default constructor for serialization only
+     * constructor for serialization only
      */
-    public AudioTrack() {
+    protected AudioTrack() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/animation/Bone.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Bone.java
@@ -176,7 +176,7 @@ public final class Bone implements Savable, JmeCloneable {
     /**
      * Serialization only. Do not use.
      */
-    public Bone() {
+    protected Bone() {
     }
     
     @Override   

--- a/jme3-core/src/main/java/com/jme3/animation/BoneTrack.java
+++ b/jme3-core/src/main/java/com/jme3/animation/BoneTrack.java
@@ -65,7 +65,7 @@ public final class BoneTrack implements JmeCloneable, Track {
     /**
      * Serialization-only. Do not use.
      */
-    public BoneTrack() {
+    protected BoneTrack() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/animation/EffectTrack.java
+++ b/jme3-core/src/main/java/com/jme3/animation/EffectTrack.java
@@ -144,9 +144,9 @@ public class EffectTrack implements ClonableTrack {
     }
 
     /**
-     * default constructor only for serialization
+     * constructor only for serialization
      */
-    public EffectTrack() {
+    protected EffectTrack() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/animation/Pose.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Pose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,7 +63,7 @@ public final class Pose implements Savable, Cloneable {
     /**
      * Serialization-only. Do not use.
      */
-    public Pose()
+    protected Pose()
     {
     }
     

--- a/jme3-core/src/main/java/com/jme3/animation/PoseTrack.java
+++ b/jme3-core/src/main/java/com/jme3/animation/PoseTrack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -62,7 +62,7 @@ public final class PoseTrack implements Track {
         /**
          * Serialization-only. Do not use.
          */
-        public PoseFrame()
+        protected PoseFrame()
         {
         }
         
@@ -114,7 +114,7 @@ public final class PoseTrack implements Track {
     /**
      * Serialization-only. Do not use.
      */
-    public PoseTrack()
+    protected PoseTrack()
     {
     }
     

--- a/jme3-core/src/main/java/com/jme3/animation/Skeleton.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Skeleton.java
@@ -121,7 +121,7 @@ public final class Skeleton implements Savable, JmeCloneable {
     /**
      * Serialization only. Do not use.
      */
-    public Skeleton() {
+    protected Skeleton() {
     }
 
     @Override   

--- a/jme3-core/src/main/java/com/jme3/animation/SkeletonControl.java
+++ b/jme3-core/src/main/java/com/jme3/animation/SkeletonControl.java
@@ -113,7 +113,7 @@ public class SkeletonControl extends AbstractControl implements Cloneable, JmeCl
     /**
      * Serialization only. Do not use.
      */
-    public SkeletonControl() {
+    protected SkeletonControl() {
     }
 
     private void switchToHardware() {

--- a/jme3-core/src/main/java/com/jme3/cinematic/Cinematic.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/Cinematic.java
@@ -105,7 +105,7 @@ public class Cinematic extends AbstractCinematicEvent implements AppState {
      * Used for serialization creates a cinematic, don't use this constructor
      * directly
      */
-    public Cinematic() {
+    protected Cinematic() {
         super();
     }
 

--- a/jme3-core/src/main/java/com/jme3/cinematic/events/AnimationEvent.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/events/AnimationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -75,7 +75,7 @@ public class AnimationEvent extends AbstractCinematicEvent {
      * used for serialization don't call directly use one of the following
      * constructors
      */
-    public AnimationEvent() {
+    protected AnimationEvent() {
         super();
     }
     

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -297,7 +297,7 @@ public class ParticleEmitter extends Geometry {
     /**
      * For serialization only. Do not use.
      */
-    public ParticleEmitter() {
+    protected ParticleEmitter() {
         super();
         setBatchHint(BatchHint.Never);
     }

--- a/jme3-core/src/main/java/com/jme3/light/LightList.java
+++ b/jme3-core/src/main/java/com/jme3/light/LightList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -69,9 +69,9 @@ public final class LightList implements Iterable<Light>, Savable, Cloneable, Jme
     };
 
     /**
-     * Default constructor for serialization. Do not use
+     * constructor for serialization. Do not use
      */
-    public LightList(){
+    protected LightList(){
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/material/MatParam.java
+++ b/jme3-core/src/main/java/com/jme3/material/MatParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -66,7 +66,7 @@ public class MatParam implements Savable, Cloneable {
     /**
      * Serialization only. Do not use.
      */
-    public MatParam() {
+    protected MatParam() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/material/MatParamOverride.java
+++ b/jme3-core/src/main/java/com/jme3/material/MatParamOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2016 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -83,7 +83,7 @@ public final class MatParamOverride extends MatParam {
     /**
      * Serialization only. Do not use.
      */
-    public MatParamOverride() {
+    protected MatParamOverride() {
         super();
     }
 

--- a/jme3-core/src/main/java/com/jme3/material/MaterialDef.java
+++ b/jme3-core/src/main/java/com/jme3/material/MaterialDef.java
@@ -59,7 +59,7 @@ public class MaterialDef{
     /**
      * Serialization only. Do not use.
      */
-    public MaterialDef(){
+    protected MaterialDef(){
     }
     
     /**

--- a/jme3-core/src/main/java/com/jme3/material/TechniqueDef.java
+++ b/jme3-core/src/main/java/com/jme3/material/TechniqueDef.java
@@ -181,7 +181,7 @@ public class TechniqueDef implements Savable, Cloneable {
     /**
      * Serialization only. Do not use.
      */
-    public TechniqueDef() {
+    protected TechniqueDef() {
         shaderLanguages = new EnumMap<Shader.ShaderType, String>(Shader.ShaderType.class);
         shaderNames = new EnumMap<Shader.ShaderType, String>(Shader.ShaderType.class);
         defineNames = new ArrayList<String>();

--- a/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
@@ -99,7 +99,7 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
      * Don't use this constructor, use {@link #FilterPostProcessor(AssetManager assetManager)}<br>
      * This constructor is used for serialization only
      */
-    public FilterPostProcessor() {
+    protected FilterPostProcessor() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/CameraNode.java
+++ b/jme3-core/src/main/java/com/jme3/scene/CameraNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,7 +52,7 @@ public class CameraNode extends Node {
     /**
      * Serialization only. Do not use.
      */
-    public CameraNode() {
+    protected CameraNode() {
         super();
     }
 

--- a/jme3-core/src/main/java/com/jme3/scene/LightNode.java
+++ b/jme3-core/src/main/java/com/jme3/scene/LightNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,7 +52,7 @@ public class LightNode extends Node {
     /**
      * Serialization only. Do not use.
      */
-    public LightNode() {
+    protected LightNode() {
     }
 
     public LightNode(String name, Light light) {

--- a/jme3-core/src/main/java/com/jme3/scene/VertexBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/VertexBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -382,7 +382,7 @@ public class VertexBuffer extends NativeObject implements Savable, Cloneable {
     /**
      * Serialization only. Do not use.
      */
-    public VertexBuffer(){
+    protected VertexBuffer(){
         super();
     }
 

--- a/jme3-core/src/main/java/com/jme3/scene/debug/Arrow.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/Arrow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -62,7 +62,7 @@ public class Arrow extends Mesh {
     /**
      * Serialization only. Do not use.
      */
-    public Arrow() {
+    protected Arrow() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/debug/custom/JointShape.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/custom/JointShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2010 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,7 +42,7 @@ public class JointShape extends Mesh {
     /**
      * Serialization only. Do not use.
      */
-    public JointShape() {
+    protected JointShape() {
         float width = 1;
         float height = 1;
         setBuffer(Type.Position, 3, new float[]{-width * 0.5f, -width * 0.5f, 0,

--- a/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedGeometry.java
+++ b/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedGeometry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -67,7 +67,7 @@ public class InstancedGeometry extends Geometry {
     /**
      * Serialization only. Do not use.
      */
-    public InstancedGeometry() {
+    protected InstancedGeometry() {
         super();
         setIgnoreTransform(true);
         setBatchHint(BatchHint.Never);

--- a/jme3-core/src/main/java/com/jme3/scene/shape/Box.java
+++ b/jme3-core/src/main/java/com/jme3/scene/shape/Box.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -130,7 +130,7 @@ public class Box extends AbstractBox {
     /**
      * Empty constructor for serialization only. Do not use.
      */
-    public Box(){
+    protected Box(){
         super();
     }
 

--- a/jme3-core/src/main/java/com/jme3/scene/shape/Curve.java
+++ b/jme3-core/src/main/java/com/jme3/scene/shape/Curve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,7 +55,7 @@ public class Curve extends Mesh {
     /**
      * Serialization only. Do not use.
      */
-    public Curve() {
+    protected Curve() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/shape/Cylinder.java
+++ b/jme3-core/src/main/java/com/jme3/scene/shape/Cylinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,9 +64,9 @@ public class Cylinder extends Mesh {
     private boolean inverted;
 
     /**
-     * Default constructor for serialization only. Do not use.
+     * constructor for serialization only. Do not use.
      */
-    public Cylinder() {
+    protected Cylinder() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/shape/Dome.java
+++ b/jme3-core/src/main/java/com/jme3/scene/shape/Dome.java
@@ -66,7 +66,7 @@ public class Dome extends Mesh {
     /**
      * Serialization only. Do not use.
      */
-    public Dome() {
+    protected Dome() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/shape/Quad.java
+++ b/jme3-core/src/main/java/com/jme3/scene/shape/Quad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2010 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,7 +56,7 @@ public class Quad extends Mesh {
     /**
      * Serialization only. Do not use.
      */
-    public Quad(){
+    protected Quad(){
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/shape/Sphere.java
+++ b/jme3-core/src/main/java/com/jme3/scene/shape/Sphere.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -84,7 +84,7 @@ public class Sphere extends Mesh {
     /**
      * Serialization only. Do not use.
      */
-    public Sphere() {
+    protected Sphere() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/shape/StripBox.java
+++ b/jme3-core/src/main/java/com/jme3/scene/shape/StripBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -124,7 +124,7 @@ public class StripBox extends AbstractBox {
     /**
      * Empty constructor for serialization only. Do not use.
      */
-    public StripBox(){
+    protected StripBox(){
         super();
     }
 

--- a/jme3-core/src/main/java/com/jme3/shadow/DirectionalLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/DirectionalLightShadowRenderer.java
@@ -77,7 +77,7 @@ public class DirectionalLightShadowRenderer extends AbstractShadowRenderer {
      * DirectionalLightShadowRenderer#DirectionalLightShadowRenderer(AssetManager
      * assetManager, int shadowMapSize, int nbSplits)
      */
-    public DirectionalLightShadowRenderer() {
+    protected DirectionalLightShadowRenderer() {
         super();
     }
 

--- a/jme3-core/src/main/java/com/jme3/shadow/PointLightShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/PointLightShadowFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -62,7 +62,7 @@ public class PointLightShadowFilter extends AbstractShadowFilter<PointLightShado
      * assetManager, int shadowMapSize)
      * instead.
      */
-    public PointLightShadowFilter() {
+    protected PointLightShadowFilter() {
         super();
     }
 

--- a/jme3-core/src/main/java/com/jme3/shadow/PointLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/PointLightShadowRenderer.java
@@ -68,7 +68,7 @@ public class PointLightShadowRenderer extends AbstractShadowRenderer {
      * assetManager, int shadowMapSize)
      * instead.
      */
-    public PointLightShadowRenderer() {
+    protected PointLightShadowRenderer() {
         super();
     }
 

--- a/jme3-core/src/main/java/com/jme3/shadow/PssmShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/PssmShadowFilter.java
@@ -75,7 +75,7 @@ public class PssmShadowFilter extends Filter {
      * assetManager, int size, int nbSplits)
      * instead.
      */
-    public PssmShadowFilter() {
+    protected PssmShadowFilter() {
         super();
     }
     

--- a/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -62,7 +62,7 @@ public class SpotLightShadowFilter extends AbstractShadowFilter<SpotLightShadowR
      * int shadowMapSize)
      * instead.
      */
-    public SpotLightShadowFilter() {
+    protected SpotLightShadowFilter() {
         super();
     }
     

--- a/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowRenderer.java
@@ -73,7 +73,7 @@ public class SpotLightShadowRenderer extends AbstractShadowRenderer {
     /**
      * Used for serialization use SpotLightShadowRenderer#SpotLightShadowRenderer(AssetManager assetManager, int shadowMapSize)
      */
-    public SpotLightShadowRenderer() {
+    protected SpotLightShadowRenderer() {
         super();
     }
     

--- a/jme3-core/src/main/java/com/jme3/ui/Picture.java
+++ b/jme3-core/src/main/java/com/jme3/ui/Picture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -83,7 +83,7 @@ public class Picture extends Geometry {
     /*
      * Serialization only. Do not use.
      */
-    public Picture(){
+    protected Picture(){
     }
 
     /**


### PR DESCRIPTION
Now that issue #1119 is closed, protect some of the public no-arg constructors that are intended only for use by JME's serialization system (`SavableClassUtil`).