### PR TITLE
Camera#contains javadoc updated

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/Camera.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Camera.java
@@ -1006,13 +1006,13 @@ public class Camera implements Savable, Cloneable {
      * on the negative side of the plane is can be culled out.
      *
      * NOTE: This method is used internally for culling, for public usage,
-     * the plane state of the bounding volume must be saved and restored, e.g:
+     * the plane state of the camera must be saved and restored, e.g:
      * <code>BoundingVolume bv;<br>
      * Camera c;<br>
-     * int planeState = bv.getPlaneState();<br>
-     * bv.setPlaneState(0);<br>
+     * int planeState = c.getPlaneState();<br>
+     * c.setPlaneState(0);<br>
      * c.contains(bv);<br>
-     * bv.setPlaneState(plateState);<br>
+     * c.setPlaneState(plateState);<br>
      * </code>
      *
      * @param bound the bound to check for culling


### PR DESCRIPTION
I've caught unpredictable behavior, when tried to use `Camera.contains`, then checked javadoc and found the reason why.
But javadoc is a bit outdated. This PR updates javadoc according observable behavior.

Old javadoc:
![image](https://user-images.githubusercontent.com/3194236/83030512-47204300-a03c-11ea-90ac-15f6d2009a1b.png)

New javadoc:
![image](https://user-images.githubusercontent.com/3194236/83039357-bdc23e00-a046-11ea-89ca-c4e2dae0028d.png)

Discussion: https://hub.jmonkeyengine.org/t/camera-contains-javadoc-outdated/43320