### PR TITLE
avoid NegativeArraySizeException if input string is "\\#FFF#"

### DIFF
--- a/jme3-core/src/main/java/com/jme3/font/ColorTags.java
+++ b/jme3-core/src/main/java/com/jme3/font/ColorTags.java
@@ -77,7 +77,7 @@ class ColorTags {
         }
         Matcher m = colorPattern.matcher(charSeq);
         if (m.find()) {
-            StringBuilder builder = new StringBuilder(charSeq.length()-7);
+            StringBuilder builder = new StringBuilder();
             int startIndex = 0;
             do {
                 String colorStr = null;


### PR DESCRIPTION
**Forum Discussion:** https://hub.jmonkeyengine.org/t/bitmaptext-colortags-negativearraysizeexception/43357

~~~

        // just for this micro-demo.
        BitmapFont font = new BitmapFont();
        font.setCharSet(new BitmapCharacterSet());
        font.setPages(new Material[0]);
        //  in game it's loaded with AssetManager, of course

        BitmapText text = new BitmapText(font);
        text.setText("\\#FFF#");
~~~

        Exception in thread "main" java.lang.NegativeArraySizeException
            at java.lang.AbstractStringBuilder.<init>(AbstractStringBuilder.java:68)
            at java.lang.StringBuilder.<init>(StringBuilder.java:101)
            at com.jme3.font.ColorTags.setText(ColorTags.java:80)
            at com.jme3.font.Letters.setText(Letters.java:68)
            at com.jme3.font.BitmapText.setText(BitmapText.java:181)

~~~
// ColorTags.java:80
StringBuilder builder = new StringBuilder(charSeq.length()-7);
~~~
Looks like it expects color tag in `\#RGBA#` (7 characters) and doesn't count that `\#RGB#` (6 characters) is valid too.