### PR TITLE
Fixes #1251 - Support OpenGL3.1 on LWJGL2 and LWJGL3

### DIFF
--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -71,19 +71,6 @@ public final class AppSettings extends HashMap<String, Object> {
     public static final String LWJGL_OPENGL2 = "LWJGL-OpenGL2";
 
     /**
-     * Use LWJGL as the display system and force using the core OpenGL3.0 renderer.
-     * <p>
-     * If the underlying system does not support OpenGL3.0, then the context
-     * initialization will throw an exception. Note that currently jMonkeyEngine
-     * does not have any shaders that support OpenGL3.0 therefore this 
-     * option is not useful.
-     * <p>
-     *
-     * @see AppSettings#setRenderer(java.lang.String)
-     */
-    public static final String LWJGL_OPENGL30 = "LWJGL-OpenGL30";
-
-    /**
      * Use LWJGL as the display system and force using the core OpenGL3.2 renderer.
      * <p>
      * If the underlying system does not support OpenGL3.2, then the context
@@ -98,6 +85,33 @@ public final class AppSettings extends HashMap<String, Object> {
      */
     @Deprecated
     public static final String LWJGL_OPENGL3 = "LWJGL-OpenGL3";
+
+
+    /**
+     * Use LWJGL as the display system and force using the core OpenGL3.0 renderer.
+     * <p>
+     * If the underlying system does not support OpenGL3.0, then the context
+     * initialization will throw an exception. Note that currently jMonkeyEngine
+     * does not have any shaders that support OpenGL3.0 therefore this 
+     * option is not useful.
+     * <p>
+     *
+     * @see AppSettings#setRenderer(java.lang.String)
+     */
+    public static final String LWJGL_OPENGL30 = "LWJGL-OpenGL30";
+
+    /**
+     * Use LWJGL as the display system and force using the core OpenGL3.1 renderer.
+     * <p>
+     * If the underlying system does not support OpenGL3.1, then the context
+     * initialization will throw an exception. Note that currently jMonkeyEngine
+     * does not have any shaders that support OpenGL3.0 therefore this
+     * option is not useful.
+     * <p>
+     *
+     * @see AppSettings#setRenderer(java.lang.String)
+     */
+    public static final String LWJGL_OPENGL31 = "LWJGL-OpenGL31";
 
     /**
      * Use LWJGL as the display system and force using the core OpenGL3.2 renderer.

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -117,6 +117,10 @@ public abstract class LwjglContext implements JmeContext {
                 maj = 3;
                 min = 0;
                 break;
+            case AppSettings.LWJGL_OPENGL31:
+                maj = 3;
+                min = 1;
+                break;
             case AppSettings.LWJGL_OPENGL32:
                 maj = 3;
                 min = 2;

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -106,6 +106,7 @@ public abstract class LwjglContext implements JmeContext {
     private static final Set<String> SUPPORTED_RENDERS = new HashSet<>(Arrays.asList(
             AppSettings.LWJGL_OPENGL2,
             AppSettings.LWJGL_OPENGL30,
+            AppSettings.LWJGL_OPENGL31,
             AppSettings.LWJGL_OPENGL32,
             AppSettings.LWJGL_OPENGL33,
             AppSettings.LWJGL_OPENGL40,

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -80,6 +80,10 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
         });
+        RENDER_CONFIGS.put(AppSettings.LWJGL_OPENGL31, () -> {
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+        });
         RENDER_CONFIGS.put(AppSettings.LWJGL_OPENGL32, () -> {
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);


### PR DESCRIPTION
Same rules apply here: No answer after 7 days, I'll merge it.

Do note that JOGL has it's own Renderer and thus this AppSettings does not affect it (which is something I'd love to address).
Also the VR backend only supports two specific versions, be it because of specific requirements or because of not having the code written dynamically for this, so this remains untouched.

Also please watch the AppSettings file itself and not the diff: I've dragged LWJGL_OPENGL3 above OPENGL30 and then added 31 as a copy, thus it looks like changing OPENGL3 to 31.