### PR TITLE
Add check for NB_PROBES identifier and set default value

### DIFF
--- a/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
@@ -2,6 +2,9 @@
 #ifndef PI
     #define PI 3.14159265358979323846264
 #endif
+#ifndef NB_PROBES
+    #define NB_PROBES 0
+#endif
 
 //Specular fresnel computation
 vec3 F_Shlick(float vh,	vec3 F0){

--- a/jme3-examples/src/main/java/jme3test/light/pbr/TestIssue1340.java
+++ b/jme3-examples/src/main/java/jme3test/light/pbr/TestIssue1340.java
@@ -1,0 +1,66 @@
+package jme3test.light.pbr;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.asset.plugins.UrlLocator;
+import com.jme3.environment.EnvironmentCamera;
+import com.jme3.environment.LightProbeFactory;
+import com.jme3.environment.generation.JobProgressAdapter;
+import com.jme3.light.DirectionalLight;
+import com.jme3.light.LightProbe;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Spatial;
+import com.jme3.system.AppSettings;
+
+/**
+ * @author: rvandoosselaer
+ */
+public class TestIssue1340 extends SimpleApplication {
+
+    public static void main(String[] args) {
+        TestIssue1340 testIssue1340 = new TestIssue1340();
+        testIssue1340.setSettings(createSettings());
+        testIssue1340.start();
+    }
+
+    private static AppSettings createSettings() {
+        AppSettings settings = new AppSettings(true);
+        settings.setRenderer(AppSettings.LWJGL_OPENGL32);
+        return settings;
+    }
+
+    @Override
+    public void simpleInitApp() {
+        stateManager.attach(new EnvironmentCamera(32));
+
+        DirectionalLight light = new DirectionalLight(Vector3f.UNIT_Y.negate(), ColorRGBA.White);
+        rootNode.addLight(light);
+
+        assetManager.registerLocator("https://github.com/KhronosGroup/glTF-Sample-Models/raw/master/2.0/RiggedFigure/", UrlLocator.class);
+
+        Spatial model = assetManager.loadModel("/glTF-Embedded/RiggedFigure.gltf");
+        rootNode.attachChild(model);
+
+        viewPort.setBackgroundColor(ColorRGBA.LightGray);
+    }
+
+    /**
+     * #ifndef NB_PROBES
+     *     #define NB_PROBES 0
+     * #endif
+     */
+    int frame;
+
+    @Override
+    public void simpleUpdate(float tpf) {
+        frame++;
+        if (frame == 2) {
+            LightProbeFactory.makeProbe(stateManager.getState(EnvironmentCamera.class), rootNode, new JobProgressAdapter<LightProbe>() {
+                @Override
+                public void done(LightProbe result) {
+                    enqueue(() -> rootNode.addLight(result));
+                }
+            });
+        }
+    }
+}

--- a/jme3-examples/src/main/java/jme3test/light/pbr/TestIssue1340.java
+++ b/jme3-examples/src/main/java/jme3test/light/pbr/TestIssue1340.java
@@ -17,6 +17,8 @@ import com.jme3.system.AppSettings;
  */
 public class TestIssue1340 extends SimpleApplication {
 
+    int frame;
+
     public static void main(String[] args) {
         TestIssue1340 testIssue1340 = new TestIssue1340();
         testIssue1340.setSettings(createSettings());
@@ -43,13 +45,6 @@ public class TestIssue1340 extends SimpleApplication {
 
         viewPort.setBackgroundColor(ColorRGBA.LightGray);
     }
-
-    /**
-     * #ifndef NB_PROBES
-     *     #define NB_PROBES 0
-     * #endif
-     */
-    int frame;
 
     @Override
     public void simpleUpdate(float tpf) {


### PR DESCRIPTION
fixes #1340 

Check if the NB_PROBES identifier is set, if not set a default value of 0.

If needed I can remove the test class as I don't think it's really 'helpful' in this case, as it only loads and displays a model.