### PR TITLE
More informative exception for unsupported images.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 ######################################################################################
-# JME CI/CD 
+# JME CI/CD
 ######################################################################################
 # Quick overview of what is going on in this script:
 #   - Build natives for android
@@ -10,7 +10,7 @@
 #   - (only when building a release) Deploy everything else to github releases, github packet registry and bintray
 #   - (only when building a release) Update javadoc.jmonkeyengine.org
 # Note:
-#   All the actions/upload-artifact and actions/download-artifact steps are used to pass 
+#   All the actions/upload-artifact and actions/download-artifact steps are used to pass
 #   stuff between jobs, github actions has some sort of storage that is local to the
 #   running workflow, we use it to store the result of each job since the filesystem
 #   is not maintained between jobs.
@@ -23,7 +23,7 @@
 #     BINTRAY_APIKEY=XXXXXX
 #     BINTRAY_LICENSE="BSD 3-Clause"
 # >> Configure  PACKAGE REGISTRY RELEASE
-#   Nothing to do here, everything is autoconfigured to work with the account/org that 
+#   Nothing to do here, everything is autoconfigured to work with the account/org that
 #   is running the build.
 # >> Configure  JAVADOC
 #     JAVADOC_GHPAGES_REPO="riccardoblsandbox/javadoc.jmonkeyengine.org.git"
@@ -31,7 +31,7 @@
 #       ssh-keygen -t rsa -b 4096 -C "actions@users.noreply.github.com" -f javadoc_deploy
 #   Set
 #     JAVADOC_GHPAGES_DEPLOY_PRIVKEY="......."
-#   In github repo -> Settings, use javadoc_deploy.pub as Deploy key with write access  
+#   In github repo -> Settings, use javadoc_deploy.pub as Deploy key with write access
 ######################################################################################
 # Resources:
 #   - Github actions docs: https://help.github.com/en/articles/about-github-actions
@@ -54,35 +54,36 @@ on:
   pull_request:
   release:
     types: [published]
-  
+
 jobs:
-  
+
   # Builds the natives on linux arm
   BuildLinuxArmNatives:
     name: Build natives for linux (arm)
     runs-on: ubuntu-18.04
     container:
       image: riccardoblb/buildenv-jme3:linuxArm
-   
+
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v1     
+        uses: actions/checkout@v1
         with:
           fetch-depth: 1
-
-      - name: Build        
+      - name: Validate the Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Build
         run: |
           # Build
           # Note: since this is crossbuild we use the buildForPlatforms filter to tell
           # the buildscript wich platforms it should build for.
           gradle -PuseCommitHashAsVersionName=true --no-daemon -PbuildForPlatforms=LinuxArm,LinuxArmHF,LinuxArm64 -PbuildNativeProjects=true \
-          :jme3-bullet-native:assemble 
+          :jme3-bullet-native:assemble
 
       - name: Upload natives
         uses: actions/upload-artifact@master
         with:
           name: linuxarm-natives
-          path: build/native 
+          path: build/native
 
   # Build the natives on android
   BuildAndroidNatives:
@@ -90,19 +91,20 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: riccardoblb/buildenv-jme3:android
-  
+
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v1     
+        uses: actions/checkout@v1
         with:
           fetch-depth: 1
-
-      - name: Build        
-        run: |       
-          gradle -PuseCommitHashAsVersionName=true --no-daemon -PbuildNativeProjects=true \
+      - name: Validate the Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Build
+        run: |
+          ./gradlew -PuseCommitHashAsVersionName=true --no-daemon -PbuildNativeProjects=true \
           :jme3-android-native:assemble \
-          :jme3-bullet-native-android:assemble 
-     
+          :jme3-bullet-native-android:assemble
+
       - name: Upload natives
         uses: actions/upload-artifact@master
         with:
@@ -114,7 +116,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04,windows-2019,macOS-latest] 
+        os: [ubuntu-18.04,windows-2019,macOS-latest]
         jdk: [8.x.x]
         include:
           - os: ubuntu-18.04
@@ -123,22 +125,23 @@ jobs:
             osName: windows
           - os: macOS-latest
             osName: mac
-              
+
     name: Build natives for ${{ matrix.osName }}
-    runs-on: ${{ matrix.os }}    
-    steps:    
-    
+    runs-on: ${{ matrix.os }}
+    steps:
+
       - name: Clone the repo
-        uses: actions/checkout@v1     
+        uses: actions/checkout@v1
         with:
           fetch-depth: 1
-           
+
       - name: Prepare java environment
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.jdk }}
-          architecture: x64 
-          
+          architecture: x64
+      - name: Validate the Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
       - name: Build Natives
         shell: bash
         env:
@@ -147,8 +150,8 @@ jobs:
           # Install dependencies
           if [ "$OS_NAME" = "mac" ];
           then
-            echo "Prepare mac"        
-          
+            echo "Prepare mac"
+
           elif [ "$OS_NAME" = "linux" ];
           then
             echo "Prepare linux"
@@ -157,25 +160,25 @@ jobs:
           else
             echo "Prepare windows"
           fi
-          
+
           # Build
           gradle  -PuseCommitHashAsVersionName=true --no-daemon  -PbuildNativeProjects=true -Dmaven.repo.local="$PWD/dist/maven" \
           build \
           :jme3-bullet-native:build
-                  
+
       # Upload natives to be used later by the BuildJMonkey job
       - name: Upload natives
         uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.osName }}-natives
           path: build/native
- 
+
 
   # Build the engine, we only deploy from ubuntu-18.04 jdk8
-  BuildJMonkey:  
+  BuildJMonkey:
     needs: [BuildNatives,BuildAndroidNatives]
     name: Build on ${{ matrix.osName }} jdk${{ matrix.jdk }}
-    runs-on: ${{ matrix.os }}    
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
@@ -188,21 +191,21 @@ jobs:
           - os: windows-2019
             osName: windows
           - os: macOS-latest
-            osName: mac 
+            osName: mac
           - jdk: 11.x.x
-            deploy: false 
+            deploy: false
 
-    steps:          
+    steps:
       - name: Clone the repo
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
-          
+
       - name: Setup the java environment
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.jdk }}
-          architecture: x64 
+          architecture: x64
 
       - name: Download natives for linux
         uses: actions/download-artifact@master
@@ -215,7 +218,7 @@ jobs:
         with:
           name: windows-natives
           path: build/native
-             
+
       - name: Download natives for mac
         uses: actions/download-artifact@master
         with:
@@ -233,26 +236,27 @@ jobs:
         with:
           name: linuxarm-natives
           path: build/native
-                                                     
+      - name: Validate the Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
       - name: Build Engine
         shell: bash
         run: |
           # Build
           gradle -PuseCommitHashAsVersionName=true -PskipPrebuildLibraries=true build
-          
+
           if [ "${{ matrix.deploy }}" = "true" ];
-          then  
+          then
             # We are going to need "zip"
             sudo apt-get update
             sudo apt-get install -y zip
 
             # Create the zip release and the javadoc
             gradle -PuseCommitHashAsVersionName=true -PskipPrebuildLibraries=true mergedJavadoc createZipDistribution
