### PR TITLE
Fix for resizing the window (issue 1191)

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -121,6 +121,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
     private GLFWErrorCallback errorCallback;
     private GLFWWindowSizeCallback windowSizeCallback;
+    private GLFWFramebufferSizeCallback framebufferSizeCallback;
     private GLFWWindowFocusCallback windowFocusCallback;
 
     private Thread mainThread;
@@ -253,16 +254,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             throw new RuntimeException("Failed to create the GLFW window");
         }
 
-        // Add a resize callback which delegates to the listener
-        glfwSetWindowSizeCallback(window, windowSizeCallback = new GLFWWindowSizeCallback() {
-            @Override
-            public void invoke(final long window, final int width, final int height) {
-                settings.setResolution(width, height);
-                listener.reshape(width, height);
-            }
-        });
-
         glfwSetWindowFocusCallback(window, windowFocusCallback = new GLFWWindowFocusCallback() {
+
             @Override
             public void invoke(final long window, final boolean focus) {
                 if (wasActive != focus) {
@@ -296,6 +289,23 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
         setWindowIcon(settings);
         showWindow();
+
+        // Add a resize callback which delegates to the listener
+        glfwSetWindowSizeCallback(window, windowSizeCallback = new GLFWWindowSizeCallback() {
+
+            @Override
+            public void invoke(final long window, final int width, final int height) {
+                settings.setResolution(width, height);
+            }
+        });
+
+        glfwSetFramebufferSizeCallback(window, framebufferSizeCallback = new GLFWFramebufferSizeCallback() {
+
+            @Override
+            public void invoke(final long window, final int width, final int height) {
+                listener.reshape(width, height);
+            }
+        });
 
         allowSwapBuffers = settings.isSwapBuffers();
     }
@@ -400,6 +410,11 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             if (windowSizeCallback != null) {
                 windowSizeCallback.close();
                 windowSizeCallback = null;
+            }
+
+            if (framebufferSizeCallback != null) {
+                framebufferSizeCallback.close();
+                framebufferSizeCallback = null;
             }
 
             if (windowFocusCallback != null) {


### PR DESCRIPTION
Ok, sorry for the branch name, it was intended to fix issue #893 but it really doesn't. But it does make that issue better actually. Only the starting status (camera) is broken anymore there.

So what this does is:
- Fixes #1191 
- The fix is to add the callbacks later that they don't trigger on window creation process, there should be no need as it looks that we actually have the correct resolution and even the correct size canvas on HDPI situations, so everything should be fine
- Fixes the resizing altogether for LWJGL 3, it wasn't really working at all. At least for some configurations the window size callback doesn't seem to trigger at all... Windows 10 with NVIDIA seems to be at least said configuration

This is made in accordance of https://www.glfw.org/docs/latest/window_guide.html#window_fbsize. I added some comments as it seems that the window size callback (the old) doesn't really work as expected. This maybe a bug or just a behavior difference between LWJGL 2 and 3. This fix now makes LWJGL 2 and 3 behave the same.