### PR TITLE
Add two convenience flags to AppSettings: GraphicsTrace and GraphicsTiming

### DIFF
--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -1179,7 +1179,7 @@ public final class AppSettings extends HashMap<String, Object> {
     }
 
     /**
-     * Determine if the renderer will be run in Graphics Debug mode, which means every openGL Call is checked and
+     * Determine if the renderer will be run in Graphics Debug mode, which means every openGL call is checked and
      * if it returns an error code, throw a {@link com.jme3.renderer.RendererException}.<br />
      * Without this, many openGL calls might fail without notice, so turning it on is recommended for development.
      *
@@ -1191,7 +1191,7 @@ public final class AppSettings extends HashMap<String, Object> {
     }
 
     /**
-     * Set whether the renderer will be run in Graphics Debug mode, which means every openGL Call is checked and
+     * Set whether the renderer will be run in Graphics Debug mode, which means every openGL call is checked and
      * if it returns an error code, throw a {@link com.jme3.renderer.RendererException}.<br />
      * Without this, many openGL calls might fail without notice, so turning it on is recommended for development.
      *
@@ -1200,5 +1200,57 @@ public final class AppSettings extends HashMap<String, Object> {
      */
     public void setGraphicsDebug(boolean debug) {
         putBoolean("GraphicsDebug", debug);
+    }
+
+    /**
+     * Determine if the renderer will be run in Graphics Timing mode, which means every openGL call is checked and
+     * if it runs for longer than a millisecond, log it.<br />
+     * It also keeps track of the time spent in GL Calls in general and displays them when
+     * {@link com.jme3.renderer.opengl.GL#resetStats()} is called.<br />
+     *
+     * @return whether the context will be run in Graphics Timing Mode or not
+     * @see #setGraphicsTiming(boolean)
+     * @see com.jme3.renderer.opengl.GLTiming
+     */
+    public boolean isGraphicsTiming() {
+        return getBoolean("GraphicsTiming");
+    }
+
+    /**
+     * Set whether the renderer will be run in Graphics Timing mode, which means every openGL call is checked and
+     * if it runs for longer than a millisecond, log it.<br />
+     * It also keeps track of the time spent in GL Calls in general and displays them when
+     * {@link com.jme3.renderer.opengl.GL#resetStats()} is called.<br />
+     *
+     * @param timing whether the context will be run in Graphics Timing Mode or not
+     * @see #isGraphicsTiming()
+     * @see com.jme3.renderer.opengl.GLTiming
+     */
+    public void setGraphicsTiming(boolean timing) {
+        putBoolean("GraphicsTiming", timing);
+    }
+
+    /**
+     * Determine if the renderer will be run in Graphics Trace mode, which means every openGL call is logged so one
+     * can trace what openGL commands where executed in which order by the engine.<br />
+     *
+     * @return whether the context will be run in Graphics Trace Mode or not
+     * @see #setGraphicsTrace(boolean)
+     * @see com.jme3.renderer.opengl.GLTracer
+     */
+    public boolean isGraphicsTrace() {
+        return getBoolean("GraphicsTrace");
+    }
+
+    /**
+     * Set whether the renderer will be run in Graphics Trace mode, which means every openGL call is logged so one
+     * can trace what openGL commands where executed in which order by the engine.<br />
+     *
+     * @param trace whether the context will be run in Graphics Trace Mode or not
+     * @see #isGraphicsTrace()
+     * @see com.jme3.renderer.opengl.GLTracer
+     */
+    public void setGraphicsTrace(boolean trace) {
+        putBoolean("GraphicsTrace", trace);
     }
 }


### PR DESCRIPTION
This is much like the previous PR #1256 but this time it adds another two gems.
For platforms where a dedicated profiler isn't available or for a quick look, we actually already have a timing code, it was just hidden behind an AppSetting.

Might again be something for @mitm001 
I didn't try these settings out yet, but in #1278 there are a few potential problems on non lwjgl platforms, which will be fixed, though.