-          
+
             # We prepare the release for deploy
             mkdir -p ./dist/release/
             mv build/distributions/*.zip dist/release/
-            
+
             # Create the maven artifacts
             mkdir -p ./dist/maven/
             gradle -PuseCommitHashAsVersionName=true -PskipPrebuildLibraries=true install -Dmaven.repo.local="$PWD/dist/maven"
@@ -261,10 +265,10 @@ jobs:
             echo "Create native zip"
             cdir="$PWD"
             cd "build/native"
-            zip -r "$cdir/dist/jme3-natives.zip" *       
+            zip -r "$cdir/dist/jme3-natives.zip" *
             cd "$cdir"
             echo "Done"
-          fi         
+          fi
 
       # Used later by DeploySnapshot
       - name: Upload merged natives
@@ -273,29 +277,29 @@ jobs:
         with:
           name: natives
           path: dist/jme3-natives.zip
-          
+
       # Upload maven artifacts to be used later by the deploy job
       - name: Upload maven artifacts
         if: matrix.deploy==true
         uses: actions/upload-artifact@master
         with:
           name: maven
-          path: dist/maven          
+          path: dist/maven
 
       - name: Upload javadoc
         if:  matrix.deploy==true
         uses: actions/upload-artifact@master
         with:
           name: javadoc
-          path: dist/javadoc        
-          
-      # Upload release archive to be used later by the deploy job    
+          path: dist/javadoc
+
+      # Upload release archive to be used later by the deploy job
       - name: Upload release
         if: github.event_name == 'release' && matrix.deploy==true
         uses: actions/upload-artifact@master
         with:
           name: release
-          path: dist/release             
+          path: dist/release
 
   # This job deploys the native snapshot.
   # The snapshot is downloaded when people build the engine without setting buildNativeProject
@@ -316,7 +320,7 @@ jobs:
           then
             git clone --single-branch --branch "$branch" https://github.com/${GITHUB_REPOSITORY}.git .
           fi
-      
+
       - name: Download merged natives
         uses: actions/download-artifact@master
         with:
@@ -334,7 +338,7 @@ jobs:
             then
               nativeSnapshot=`cat "natives-snapshot.properties"`
               nativeSnapshot="${nativeSnapshot#*=}"
-              
+
               # We deploy ONLY if GITHUB_SHA (the current commit hash) is newer than $nativeSnapshot
               if [ "`git rev-list --count $nativeSnapshot..$GITHUB_SHA`" = "0" ];
               then
@@ -355,9 +359,9 @@ jobs:
               echo "No changes, skip."
             else
               if [ "${{ secrets.BINTRAY_GENERIC_REPO }}" = "" ];
-              then               
+              then
                 echo "Configure the following secrets to enable native snapshot deployment"
-                echo "BINTRAY_GENERIC_REPO, BINTRAY_USER, BINTRAY_APIKEY"           
+                echo "BINTRAY_GENERIC_REPO, BINTRAY_USER, BINTRAY_APIKEY"
               else
                 # Deploy snapshot
                 bintray_uploadFile dist/jme3-natives.zip \
@@ -368,17 +372,17 @@ jobs:
                   "https://github.com/${GITHUB_REPOSITORY}" \
                   "${{ secrets.BINTRAY_LICENSE }}" "true"
 
-                # We reference the snapshot by writing its commit hash in  natives-snapshot.properties 
+                # We reference the snapshot by writing its commit hash in  natives-snapshot.properties
                 echo "natives.snapshot=$GITHUB_SHA" > natives-snapshot.properties
-                
+
                 # We commit the updated  natives-snapshot.properties
                 git config --global user.name "Github Actions"
                 git config --global user.email "actions@users.noreply.github.com"
-      
+
                 git add natives-snapshot.properties
-              
+
                 git commit -m "[skip ci] update natives snapshot"
-                
+
                 # Pull rebase from the remote repo, just in case there was a push in the meantime
                 git pull -q --rebase
 
@@ -387,39 +391,39 @@ jobs:
 
                 # Push
                 (git -c http.extraheader="AUTHORIZATION: basic $header" push origin "$branch" || true)
-              
+
               fi
             fi
           fi
 
   # This job deploys the release
-  DeployRelease:  
+  DeployRelease:
     needs: [BuildJMonkey]
     name: Deploy Release
     runs-on: ubuntu-18.04
     if: github.event_name == 'release'
-    steps:   
-    
+    steps:
+
       # We need to clone everything again for uploadToMaven.sh ...
       - name: Clone the repo
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
-    
+
       # Download all the stuff...
       - name: Download maven artifacts
         uses: actions/download-artifact@master
         with:
           name: maven
           path: dist/maven
-      
+
       - name: Download release
         uses: actions/download-artifact@master
         with:
           name: release
-          path: dist/release      
-      
-      - name: Deploy to github releases    
+          path: dist/release
+
+      - name: Deploy to github releases
         run: |
           # We need to get the release id (yeah, it's not the same as the tag)
           echo "${GITHUB_EVENT_PATH}"
@@ -436,7 +440,7 @@ jobs:
           -H "Content-Type: application/zip" \
           --data-binary @"$filename" \
           "$url"
-            
+
       - name: Deploy to bintray
         run: |
           source .github/actions/tools/uploadToMaven.sh
@@ -447,22 +451,22 @@ jobs:
           else
             uploadAllToMaven dist/maven/ https://api.bintray.com/maven/${{ secrets.BINTRAY_MAVEN_REPO }} ${{ secrets.BINTRAY_USER }} ${{ secrets.BINTRAY_APIKEY }} "https://github.com/${GITHUB_REPOSITORY}" "${{ secrets.BINTRAY_LICENSE }}"
           fi
-      
+
       # - name: Deploy to github package registry
       #   run: |
       #     source .github/actions/tools/uploadToMaven.sh
       #     registry="https://maven.pkg.github.com/$GITHUB_REPOSITORY"
       #     echo "Deploy to github package registry $registry"
       #     uploadAllToMaven dist/maven/ $registry "token" ${{ secrets.GITHUB_TOKEN }}
-          
+
   # Deploy the javadoc
-  DeployJavaDoc:  
+  DeployJavaDoc:
     needs: [BuildJMonkey]
     name: Deploy Javadoc
     runs-on: ubuntu-18.04
     if: github.event_name == 'release'
-    steps:   
-      
+    steps:
+
       # We are going to need a deploy key for this, since we need
       # to push to a different repo
       - name: Set ssh key
@@ -477,16 +481,16 @@ jobs:
           branch="gh-pages"
           export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy.key"
           git clone --single-branch --branch "$branch" git@github.com:${{ secrets.JAVADOC_GHPAGES_REPO }} .
-          
+
       # Download the javadoc in the new directory "newdoc"
       - name: Download javadoc
         uses: actions/download-artifact@master
         with:
           name: javadoc
           path: newdoc
-      
+
       # The actual deploy
-      - name: Deploy to github pages    
+      - name: Deploy to github pages
         run: |
           set -f
           IFS=$'\n'
@@ -508,10 +512,10 @@ jobs:
             # if there isn't an index.txt we create one (we need this to list the versions)
             if [ ! -f "index.txt" ]; then echo "" > index.txt ; fi
             index="`cat index.txt`"
-         
+
             # Check if this version is already in index.txt
             addNew=true
-            for v in $index; 
+            for v in $index;
             do
               if [ "$v" = "$version" ];
               then
@@ -538,11 +542,11 @@ jobs:
             # Commit the changes
             git config --global user.name "Github Actions"
             git config --global user.email "actions@users.noreply.github.com"
-      
+
             git add .
             git commit -m "$version"
 
-            branch="gh-pages"                   
-            git push origin "$branch" --force 
+            branch="gh-pages"
+            git push origin "$branch" --force
 
           fi

--- a/build.gradle
+++ b/build.gradle
@@ -158,29 +158,29 @@ task configureAndroidNDK {
 
 gradle.rootProject.ext.set("usePrebuildNatives", buildNativeProjects!="true");
 
-if(skipPrebuildLibraries!="true"&&buildNativeProjects!="true"){
+if (skipPrebuildLibraries != "true" && buildNativeProjects != "true") {
     String rootPath = rootProject.projectDir.absolutePath
 
     Properties nativesSnasphotProp = new Properties()
-    File nativesSnasphotPropF=new File("${rootPath}/natives-snapshot.properties");
-    
-    if(nativesSnasphotPropF.exists()){
+    File nativesSnasphotPropF = new File("${rootPath}/natives-snapshot.properties");
+
+    if (nativesSnasphotPropF.exists()) {
 
         nativesSnasphotPropF.withInputStream { nativesSnasphotProp.load(it) }
 
-        String nativesSnasphot=nativesSnasphotProp.getProperty("natives.snapshot");
-        String nativesUrl=PREBUILD_NATIVES_URL.replace('${natives.snapshot}',nativesSnasphot)
-        println "Use natives snapshot: "+nativesUrl
+        String nativesSnasphot = nativesSnasphotProp.getProperty("natives.snapshot");
+        String nativesUrl = PREBUILD_NATIVES_URL.replace('${natives.snapshot}', nativesSnasphot)
+        println "Use natives snapshot: " + nativesUrl
 
-        String nativesZipFile="${rootPath}" + File.separator + "build"+ File.separator +nativesSnasphot+"-natives.zip"
-        String nativesPath="${rootPath}" + File.separator + "build"+ File.separator +"native"
+        String nativesZipFile = "${rootPath}" + File.separator + "build" + File.separator + nativesSnasphot + "-natives.zip"
+        String nativesPath = "${rootPath}" + File.separator + "build" + File.separator + "native"
 
 
         task getNativesZipFile {
             outputs.file nativesZipFile
             doFirst {
                 File target = file(nativesZipFile);
-                println("Download natives from "+nativesUrl+" to "+nativesZipFile);
+                println("Download natives from " + nativesUrl + " to " + nativesZipFile);
                 target.getParentFile().mkdirs();
                 ant.get(src: nativesUrl, dest: target);
             }
@@ -192,26 +192,24 @@ if(skipPrebuildLibraries!="true"&&buildNativeProjects!="true"){
             dependsOn getNativesZipFile
 
             doFirst {
-                for(File src : zipTree(nativesZipFile)){
-                    String srcRel=src.getAbsolutePath().substring((int)(nativesZipFile.length()+1));
-                    srcRel=srcRel.substring(srcRel.indexOf( File.separator)+1);
+                for (File src : zipTree(nativesZipFile)) {
+                    String srcRel = src.getAbsolutePath().substring((int) (nativesZipFile.length() + 1));
+                    srcRel = srcRel.substring(srcRel.indexOf(File.separator) + 1);
 
-                    File dest=new File(nativesPath+File.separator+srcRel);
+                    File dest = new File(nativesPath + File.separator + srcRel);
                     boolean doCopy = !(dest.exists() && dest.lastModified() > src.lastModified())
                     if (doCopy) {
-                        println("Copy "+src+" "+dest);
+                        println("Copy " + src + " " + dest);
                         dest.getParentFile().mkdirs();
                         Files.copy(src.toPath(), dest.toPath(), StandardCopyOption.REPLACE_EXISTING);
                     }
                 }
             }
         }
-        build.dependsOn extractPrebuiltNatives
+
+        assemble.dependsOn extractPrebuiltNatives
     }
 }
-
-
-
 
 
 //class IncrementalReverseTask extends DefaultTask {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,10 @@ jmeVersionName =
 # If true, the version name will contain the commit hash
 useCommitHashAsVersionName = false
 
+# Set to true if a non-master branch name should be included in the automatically 
+# generated version.
+includeBranchInVersion = false
+
 # specify if JavaDoc should be built
 buildJavaDoc = true
 

--- a/jme3-android-native/decode.gradle
+++ b/jme3-android-native/decode.gradle
@@ -1,5 +1,5 @@
 String tremorZipFile = "TremorAndroid.zip"
-String stbiUrl = 'https://raw.githubusercontent.com/nothings/stb/master/stb_image.h'
+String stbiUrl = 'https://raw.githubusercontent.com/jMonkeyEngine/stb/0224a44a10564a214595797b4c88323f79a5f934/stb_image.h'
 
 // Working directories for the ndk build.
 String decodeBuildDir = "${buildDir}" + File.separator + 'decode'

--- a/jme3-android-native/openalsoft.gradle
+++ b/jme3-android-native/openalsoft.gradle
@@ -1,11 +1,11 @@
 // OpenAL Soft r1.16
-String openALSoftUrl = 'http://repo.or.cz/w/openal-soft.git/snapshot/e5016f814a265ed592a88acea95cf912c4bfdf12.zip'
+String openALSoftUrl = 'https://github.com/jMonkeyEngine/openal-soft/archive/e5016f814a265ed592a88acea95cf912c4bfdf12.zip'
 String openALSoftZipFile = 'OpenALSoft.zip'
 
 // OpenAL Soft directory the download is extracted into
 // Typically, the downloaded OpenAL Soft zip file will extract to a directory
 // called "openal-soft"
-String openALSoftFolder = 'openal-soft-e5016f8'
+String openALSoftFolder = 'openal-soft-e5016f814a265ed592a88acea95cf912c4bfdf12'
 
 //Working directories for the ndk build.
 String openalsoftBuildDir = "${buildDir}" + File.separator + 'openalsoft'

--- a/jme3-core/src/main/java/com/jme3/animation/AnimControl.java
+++ b/jme3-core/src/main/java/com/jme3/animation/AnimControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2019 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -102,7 +102,9 @@ public final class AnimControl extends AbstractControl implements Cloneable, Jme
     }
 
     /**
-     * Serialization only. Do not use.
+     * Instantiate an animation control with no skeleton, suitable only for
+     * animations that don't contain any bone tracks. Also used for
+     * serialization.
      */
     public AnimControl() {
     }
