### PR TITLE
KeyInputEvent javadoc corrected

### DIFF
--- a/jme3-core/src/main/java/com/jme3/input/event/KeyInputEvent.java
+++ b/jme3-core/src/main/java/com/jme3/input/event/KeyInputEvent.java
@@ -82,7 +82,7 @@ public class KeyInputEvent extends InputEvent {
     }
 
     /**
-     * Returns true if this event is a repeat event. Not used anymore.
+     * Returns true if this event is a repeat event.
      * 
      * @return true if this event is a repeat event
      */


### PR DESCRIPTION
`repeating` flag still used and work well.
Discussion: https://hub.jmonkeyengine.org/t/keyinputevent-isrepeating-not-used-anymore/43318