### PR TITLE
Fixes #1304 - Don't use mat3() constructor to keep compatibility with…

### DIFF
--- a/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
@@ -143,7 +143,11 @@ float renderProbe(vec3 viewDir, vec3 worldPos, vec3 normal, vec3 norm, float Rou
 
     if(lightProbeData[0][3] != 0.0){
         // oriented box probe
-        mat3 wToLocalRot = mat3(lightProbeData);
+        mat3 wToLocalRot;
+        wToLocalRot[0].xyz = lightProbeData[0].xyz;
+        wToLocalRot[1].xyz = lightProbeData[1].xyz;
+        wToLocalRot[2].xyz = lightProbeData[2].xyz;
+
         wToLocalRot = inverse(wToLocalRot);
         vec3 scale = vec3(lightProbeData[0][3], lightProbeData[1][3], lightProbeData[2][3]);
         #if NB_PROBES >= 2


### PR DESCRIPTION
… GLSL110

Since I am not shader savy, please check all the relevant things for me (e.g. is L146 even needed? does the index refer to the individual column/row?).

I could however confirm that it does compile on my Compat Profile.