### PR TITLE
Packing AO in the metallic roughness map

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -227,7 +227,7 @@ void main(){
     #endif
 
     #if defined(AO_PACKED_IN_MR_MAP) && defined(USE_PACKED_MR)
-       ao *= aoRoughnessMetallicValue.rrr;
+       ao = aoRoughnessMetallicValue.rrr;
     #endif
 
     float ndotv = max( dot( normal, viewDir ),0.0);

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -72,7 +72,7 @@ MaterialDef PBR Lighting {
         Boolean SeparateTexCoord
         // the light map is a gray scale ao map, on ly the r channel will be read.
         Boolean LightMapAsAOMap
-
+        Boolean AoPackedInMRMap
         //shadows
         Int FilterMode
         Boolean HardwareShadows
@@ -158,6 +158,7 @@ MaterialDef PBR Lighting {
             NORMAL_TYPE: NormalType
             VERTEX_COLOR : UseVertexColor
             AO_MAP: LightMapAsAOMap
+            AO_PACKED_IN_MR_MAP : AoPackedInMRMap
             NUM_MORPH_TARGETS: NumberOfMorphTargets
             NUM_TARGETS_BUFFERS: NumberOfTargetsBuffers
             HORIZON_FADE: HorizonFade


### PR DESCRIPTION
Updated frag shader to support reading the AmbientOcclusion value from the Red channel of the packed MetallicRoughness map. 
Adds a single boolean define that does this when set to true, so long as a metallic roughness map is also defined.

In response to this open issue: 
https://github.com/jMonkeyEngine/jmonkeyengine/issues/999