### PR TITLE
LWJGL2 early create issue

### DIFF
--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglAbstractDisplay.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglAbstractDisplay.java
@@ -113,7 +113,6 @@ public abstract class LwjglAbstractDisplay extends LwjglContext implements Runna
             createContext(settings);
             printContextInitInfo();
 
-            created.set(true);
             super.internalCreate();
         } catch (Exception ex){
             try {

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -416,14 +416,14 @@ public abstract class LwjglContext implements JmeContext {
     }
     public void internalCreate() {
         timer = new LwjglTimer();
-        synchronized (createdLock) {
-            created.set(true);
-            createdLock.notifyAll();
-        }
         if (renderable.get()) {
             initContextFirstTime();
         } else {
             assert getType() == Type.Canvas;
+        }
+        synchronized (createdLock) {
+            created.set(true);
+            createdLock.notifyAll();
         }
     }
 


### PR DESCRIPTION
Fixes an issue where LWJGL2 was returning created too early, so that when having issues during initialization, it would return as sucessfully created.

Note: I am quite uncertain on this issue, but in my unit testing I discovered, that when trying to access OpenGL Contexts with Graphics Debug (where I know initialization should fail with a RendererException), and it was just freezing in start().

Quick debugging showed me that created.set(true) is called twice and thus the first time is too early in any case.
Also I've put it _after_ the openGL Context Init in _initContextFirstTime_.

I have yet to investigate the real case for the hang up in my case and whether this PR fixes it. Specifically I wonder why I am not notified about the exception which might be the root cause for my problem. Still this looks wrong, so please test it and if you think it's confident, merge it.