### PR TITLE
Add base classes to jme-network serializer

### DIFF
--- a/jme3-networking/src/main/java/com/jme3/network/serializing/Serializer.java
+++ b/jme3-networking/src/main/java/com/jme3/network/serializing/Serializer.java
@@ -32,6 +32,7 @@
 package com.jme3.network.serializing;
 
 import com.jme3.math.ColorRGBA;
+import com.jme3.math.Quaternion;
 import com.jme3.math.Vector3f;
 import com.jme3.network.message.ChannelInfoMessage;
 import com.jme3.network.message.ClientRegistrationMessage;
@@ -123,6 +124,7 @@ public abstract class Serializer {
 
         registerClass(Vector3f.class,  new Vector3Serializer());
         registerClass(ColorRGBA.class,  new ColorRGBASerializer());
+        registerClass(Quaternion.class, new QuaternionSerializer());
 
         registerClass(Date.class,      new DateSerializer());
         

--- a/jme3-networking/src/main/java/com/jme3/network/serializing/Serializer.java
+++ b/jme3-networking/src/main/java/com/jme3/network/serializing/Serializer.java
@@ -31,6 +31,7 @@
  */
 package com.jme3.network.serializing;
 
+import com.jme3.math.ColorRGBA;
 import com.jme3.math.Vector3f;
 import com.jme3.network.message.ChannelInfoMessage;
 import com.jme3.network.message.ClientRegistrationMessage;
@@ -121,6 +122,7 @@ public abstract class Serializer {
         registerClass(String.class,    new StringSerializer());
 
         registerClass(Vector3f.class,  new Vector3Serializer());
+        registerClass(ColorRGBA.class,  new ColorRGBASerializer());
 
         registerClass(Date.class,      new DateSerializer());
         

--- a/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/ColorRGBASerializer.java
+++ b/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/ColorRGBASerializer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2009-2020 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.network.serializing.serializers;
+
+import com.jme3.math.ColorRGBA;
+import com.jme3.network.serializing.Serializer;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * @author Trevor Flynn
+ */
+@SuppressWarnings("unchecked")
+public class ColorRGBASerializer extends Serializer {
+
+    @Override
+    public ColorRGBA readObject(ByteBuffer data, Class c) throws IOException {
+        ColorRGBA color = new ColorRGBA();
+        color.r = data.getFloat();
+        color.g = data.getFloat();
+        color.b = data.getFloat();
+        color.a = data.getFloat();
+        return color;
+    }
+
+    @Override
+    public void writeObject(ByteBuffer buffer, Object object) throws IOException {
+        ColorRGBA color = (ColorRGBA) object;
+        buffer.putFloat(color.r);
+        buffer.putFloat(color.g);
+        buffer.putFloat(color.b);
+        buffer.putFloat(color.a);
+    }
+}

--- a/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/QuaternionSerializer.java
+++ b/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/QuaternionSerializer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2009-2020 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.network.serializing.serializers;
+
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.Quaternion;
+import com.jme3.network.serializing.Serializer;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * @author Trevor Flynn
+ */
+@SuppressWarnings("unchecked")
+public class QuaternionSerializer extends Serializer {
+
+    @Override
+    public Quaternion readObject(ByteBuffer data, Class c) throws IOException {
+        Quaternion quaternion = new Quaternion();
+        quaternion.set(data.getFloat(), data.getFloat(), data.getFloat(), data.getFloat());
+        return quaternion;
+    }
+
+    @Override
+    public void writeObject(ByteBuffer buffer, Object object) throws IOException {
+        Quaternion quaternion = (Quaternion) object;
+        buffer.putFloat(quaternion.getX());
+        buffer.putFloat(quaternion.getY());
+        buffer.putFloat(quaternion.getZ());
+        buffer.putFloat(quaternion.getW());
+    }
+}


### PR DESCRIPTION
Adds ColorRGBA to the serializer. 
Adds Quaternion to the serializer.
I was surprised that neither of these were in there.

Edit: If there are others that people would like me to add in pr, I will do so. 