### PR TITLE
Fixes #1261 - Clone the Terrain Picker, so that loading a terrain from file still works (after cloning, the picker would have the wrong terrain quad instance)

### DIFF
--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1793,9 +1793,8 @@ public class TerrainQuad extends Node implements Terrain {
         // This was not cloned before... I think that's a mistake.
         this.affectedAreaBBox = cloner.clone(affectedAreaBBox);
 
-        // picker is not cloneable and not cloned.  This also seems like
-        // a mistake if you ever load the same terrain twice.
-        // this.picker = cloner.clone(picker);
+        // Otherwise, picker would be cloned by reference and thus "this" would be wrong
+        this.picker = new BresenhamTerrainPicker(this);
 
         // neighbourFinder is also not cloned.  Maybe that's ok.
     }


### PR DESCRIPTION
Actually mind the comment that has been removed.
Earlier versions had the picker init in collideWith(), to bypass this problem partially, but I think this is the best solution (apart from making Picker cloneable, but it doesn't preserve "much" state anyway).

So: This would be a fast fix for 3.3 (cherry picking) and we can think about cloning later.
Actually the code has been written like that to allow for multiple terrain picker algorithms, where currently we only have Bresenham.

What would _need_ cloning, is the field `multipleCollisions` of `BresenhamTerrainPicker`, but since most cloning happens when loading, this isn't critical.

Unless you prefer that we'd be doing things right right away and make the Picker Cloneable, for this I'd need guidance, though.