### PR TITLE
Expose ViewPorts

### DIFF
--- a/jme3-core/src/main/java/com/jme3/environment/EnvironmentCamera.java
+++ b/jme3-core/src/main/java/com/jme3/environment/EnvironmentCamera.java
@@ -249,6 +249,15 @@ public class EnvironmentCamera extends BaseAppState {
         }
     }
 
+    /**
+     * Returns an array of the 6 ViewPorts used to capture the snapshot.
+     * Note that this will be null until after initialize() is called.
+     * @return array of ViewPorts
+     */
+    public ViewPort[] getViewPorts(){
+        return viewports;
+    }
+
     @Override
     protected void initialize(Application app) {
         this.backGroundColor = app.getViewPort().getBackgroundColor();


### PR DESCRIPTION
This commit allows EnvironmentCamera users to access the ViewPorts used
for rendering the snapshots. This allows incorporating screenspace and other
SceneProcessor-based effects into the snapshots as well as the scene geometry.