### PR TITLE
protect 52 no-arg constructors in the jme3-bullet/jme3-jbullet libraries

### DIFF
--- a/jme3-bullet/src/common/java/com/jme3/bullet/animation/BoneLink.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/animation/BoneLink.java
@@ -99,7 +99,7 @@ public class BoneLink extends PhysicsLink {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public BoneLink() {
+    protected BoneLink() {
     }
 
     /**

--- a/jme3-bullet/src/common/java/com/jme3/bullet/animation/PhysicsLink.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/animation/PhysicsLink.java
@@ -130,7 +130,7 @@ abstract public class PhysicsLink
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public PhysicsLink() {
+    protected PhysicsLink() {
     }
 
     /**

--- a/jme3-bullet/src/common/java/com/jme3/bullet/animation/TorsoLink.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/animation/TorsoLink.java
@@ -107,7 +107,7 @@ public class TorsoLink extends PhysicsLink {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public TorsoLink() {
+    protected TorsoLink() {
     }
 
     /**

--- a/jme3-bullet/src/common/java/com/jme3/bullet/collision/shapes/infos/ChildCollisionShape.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/collision/shapes/infos/ChildCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -65,7 +65,7 @@ public class ChildCollisionShape implements Savable {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public ChildCollisionShape() {
+    protected ChildCollisionShape() {
     }
 
     /**

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/BetterCharacterControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/BetterCharacterControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -136,7 +136,7 @@ public class BetterCharacterControl extends AbstractPhysicsControl implements Ph
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public BetterCharacterControl() {
+    protected BetterCharacterControl() {
         jumpForce = new Vector3f();
     }
 

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/GhostControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/GhostControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -86,7 +86,7 @@ public class GhostControl extends PhysicsGhostObject implements PhysicsControl, 
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public GhostControl() {
+    protected GhostControl() {
     }
 
     /**

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/RigidBodyControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/RigidBodyControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -89,7 +89,7 @@ public class RigidBodyControl extends PhysicsRigidBody implements PhysicsControl
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public RigidBodyControl() {
+    protected RigidBodyControl() {
     }
 
     /**

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/VehicleControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/VehicleControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -80,7 +80,7 @@ public class VehicleControl extends PhysicsVehicle implements PhysicsControl, Jm
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public VehicleControl() {
+    protected VehicleControl() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/BoxCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/BoxCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,7 +57,7 @@ public class BoxCollisionShape extends CollisionShape {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public BoxCollisionShape() {
+    protected BoxCollisionShape() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/CapsuleCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/CapsuleCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,7 +64,7 @@ public class CapsuleCollisionShape extends CollisionShape{
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public CapsuleCollisionShape() {
+    protected CapsuleCollisionShape() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/ConeCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/ConeCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -65,7 +65,7 @@ public class ConeCollisionShape extends CollisionShape {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public ConeCollisionShape() {
+    protected ConeCollisionShape() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/CylinderCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/CylinderCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -62,7 +62,7 @@ public class CylinderCollisionShape extends CollisionShape {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public CylinderCollisionShape() {
+    protected CylinderCollisionShape() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/GImpactCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/GImpactCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,7 +68,7 @@ public class GImpactCollisionShape extends CollisionShape {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public GImpactCollisionShape() {
+    protected GImpactCollisionShape() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/HeightfieldCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/HeightfieldCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -93,7 +93,7 @@ public class HeightfieldCollisionShape extends CollisionShape {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public HeightfieldCollisionShape() {
+    protected HeightfieldCollisionShape() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/HullCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/HullCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,7 +56,7 @@ public class HullCollisionShape extends CollisionShape {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public HullCollisionShape() {
+    protected HullCollisionShape() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/MeshCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/MeshCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -75,7 +75,7 @@ public class MeshCollisionShape extends CollisionShape {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public MeshCollisionShape() {
+    protected MeshCollisionShape() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/PlaneCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/PlaneCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,7 +56,7 @@ public class PlaneCollisionShape extends CollisionShape{
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public PlaneCollisionShape() {
+    protected PlaneCollisionShape() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/SimplexCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/SimplexCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,7 +57,7 @@ public class SimplexCollisionShape extends CollisionShape {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public SimplexCollisionShape() {
+    protected SimplexCollisionShape() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/SphereCollisionShape.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/collision/shapes/SphereCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,7 +57,7 @@ public class SphereCollisionShape extends CollisionShape {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public SphereCollisionShape() {
+    protected SphereCollisionShape() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/joints/ConeJoint.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/joints/ConeJoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,7 +64,7 @@ public class ConeJoint extends PhysicsJoint {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public ConeJoint() {
+    protected ConeJoint() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/joints/HingeJoint.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/joints/HingeJoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -80,7 +80,7 @@ public class HingeJoint extends PhysicsJoint {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public HingeJoint() {
+    protected HingeJoint() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/joints/PhysicsJoint.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/joints/PhysicsJoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -76,7 +76,7 @@ public abstract class PhysicsJoint implements Savable {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public PhysicsJoint() {
+    protected PhysicsJoint() {
     }
 
     /**
@@ -208,8 +208,8 @@ public abstract class PhysicsJoint implements Savable {
      */
     public void read(JmeImporter im) throws IOException {
         InputCapsule capsule = im.getCapsule(this);
-        this.nodeA = ((PhysicsRigidBody) capsule.readSavable("nodeA", new PhysicsRigidBody()));
-        this.nodeB = (PhysicsRigidBody) capsule.readSavable("nodeB", new PhysicsRigidBody());
+        this.nodeA = ((PhysicsRigidBody) capsule.readSavable("nodeA", null));
+        this.nodeB = (PhysicsRigidBody) capsule.readSavable("nodeB", null);
         this.pivotA = (Vector3f) capsule.readSavable("pivotA", new Vector3f());
         this.pivotB = (Vector3f) capsule.readSavable("pivotB", new Vector3f());
     }

--- a/jme3-bullet/src/main/java/com/jme3/bullet/joints/Point2PointJoint.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/joints/Point2PointJoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,7 +57,7 @@ public class Point2PointJoint extends PhysicsJoint {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public Point2PointJoint() {
+    protected Point2PointJoint() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/joints/SixDofJoint.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/joints/SixDofJoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -99,7 +99,7 @@ public class SixDofJoint extends PhysicsJoint {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public SixDofJoint() {
+    protected SixDofJoint() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/joints/SliderJoint.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/joints/SliderJoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -60,7 +60,7 @@ public class SliderJoint extends PhysicsJoint {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public SliderJoint() {
+    protected SliderJoint() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsCharacter.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsCharacter.java
@@ -71,7 +71,7 @@ public class PhysicsCharacter extends PhysicsCollisionObject {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public PhysicsCharacter() {
+    protected PhysicsCharacter() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsGhostObject.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsGhostObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,7 +68,7 @@ public class PhysicsGhostObject extends PhysicsCollisionObject {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public PhysicsGhostObject() {
+    protected PhysicsGhostObject() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -81,7 +81,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public PhysicsRigidBody() {
+    protected PhysicsRigidBody() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsVehicle.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/objects/PhysicsVehicle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -90,7 +90,7 @@ public class PhysicsVehicle extends PhysicsRigidBody {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public PhysicsVehicle() {
+    protected PhysicsVehicle() {
     }
 
     /**

--- a/jme3-bullet/src/main/java/com/jme3/bullet/objects/VehicleWheel.java
+++ b/jme3-bullet/src/main/java/com/jme3/bullet/objects/VehicleWheel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -136,7 +136,7 @@ public class VehicleWheel implements Savable {
      * No-argument constructor needed by SavableClassUtil. Do not invoke
      * directly!
      */
-    public VehicleWheel() {
+    protected VehicleWheel() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/BoxCollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/BoxCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,7 @@ public class BoxCollisionShape extends CollisionShape {
 
     private Vector3f halfExtents;
 
-    public BoxCollisionShape() {
+    protected BoxCollisionShape() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/CapsuleCollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/CapsuleCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,7 +49,7 @@ public class CapsuleCollisionShape extends CollisionShape{
     protected float radius,height;
     protected int axis;
 
-    public CapsuleCollisionShape() {
+    protected CapsuleCollisionShape() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/CollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/CollisionShape.java
@@ -56,7 +56,7 @@ public abstract class CollisionShape implements Savable {
      */
     protected float margin = defaultMargin;
 
-    public CollisionShape() {
+    protected CollisionShape() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/ConeCollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/ConeCollisionShape.java
@@ -56,7 +56,7 @@ public class ConeCollisionShape extends CollisionShape {
     /**
      * Serialization only, do not use.
      */
-    public ConeCollisionShape() {
+    protected ConeCollisionShape() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/CylinderCollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/CylinderCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -53,7 +53,7 @@ public class CylinderCollisionShape extends CollisionShape {
     protected Vector3f halfExtents;
     protected int axis;
 
-    public CylinderCollisionShape() {
+    protected CylinderCollisionShape() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/GImpactCollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/GImpactCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,7 +55,7 @@ public class GImpactCollisionShape extends CollisionShape{
     protected ByteBuffer triangleIndexBase, vertexBase;
     protected IndexedMesh bulletMesh;
 
-    public GImpactCollisionShape() {
+    protected GImpactCollisionShape() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/HeightfieldCollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/HeightfieldCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -65,7 +65,7 @@ public class HeightfieldCollisionShape extends CollisionShape {
 	protected int upAxis;
 	protected boolean flipQuadEdges;
 
-	public HeightfieldCollisionShape() {
+	protected HeightfieldCollisionShape() {
 
 	}
 

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/HullCollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/HullCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,7 @@ public class HullCollisionShape extends CollisionShape {
 
     private float[] points;
 
-    public HullCollisionShape() {
+    protected HullCollisionShape() {
     }
 
     public HullCollisionShape(Mesh mesh) {

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/MeshCollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/MeshCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,7 +54,7 @@ public class MeshCollisionShape extends CollisionShape {
     protected ByteBuffer triangleIndexBase, vertexBase;
     protected IndexedMesh bulletMesh;
 
-    public MeshCollisionShape() {
+    protected MeshCollisionShape() {
     }
 
     /** 

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/PlaneCollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/PlaneCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,7 +47,7 @@ import java.io.IOException;
 public class PlaneCollisionShape extends CollisionShape{
     private Plane plane;
 
-    public PlaneCollisionShape() {
+    protected PlaneCollisionShape() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/SphereCollisionShape.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/collision/shapes/SphereCollisionShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,7 +47,7 @@ public class SphereCollisionShape extends CollisionShape {
 
     protected float radius;
 
-    public SphereCollisionShape() {
+    protected SphereCollisionShape() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/joints/ConeJoint.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/joints/ConeJoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -58,7 +58,7 @@ public class ConeJoint extends PhysicsJoint {
     protected float twistSpan = 1e30f;
     protected boolean angularOnly = false;
 
-    public ConeJoint() {
+    protected ConeJoint() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/joints/HingeJoint.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/joints/HingeJoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -58,7 +58,7 @@ public class HingeJoint extends PhysicsJoint {
     protected float relaxationFactor = 1.0f;
     protected float limitSoftness = 0.9f;
 
-    public HingeJoint() {
+    protected HingeJoint() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/joints/PhysicsJoint.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/joints/PhysicsJoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,7 @@ public abstract class PhysicsJoint implements Savable {
     protected Vector3f pivotB;
     protected boolean collisionBetweenLinkedBodys = true;
 
-    public PhysicsJoint() {
+    protected PhysicsJoint() {
     }
 
     /**
@@ -127,8 +127,8 @@ public abstract class PhysicsJoint implements Savable {
 
     public void read(JmeImporter im) throws IOException {
         InputCapsule capsule = im.getCapsule(this);
-        this.nodeA = ((PhysicsRigidBody) capsule.readSavable("nodeA", new PhysicsRigidBody()));
-        this.nodeB = (PhysicsRigidBody) capsule.readSavable("nodeB", new PhysicsRigidBody());
+        this.nodeA = ((PhysicsRigidBody) capsule.readSavable("nodeA", null));
+        this.nodeB = (PhysicsRigidBody) capsule.readSavable("nodeB", null);
         this.pivotA = (Vector3f) capsule.readSavable("pivotA", new Vector3f());
         this.pivotB = (Vector3f) capsule.readSavable("pivotB", new Vector3f());
     }

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/joints/Point2PointJoint.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/joints/Point2PointJoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,7 @@ import java.io.IOException;
  */
 public class Point2PointJoint extends PhysicsJoint {
 
-    public Point2PointJoint() {
+    protected Point2PointJoint() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/joints/SixDofJoint.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/joints/SixDofJoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,7 +68,7 @@ public class SixDofJoint extends PhysicsJoint {
     private Vector3f linearUpperLimit = new Vector3f(Vector3f.POSITIVE_INFINITY);
     private Vector3f linearLowerLimit = new Vector3f(Vector3f.NEGATIVE_INFINITY);
 
-    public SixDofJoint() {
+    protected SixDofJoint() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/joints/SliderJoint.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/joints/SliderJoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,7 +52,7 @@ public class SliderJoint extends PhysicsJoint {
     protected Matrix3f rotA, rotB;
     protected boolean useLinearReferenceFrameA;
 
-    public SliderJoint() {
+    protected SliderJoint() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsCharacter.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsCharacter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,7 +68,7 @@ public class PhysicsCharacter extends PhysicsCollisionObject {
     private com.jme3.math.Transform physicsLocation = new com.jme3.math.Transform();
     private javax.vecmath.Vector3f tempVec = new javax.vecmath.Vector3f();
 
-    public PhysicsCharacter() {
+    protected PhysicsCharacter() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsGhostObject.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsGhostObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,7 +68,7 @@ public class PhysicsGhostObject extends PhysicsCollisionObject {
     protected javax.vecmath.Quat4f tempRot = new javax.vecmath.Quat4f();
     private List<PhysicsCollisionObject> overlappingObjects = new LinkedList<PhysicsCollisionObject>();
 
-    public PhysicsGhostObject() {
+    protected PhysicsGhostObject() {
     }
 
     public PhysicsGhostObject(CollisionShape shape) {

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
@@ -72,7 +72,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     protected javax.vecmath.Vector3f localInertia = new javax.vecmath.Vector3f();
     protected ArrayList<PhysicsJoint> joints = new ArrayList<PhysicsJoint>();
 
-    public PhysicsRigidBody() {
+    protected PhysicsRigidBody() {
     }
 
     /**

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsVehicle.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsVehicle.java
@@ -67,7 +67,7 @@ public class PhysicsVehicle extends PhysicsRigidBody {
     protected ArrayList<VehicleWheel> wheels = new ArrayList<VehicleWheel>();
     protected PhysicsSpace physicsSpace;
 
-    public PhysicsVehicle() {
+    protected PhysicsVehicle() {
     }
 
     public PhysicsVehicle(CollisionShape shape) {

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/objects/VehicleWheel.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/objects/VehicleWheel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -67,7 +67,7 @@ public class VehicleWheel implements Savable {
     protected final Quaternion tmp_inverseWorldRotation = new Quaternion();
     private boolean applyLocal = false;
 
-    public VehicleWheel() {
+    protected VehicleWheel() {
     }
 
     public VehicleWheel(Spatial spat, Vector3f location, Vector3f direction, Vector3f axle,


### PR DESCRIPTION
Now that issue #1119 is closed, protect some more of the public no-arg constructors that are intended only for use by JME's serialization system (`SavableClassUtil`).