### PR TITLE
Fixed an issue with AndroidNativeImageLoader which was opening stream…

### DIFF
--- a/jme3-android/src/main/java/com/jme3/texture/plugins/AndroidNativeImageLoader.java
+++ b/jme3-android/src/main/java/com/jme3/texture/plugins/AndroidNativeImageLoader.java
@@ -31,7 +31,7 @@ public class AndroidNativeImageLoader  implements AssetLoader {
         InputStream in = null;
         try {
             in = info.openStream();
-            return load(info.openStream(), flip, tmpArray);
+            return load(in, flip, tmpArray);
         } finally {
             if (in != null){
                 in.close();


### PR DESCRIPTION
… twice.

Relevent forum topic: 
https://hub.jmonkeyengine.org/t/solved-gltf-error-with-textured-mesh/43079