### PR TITLE
Fixing PBR on <= GLSL 130:

### DIFF
--- a/jme3-core/src/main/resources/Common/ShaderLib/GLSLCompat.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/GLSLCompat.glsllib
@@ -43,9 +43,11 @@ out vec4 outFragColor;
 #endif
 
 #if __VERSION__ == 110
-mat3 mat3(mat4 m) {
+mat3 mat3_sub(mat4 m) {
   return mat3(m[0].xyz, m[1].xyz, m[2].xyz);
 }
+#else
+ #define mat3_sub mat3
 #endif
 
 #if __VERSION__ <= 140

--- a/jme3-core/src/main/resources/Common/ShaderLib/GLSLCompat.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/GLSLCompat.glsllib
@@ -42,4 +42,40 @@ out vec4 outFragColor;
 #  define isnan(val) !(val<0.0||val>0.0||val==0.0)
 #endif
 
+#if __VERSION__ == 110
+mat3 mat3(mat4 m) {
+  return mat3(m[0].xyz, m[1].xyz, m[2].xyz);
+}
+#endif
+
+#if __VERSION__ <= 140
+float determinant(mat2 m) {
+  return m[0][0] * m[1][1] - m[1][0] * m[0][1];
+}
+
+float determinant(mat3 m) {
+  return  + m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+          - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+          + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
+}
+#endif
+
+#if __VERSION__ <= 130
+mat2 inverse(mat2 m) {
+  return mat2(m[1][1], -m[0][1], -m[1][0], m[0][0]) / determinant(m);
+}
+
+mat3 inverse(mat3 m) {
+  return mat3(
+    + (m[1][1] * m[2][2] - m[2][1] * m[1][2]),
+    - (m[1][0] * m[2][2] - m[2][0] * m[1][2]),
+    + (m[1][0] * m[2][1] - m[2][0] * m[1][1]),
+    - (m[0][1] * m[2][2] - m[2][1] * m[0][2]),
+    + (m[0][0] * m[2][2] - m[2][0] * m[0][2]),
+    - (m[0][0] * m[2][1] - m[2][0] * m[0][1]),
+    + (m[0][1] * m[1][2] - m[1][1] * m[0][2]),
+    - (m[0][0] * m[1][2] - m[1][0] * m[0][2]),
+    + (m[0][0] * m[1][1] - m[1][0] * m[0][1])) / determinant(m);
+}
+#endif
 

--- a/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
@@ -143,7 +143,8 @@ float renderProbe(vec3 viewDir, vec3 worldPos, vec3 normal, vec3 norm, float Rou
 
     if(lightProbeData[0][3] != 0.0){
         // oriented box probe
-        mat3 wToLocalRot = inverse(mat3(lightProbeData));
+        // mat3_sub our compat wrapper for mat3(mat4)
+        mat3 wToLocalRot = inverse(mat3_sub(lightProbeData));
 
         vec3 scale = vec3(lightProbeData[0][3], lightProbeData[1][3], lightProbeData[2][3]);
         #if NB_PROBES >= 2

--- a/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
@@ -143,12 +143,8 @@ float renderProbe(vec3 viewDir, vec3 worldPos, vec3 normal, vec3 norm, float Rou
 
     if(lightProbeData[0][3] != 0.0){
         // oriented box probe
-        mat3 wToLocalRot;
-        wToLocalRot[0].xyz = lightProbeData[0].xyz;
-        wToLocalRot[1].xyz = lightProbeData[1].xyz;
-        wToLocalRot[2].xyz = lightProbeData[2].xyz;
+        mat3 wToLocalRot = inverse(mat3(lightProbeData));
 
-        wToLocalRot = inverse(wToLocalRot);
         vec3 scale = vec3(lightProbeData[0][3], lightProbeData[1][3], lightProbeData[2][3]);
         #if NB_PROBES >= 2
             // probe blending


### PR DESCRIPTION
 - GLSLCompat now implements mat3(mat4) and determinant() and inverse() for mat2 and mat3
 - PBR.glslib uses this functions again instead of one-off workarounds