Edit: For the curious, here is a print out of the blue quad with Graphics Timing:
```
Feb 02, 2020 8:40:45 PM com.jme3.system.JmeDesktopSystem initialize
INFORMATION: Running on jMonkeyEngine 3.3.0-SNAPSHOT
 * Branch: fix-lwjgl3-key-input
 * Git Hash: 68fb1af
 * Build Date: 2019-12-28
Feb 02, 2020 8:40:46 PM com.jme3.system.lwjgl.LwjglContext printContextInitInfo
INFORMATION: LWJGL 3.2.3 build 13 context running on thread pool-1-thread-1
 * Graphics Adapter: GLFW 3.4.0 Win32 WGL EGL OSMesa VisualC DLL
GL call glGetString took 2249us to execute!
GL call glGetString took 5305us to execute!
Feb 02, 2020 8:40:46 PM com.jme3.renderer.opengl.GLRenderer loadCapabilitiesCommon
INFORMATION: OpenGL Renderer Information
 * Vendor: NVIDIA Corporation
 * Renderer: GeForce GTX 1060 6GB/PCIe/SSE2
 * OpenGL Version: 4.6.0 NVIDIA 441.12
 * GLSL Version: 4.60 NVIDIA
 * Profile: Compatibility
Feb 02, 2020 8:40:46 PM com.jme3.asset.AssetConfig loadText
WARNUNG: Cannot find loader com.jme3.scene.plugins.ogre.MeshLoader
Feb 02, 2020 8:40:46 PM com.jme3.asset.AssetConfig loadText
WARNUNG: Cannot find loader com.jme3.scene.plugins.ogre.SkeletonLoader
Feb 02, 2020 8:40:46 PM com.jme3.asset.AssetConfig loadText
WARNUNG: Cannot find loader com.jme3.scene.plugins.ogre.MaterialLoader
Feb 02, 2020 8:40:46 PM com.jme3.asset.AssetConfig loadText
WARNUNG: Cannot find loader com.jme3.scene.plugins.ogre.SceneLoader
Feb 02, 2020 8:40:46 PM com.jme3.asset.AssetConfig loadText
WARNUNG: Cannot find loader com.jme3.scene.plugins.blender.BlenderModelLoader
Feb 02, 2020 8:40:46 PM com.jme3.asset.AssetConfig loadText
WARNUNG: Cannot find loader com.jme3.scene.plugins.fbx.FbxLoader
Feb 02, 2020 8:40:46 PM com.jme3.asset.AssetConfig loadText
WARNUNG: Cannot find loader com.jme3.scene.plugins.gltf.GltfLoader
Feb 02, 2020 8:40:46 PM com.jme3.asset.AssetConfig loadText
WARNUNG: Cannot find loader com.jme3.scene.plugins.gltf.BinLoader
Feb 02, 2020 8:40:46 PM com.jme3.asset.AssetConfig loadText
WARNUNG: Cannot find loader com.jme3.scene.plugins.gltf.GlbLoader
Feb 02, 2020 8:40:46 PM com.jme3.asset.AssetConfig loadText
WARNUNG: Cannot find loader com.jme3.audio.plugins.OGGLoader
Feb 02, 2020 8:40:46 PM com.jme3.audio.openal.ALAudioRenderer initOpenAL
INFORMATION: Audio Renderer Information
 * Device: OpenAL Soft
 * Vendor: OpenAL Community
 * Renderer: OpenAL Soft
 * Version: 1.1 ALSOFT 1.19.1
 * Supported channels: 64
 * ALC extensions: ALC_ENUMERATE_ALL_EXT ALC_ENUMERATION_EXT ALC_EXT_CAPTURE ALC_EXT_DEDICATED ALC_EXT_disconnect ALC_EXT_EFX ALC_EXT_thread_local_context ALC_SOFT_device_clock ALC_SOFT_HRTF ALC_SOFT_loopback ALC_SOFT_output_limiter ALC_SOFT_pause_device
 * AL extensions: AL_EXT_ALAW AL_EXT_BFORMAT AL_EXT_DOUBLE AL_EXT_EXPONENT_DISTANCE AL_EXT_FLOAT32 AL_EXT_IMA4 AL_EXT_LINEAR_DISTANCE AL_EXT_MCFORMATS AL_EXT_MULAW AL_EXT_MULAW_BFORMAT AL_EXT_MULAW_MCFORMATS AL_EXT_OFFSET AL_EXT_source_distance_model AL_EXT_SOURCE_RADIUS AL_EXT_STEREO_ANGLES AL_LOKI_quadriphonic AL_SOFT_block_alignment AL_SOFT_deferred_updates AL_SOFT_direct_channels AL_SOFTX_events AL_SOFTX_filter_gain_ex AL_SOFT_gain_clamp_ex AL_SOFT_loop_points AL_SOFTX_map_buffer AL_SOFT_MSADPCM AL_SOFT_source_latency AL_SOFT_source_length AL_SOFT_source_resampler AL_SOFT_source_spatialize
Feb 02, 2020 8:40:46 PM com.jme3.audio.openal.ALAudioRenderer initOpenAL
INFORMATION: Audio effect extension version: 1.0
Feb 02, 2020 8:40:46 PM com.jme3.audio.openal.ALAudioRenderer initOpenAL
INFORMATION: Audio max auxiliary sends: 2
GL call glTexParameteri took 23035us to execute!
GL call glShaderSource took 1803us to execute!
--- TOTAL TIME SPENT IN GL CALLS: 46554us
	glTexParameteri               23517us
	glGetString                   11173us
	glShaderSource                3935us
	glLinkProgram                 1036us
	glTexImage2D                  960us
	glDrawRangeElements           764us
	glBufferData                  714us
	glVertexAttribPointer         485us
	glGetUniformLocation          482us
	glGetInteger                  419us
	glBindBuffer                  402us
GL call glBindBuffer took 21938us to execute!
--- TOTAL TIME SPENT IN GL CALLS: 1086us
	glBindBuffer                  809us
	glClear                       54us
	glDrawRangeElements           49us
	glVertexAttribPointer         28us
	glUniformMatrix4              23us
	glUniform4f                   20us
	glUseProgram                  19us
	glDepthRange                  16us
	glBufferData                  15us
	glDisableVertexAttribArray    13us
	glBindTexture                 12us
GL call glVertexAttribPointer took 20255us to execute!
--- TOTAL TIME SPENT IN GL CALLS: 897us
	glVertexAttribPointer         736us
	glDrawRangeElements           38us
	glClear                       38us
	glUniformMatrix4              15us
	glBindBuffer                  13us
	glUseProgram                  11us
	glBufferData                  10us
	glUniform4f                   6us
	glDepthRange                  6us
	glBindTexture                 5us
	glDisable                     4us
--- TOTAL TIME SPENT IN GL CALLS: 155us
	glClear                       35us
	glDrawRangeElements           35us
	glUseProgram                  12us
	glUniformMatrix4              12us
	glVertexAttribPointer         11us
	glBindBuffer                  11us
	glUniform4f                   8us
	glDepthRange                  7us
	glBindTexture                 5us
	glDisableVertexAttribArray    4us
	glDisable                     3us
--- TOTAL TIME SPENT IN GL CALLS: 167us
	glDrawRangeElements           39us
	glClear                       39us
	glVertexAttribPointer         13us
	glUniformMatrix4              12us
	glBindBuffer                  12us
	glUseProgram                  12us
	glUniform4f                   8us
	glDepthRange                  7us
	glBindTexture                 6us
	glDisable                     4us
	glEnableVertexAttribArray     3us
--- TOTAL TIME SPENT IN GL CALLS: 165us
	glDrawRangeElements           39us
	glClear                       39us
	glBindBuffer                  15us
	glVertexAttribPointer         12us
	glUseProgram                  11us
	glUniformMatrix4              10us
	glUniform4f                   8us
	glDepthRange                  7us
	glBindTexture                 5us
	glEnable                      4us
	glDisable                     4us

```

GraphicsTracing looks similar but outputs the exact commands once per frame, with the following example showing the extension detection during startup
```
GetString(VERSION) = "4.6.0 NVIDIA 441.12"
GetString(SHADING_LANGUAGE_VERSION) = "4.60 NVIDIA"
GetInteger(DRAW_BUFFER, out=BACK)
GetInteger(READ_BUFFER, out=BACK)
GetInteger(NUM_EXTENSIONS, out=389)
GetString(EXTENSIONS, 0) = "GL_AMD_multi_draw_indirect"
GetString(EXTENSIONS, 1) = "GL_AMD_seamless_cubemap_per_texture"
GetString(EXTENSIONS, 2) = "GL_AMD_vertex_shader_viewport_index"
```