### PR TITLE
Add ability to remove morph targets from mesh

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -1533,17 +1533,19 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
     /**
      * Remove the given MorphTarget from the Mesh
      * @param target The MorphTarget to remove
+     * @return If the MorphTarget was removed
      */
-    public void removeMorphTarget(MorphTarget target) {
-        morphTargets.remove(target);
+    public boolean removeMorphTarget(MorphTarget target) {
+        return morphTargets.remove(target);
     }
 
     /**
      * Remove the MorphTarget from the Mesh at the given index
      * @param index Index of the MorphTarget to remove
+     * @return The MorphTarget that was removed
      */
-    public void removeMorphTarget(int index) {
-        morphTargets.remove(index);
+    public MorphTarget removeMorphTarget(int index) {
+        return morphTargets.remove(index);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -1536,7 +1536,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
      * @return If the MorphTarget was removed
      */
     public boolean removeMorphTarget(MorphTarget target) {
-        return morphTargets != null ? morphTargets.remove(target) : null;
+        return morphTargets != null ? morphTargets.remove(target) : false;
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -1530,6 +1530,32 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
         morphTargets.add(target);
     }
 
+    /**
+     * Remove the given MorphTarget from the Mesh
+     * @param target The MorphTarget to remove
+     */
+    public void removeMorphTarget(MorphTarget target) {
+        morphTargets.remove(target);
+    }
+
+    /**
+     * Remove the MorphTarget from the Mesh at the given index
+     * @param index Index of the MorphTarget to remove
+     */
+    public void removeMorphTarget(int index) {
+        morphTargets.remove(index);
+    }
+
+    /**
+     * Get the MorphTarget at the given index
+     * @throws IndexOutOfBoundsException if the index is less than 0, or larger than the number of morph targets
+     * @param index The index of the morph target to get
+     * @return The MorphTarget at the index
+     */
+    public MorphTarget getMorphTarget(int index) {
+        return morphTargets.get(index);
+    }
+
     public MorphTarget[] getMorphTargets() {
         if (morphTargets == null) {
             return new MorphTarget[0];

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -1536,25 +1536,32 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
      * @return If the MorphTarget was removed
      */
     public boolean removeMorphTarget(MorphTarget target) {
-        return morphTargets.remove(target);
+        return morphTargets != null ? morphTargets.remove(target) : null;
     }
 
     /**
      * Remove the MorphTarget from the Mesh at the given index
+     * @throws IndexOutOfBoundsException if the index outside the number of morph targets
      * @param index Index of the MorphTarget to remove
      * @return The MorphTarget that was removed
      */
     public MorphTarget removeMorphTarget(int index) {
+        if (morphTargets == null) {
+            throw new IndexOutOfBoundsException("Index:" + index + ", Size:0");
+        }
         return morphTargets.remove(index);
     }
 
     /**
      * Get the MorphTarget at the given index
-     * @throws IndexOutOfBoundsException if the index is less than 0, or larger than the number of morph targets
+     * @throws IndexOutOfBoundsException if the index outside the number of morph targets
      * @param index The index of the morph target to get
      * @return The MorphTarget at the index
      */
     public MorphTarget getMorphTarget(int index) {
+        if (morphTargets == null) {
+            throw new IndexOutOfBoundsException("Index:" + index + ", Size:0");
+        }
         return morphTargets.get(index);
     }
 


### PR DESCRIPTION
This PR adds the ability to remove MorphTargets from Mesh. 
It also adds a helper function to get a single MorphTarget. 

~Trevor