### PR TITLE
Actually use ease functions input to InOut when applying

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Easing.java
+++ b/jme3-core/src/main/java/com/jme3/math/Easing.java
@@ -159,10 +159,10 @@ public class Easing {
         public float apply(float value) {
             if (value < 0.5) {
                 value = value * 2;
-                return inQuad.apply(value) / 2;
+                return in.apply(value) / 2;
             } else {
                 value = (value - 0.5f) * 2;
-                return outQuad.apply(value) / 2 + 0.5f;
+                return out.apply(value) / 2 + 0.5f;
             }
         }
     }


### PR DESCRIPTION
The inputs supplied to InOut were unused, previously it always used the Quad ease functions declared earlier in the file.