### PR TITLE
Allow depth-only copy with Renderer.copyFrameBuffer

### DIFF
--- a/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
@@ -331,7 +331,7 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
 
         FrameBuffer sceneBuffer = renderFrameBuffer;
         if (renderFrameBufferMS != null && !renderer.getCaps().contains(Caps.OpenGL32)) {
-            renderer.copyFrameBuffer(renderFrameBufferMS, renderFrameBuffer, true);
+            renderer.copyFrameBuffer(renderFrameBufferMS, renderFrameBuffer, true, true);
         } else if (renderFrameBufferMS != null) {
             sceneBuffer = renderFrameBufferMS;
         }

--- a/jme3-core/src/main/java/com/jme3/post/HDRRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/post/HDRRenderer.java
@@ -364,7 +364,7 @@ public class HDRRenderer implements SceneProcessor {
 //            renderManager.renderViewPortRaw(viewPort);
 
             // render back to non-multisampled FB
-            renderer.copyFrameBuffer(msFB, mainSceneFB, true);
+            renderer.copyFrameBuffer(msFB, mainSceneFB, true, true);
         }else{
 //            renderer.setFrameBuffer(mainSceneFB);
 //            renderer.clearBuffers(true,true,false);

--- a/jme3-core/src/main/java/com/jme3/renderer/Renderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Renderer.java
@@ -184,11 +184,21 @@ public interface Renderer {
      */
     public void deleteShaderSource(ShaderSource source);
 
+
+    
     /**
      * Copies contents from src to dst, scaling if necessary.
      * set copyDepth to false to only copy the color buffers.
+     * @deprecated  Use {@link Renderer#copyFrameBuffer(com.jme3.texture.FrameBuffer, com.jme3.texture.FrameBuffer, boolean, boolean)}.
      */
-    public void copyFrameBuffer(FrameBuffer src, FrameBuffer dst, boolean copyDepth);
+    @Deprecated public void copyFrameBuffer(FrameBuffer src, FrameBuffer dst, boolean copyDepth);
+
+
+    /**
+     * Copies contents from src to dst, scaling if necessary.
+    */
+    public void copyFrameBuffer(FrameBuffer src, FrameBuffer dst, boolean copyColor, boolean copyDepth);
+
 
     /**
      * Sets the framebuffer that will be drawn to.

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -1635,11 +1635,16 @@ public final class GLRenderer implements Renderer {
      |* Framebuffers                                                      *|
      \*********************************************************************/
     public void copyFrameBuffer(FrameBuffer src, FrameBuffer dst) {
-        copyFrameBuffer(src, dst, true);
+        copyFrameBuffer(src, dst, true, true);
     }
 
     @Override
     public void copyFrameBuffer(FrameBuffer src, FrameBuffer dst, boolean copyDepth) {
+        copyFrameBuffer(src, dst, true, copyDepth);
+    }
+
+    @Override
+    public void copyFrameBuffer(FrameBuffer src, FrameBuffer dst, boolean copyColor,boolean copyDepth) {
         if (caps.contains(Caps.FrameBufferBlit)) {
             int srcX0 = 0;
             int srcY0 = 0;
@@ -1692,7 +1697,13 @@ public final class GLRenderer implements Renderer {
                 dstX1 = dst.getWidth();
                 dstY1 = dst.getHeight();
             }
-            int mask = GL.GL_COLOR_BUFFER_BIT;
+            
+            int mask = 0;
+            
+            if(copyColor){
+                mask|=GL.GL_COLOR_BUFFER_BIT;
+            }
+
             if (copyDepth) {
                 mask |= GL.GL_DEPTH_BUFFER_BIT;
             }

--- a/jme3-core/src/main/java/com/jme3/system/NullRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/system/NullRenderer.java
@@ -143,6 +143,11 @@ public class NullRenderer implements Renderer {
     @Override
     public void copyFrameBuffer(FrameBuffer src, FrameBuffer dst, boolean copyDepth) {
     }
+
+    @Override
+    public void copyFrameBuffer(FrameBuffer src, FrameBuffer dst, boolean copyColor, boolean copyDepth) {
+    }
+    
     
     @Override
     public void setMainFrameBufferOverride(FrameBuffer fb) {

--- a/jme3-core/src/main/java/com/jme3/texture/FrameBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/texture/FrameBuffer.java
@@ -56,7 +56,7 @@ import java.util.ArrayList;
  * depth testing (which requires a depth buffer).
  * Buffers can be copied to other framebuffers
  * including the main screen, by using
- * {@link Renderer#copyFrameBuffer(com.jme3.texture.FrameBuffer, com.jme3.texture.FrameBuffer, boolean)}.
+ * {@link Renderer#copyFrameBuffer(com.jme3.texture.FrameBuffer, com.jme3.texture.FrameBuffer, boolean, boolean)}.
  * The content of a {@link RenderBuffer} can be retrieved by using
  * {@link Renderer#readFrameBuffer(com.jme3.texture.FrameBuffer, java.nio.ByteBuffer) }.
  * <p>

--- a/jme3-effects/src/main/java/com/jme3/post/filters/TranslucentBucketFilter.java
+++ b/jme3-effects/src/main/java/com/jme3/post/filters/TranslucentBucketFilter.java
@@ -124,7 +124,7 @@ public final class TranslucentBucketFilter extends Filter {
     protected void postFrame(RenderManager renderManager, ViewPort viewPort, FrameBuffer prevFilterBuffer, FrameBuffer sceneBuffer) {
         renderManager.setCamera(viewPort.getCamera(), false);
         if (prevFilterBuffer != sceneBuffer) {
-            renderManager.getRenderer().copyFrameBuffer(prevFilterBuffer, sceneBuffer, false);
+            renderManager.getRenderer().copyFrameBuffer(prevFilterBuffer, sceneBuffer, true, false);
         }
         renderManager.getRenderer().setFrameBuffer(sceneBuffer);
         viewPort.getQueue().renderQueue(RenderQueue.Bucket.Translucent, renderManager, viewPort.getCamera());

--- a/jme3-vr/src/main/java/com/jme3/post/PreNormalCaching.java
+++ b/jme3-vr/src/main/java/com/jme3/post/PreNormalCaching.java
@@ -33,7 +33,7 @@ public class PreNormalCaching {
         // do we already have a valid cache to set the framebuffer to?
         Renderer r = renderManager.getRenderer();
         if( cachedPreNormals != null ) {
-            r.copyFrameBuffer(cachedPreNormals, normalPass.getRenderFrameBuffer(), false);
+            r.copyFrameBuffer(cachedPreNormals, normalPass.getRenderFrameBuffer(),true,  false);
         } else {
             // lets make the prenormals
             r.setFrameBuffer(normalPass.getRenderFrameBuffer());


### PR DESCRIPTION
This pr allows to exclude color copy when using Renderer.copyFrameBuffer. 
The old method is deprecated and redirected to the new one.