### PR TITLE
Fixes #1341: AudioBuffer.updateData only allows direct buffers

### DIFF
--- a/jme3-core/src/main/java/com/jme3/audio/AudioBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/audio/AudioBuffer.java
@@ -31,9 +31,9 @@
  */
 package com.jme3.audio;
 
-import com.jme3.audio.AudioData.DataType;
 import com.jme3.util.BufferUtils;
 import com.jme3.util.NativeObject;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -87,8 +87,12 @@ public class AudioBuffer extends AudioData {
     /**
      * Update the data in the buffer with new data.
      * @param data
+     * @throws IllegalArgumentException if the provided buffer is not a direct buffer
      */
     public void updateData(ByteBuffer data){
+        if (!data.isDirect())
+            throw new IllegalArgumentException("Currently only direct buffers are allowed");
+
         this.audioData = data;
         updateNeeded = true;
     }

--- a/jme3-core/src/main/java/com/jme3/audio/AudioBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/audio/AudioBuffer.java
@@ -90,8 +90,10 @@ public class AudioBuffer extends AudioData {
      * @throws IllegalArgumentException if the provided buffer is not a direct buffer
      */
     public void updateData(ByteBuffer data){
-        if (!data.isDirect())
-            throw new IllegalArgumentException("Currently only direct buffers are allowed");
+        if (!data.isDirect()) {
+            throw new IllegalArgumentException(
+                    "Currently only direct buffers are allowed");
+        }
 
         this.audioData = data;
         updateNeeded = true;


### PR DESCRIPTION
See forum topic: 
https://hub.jmonkeyengine.org/t/solved-playing-audio-from-audiobuffer-in-audionode-causes-jre-to-die/43091/12