### PR TITLE
GltfLoader decodes file path uri

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -48,11 +48,9 @@ import com.jme3.texture.Texture2D;
 import com.jme3.util.IntMap;
 import com.jme3.util.mikktspace.MikktspaceTangentGenerator;
 import java.io.*;
-import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.Buffer;
 import java.nio.FloatBuffer;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -439,7 +437,7 @@ public class GltfLoader implements AssetLoader {
                     targetNames.add(target.getAsString());
                 }
             }
-            
+
             //Read morph targets
             JsonArray targets = meshObject.getAsJsonArray("targets");
             if(targets != null){
@@ -459,7 +457,7 @@ public class GltfLoader implements AssetLoader {
                     mesh.addMorphTarget(morphTarget);
                 }
             }
-        
+
             //Read mesh extras
             mesh = customContentManager.readExtensionAndExtras("primitive", meshObject, mesh);
 
@@ -1131,7 +1129,7 @@ public class GltfLoader implements AssetLoader {
 //                    skinData.rootBoneTransformOffset.combineWithParent(skinData.parent.getWorldTransform());
 //                }
 //            }
-            
+
             if (skinData.animComposer != null && skinData.animComposer.getSpatial() == null) {
                 spatial.addControl(skinData.animComposer);
             }

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -437,7 +437,7 @@ public class GltfLoader implements AssetLoader {
                     targetNames.add(target.getAsString());
                 }
             }
-
+            
             //Read morph targets
             JsonArray targets = meshObject.getAsJsonArray("targets");
             if(targets != null){
@@ -457,7 +457,7 @@ public class GltfLoader implements AssetLoader {
                     mesh.addMorphTarget(morphTarget);
                 }
             }
-
+        
             //Read mesh extras
             mesh = customContentManager.readExtensionAndExtras("primitive", meshObject, mesh);
 
@@ -1129,7 +1129,7 @@ public class GltfLoader implements AssetLoader {
 //                    skinData.rootBoneTransformOffset.combineWithParent(skinData.parent.getWorldTransform());
 //                }
 //            }
-
+            
             if (skinData.animComposer != null && skinData.animComposer.getSpatial() == null) {
                 spatial.addControl(skinData.animComposer);
             }

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -1428,4 +1428,3 @@ public class GltfLoader implements AssetLoader {
     }
 
 }
-

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -1191,7 +1191,7 @@ public class GltfLoader implements AssetLoader {
 
     private String decodeUri(String uri) {
         try {
-            return URLDecoder.decode(uri.replace("+", "%2B"), "UTF-8");
+            return URLDecoder.decode(uri, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             return uri; //This would mean that UTF-8 is unsupported on the platform.
         }


### PR DESCRIPTION
This is a fix for the GltfLoader to properly decode the percent-format uri references in the gltf model file. 
See https://hub.jmonkeyengine.org/t/jme-not-decoding-gltf-uri/43619/12 for discussion. 

Thanks,
Trevor