### PR TITLE
Added a SpotBugs Implementation, which does not cause tasks to fail …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,15 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'me.tatarka:gradle-retrolambda:3.7.1'
+        classpath "com.github.spotbugs:spotbugs-gradle-plugin:3.0.0"
     }
 }
 
@@ -21,6 +25,7 @@ allprojects {
 }
 
 apply plugin: 'base'
+apply plugin: 'com.github.spotbugs'
 apply from: file('version.gradle')
 
 apply plugin: 'me.tatarka.retrolambda'
@@ -34,6 +39,22 @@ subprojects {
         }
     } else {
         apply from: rootProject.file('common-android-app.gradle')
+    }
+
+    if (!project.name.endsWith("-native") && project.name != "jme3-bullet-native-android") {
+        apply plugin: 'com.github.spotbugs'
+
+        // Currently we only warn about issues and try to fix them as we go, but those aren't mission critical.
+        spotbugs {
+            ignoreFailures = true
+        }
+
+        tasks.withType(com.github.spotbugs.SpotBugsTask) {
+            reports {
+                html.enabled = !project.hasProperty("xml-reports")
+                xml.enabled = project.hasProperty("xml-reports")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
…and so is purely optional

So this is a controverse topic, specifically because the opinions on static analysis tools vary.
Let me outline the reason behind this change:
In the future we might have a bot comparing the spotbugs results of a PR with the "expected" results, highlighting additions or removals. This should be purely supportive, just a hint when reviewing a PR.

Since SpotBugs needs to be run on .class files and since some folks might want to run it locally, I've decided to add it as a gradle plugin, which adds the `spotbugsMain` task to the root project and all (expect native) subprojects.

One Cautious Word: I had to upgrade the android build tools, because they supplied an outdated Guava Version, which caused spotbugs to fail. I straight upgraded to the latest version released in december and compatible with our current gradle version (it requires our current gradle version as minimum).
I did _NOT_ check the android build after that, but the android compilation succeeded so at worst it's runtime errors which we might have to check in the future.