### PR TITLE
[fix]: add automatic module names to manifest

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -50,7 +50,8 @@ test {
 jar {
     manifest {
         attributes 'Implementation-Title': 'jMonkeyEngine',
-                   'Implementation-Version': jmeFullVersion
+                   'Implementation-Version': jmeFullVersion,
+                   'Automatic-Module-Name': "${project.name.replace("-", ".")}" 
     }
 }
 


### PR DESCRIPTION
Set manifest automatic module name.

See: https://hub.jmonkeyengine.org/t/modularize-engine/43578