### PR TITLE
restore the JOGL/JOAL hooks

### DIFF
--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -248,7 +248,7 @@ public final class AppSettings extends HashMap<String, Object> {
     public static final String JOGL_OPENGL_FORWARD_COMPATIBLE = "JOGL_OPENGL_FORWARD_COMPATIBLE";
     
     /**
-     * Use JogAmp's JOGL as the display system with the backward compatible profile
+     * Use JogAmp's JOGL as the display system, with the backward compatible profile
      * <p>
      * N.B: This backend is EXPERIMENTAL
      *
@@ -257,11 +257,11 @@ public final class AppSettings extends HashMap<String, Object> {
     public static final String JOGL_OPENGL_BACKWARD_COMPATIBLE = "JOGL_OPENGL_BACKWARD_COMPATIBLE";
     
     /**
-     * Use JogAmp's JOAL as the display system
+     * Use JogAmp's JOAL as the audio renderer.
      * <p>
      * N.B: This backend is EXPERIMENTAL
      *
-     * @see AppSettings#setRenderer(java.lang.String)
+     * @see AppSettings#setAudioRenderer(java.lang.String)
      */
     public static final String JOAL = "JOAL";
 
@@ -671,6 +671,8 @@ public final class AppSettings extends HashMap<String, Object> {
      * <li>AppSettings.LWJGL_OPENGL3 - Force OpenGL3.3 compatability</li>
      * <li>AppSettings.LWJGL_OPENGL_ANY - Choose an appropriate
      * OpenGL version based on system capabilities</li>
+     * <li>AppSettings.JOGL_OPENGL_BACKWARD_COMPATIBLE</li>
+     * <li>AppSettings.JOGL_OPENGL_FORWARD_COMPATIBLE</li>
      * <li>null - Disable graphics rendering</li>
      * </ul>
      * @param renderer The renderer to set
@@ -694,6 +696,7 @@ public final class AppSettings extends HashMap<String, Object> {
      * Set the audio renderer to use. One of:<br>
      * <ul>
      * <li>AppSettings.LWJGL_OPENAL - Default for LWJGL</li>
+     * <li>AppSettings.JOAL</li>
      * <li>null - Disable audio</li>
      * </ul>
      * @param audioRenderer

--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -237,6 +237,33 @@ public final class AppSettings extends HashMap<String, Object> {
      * @see AppSettings#setAudioRenderer(java.lang.String)
      */
     public static final String ANDROID_OPENAL_SOFT = "OpenAL_SOFT";
+    
+    /**
+     * Use JogAmp's JOGL as the display system, with the OpenGL forward compatible profile
+     * <p>
+     * N.B: This backend is EXPERIMENTAL
+     *
+     * @see AppSettings#setRenderer(java.lang.String)
+     */
+    public static final String JOGL_OPENGL_FORWARD_COMPATIBLE = "JOGL_OPENGL_FORWARD_COMPATIBLE";
+    
+    /**
+     * Use JogAmp's JOGL as the display system with the backward compatible profile
+     * <p>
+     * N.B: This backend is EXPERIMENTAL
+     *
+     * @see AppSettings#setRenderer(java.lang.String)
+     */
+    public static final String JOGL_OPENGL_BACKWARD_COMPATIBLE = "JOGL_OPENGL_BACKWARD_COMPATIBLE";
+    
+    /**
+     * Use JogAmp's JOAL as the display system
+     * <p>
+     * N.B: This backend is EXPERIMENTAL
+     *
+     * @see AppSettings#setRenderer(java.lang.String)
+     */
+    public static final String JOAL = "JOAL";
 
     static {
         defaults.put("Width", 640);

--- a/jme3-desktop/src/main/java/com/jme3/system/JmeDesktopSystem.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/JmeDesktopSystem.java
@@ -245,7 +245,7 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
             logger.log(Level.SEVERE, "Failed to create context", ex);
         } catch (ClassNotFoundException ex) {
             logger.log(Level.SEVERE, "CRITICAL ERROR: Context class is missing!\n"
-                    + "Make sure jme3_jogl is on the classpath.", ex);
+                    + "Make sure jme3-jogl is on the classpath.", ex);
         }
 
         return null;
@@ -300,8 +300,8 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
             Class<T> clazz = (Class<T>) Class.forName(className);
             return clazz.newInstance();
         } catch (ClassNotFoundException ex) {
-            logger.log(Level.SEVERE, "CRITICAL ERROR: Audio implementation class is missing!\n"
-                                   + "Make sure jme3_lwjgl-oal or jm3_joal is on the classpath.", ex);
+            logger.log(Level.SEVERE, "CRITICAL ERROR: Audio implementation class "
+                    + className + " is missing!\n", ex);
         } catch (IllegalAccessException ex) {
             logger.log(Level.SEVERE, "Failed to create context", ex);
         } catch (InstantiationException ex) {

--- a/jme3-desktop/src/main/java/com/jme3/system/JmeDesktopSystem.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/JmeDesktopSystem.java
@@ -221,6 +221,36 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
         return null;
     }
 
+    private JmeContext newContextJogl(AppSettings settings, JmeContext.Type type) {
+        try {
+            Class ctxClazz = null;
+            switch (type) {
+                case Display:
+                    ctxClazz = Class.forName("com.jme3.system.jogl.JoglNewtDisplay");
+                    break;
+                case Canvas:
+                    ctxClazz = Class.forName("com.jme3.system.jogl.JoglNewtCanvas");
+                    break;
+                case OffscreenSurface:
+                    ctxClazz = Class.forName("com.jme3.system.jogl.JoglOffscreenBuffer");
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unsupported context type " + type);
+            }
+
+            return (JmeContext) ctxClazz.newInstance();
+        } catch (InstantiationException ex) {
+            logger.log(Level.SEVERE, "Failed to create context", ex);
+        } catch (IllegalAccessException ex) {
+            logger.log(Level.SEVERE, "Failed to create context", ex);
+        } catch (ClassNotFoundException ex) {
+            logger.log(Level.SEVERE, "CRITICAL ERROR: Context class is missing!\n"
+                    + "Make sure jme3_jogl is on the classpath.", ex);
+        }
+
+        return null;
+    }
+
     private JmeContext newContextCustom(AppSettings settings, JmeContext.Type type) {
         try {
             String className = settings.getRenderer().substring("CUSTOM".length());
@@ -250,6 +280,9 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
         } else if (settings.getRenderer().startsWith("LWJGL")) {
             ctx = newContextLwjgl(settings, contextType);
             ctx.setSettings(settings);
+        } else if (settings.getRenderer().startsWith("JOGL")) {
+            ctx = newContextJogl(settings, contextType);
+            ctx.setSettings(settings);
         } else if (settings.getRenderer().startsWith("CUSTOM")) {
             ctx = newContextCustom(settings, contextType);
             ctx.setSettings(settings);
@@ -268,7 +301,7 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
             return clazz.newInstance();
         } catch (ClassNotFoundException ex) {
             logger.log(Level.SEVERE, "CRITICAL ERROR: Audio implementation class is missing!\n"
-                                   + "Make sure jme3_lwjgl-oal is on the classpath.", ex);
+                                   + "Make sure jme3_lwjgl-oal or jm3_joal is on the classpath.", ex);
         } catch (IllegalAccessException ex) {
             logger.log(Level.SEVERE, "Failed to create context", ex);
         } catch (InstantiationException ex) {
@@ -289,6 +322,10 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
             al = newObject("com.jme3.audio.lwjgl.LwjglAL");
             alc = newObject("com.jme3.audio.lwjgl.LwjglALC");
             efx = newObject("com.jme3.audio.lwjgl.LwjglEFX");
+        } else if (settings.getAudioRenderer().startsWith("JOAL")) {
+            al = newObject("com.jme3.audio.joal.JoalAL");
+            alc = newObject("com.jme3.audio.joal.JoalALC");
+            efx = newObject("com.jme3.audio.joal.JoalEFX");
         } else {
             throw new UnsupportedOperationException(
                     "Unrecognizable audio renderer specified: "


### PR DESCRIPTION
This PR restores the "hooks" for using JOGL/JOAL as JMonkeyEngine's backend (instead of, say, LWJGL).

Said hooks were deleted when jme3-jogl was removed from the Engine by PR #1339. However, the situation has changed. As discussed [at the Forum](https://hub.jmonkeyengine.org/t/merged-dropping-jogl/43046/16), jme3-jogl could be hosted in JogAmp’s repository and maintained by the JogAmp community. Restoring the hooks should enable them to do so without forking JMonkeyEngine.