@@ -144,6 +146,7 @@ public final class AnimControl extends AbstractControl implements Cloneable, Jme
 
     /**
      * Retrieve an animation from the list of animations.
+     *
      * @param name The name of the animation to retrieve.
      * @return The animation corresponding to the given name, or null, if no
      * such named animation exists.
@@ -155,6 +158,7 @@ public final class AnimControl extends AbstractControl implements Cloneable, Jme
     /**
      * Adds an animation to be available for playing to this
      * <code>AnimControl</code>.
+     *
      * @param anim The animation to add.
      */
     public void addAnim(Animation anim) {
@@ -163,6 +167,7 @@ public final class AnimControl extends AbstractControl implements Cloneable, Jme
 
     /**
      * Remove an animation so that it is no longer available for playing.
+     *
      * @param anim The animation to remove.
      */
     public void removeAnim(Animation anim) {
@@ -231,6 +236,7 @@ public final class AnimControl extends AbstractControl implements Cloneable, Jme
 
     /**
      * Adds a new listener to receive animation related events.
+     *
      * @param listener The listener to add.
      */
     public void addListener(AnimEventListener listener) {
@@ -244,6 +250,7 @@ public final class AnimControl extends AbstractControl implements Cloneable, Jme
 
     /**
      * Removes the given listener from listening to events.
+     *
      * @param listener
      * @see AnimControl#addListener(com.jme3.animation.AnimEventListener)
      */
@@ -308,6 +315,7 @@ public final class AnimControl extends AbstractControl implements Cloneable, Jme
 
     /**
      * Returns the length of the given named animation.
+     *
      * @param name The name of the animation
      * @return The length of time, in seconds, of the named animation.
      */

--- a/jme3-core/src/main/java/com/jme3/renderer/RenderContext.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderContext.java
@@ -32,7 +32,6 @@
 package com.jme3.renderer;
 
 import com.jme3.material.RenderState;
-import com.jme3.material.RenderState.BlendFunc;
 import com.jme3.math.ColorRGBA;
 import com.jme3.scene.Mesh;
 import com.jme3.scene.VertexBuffer;
@@ -49,123 +48,123 @@ public class RenderContext {
     /**
      * @see RenderState#setFaceCullMode(com.jme3.material.RenderState.FaceCullMode)
      */
-    public RenderState.FaceCullMode cullMode = RenderState.FaceCullMode.Off;
+    public RenderState.FaceCullMode cullMode;
 
     /**
-     * @see RenderState#setDepthTest(boolean) 
+     * @see RenderState#setDepthTest(boolean)
      */
-    public boolean depthTestEnabled = false;
+    public boolean depthTestEnabled;
 
     /**
-     * @see RenderState#setDepthWrite(boolean) 
+     * @see RenderState#setDepthWrite(boolean)
      */
-    public boolean depthWriteEnabled = true;
+    public boolean depthWriteEnabled;
 
     /**
-     * @see RenderState#setColorWrite(boolean) 
+     * @see RenderState#setColorWrite(boolean)
      */
-    public boolean colorWriteEnabled = true;
+    public boolean colorWriteEnabled;
 
     /**
-     * @see Renderer#setClipRect(int, int, int, int) 
+     * @see Renderer#setClipRect(int, int, int, int)
      */
-    public boolean clipRectEnabled = false;
+    public boolean clipRectEnabled;
 
     /**
-     * @see RenderState#setPolyOffset(float, float) 
+     * @see RenderState#setPolyOffset(float, float)
      */
-    public boolean polyOffsetEnabled = false;
-    
-    /**
-     * @see RenderState#setPolyOffset(float, float) 
-     */
-    public float polyOffsetFactor = 0;
-    
-    /**
-     * @see RenderState#setPolyOffset(float, float) 
-     */
-    public float polyOffsetUnits = 0;
+    public boolean polyOffsetEnabled;
 
     /**
-     * @see Mesh#setPointSize(float) 
+     * @see RenderState#setPolyOffset(float, float)
      */
-    public float pointSize = 1;
-    
+    public float polyOffsetFactor;
+
+    /**
+     * @see RenderState#setPolyOffset(float, float)
+     */
+    public float polyOffsetUnits;
+
+    /**
+     * @see Mesh#setPointSize(float)
+     */
+    public float pointSize;
+
     /**
      * @see RenderState#setLineWidth(float)
      */
-    public float lineWidth = 1;
+    public float lineWidth;
 
     /**
-     * @see RenderState#setBlendMode(com.jme3.material.RenderState.BlendMode) 
+     * @see RenderState#setBlendMode(com.jme3.material.RenderState.BlendMode)
      */
-    public RenderState.BlendMode blendMode = RenderState.BlendMode.Off;
+    public RenderState.BlendMode blendMode;
 
     /**
-     * @see RenderState#setBlendEquation(com.jme3.material.RenderState.BlendEquation) 
+     * @see RenderState#setBlendEquation(com.jme3.material.RenderState.BlendEquation)
      */
-    public RenderState.BlendEquation blendEquation = RenderState.BlendEquation.Add;
-    
-    /**
-     * @see RenderState#setBlendEquationAlpha(com.jme3.material.RenderState.BlendEquationAlpha) 
-     */
-    public RenderState.BlendEquationAlpha blendEquationAlpha = RenderState.BlendEquationAlpha.InheritColor;
+    public RenderState.BlendEquation blendEquation;
 
     /**
-     * @see RenderState#setCustomBlendFactors(com.jme3.material.RenderState.BlendFunc, com.jme3.material.RenderState.BlendFunc,
-     *      com.jme3.material.RenderState.BlendFunc, com.jme3.material.RenderState.BlendFunc)
+     * @see RenderState#setBlendEquationAlpha(com.jme3.material.RenderState.BlendEquationAlpha)
      */
-    public RenderState.BlendFunc sfactorRGB = RenderState.BlendFunc.One;
+    public RenderState.BlendEquationAlpha blendEquationAlpha;
 
     /**
      * @see RenderState#setCustomBlendFactors(com.jme3.material.RenderState.BlendFunc, com.jme3.material.RenderState.BlendFunc,
      *      com.jme3.material.RenderState.BlendFunc, com.jme3.material.RenderState.BlendFunc)
      */
-    public RenderState.BlendFunc dfactorRGB = RenderState.BlendFunc.One;
+    public RenderState.BlendFunc sfactorRGB;
 
     /**
      * @see RenderState#setCustomBlendFactors(com.jme3.material.RenderState.BlendFunc, com.jme3.material.RenderState.BlendFunc,
      *      com.jme3.material.RenderState.BlendFunc, com.jme3.material.RenderState.BlendFunc)
      */
-    public RenderState.BlendFunc sfactorAlpha = RenderState.BlendFunc.One;
+    public RenderState.BlendFunc dfactorRGB;
 
     /**
      * @see RenderState#setCustomBlendFactors(com.jme3.material.RenderState.BlendFunc, com.jme3.material.RenderState.BlendFunc,
      *      com.jme3.material.RenderState.BlendFunc, com.jme3.material.RenderState.BlendFunc)
      */
-    public RenderState.BlendFunc dfactorAlpha = RenderState.BlendFunc.One;
+    public RenderState.BlendFunc sfactorAlpha;
 
     /**
-     * @see RenderState#setWireframe(boolean) 
+     * @see RenderState#setCustomBlendFactors(com.jme3.material.RenderState.BlendFunc, com.jme3.material.RenderState.BlendFunc,
+     *      com.jme3.material.RenderState.BlendFunc, com.jme3.material.RenderState.BlendFunc)
      */
-    public boolean wireframe = false;
+    public RenderState.BlendFunc dfactorAlpha;
 
     /**
-     * @see Renderer#setShader(com.jme3.shader.Shader) 
+     * @see RenderState#setWireframe(boolean)
+     */
+    public boolean wireframe;
+
+    /**
+     * @see Renderer#setShader(com.jme3.shader.Shader)
      */
     public int boundShaderProgram;
-    
+
     /**
-     * @see Renderer#setShader(com.jme3.shader.Shader) 
+     * @see Renderer#setShader(com.jme3.shader.Shader)
      */
     public Shader boundShader;
 
     /**
-     * @see Renderer#setFrameBuffer(com.jme3.texture.FrameBuffer) 
+     * @see Renderer#setFrameBuffer(com.jme3.texture.FrameBuffer)
      */
-    public int boundFBO = 0;
-    
+    public int boundFBO;
+
     /**
-     * @see Renderer#setFrameBuffer(com.jme3.texture.FrameBuffer) 
+     * @see Renderer#setFrameBuffer(com.jme3.texture.FrameBuffer)
      */
     public FrameBuffer boundFB;
 
     /**
      * Currently bound Renderbuffer
-     * 
-     * @see Renderer#setFrameBuffer(com.jme3.texture.FrameBuffer) 
+     *
+     * @see Renderer#setFrameBuffer(com.jme3.texture.FrameBuffer)
      */
-    public int boundRB = 0;
+    public int boundRB;
 
     /**
      * Currently bound draw buffer
@@ -174,20 +173,20 @@ public class RenderContext {
      *  0 = GL_COLOR_ATTACHMENT0
      *  n = GL_COLOR_ATTACHMENTn
      *  where n is an integer greater than 1
-     * 
-     * @see Renderer#setFrameBuffer(com.jme3.texture.FrameBuffer) 
-     * @see FrameBuffer#setTargetIndex(int) 
+     *
+     * @see Renderer#setFrameBuffer(com.jme3.texture.FrameBuffer)
+     * @see FrameBuffer#setTargetIndex(int)
      */
-    public int boundDrawBuf = -1;
+    public int boundDrawBuf;
 
     /**
      * Currently bound read buffer
      *
      * @see RenderContext#boundDrawBuf
-     * @see Renderer#setFrameBuffer(com.jme3.texture.FrameBuffer) 
-     * @see FrameBuffer#setTargetIndex(int) 
+     * @see Renderer#setFrameBuffer(com.jme3.texture.FrameBuffer)
+     * @see FrameBuffer#setTargetIndex(int)
      */
-    public int boundReadBuf = -1;
+    public int boundReadBuf;
 
     /**
      * Currently bound element array vertex buffer.
@@ -207,118 +206,114 @@ public class RenderContext {
      * @see Renderer#renderMesh(com.jme3.scene.Mesh, int, int, com.jme3.scene.VertexBuffer[]) 
      */
     public int boundArrayVBO;
-    
+
     /**
      * Currently bound pixel pack pixel buffer.
      */
     public int boundPixelPackPBO;
 
-    public int numTexturesSet = 0;
+    public int numTexturesSet;
 
     /**
      * Current bound texture IDs for each texture unit.
-     * 
-     * @see Renderer#setTexture(int, com.jme3.texture.Texture) 
+     *
+     * @see Renderer#setTexture(int, com.jme3.texture.Texture)
      */
-    public Image[] boundTextures = new Image[16];
+    public final Image[] boundTextures = new Image[16];
 
     /**
      * IDList for texture units
-     * 
-     * @see Renderer#setTexture(int, com.jme3.texture.Texture) 
+     *
+     * @see Renderer#setTexture(int, com.jme3.texture.Texture)
      */
-    public IDList textureIndexList = new IDList();
+    public final IDList textureIndexList = new IDList();
 
     /**
      * Currently bound texture unit
-     * 
-     * @see Renderer#setTexture(int, com.jme3.texture.Texture) 
+     *
+     * @see Renderer#setTexture(int, com.jme3.texture.Texture)
      */
-    public int boundTextureUnit = 0;
+    public int boundTextureUnit;
 
     /**
      * Stencil Buffer state
      */
-    public boolean stencilTest = false;
-    public RenderState.StencilOperation frontStencilStencilFailOperation = RenderState.StencilOperation.Keep;
-    public RenderState.StencilOperation frontStencilDepthFailOperation = RenderState.StencilOperation.Keep;
-    public RenderState.StencilOperation frontStencilDepthPassOperation = RenderState.StencilOperation.Keep;
-    public RenderState.StencilOperation backStencilStencilFailOperation = RenderState.StencilOperation.Keep;
-    public RenderState.StencilOperation backStencilDepthFailOperation = RenderState.StencilOperation.Keep;
-    public RenderState.StencilOperation backStencilDepthPassOperation = RenderState.StencilOperation.Keep;
-    public RenderState.TestFunction frontStencilFunction = RenderState.TestFunction.Always;
-    public RenderState.TestFunction backStencilFunction = RenderState.TestFunction.Always;
+    public boolean stencilTest;
+    public RenderState.StencilOperation frontStencilStencilFailOperation;
+    public RenderState.StencilOperation frontStencilDepthFailOperation;
+    public RenderState.StencilOperation frontStencilDepthPassOperation;
+    public RenderState.StencilOperation backStencilStencilFailOperation;
+    public RenderState.StencilOperation backStencilDepthFailOperation;
+    public RenderState.StencilOperation backStencilDepthPassOperation;
+    public RenderState.TestFunction frontStencilFunction;
+    public RenderState.TestFunction backStencilFunction;
 
     /**
      * Vertex attribs currently bound and enabled. If a slot is null, then
      * it is disabled.
      */
-    public VertexBuffer[] boundAttribs = new VertexBuffer[16];
+    public final VertexBuffer[] boundAttribs = new VertexBuffer[16];
 
     /**
      * IDList for vertex attributes
      */
-    public IDList attribIndexList = new IDList();
-    
+    public final IDList attribIndexList = new IDList();
+
     /**
      * depth test function
      */
-    public RenderState.TestFunction depthFunc = RenderState.TestFunction.Less;
-    
+    public RenderState.TestFunction depthFunc;
+
      /**
      * alpha test function
      */
-    public RenderState.TestFunction alphaFunc = RenderState.TestFunction.Greater;
+    public RenderState.TestFunction alphaFunc;
 
     public int initialDrawBuf;
     public int initialReadBuf;
-    
-    public ColorRGBA clearColor = new ColorRGBA(0,0,0,0);
-    
-    /**
-     * Reset the RenderContext to default GL state
-     */
-    public void reset(){
+
+    public ColorRGBA clearColor = new ColorRGBA(0, 0, 0, 0);
+
+    public RenderContext() {
+        init();
+    }
+
+
+    private void init() {
         cullMode = RenderState.FaceCullMode.Off;
         depthTestEnabled = false;
-        depthWriteEnabled = false;
-        colorWriteEnabled = false;
+        depthWriteEnabled = true;
+        colorWriteEnabled = true;
         clipRectEnabled = false;
         polyOffsetEnabled = false;
         polyOffsetFactor = 0;
         polyOffsetUnits = 0;
         pointSize = 1;
+        lineWidth = 1;
         blendMode = RenderState.BlendMode.Off;
         blendEquation = RenderState.BlendEquation.Add;
         blendEquationAlpha = RenderState.BlendEquationAlpha.InheritColor;
-        sfactorRGB = BlendFunc.One;
-        dfactorRGB = BlendFunc.One;
-        sfactorAlpha = BlendFunc.One;
-        dfactorAlpha = BlendFunc.One;
+        sfactorRGB = RenderState.BlendFunc.One;
+        dfactorRGB = RenderState.BlendFunc.One;
+        sfactorAlpha = RenderState.BlendFunc.One;
+        dfactorAlpha = RenderState.BlendFunc.One;
         wireframe = false;
+
         boundShaderProgram = 0;
         boundShader = null;
         boundFBO = 0;
         boundFB = null;
         boundRB = 0;
-        boundDrawBuf = -1; 
+        boundDrawBuf = -1;
         boundReadBuf = -1;
         boundElementArrayVBO = 0;
         boundVertexArray = 0;
         boundArrayVBO = 0;
         boundPixelPackPBO = 0;
         numTexturesSet = 0;
-        for (int i = 0; i < boundTextures.length; i++)
-            boundTextures[i] = null;
-
-        textureIndexList.reset();
         boundTextureUnit = 0;
-        for (int i = 0; i < boundAttribs.length; i++)
-            boundAttribs[i] = null;
-
-        attribIndexList.reset();
-        
         stencilTest = false;
+
         frontStencilStencilFailOperation = RenderState.StencilOperation.Keep;
         frontStencilDepthFailOperation = RenderState.StencilOperation.Keep;
         frontStencilDepthPassOperation = RenderState.StencilOperation.Keep;
@@ -327,9 +322,30 @@ public class RenderContext {
         backStencilDepthPassOperation = RenderState.StencilOperation.Keep;
         frontStencilFunction = RenderState.TestFunction.Always;
         backStencilFunction = RenderState.TestFunction.Always;
-        
-        depthFunc = RenderState.TestFunction.LessOrEqual;    
+
+        depthFunc = RenderState.TestFunction.Less;
         alphaFunc = RenderState.TestFunction.Greater;
-        clearColor.set(0,0,0,0);
+        cullMode = RenderState.FaceCullMode.Off;
+
+        clearColor.set(0, 0, 0, 0);
+    }
+
+    /**
+     * Reset the RenderContext to default GL state
+     */
+    public void reset(){
+        init();
+
+        for (int i = 0; i < boundTextures.length; i++) {
+            boundTextures[i] = null;
+        }
+
+        textureIndexList.reset();
+
+        for (int i = 0; i < boundAttribs.length; i++) {
+            boundAttribs[i] = null;
+        }
+
+        attribIndexList.reset();
     }
 }

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -1527,7 +1527,11 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
     }
 
     public MorphTarget[] getMorphTargets() {
-        return morphTargets.getArray();
+        if (morphTargets == null) {
+            return new MorphTarget[0];
+        } else {
+            return morphTargets.getArray();
+        }
     }
     
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/shape/Line.java
+++ b/jme3-core/src/main/java/com/jme3/scene/shape/Line.java
@@ -55,7 +55,7 @@ public class Line extends Mesh {
     /**
      * No-argument constructor needed by SavableClassUtil.
      */
-    public Line() { // TODO protected
+    protected Line() {
     }
 
     public Line(Vector3f start, Vector3f end) {
@@ -68,7 +68,6 @@ public class Line extends Mesh {
         this.end.set(end);
         setBuffer(Type.Position, 3, new float[]{start.x,    start.y,    start.z,
                                                 end.x,      end.y,      end.z,});
-
 
         setBuffer(Type.TexCoord, 2, new float[]{0, 0,
                                                 1, 1});

--- a/jme3-core/src/main/java/com/jme3/system/JmeSystemDelegate.java
+++ b/jme3-core/src/main/java/com/jme3/system/JmeSystemDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 jMonkeyEngine
+ * Copyright (c) 2009-2020 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -171,7 +171,7 @@ public abstract class JmeSystemDelegate {
             return is64 ? Platform.Windows64 : Platform.Windows32;
         } else if (os.contains("linux") || os.contains("freebsd") 
                 || os.contains("sunos") || os.contains("unix")) {
-            if (arch.startsWith("arm")) {
+            if (arch.startsWith("arm") || arch.startsWith("aarch")) {
                 return is64 ? Platform.Linux_ARM64 : Platform.Linux_ARM32;
             } else {
                 return is64 ? Platform.Linux64 : Platform.Linux32;

--- a/jme3-core/src/main/java/com/jme3/util/BufferUtils.java
+++ b/jme3-core/src/main/java/com/jme3/util/BufferUtils.java
@@ -54,7 +54,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * <code>BufferUtils</code> is a helper class for generating nio buffers from
  * jME data classes such as Vectors and ColorRGBA.
- * 
+ *
  * @author Joshua Slack
  * @version $Id: BufferUtils.java,v 1.16 2007/10/29 16:56:18 nca Exp $
  */
@@ -74,7 +74,7 @@ public final class BufferUtils {
      * Set it to true if you want to enable direct memory tracking for debugging
      * purpose. Default is false. To print direct memory usage use
      * BufferUtils.printCurrentDirectMemory(StringBuilder store);
-     * 
+     *
      * @param enabled
      */
     public static void setTrackDirectMemoryEnabled(boolean enabled) {
@@ -84,7 +84,7 @@ public final class BufferUtils {
     /**
      * Creates a clone of the given buffer. The clone's capacity is equal to the
      * given buffer's limit.
-     * 
+     *
      * @param buf
      *            The buffer to clone
      * @return The cloned buffer
@@ -141,7 +141,7 @@ public final class BufferUtils {
      * Generate a new FloatBuffer using the given array of Vector3f objects. The
      * FloatBuffer will be 3 * data.length long and contain the vector data as
      * data[0].x, data[0].y, data[0].z, data[1].x... etc.
-     * 
+     *
      * @param data
      *            array of Vector3f objects to place into a new FloatBuffer
      */
@@ -164,7 +164,7 @@ public final class BufferUtils {
     /**
      * Generate a new FloatBuffer using the given array of Quaternion objects.
      * The FloatBuffer will be 4 * data.length long and contain the vector data.
-     * 
+     *
      * @param data
      *            array of Quaternion objects to place into a new FloatBuffer
      */
@@ -232,7 +232,7 @@ public final class BufferUtils {
 
     /**
      * Generate a new FloatBuffer using the given array of float primitives.
-     * 
+     *
      * @param data
      *            array of float primitives to place into a new FloatBuffer
      */
@@ -250,7 +250,7 @@ public final class BufferUtils {
     /**
      * Create a new FloatBuffer of an appropriate size to hold the specified
      * number of Vector3f object data.
-     * 
+     *
      * @param vertices
      *            number of vertices that need to be held by the newly created
      *            buffer
@@ -265,7 +265,7 @@ public final class BufferUtils {
      * Create a new FloatBuffer of an appropriate size to hold the specified
      * number of Vector3f object data only if the given buffer if not already
      * the right size.
-     * 
+     *
      * @param buf
      *            the buffer to first check and rewind
      * @param vertices
@@ -285,7 +285,7 @@ public final class BufferUtils {
     /**
      * Sets the data contained in the given color into the FloatBuffer at the
      * specified index.
-     * 
+     *
      * @param color
      *            the data to insert
      * @param buf
@@ -304,7 +304,7 @@ public final class BufferUtils {
     /**
      * Sets the data contained in the given quaternion into the FloatBuffer at
      * the specified index.
-     * 
+     *
      * @param quat
      *            the {@link Quaternion} to insert
      * @param buf
@@ -343,7 +343,7 @@ public final class BufferUtils {
     /**
      * Sets the data contained in the given Vector3F into the FloatBuffer at the
      * specified index.
-     * 
+     *
      * @param vector
      *            the data to insert
      * @param buf
@@ -369,7 +369,7 @@ public final class BufferUtils {
     /**
      * Updates the values of the given vector from the specified buffer at the
      * index provided.
-     * 
+     *
      * @param vector
      *            the vector to set data on
      * @param buf
@@ -387,7 +387,7 @@ public final class BufferUtils {
     /**
      * Updates the values of the given vector from the specified buffer at the
      * index provided.
-     * 
+     *
      * @param vector
      *            the vector to set data on
      * @param buf
@@ -405,7 +405,7 @@ public final class BufferUtils {
 
     /**
      * Generates a Vector3f array from the given FloatBuffer.
-     * 
+     *
      * @param buff
      *            the FloatBuffer to read from
      * @return a newly generated array of Vector3f objects
@@ -424,7 +424,7 @@ public final class BufferUtils {
      * Copies a Vector3f from one position in the buffer to another. The index
      * values are in terms of vector number (eg, vector number 0 is positions
      * 0-2 in the FloatBuffer.)
-     * 
+     *
      * @param buf
      *            the buffer to copy from/to
      * @param fromPos
@@ -438,7 +438,7 @@ public final class BufferUtils {
 
     /**
      * Normalize a Vector3f in-buffer.
-     * 
+     *
      * @param buf
      *            the buffer to find the Vector3f within
      * @param index
@@ -456,7 +456,7 @@ public final class BufferUtils {
 
     /**
      * Add to a Vector3f in-buffer.
-     * 
+     *
      * @param toAdd
      *            the vector to add from
      * @param buf
@@ -476,7 +476,7 @@ public final class BufferUtils {
 
     /**
      * Multiply and store a Vector3f in-buffer.
-     * 
+     *
      * @param toMult
      *            the vector to multiply against
      * @param buf
@@ -497,7 +497,7 @@ public final class BufferUtils {
     /**
      * Checks to see if the given Vector3f is equals to the data stored in the
      * buffer at the given data index.
-     * 
+     *
      * @param check
      *            the vector to check against - null will return false.
      * @param buf
@@ -521,7 +521,7 @@ public final class BufferUtils {
      * Generate a new FloatBuffer using the given array of Vector2f objects. The
      * FloatBuffer will be 2 * data.length long and contain the vector data as
      * data[0].x, data[0].y, data[1].x... etc.
-     * 
+     *
      * @param data
      *            array of Vector2f objects to place into a new FloatBuffer
      */
@@ -544,7 +544,7 @@ public final class BufferUtils {
     /**
      * Create a new FloatBuffer of an appropriate size to hold the specified
      * number of Vector2f object data.
-     * 
+     *
      * @param vertices
      *            number of vertices that need to be held by the newly created
      *            buffer
@@ -559,7 +559,7 @@ public final class BufferUtils {
      * Create a new FloatBuffer of an appropriate size to hold the specified
      * number of Vector2f object data only if the given buffer if not already
      * the right size.
-     * 
+     *
      * @param buf
      *            the buffer to first check and rewind
      * @param vertices
@@ -579,7 +579,7 @@ public final class BufferUtils {
     /**
      * Sets the data contained in the given Vector2F into the FloatBuffer at the
      * specified index.
-     * 
+     *
      * @param vector
      *            the data to insert
      * @param buf
@@ -595,7 +595,7 @@ public final class BufferUtils {
     /**
      * Updates the values of the given vector from the specified buffer at the
      * index provided.
-     * 
+     *
      * @param vector
      *            the vector to set data on
      * @param buf
@@ -611,7 +611,7 @@ public final class BufferUtils {
 
     /**
      * Generates a Vector2f array from the given FloatBuffer.
-     * 
+     *
      * @param buff
      *            the FloatBuffer to read from
      * @return a newly generated array of Vector2f objects
@@ -630,7 +630,7 @@ public final class BufferUtils {
      * Copies a Vector2f from one position in the buffer to another. The index
      * values are in terms of vector number (eg, vector number 0 is positions
      * 0-1 in the FloatBuffer.)
-     * 
+     *
      * @param buf
      *            the buffer to copy from/to
      * @param fromPos
@@ -644,7 +644,7 @@ public final class BufferUtils {
 
     /**
      * Normalize a Vector2f in-buffer.
-     * 
+     *
      * @param buf
      *            the buffer to find the Vector2f within
      * @param index
@@ -662,7 +662,7 @@ public final class BufferUtils {
 
     /**
      * Add to a Vector2f in-buffer.
-     * 
+     *
      * @param toAdd
      *            the vector to add from
      * @param buf
@@ -682,7 +682,7 @@ public final class BufferUtils {
 
     /**
      * Multiply and store a Vector2f in-buffer.
-     * 
+     *
      * @param toMult
      *            the vector to multiply against
      * @param buf
@@ -703,7 +703,7 @@ public final class BufferUtils {
     /**
      * Checks to see if the given Vector2f is equals to the data stored in the
      * buffer at the given data index.
-     * 
+     *
      * @param check
      *            the vector to check against - null will return false.
      * @param buf
@@ -727,7 +727,7 @@ public final class BufferUtils {
      * Generate a new IntBuffer using the given array of ints. The IntBuffer
      * will be data.length long and contain the int data as data[0], data[1]...
      * etc.
-     * 
+     *
      * @param data
      *            array of ints to place into a new IntBuffer
      */
@@ -745,7 +745,7 @@ public final class BufferUtils {
     /**
      * Create a new int[] array and populate it with the given IntBuffer's
      * contents.
-     * 
+     *
      * @param buff
      *            the IntBuffer to read from
      * @return a new int array populated from the IntBuffer
@@ -765,7 +765,7 @@ public final class BufferUtils {
     /**
      * Create a new float[] array and populate it with the given FloatBuffer's
      * contents.
-     * 
+     *
      * @param buff
      *            the FloatBuffer to read from
      * @return a new float array populated from the FloatBuffer
@@ -785,7 +785,7 @@ public final class BufferUtils {
     //// -- GENERAL DOUBLE ROUTINES -- ////
     /**
      * Create a new DoubleBuffer of the specified size.
-     * 
+     *
      * @param size
      *            required number of double to store.
      * @return the new DoubleBuffer
@@ -800,7 +800,7 @@ public final class BufferUtils {
     /**
      * Create a new DoubleBuffer of an appropriate size to hold the specified
      * number of doubles only if the given buffer if not already the right size.
-     * 
+     *
      * @param buf
      *            the buffer to first check and rewind
      * @param size
@@ -823,7 +823,7 @@ public final class BufferUtils {
      * DoubleBuffer. The new DoubleBuffer is separate from the old one and
      * changes are not reflected across. If you want to reflect changes,
      * consider using Buffer.duplicate().
-     * 
+     *
      * @param buf
      *            the DoubleBuffer to copy
      * @return the copy
@@ -848,7 +848,7 @@ public final class BufferUtils {
     //// -- GENERAL FLOAT ROUTINES -- ////
     /**
      * Create a new FloatBuffer of the specified size.
-     * 
+     *
      * @param size
      *            required number of floats to store.
      * @return the new FloatBuffer
@@ -862,7 +862,7 @@ public final class BufferUtils {
 
     /**
      * Copies floats from one position in the buffer to another.
-     * 
+     *
      * @param buf
      *            the buffer to copy from/to
      * @param fromPos
@@ -885,7 +885,7 @@ public final class BufferUtils {
      * FloatBuffer. The new FloatBuffer is separate from the old one and changes
      * are not reflected across. If you want to reflect changes, consider using
      * Buffer.duplicate().
-     * 
+     *
      * @param buf
      *            the FloatBuffer to copy
      * @return the copy
@@ -910,7 +910,7 @@ public final class BufferUtils {
     //// -- GENERAL INT ROUTINES -- ////
     /**
      * Create a new IntBuffer of the specified size.
-     * 
+     *
      * @param size
      *            required number of ints to store.
      * @return the new IntBuffer
@@ -925,7 +925,7 @@ public final class BufferUtils {
     /**
      * Create a new IntBuffer of an appropriate size to hold the specified
      * number of ints only if the given buffer if not already the right size.
-     * 
+     *
      * @param buf
      *            the buffer to first check and rewind
      * @param size
@@ -948,7 +948,7 @@ public final class BufferUtils {
      * The new IntBuffer is separate from the old one and changes are not
      * reflected across. If you want to reflect changes, consider using
      * Buffer.duplicate().
-     * 
+     *
      * @param buf
      *            the IntBuffer to copy
      * @return the copy
@@ -973,7 +973,7 @@ public final class BufferUtils {
     //// -- GENERAL BYTE ROUTINES -- ////
     /**
      * Create a new ByteBuffer of the specified size.
-     * 
+     *
      * @param size
      *            required number of ints to store.
      * @return the new IntBuffer
@@ -988,7 +988,7 @@ public final class BufferUtils {
     /**
      * Create a new ByteBuffer of an appropriate size to hold the specified
      * number of ints only if the given buffer if not already the right size.
-     * 
+     *
      * @param buf
      *            the buffer to first check and rewind
      * @param size
@@ -1030,7 +1030,7 @@ public final class BufferUtils {
      * The new ByteBuffer is separate from the old one and changes are not
      * reflected across. If you want to reflect changes, consider using
      * Buffer.duplicate().
-     * 
+     *
      * @param buf
      *            the ByteBuffer to copy
      * @return the copy
@@ -1055,7 +1055,7 @@ public final class BufferUtils {
     //// -- GENERAL SHORT ROUTINES -- ////
     /**
      * Create a new ShortBuffer of the specified size.
-     * 
+     *
      * @param size
      *            required number of shorts to store.
      * @return the new ShortBuffer
@@ -1070,7 +1070,7 @@ public final class BufferUtils {
     /**
      * Create a new ShortBuffer of an appropriate size to hold the specified
      * number of shorts only if the given buffer if not already the right size.
-     * 
+     *
      * @param buf
      *            the buffer to first check and rewind
      * @param size
@@ -1104,7 +1104,7 @@ public final class BufferUtils {
      * ShortBuffer. The new ShortBuffer is separate from the old one and changes
      * are not reflected across. If you want to reflect changes, consider using
      * Buffer.duplicate().
-     * 
+     *
      * @param buf
      *            the ShortBuffer to copy
      * @return the copy
@@ -1130,7 +1130,7 @@ public final class BufferUtils {
      * Ensures there is at least the <code>required</code> number of entries
      * left after the current position of the buffer. If the buffer is too small
      * a larger one is created and the old one copied to the new buffer.
-     * 
+     *
      * @param buffer
      *            buffer that should be checked/copied (may be null)
      * @param required
@@ -1277,36 +1277,14 @@ public final class BufferUtils {
         allocator.destroyDirectBuffer(toBeDestroyed);
     }
 
-    /*
-     * FIXME when java 1.5 supprt is dropped - replace calls to this method with
-     * Buffer.isDirect
-     * 
-     * Buffer.isDirect() is only java 6. Java 5 only have this method on Buffer
-     * subclasses : FloatBuffer, IntBuffer, ShortBuffer,
-     * ByteBuffer,DoubleBuffer, LongBuffer. CharBuffer has been excluded as we
-     * don't use it.
-     * 
+    /**
+     * Test whether the specified buffer is direct.
+     *
+     * @param buf the buffer to test (not null, unaffected)
+     * @return true if direct, otherwise false
      */
     private static boolean isDirect(Buffer buf) {
-        if (buf instanceof FloatBuffer) {
-            return ((FloatBuffer) buf).isDirect();
-        }
-        if (buf instanceof IntBuffer) {
-            return ((IntBuffer) buf).isDirect();
-        }
-        if (buf instanceof ShortBuffer) {
-            return ((ShortBuffer) buf).isDirect();
-        }
-        if (buf instanceof ByteBuffer) {
-            return ((ByteBuffer) buf).isDirect();
-        }
-        if (buf instanceof DoubleBuffer) {
-            return ((DoubleBuffer) buf).isDirect();
-        }
-        if (buf instanceof LongBuffer) {
-            return ((LongBuffer) buf).isDirect();
-        }
-        throw new UnsupportedOperationException(" BufferUtils.isDirect was called on " + buf.getClass().getName());
+        return buf.isDirect();
     }
 
     private static class BufferInfo extends PhantomReference<Buffer> {

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -196,9 +196,9 @@ MaterialDef PBR Lighting {
     }
 
 
-    Technique PostShadow{
-        VertexShader GLSL310 GLSL300 GLSL150:   Common/MatDefs/Shadow/PostShadow.vert
-        FragmentShader GLSL310 GLSL300 GLSL150: Common/MatDefs/Shadow/PostShadowPBR.frag
+    Technique PostShadow {
+        VertexShader GLSL310 GLSL300 GLSL100 GLSL150:   Common/MatDefs/Shadow/PostShadow.vert
+        FragmentShader GLSL310 GLSL300 GLSL100 GLSL150: Common/MatDefs/Shadow/PostShadowPBR.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -212,7 +212,6 @@ MaterialDef PBR Lighting {
             FILTER_MODE : FilterMode
             PCFEDGE : PCFEdge
             DISCARD_ALPHA : AlphaDiscardThreshold           
-            SHADOWMAP_SIZE : ShadowMapSize
             SHADOWMAP_SIZE : ShadowMapSize
             FADE : FadeInfo
             PSSM : Splits
@@ -228,40 +227,6 @@ MaterialDef PBR Lighting {
             Blend Modulate
             DepthWrite Off                 
             PolyOffset -0.1 0
-        }
-    }
-
-    Technique PostShadow{
-        VertexShader GLSL100:   Common/MatDefs/Shadow/PostShadow.vert
-        FragmentShader GLSL100: Common/MatDefs/Shadow/PostShadowPBR.frag
-
-        WorldParameters {
-            WorldViewProjectionMatrix
-            WorldMatrix
-            ViewProjectionMatrix
-            ViewMatrix
-        }
-
-        Defines {
-            HARDWARE_SHADOWS : HardwareShadows
-            FILTER_MODE : FilterMode
-            PCFEDGE : PCFEdge
-            DISCARD_ALPHA : AlphaDiscardThreshold           
-            SHADOWMAP_SIZE : ShadowMapSize
-            FADE : FadeInfo
-            PSSM : Splits
-            POINTLIGHT : LightViewProjectionMatrix5
-            NUM_BONES : NumberOfBones
-            INSTANCING : UseInstancing
-            BACKFACE_SHADOWS: BackfaceShadows
-            NUM_MORPH_TARGETS: NumberOfMorphTargets
-            NUM_TARGETS_BUFFERS: NumberOfTargetsBuffers
-        }
-
-        ForcedRenderState {
-            Blend Modulate
-            DepthWrite Off   
-            PolyOffset -0.1 0  
         }
     }
 

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -168,7 +168,7 @@ MaterialDef PBR Lighting {
     Technique PreShadow {
 
         VertexShader GLSL300 GLSL100 GLSL150 :   Common/MatDefs/Shadow/PreShadow.vert
-        FragmentShader GLSL300 GLSL100 GLSL150 : Common/MatDefs/Shadow/PreShadow.frag
+        FragmentShader GLSL300 GLSL100 GLSL150 : Common/MatDefs/Shadow/PreShadowPBR.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -198,7 +198,7 @@ MaterialDef PBR Lighting {
 
     Technique PostShadow{
         VertexShader GLSL310 GLSL300 GLSL150:   Common/MatDefs/Shadow/PostShadow.vert
-        FragmentShader GLSL310 GLSL300 GLSL150: Common/MatDefs/Shadow/PostShadow.frag
+        FragmentShader GLSL310 GLSL300 GLSL150: Common/MatDefs/Shadow/PostShadowPBR.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -233,7 +233,7 @@ MaterialDef PBR Lighting {
 
     Technique PostShadow{
         VertexShader GLSL100:   Common/MatDefs/Shadow/PostShadow.vert
-        FragmentShader GLSL100: Common/MatDefs/Shadow/PostShadow.frag
+        FragmentShader GLSL100: Common/MatDefs/Shadow/PostShadowPBR.frag
 
         WorldParameters {
             WorldViewProjectionMatrix

--- a/jme3-core/src/main/resources/Common/MatDefs/Shadow/PostShadowPBR.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Shadow/PostShadowPBR.frag
@@ -1,0 +1,89 @@
+  
+#import "Common/ShaderLib/GLSLCompat.glsllib"
+#import "Common/ShaderLib/Shadows.glsllib"
+#if defined(PSSM) || defined(FADE)
+varying float shadowPosition;
+#endif
+
+varying vec4 projCoord0;
+varying vec4 projCoord1;
+varying vec4 projCoord2;
+varying vec4 projCoord3;
+#ifndef BACKFACE_SHADOWS
+    varying float nDotL;
+#endif
+
+#ifdef POINTLIGHT
+    varying vec4 projCoord4;
+    varying vec4 projCoord5;
+    uniform vec3 m_LightPos;
+    varying vec4 worldPos;
+#else
+    #ifndef PSSM        
+        varying float lightDot;
+    #endif
+#endif
+
+#ifdef DISCARD_ALPHA
+    #ifdef COLOR_MAP
+        uniform sampler2D m_ColorMap;
+    #else    
+        uniform sampler2D m_BaseColorMap;
+    #endif
+    uniform float m_AlphaDiscardThreshold;
+    varying vec2 texCoord;
+#endif
+
+#ifdef FADE
+uniform vec2 m_FadeInfo;
+#endif
+
+void main(){   
+ 
+    #ifdef DISCARD_ALPHA
+        #ifdef COLOR_MAP
+            float alpha = texture2D(m_ColorMap,texCoord).a;
+        #else    
+            float alpha = texture2D(m_BaseColorMap,texCoord).a;
+        #endif
+        if(alpha<=m_AlphaDiscardThreshold){
+            discard;
+        }
+    #endif
+
+    #ifndef BACKFACE_SHADOWS
+        if(nDotL > 0.0){
+            discard;
+        }
+    #endif
+
+
+    float shadow = 1.0;
+ 
+    #ifdef POINTLIGHT         
+            shadow = getPointLightShadows(worldPos, m_LightPos,
+                           m_ShadowMap0,m_ShadowMap1,m_ShadowMap2,m_ShadowMap3,m_ShadowMap4,m_ShadowMap5,
+                           projCoord0, projCoord1, projCoord2, projCoord3, projCoord4, projCoord5);
+    #else
+       #ifdef PSSM
+            shadow = getDirectionalLightShadows(m_Splits, shadowPosition,
+                           m_ShadowMap0,m_ShadowMap1,m_ShadowMap2,m_ShadowMap3,
+                           projCoord0, projCoord1, projCoord2, projCoord3);
+       #else 
+            //spotlight
+            if(lightDot < 0.0){
+                gl_FragColor = vec4(1.0);
+                return;
+            }
+            shadow = getSpotLightShadows(m_ShadowMap0,projCoord0);
+       #endif
+    #endif   
+
+    #ifdef FADE
+        shadow = max(0.0, mix(shadow, 1.0, max(0.0, (shadowPosition - m_FadeInfo.x) * m_FadeInfo.y)));
+    #endif
+
+    shadow = shadow * m_ShadowIntensity + (1.0 - m_ShadowIntensity);
+    gl_FragColor = vec4(shadow, shadow, shadow, 1.0);
+
+}

--- a/jme3-core/src/main/resources/Common/MatDefs/Shadow/PreShadowPBR.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Shadow/PreShadowPBR.frag
@@ -1,0 +1,28 @@
+#import "Common/ShaderLib/GLSLCompat.glsllib"
+varying vec2 texCoord;
+
+#ifdef DISCARD_ALPHA
+   #ifdef COLOR_MAP
+      uniform sampler2D m_ColorMap;
+   #else    
+      uniform sampler2D m_BaseColorMap;
+   #endif
+    uniform float m_AlphaDiscardThreshold;
+#endif
+
+
+void main(){
+   #ifdef DISCARD_ALPHA
+       #ifdef COLOR_MAP
+            if (texture2D(m_ColorMap, texCoord).a <= m_AlphaDiscardThreshold){
+                discard;
+            }
+       #else    
+            if (texture2D(m_BaseColorMap, texCoord).a <= m_AlphaDiscardThreshold){
+                discard;
+            }
+       #endif
+   #endif
+
+   gl_FragColor = vec4(1.0);
+}

--- a/jme3-core/src/main/resources/Common/ShaderLib/MorphAnim.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/MorphAnim.glsllib
@@ -173,10 +173,13 @@ Note that it only handles morphing position, normals and tangents.
 
     void Morph_Compute(inout vec4 pos){
         #if (NUM_TARGETS_BUFFERS == 2)
-            Morph_Compute_Pos_Norm(pos,vec3(0.0));
+            vec3 dummy_norm = vec3(0.0);
+            Morph_Compute_Pos_Norm(pos, dummy_norm);
             return;
         #elif (NUM_TARGETS_BUFFERS == 3)
-            Morph_Compute_Pos_Norm_Tan(pos, vec3(0.0), vec3(0.0));
+            vec3 dummy_norm = vec3(0.0);
+            vec3 dummy_tan = vec3(0.0);
+            Morph_Compute_Pos_Norm_Tan(pos, dummy_norm, dummy_tan);
             return;
         #endif
         Morph_Compute_Pos(pos);
@@ -187,7 +190,9 @@ Note that it only handles morphing position, normals and tangents.
             Morph_Compute_Pos(pos);
             return;
         #elif (NUM_TARGETS_BUFFERS == 3)
-            Morph_Compute_Pos_Norm_Tan(pos, vec3(0.0), vec3(0.0));
+            vec3 dummy_norm = vec3(0.0);
+            vec3 dummy_tan = vec3(0.0);
+            Morph_Compute_Pos_Norm_Tan(pos, dummy_norm, dummy_tan);
             return;
         #elif  (NUM_TARGETS_BUFFERS == 2)
             Morph_Compute_Pos_Norm(pos, norm);

--- a/jme3-examples/src/main/java/jme3test/niftygui/TestIssue1013.java
+++ b/jme3-examples/src/main/java/jme3test/niftygui/TestIssue1013.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2009-2020 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package jme3test.niftygui;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.material.Material;
+import com.jme3.niftygui.NiftyJmeDisplay;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.shape.Box;
+import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.builder.LayerBuilder;
+import de.lessvoid.nifty.builder.PanelBuilder;
+import de.lessvoid.nifty.builder.ScreenBuilder;
+import de.lessvoid.nifty.controls.button.builder.ButtonBuilder;
+import de.lessvoid.nifty.screen.Screen;
+import de.lessvoid.nifty.screen.ScreenController;
+
+public class TestIssue1013 extends SimpleApplication implements ScreenController {
+
+    public static void main(String[] args) {
+        new TestIssue1013().start();
+    }
+
+    private NiftyJmeDisplay niftyDisplay;
+
+    @Override
+    public void simpleInitApp() {
+
+        // this box here always renders
+        Box b = new Box(1, 1, 1);
+        Geometry geom = new Geometry("Box", b);
+        Material mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+        mat.setTexture("ColorMap", assetManager.loadTexture("/com/jme3/app/Monkey.png"));
+        geom.setMaterial(mat);
+        rootNode.attachChild(geom);
+
+        niftyDisplay = NiftyJmeDisplay.newNiftyJmeDisplay(assetManager, inputManager, audioRenderer, guiViewPort);
+
+        Nifty nifty = niftyDisplay.getNifty();
+        nifty.loadStyleFile("nifty-default-styles.xml");
+        nifty.loadControlFile("nifty-default-controls.xml");
+
+        ScreenController ctrl = this;
+
+        new ScreenBuilder("start") {
+            {
+                controller(ctrl);
+                layer(new LayerBuilder() {
+                    {
+                        childLayoutVertical();
+                        panel(new PanelBuilder() {
+                            {
+                                childLayoutCenter();
+                                width("100%");
+                                height("50%");
+                                backgroundColor("#ff0000");
+                            }
+                        });
+                        control(new ButtonBuilder("RestartButton", "Restart Context") {
+                            {
+                                alignCenter();
+                                valignCenter();
+                                height("32px");
+                                width("480px");
+                                interactOnClick("restartContext()");
+                            }
+                        });
+                    }
+                });
+            }
+        }.build(nifty);
+
+        guiViewPort.addProcessor(niftyDisplay);
+        nifty.gotoScreen("start");
+
+        flyCam.setDragToRotate(true);
+    }
+
+    @Override
+    public void bind(Nifty nifty, Screen screen) {
+    }
+
+    @Override
+    public void onStartScreen() {
+    }
+
+    @Override
+    public void onEndScreen() {
+    }
+
+    public void restartContext() {
+        // even without changing settings, stuff breaks!
+        restart();
+        // ...and re-adding the processor doesn't help at all
+        guiViewPort.addProcessor(niftyDisplay);
+    }
+
+}

--- a/jme3-examples/src/main/java/jme3test/renderer/TestIssue801.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestIssue801.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2009-2020 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package jme3test.renderer;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.input.KeyInput;
+import com.jme3.input.controls.ActionListener;
+import com.jme3.input.controls.KeyTrigger;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.shape.Box;
+import com.jme3.system.AppSettings;
+
+public class TestIssue801 extends SimpleApplication {
+
+    public static void main(String[] args) {
+        AppSettings initialSettings = new AppSettings(true);
+        initialSettings.setBitsPerPixel(24);
+
+        TestIssue801 app = new TestIssue801();
+        app.setSettings(initialSettings);
+        app.start();
+    }
+
+    @Override
+    public void simpleInitApp() {
+        viewPort.setBackgroundColor(new ColorRGBA(0.3f, 0.3f, 0.3f, 1f));
+
+        Box b = new Box(1, 1, 1);
+        Geometry geom = new Geometry("Box", b);
+
+        Material mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+        mat.setColor("Color", ColorRGBA.Blue);
+        geom.setMaterial(mat);
+
+        rootNode.attachChild(geom);
+        inputManager.addMapping("changeBpp", new KeyTrigger(KeyInput.KEY_P));
+        ActionListener listener = new ActionListener() {
+            @Override
+            public void onAction(String name, boolean keyPressed, float tpf) {
+                if (name.equals("changeBpp") && keyPressed) {
+                    goWindowed();
+                }
+            }
+        };
+        inputManager.addListener(listener, "changeBpp");
+    }
+
+    void goWindowed() {
+        AppSettings newSettings = new AppSettings(false);
+        newSettings.copyFrom(settings);
+        newSettings.setBitsPerPixel(16);
+
+        setSettings(newSettings);
+        restart();
+    }
+}

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwKeyInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwKeyInput.java
@@ -83,11 +83,33 @@ public class GlfwKeyInput implements KeyInput {
 
     @Override
     public void initialize() {
+        if (!context.isRenderable()) {
+            return;
+        }
+        initCallbacks();
 
+        initialized = true;
+        logger.fine("Keyboard created.");
+    }
+
+    /**
+     * Re-initializes the key input context window specific callbacks
+     */
+    public void resetContext() {
         if (!context.isRenderable()) {
             return;
         }
 
+        closeCallbacks();
+        initCallbacks();
+    }
+
+    private void closeCallbacks() {
+        keyCallback.close();
+        charCallback.close();
+    }
+
+    private void initCallbacks() {
         glfwSetKeyCallback(context.getWindowHandle(), keyCallback = new GLFWKeyCallback() {
             @Override
             public void invoke(final long window, final int key, final int scancode, final int action, final int mods) {
@@ -122,9 +144,6 @@ public class GlfwKeyInput implements KeyInput {
                 keyInputEvents.add(released);
             }
         });
-
-        initialized = true;
-        logger.fine("Keyboard created.");
     }
 
     public int getKeyCount() {
@@ -149,8 +168,7 @@ public class GlfwKeyInput implements KeyInput {
             return;
         }
 
-        keyCallback.close();
-        charCallback.close();
+        closeCallbacks();
         logger.fine("Keyboard destroyed.");
     }
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwMouseInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwMouseInput.java
@@ -176,7 +176,30 @@ public class GlfwMouseInput implements MouseInput {
 
     @Override
     public void initialize() {
+        initCallbacks();
 
+        if (listener != null) {
+            sendFirstMouseEvent();
+        }
+
+        setCursorVisible(cursorVisible);
+        logger.fine("Mouse created.");
+        initialized = true;
+    }
+
+    /**
+     * Re-initializes the mouse input context window specific callbacks
+     */
+    public void resetContext() {
+        if (!context.isRenderable()) {
+            return;
+        }
+
+        closeCallbacks();
+        initCallbacks();
+    }
+
+    private void initCallbacks() {
         final long window = context.getWindowHandle();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -219,14 +242,6 @@ public class GlfwMouseInput implements MouseInput {
                 currentWidth = width;
             }
         });
-
-        if(listener != null) {
-            sendFirstMouseEvent();
-        }
-
-        setCursorVisible(cursorVisible);
-        logger.fine("Mouse created.");
-        initialized = true;
     }
 
     private void initCurrentMousePosition(long window) {
@@ -295,9 +310,7 @@ public class GlfwMouseInput implements MouseInput {
             return;
         }
 
-        cursorPosCallback.close();
-        scrollCallback.close();
-        mouseButtonCallback.close();
+        closeCallbacks();
 
         currentCursor = null;
         currentCursorDelays = null;
@@ -311,6 +324,12 @@ public class GlfwMouseInput implements MouseInput {
         jmeToGlfwCursorMap.clear();
 
         logger.fine("Mouse destroyed.");
+    }
+
+    private void closeCallbacks() {
+        cursorPosCallback.close();
+        scrollCallback.close();
+        mouseButtonCallback.close();
     }
 
     @Override

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -47,6 +47,7 @@ import com.jme3.util.BufferUtils;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -121,6 +122,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
     private GLFWErrorCallback errorCallback;
     private GLFWWindowSizeCallback windowSizeCallback;
+    private GLFWFramebufferSizeCallback framebufferSizeCallback;
     private GLFWWindowFocusCallback windowFocusCallback;
 
     private Thread mainThread;
@@ -250,16 +252,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             throw new RuntimeException("Failed to create the GLFW window");
         }
 
-        // Add a resize callback which delegates to the listener
-        glfwSetWindowSizeCallback(window, windowSizeCallback = new GLFWWindowSizeCallback() {
-            @Override
-            public void invoke(final long window, final int width, final int height) {
-                settings.setResolution(width, height);
-                listener.reshape(width, height);
-            }
-        });
-
         glfwSetWindowFocusCallback(window, windowFocusCallback = new GLFWWindowFocusCallback() {
+
             @Override
             public void invoke(final long window, final boolean focus) {
                 if (wasActive != focus) {
@@ -294,12 +288,46 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         setWindowIcon(settings);
         showWindow();
 
+        // Windows resize callback
+        glfwSetWindowSizeCallback(window, windowSizeCallback = new GLFWWindowSizeCallback() {
+
+            @Override
+            public void invoke(final long window, final int width, final int height) {
+
+                // This is the window size, never to passed to any pixel based stuff!
+                // https://www.glfw.org/docs/latest/window_guide.html#window_size
+                onWindowSizeChanged(width, height);
+            }
+        });
+
+        // Add a framebuffer resize callback which delegates to the listener
+        glfwSetFramebufferSizeCallback(window, framebufferSizeCallback = new GLFWFramebufferSizeCallback() {
+
+            @Override
+            public void invoke(final long window, final int width, final int height) {
+
+                // The window size might be also changed, but the window size callback might not trigger
+                // Maybe a bug in graphics drivers or LWJGL 3...? So make sure we emulate the original JME behavior here
+                IntBuffer windowWidth = BufferUtils.createIntBuffer(1);
+                IntBuffer windowHeight = BufferUtils.createIntBuffer(1);
+                glfwGetWindowSize(window, windowWidth, windowHeight);
+                onWindowSizeChanged(windowWidth.get(), windowHeight.get());
+
+                // https://www.glfw.org/docs/latest/window_guide.html#window_fbsize
+                listener.reshape(width, height);
+            }
+        });
+
         allowSwapBuffers = settings.isSwapBuffers();
 
         // Create OpenCL
         if (settings.isOpenCLSupport()) {
             initOpenCL(window);
         }
+    }
+
+    private void onWindowSizeChanged(final int width, final int height) {
+        settings.setResolution(width, height);
     }
 
     protected void showWindow() {
@@ -404,6 +432,11 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             if (windowSizeCallback != null) {
                 windowSizeCallback.close();
                 windowSizeCallback = null;
+            }
+
+            if (framebufferSizeCallback != null) {
+                framebufferSizeCallback.close();
+                framebufferSizeCallback = null;
             }
 
             if (windowFocusCallback != null) {

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -295,6 +295,11 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         showWindow();
 
         allowSwapBuffers = settings.isSwapBuffers();
+
+        // Create OpenCL
+        if (settings.isOpenCLSupport()) {
+            initOpenCL(window);
+        }
     }
 
     protected void showWindow() {
@@ -303,6 +308,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
     /**
      * Set custom icons to the window of this application.
+     *
+     * @param settings settings for getting the icons
      */
     protected void setWindowIcon(final AppSettings settings) {
 
@@ -409,7 +416,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
                 window = NULL;
             }
 
-            glfwTerminate();
         } catch (final Exception ex) {
             listener.handleError("Failed to destroy context", ex);
         }
@@ -429,6 +435,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
     /**
      * Does LWJGL display initialization in the OpenGL thread
+     *
+     * @return returns {@code true} if the context initialization was successful
      */
     protected boolean initInThread() {
         try {
@@ -455,13 +463,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
             created.set(true);
             super.internalCreate();
-
-            //create OpenCL
-            //Must be done here because the window handle is needed
-            if (settings.isOpenCLSupport()) {
-                initOpenCL(window);
-            }
-
         } catch (Exception ex) {
             try {
                 if (window != NULL) {
@@ -486,14 +487,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
     protected void runLoop() {
         // If a restart is required, lets recreate the context.
         if (needRestart.getAndSet(false)) {
-            try {
-                destroyContext();
-                createContext(settings);
-            } catch (Exception ex) {
-                LOGGER.log(Level.SEVERE, "Failed to set display settings!", ex);
-            }
-
-            LOGGER.fine("Display restarted.");
+            restartContext();
         }
 
         if (!created.get()) {
@@ -549,6 +543,25 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         glfwPollEvents();
     }
 
+    private void restartContext() {
+        try {
+            destroyContext();
+            createContext(settings);
+        } catch (Exception ex) {
+            LOGGER.log(Level.SEVERE, "Failed to set display settings!", ex);
+        }
+
+        // We need to reinit the mouse and keyboard input as they are tied to a window handle
+        if (keyInput != null && keyInput.isInitialized()) {
+            keyInput.resetContext();
+        }
+        if (mouseInput != null && mouseInput.isInitialized()) {
+            mouseInput.resetContext();
+        }
+
+        LOGGER.fine("Display restarted.");
+    }
+
     private void setFrameRateLimit(int frameRateLimit) {
         this.frameRateLimit = frameRateLimit;
         frameSleepTime = 1000.0 / this.frameRateLimit;
@@ -562,6 +575,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
         destroyContext();
         super.internalDestroy();
+        glfwTerminate();
 
         LOGGER.fine("Display destroyed.");
     }

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1793,9 +1793,8 @@ public class TerrainQuad extends Node implements Terrain {
         // This was not cloned before... I think that's a mistake.
         this.affectedAreaBBox = cloner.clone(affectedAreaBBox);
 
-        // picker is not cloneable and not cloned.  This also seems like
-        // a mistake if you ever load the same terrain twice.
-        // this.picker = cloner.clone(picker);
+        // Otherwise, picker would be cloned by reference and thus "this" would be wrong
+        this.picker = new BresenhamTerrainPicker(this);
 
         // neighbourFinder is also not cloned.  Maybe that's ok.
     }

--- a/version.gradle
+++ b/version.gradle
@@ -24,39 +24,108 @@ ext {
 
 task configureVersionInfo {
     try {
+        // Users can configure behavior by setting properties on the command
+        // line:
+        //
+        // jmeVersionName:
+        // If set this will override all automatic version detection.
+        //
+        // useCommitHashAsVersionName:
+        // If there is no jmeVersionName set and the current commit has no
+        // specific tag then setting this to 'true' will cause the version to
+        // be the full commit ID.
+        //
+        // includeBranchInVersion:
+        // Set to true if a non-master branch name should be included in the automatically
+        // generated version.
+
         def grgit = Grgit.open(project.file('.'))
         def head = grgit.head()
         jmeRevision = grgit.log(includes: [head]).size()
         jmeGitHash = head.id
         jmeShortGitHash = head.abbreviatedId
         jmeBranchName = grgit.branch.current.name
-        jmeGitTag = grgit.tag.list().find { it.commit == head }
 
-        if(jmeVersionName==""){
-            if (jmeGitTag != null) {
-                jmeGitTag = jmeGitTag.name
-                jmeFullVersion  = jmeGitTag
-                jmeVersionTag = ""
-                if(jmeFullVersion.startsWith("v")&&Character.isDigit(jmeFullVersion.charAt(1))){
-                    jmeFullVersion=jmeFullVersion.substring(1);
-                }
-            } else {
-                if(useCommitHashAsVersionName=="true"&&jmeGitHash!=null&&!jmeGitHash.equals("")){
-                    jmeFullVersion  = jmeGitHash
-                    jmeVersionTag = ""
-                }else{
-                    jmeFullVersion="${jmeVersion}-";
-                    if(jmeBranchName!="master")jmeFullVersion+="${jmeBranchName}-";
-                    jmeFullVersion+="SNAPSHOT"
-                    jmeVersionTag="SNAPSHOT"
-                }
-            }
-        }else{
-            jmeVersionTag=""
-            jmeFullVersion=jmeVersionName
+        // This code will find an exact-match tag if the current
+        // commit is the same as the tag commit.
+        jmeGitTag = grgit.tag.list().find { it.commit == head }
+        def latestTag;
+        if( jmeGitTag ) {
+            // Just use the name.  We keep jmeGitTag separate because there
+            // is some logic that wants to know if this specific commit has
+            // a tag versus 'whatever tag we are a child of'... which is what
+            // 'latestTag' will be.
+            jmeGitTag = jmeGitTag.name
+            latestTag = jmeGitTag;
+        } else {
+            // Use describe to find the most recent tag.  Unfortunately,
+            // in this version of grgit, we don't have the 'always' options
+            // so we can't make as many assumptions about the format of the
+            // string.
+            // If the commit is an exact match then it will return just the
+            // tag name... else it will be tagName-commitCount-abbreviatedId
+            // We'll use some groovy regex magic to get the tag either way.
+            def describe = grgit.describe()
+            def fullDescribe = (describe =~/(.*?)-(\d+)-g$jmeShortGitHash/)
+            latestTag = fullDescribe ? fullDescribe[0][1] : describe
+            println "Latest tag:" + latestTag
         }
 
-    
+        // We could enhance this with some more regex if we wanted to sanity
+        // check that it was formatted like our versions.
+        def tagVersion = (latestTag =~/v?(.*)/)[0][1];
+        // If the branch is not master then use the tag.
+        if( jmeBranchName != "master" ) {
+            jmeVersion = tagVersion
+        }
+
+        // Parse out just the base version part.  -SNAPSHOT versions
+        // shouldn't really include our release suffixes
+        def baseVersion = (tagVersion =~/(\d+\.\d+.\d+)/)
+        baseVersion = baseVersion.size() > 0 ? baseVersion[0][0] : tagVersion
+
+        if( !jmeVersionName ) {
+            // If there is a specific tag for the top commit then we always
+            // use that.
+            if( jmeGitTag ) {
+                println "Using GIT tag as version"
+                jmeFullVersion = tagVersion; // already cleaned up
+                jmeVersionTag = ""  // and no SNAPSHOT suffix for an exact version tag
+
+                // Note: this will not automatically add SNAPSHOT if the user has
+                // local changes that they haven't committed.  Technically, only
+                // real CI builds should be using non-SNAPSHOT versions so we may
+                // eventually want to change the script to always use -SNAPSHOT with
+                // a CI option to turn it off.
+                // We could also check the grgit.status for unstaged modified/removed files.
+                //     def unstaged = grgit.status().unstaged;
+                //     def modCount = unstaged.modified.size() + unstaged.removed.size()
+                // ...but that seems like a wasteful check considering only official
+                // version builds should not have a -SNAPSHOT.
+
+            } else if( useCommitHashAsVersionName == "true" && jmeGitHash ) {
+                // The user has opted to use the hash... and we actually have
+                // a hash.
+                println "Using commit ID as version"
+                jmeFullVersion = jmeGitHash;
+                jmeVersionTag = ""
+            } else {
+                println "Auto-detecting version"
+                jmeVersionTag = "SNAPSHOT"
+
+                if( includeBranchInVersion == "true" && jmeBranchName != "master" ) {
+                    jmeFullVersion = baseVersion + "-" + jmeBranchName + "-" + jmeVersionTag;
+                } else {
+                    jmeFullVersion = baseVersion + "-" + jmeVersionTag;
+                }
+            }
+        } else {
+            // Just use defaults
+            println "Using user-defined version"
+            jmeFullVersion=jmeVersionName
+            jmeVersionTag = "SNAPSHOT"
+        }
+
         println("Revision: ${jmeRevision}")
         println("Hash: ${jmeGitHash}")
         println("Short Hash: ${jmeShortGitHash}")
@@ -64,7 +133,8 @@ task configureVersionInfo {
         println("Build Date: ${jmeBuildDate}")
         println("Build Branch: ${jmeBranchName}")
         println("Use commit hash as version ${useCommitHashAsVersionName}")
-        println("Build Tag: ${jmeVersionTag}")
+        println("Base Version: ${baseVersion}")
+        println("Build Suffix: ${jmeVersionTag}")
         println("Build Version: ${jmeFullVersion}")
 
     } catch (ex) {

--- a/version.gradle
+++ b/version.gradle
@@ -37,6 +37,9 @@ task configureVersionInfo {
                 jmeGitTag = jmeGitTag.name
                 jmeFullVersion  = jmeGitTag
                 jmeVersionTag = ""
+                if(jmeFullVersion.startsWith("v")&&Character.isDigit(jmeFullVersion.charAt(1))){
+                    jmeFullVersion=jmeFullVersion.substring(1);
+                }
             } else {
                 if(useCommitHashAsVersionName=="true"&&jmeGitHash!=null&&!jmeGitHash.equals("")){
                     jmeFullVersion  = jmeGitHash


### PR DESCRIPTION
When I call jme3tools.converters.ImageToAwt.DecodeParams#convert with an illgeal image format, it throws UnsupportedOperationException. So in my code, I catch this exception to handle unsupported images. However, I find that some other methods do not throw this exception when image is unsupported. For example, com.jme3.renderer.opengl.TextureUtil#getImageFormatWithError throws RendererException when image is unsupported:

`public GLImageFormat getImageFormatWithError(Format fmt, boolean isSrgb) {

        GLImageFormat glFmt = getImageFormat(fmt, isSrgb);

...

        if (glFmt == null) { 
  
          throw new RendererException("Image format '" + fmt + "' is unsupported by the video hardware.");
  
      }

        return glFmt;

    }
    ` 

Can the thrown exception of getImageFormatWithError be modified, so my code is cleaner?