### PR TITLE
Packing AO in the metallic roughness map

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -72,7 +72,7 @@ MaterialDef PBR Lighting {
         Boolean SeparateTexCoord
         // the light map is a gray scale ao map, on ly the r channel will be read.
         Boolean LightMapAsAOMap
-
+        Boolean AoPackedInMRMap
         //shadows
         Int FilterMode
         Boolean HardwareShadows
@@ -158,6 +158,7 @@ MaterialDef PBR Lighting {
             NORMAL_TYPE: NormalType
             VERTEX_COLOR : UseVertexColor
             AO_MAP: LightMapAsAOMap
+            AO_PACKED_IN_MR_MAP : AoPackedInMRMap
             NUM_MORPH_TARGETS: NumberOfMorphTargets
             NUM_TARGETS_BUFFERS: NumberOfTargetsBuffers
             HORIZON_FADE: HorizonFade


### PR DESCRIPTION
Update j3md file to contain a boolean and corresponding define that tells the fragment shader if the ao map is packed in the metallic roughness map