### PR TITLE
Lwjgl3 impl patches

### DIFF
--- a/jme3-core/src/main/java/com/jme3/input/InputManager.java
+++ b/jme3-core/src/main/java/com/jme3/input/InputManager.java
@@ -154,6 +154,10 @@ public class InputManager implements RawInputListener {
         firstTime = keys.getInputTimeNanos();
     }
 
+    public String getKeyName(int key){
+        return keys.getKeyName(key);
+    }
+
     private void invokeActions(int hash, boolean pressed) {
         ArrayList<Mapping> maps = bindings.get(hash);
         if (maps == null) {

--- a/jme3-core/src/main/java/com/jme3/input/KeyInput.java
+++ b/jme3-core/src/main/java/com/jme3/input/KeyInput.java
@@ -558,4 +558,6 @@ public interface KeyInput extends Input {
      * the last key.
      */
     public static final int KEY_LAST = 0xE0;
+
+    public String getKeyName(int key);
 }

--- a/jme3-core/src/main/java/com/jme3/input/KeyInput.java
+++ b/jme3-core/src/main/java/com/jme3/input/KeyInput.java
@@ -559,5 +559,10 @@ public interface KeyInput extends Input {
      */
     public static final int KEY_LAST = 0xE0;
 
+
+    /**
+    * Returns the name of the specified keycode in the current system language.
+    * @param key The keycode from {@link com.jme3.input.KeyInput}
+    */
     public String getKeyName(int key);
 }

--- a/jme3-core/src/main/java/com/jme3/input/dummy/DummyKeyInput.java
+++ b/jme3-core/src/main/java/com/jme3/input/dummy/DummyKeyInput.java
@@ -50,7 +50,7 @@ public class DummyKeyInput extends DummyInput implements KeyInput {
 
     
     public String getKeyName(int key){
-        return null;
+        return "Unknown";
     }
 
 }

--- a/jme3-core/src/main/java/com/jme3/input/dummy/DummyKeyInput.java
+++ b/jme3-core/src/main/java/com/jme3/input/dummy/DummyKeyInput.java
@@ -48,4 +48,9 @@ public class DummyKeyInput extends DummyInput implements KeyInput {
         return 0;
     }
 
+    
+    public String getKeyName(int key){
+        return null;
+    }
+
 }

--- a/jme3-desktop/src/main/java/com/jme3/input/AWTKeyInput.java
+++ b/jme3-desktop/src/main/java/com/jme3/input/AWTKeyInput.java
@@ -234,4 +234,8 @@ public class AWTKeyInput extends AWTInput implements KeyInput, KeyListener{
       System.out.println("Key released "+e.getKeyChar());
       onKeyEvent(e, false);
     }
+
+    public String getKeyName(int key){
+      return null;
+  }
 }

--- a/jme3-desktop/src/main/java/com/jme3/input/AWTKeyInput.java
+++ b/jme3-desktop/src/main/java/com/jme3/input/AWTKeyInput.java
@@ -236,6 +236,6 @@ public class AWTKeyInput extends AWTInput implements KeyInput, KeyListener{
     }
 
     public String getKeyName(int key){
-      return null;
-  }
+      throw new UnsupportedOperationException("getKeyName is not implemented in AWTKeyInput");
+    }
 }

--- a/jme3-desktop/src/main/java/com/jme3/input/awt/AwtKeyInput.java
+++ b/jme3-desktop/src/main/java/com/jme3/input/awt/AwtKeyInput.java
@@ -623,4 +623,8 @@ public class AwtKeyInput implements KeyInput, KeyListener {
         return 0;
     }
 
+    public String getKeyName(int key){
+        throw new UnsupportedOperationException("getKeyName not implemented for awt input");
+    }
+
 }

--- a/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/LwjglKeyInput.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/LwjglKeyInput.java
@@ -114,5 +114,8 @@ public class LwjglKeyInput implements KeyInput {
     public long getInputTimeNanos() {
         return Sys.getTime() * LwjglTimer.LWJGL_TIME_TO_NANOS;
     }
-
+    
+    public String getKeyName(int key){
+        throw new UnsupportedOperationException("getKeyName not implemented for lwjgl input");    
+    }
 }

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwKeyInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwKeyInput.java
@@ -110,9 +110,9 @@ public class GlfwKeyInput implements KeyInput {
     }
 
     @Override
-    public String getKeyName(int jmeKey){
-        int glfwkey=GlfwKeyMap.fromJmeKeyCode(jmeKey);
-        return glfwGetKeyName(glfwkey,0);
+    public String getKeyName(int jmeKey) {
+        int glfwkey = GlfwKeyMap.fromJmeKeyCode(jmeKey);
+        return glfwGetKeyName(glfwkey, 0);
     }
 
     private void initCallbacks() {

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwKeyInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwKeyInput.java
@@ -109,6 +109,12 @@ public class GlfwKeyInput implements KeyInput {
         charCallback.close();
     }
 
+    @Override
+    public String getKeyName(int jmeKey){
+        int glfwkey=GlfwKeyMap.fromJmeKeyCode(jmeKey);
+        return glfwGetKeyName(glfwkey,0);
+    }
+
     private void initCallbacks() {
         glfwSetKeyCallback(context.getWindowHandle(), keyCallback = new GLFWKeyCallback() {
             @Override

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwKeyMap.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwKeyMap.java
@@ -168,4 +168,14 @@ public class GlfwKeyMap {
     public static int toJmeKeyCode(final int glfwKey) {
         return GLFW_TO_JME_KEY_MAP[glfwKey];
     }
+
+    public static int fromJmeKeyCode(final int jmeKey) {
+        for(int i=0;i<GLFW_TO_JME_KEY_MAP.length;i++){
+            if(GLFW_TO_JME_KEY_MAP[i]==jmeKey){
+                return i;
+            }
+        }
+        return GLFW_KEY_UNKNOWN;
+    }
+    
 }

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwKeyMap.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwKeyMap.java
@@ -165,15 +165,24 @@ public class GlfwKeyMap {
         reg(KEY_RMETA, GLFW_KEY_RIGHT_SUPER);
     }
 
+    /**
+     * Returns the jme keycode that matches the specified glfw keycode
+     * @param glfwKey the glfw keycode
+     */
     public static int toJmeKeyCode(final int glfwKey) {
         return GLFW_TO_JME_KEY_MAP[glfwKey];
     }
 
+
+    /**
+     * Returns the glfw keycode that matches the specified jme keycode or
+     * GLFW_KEY_UNKNOWN if there isn't any match.
+     * 
+     * @param jmeKey the jme keycode
+     */
     public static int fromJmeKeyCode(final int jmeKey) {
-        for(int i=0;i<GLFW_TO_JME_KEY_MAP.length;i++){
-            if(GLFW_TO_JME_KEY_MAP[i]==jmeKey){
-                return i;
-            }
+        for (int i = 0; i < GLFW_TO_JME_KEY_MAP.length; i++) {
+            if (GLFW_TO_JME_KEY_MAP[i] == jmeKey) return i;
         }
         return GLFW_KEY_UNKNOWN;
     }

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -469,6 +469,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
         // NOTE: this is required for Mac OS X!
         mainThread = Thread.currentThread();
+        mainThread.setName("jME3 Main");
         run();
     }
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/Sync.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/Sync.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2002-2012 LWJGL Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'LWJGL' nor the names of
+ *   its contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.system.lwjgl;
+
+
+/**
+* A highly accurate sync method that continually adapts to the system 
+* it runs on to provide reliable results.
+*
+* @author Riven
+* @author kappaOne
+*/
+class Sync {
+
+
+
+	/** number of nano seconds in a second */
+	private static final long NANOS_IN_SECOND = 1000L * 1000L * 1000L;
+
+	/** The time to sleep/yield until the next frame */
+	private static long nextFrame = 0;
+	
+	/** whether the initialisation code has run */
+	private static boolean initialised = false;
+	
+	/** for calculating the averages the previous sleep/yield times are stored */
+	private static RunningAvg sleepDurations = new RunningAvg(10);
+	private static RunningAvg yieldDurations = new RunningAvg(10);
+	
+	
+	/**
+	 * An accurate sync method that will attempt to run at a constant frame rate.
+	 * It should be called once every frame.
+	 * 
+	 * @param fps - the desired frame rate, in frames per second
+	 */
+	public static void sync(int fps) {
+		if (fps <= 0) return;
+		if (!initialised) initialise();
+		
+		try {
+			// sleep until the average sleep time is greater than the time remaining till nextFrame
+			for (long t0 = getTime(), t1; (nextFrame - t0) > sleepDurations.avg(); t0 = t1) {
+				Thread.sleep(1);
+				sleepDurations.add((t1 = getTime()) - t0); // update average sleep time
+			}
+	
+			// slowly dampen sleep average if too high to avoid yielding too much
+			sleepDurations.dampenForLowResTicker();
+	
+			// yield until the average yield time is greater than the time remaining till nextFrame
+			for (long t0 = getTime(), t1; (nextFrame - t0) > yieldDurations.avg(); t0 = t1) {
+				Thread.yield();
+				yieldDurations.add((t1 = getTime()) - t0); // update average yield time
+			}
+		} catch (InterruptedException e) {
+			
+		}
+		
+		// schedule next frame, drop frame(s) if already too late for next frame
+		nextFrame = Math.max(nextFrame + NANOS_IN_SECOND / fps, getTime());
+	}
+	
+	/**
+	 * This method will initialise the sync method by setting initial
+	 * values for sleepDurations/yieldDurations and nextFrame.
+	 * 
+	 * If running on windows it will start the sleep timer fix.
+	 */
+	private static void initialise() {
+		initialised = true;
+		
+		sleepDurations.init(1000 * 1000);
+		yieldDurations.init((int) (-(getTime() - getTime()) * 1.333));
+		
+		nextFrame = getTime();
+		
+		
+			// On windows the sleep functions can be highly inaccurate by 
+			// over 10ms making in unusable. However it can be forced to 
+			// be a bit more accurate by running a separate sleeping daemon
+			// thread.
+			Thread timerAccuracyThread = new Thread(new Runnable() {
+				public void run() {
+					try {
+						while(true)Thread.sleep(Long.MAX_VALUE);
+					} catch (Exception e) {}
+				}
+			});
+			
+			timerAccuracyThread.setName("LWJGL Timer");
+			timerAccuracyThread.setDaemon(true);
+			timerAccuracyThread.start();
+		}
+	
+
+	/**
+	 * Get the system time in nano seconds
+	 * 
+	 * @return will return the current time in nano's
+	 */
+	private static long getTime() {
+		long time= System.currentTimeMillis()& 0x7FFFFFFFFFFFFFFFL;
+		long res= 1000;
+		return (time * NANOS_IN_SECOND) / res;
+	}
+
+	private static class RunningAvg {
+		private final long[] slots;
+		private int offset;
+		
+		private static final long DAMPEN_THRESHOLD = 10 * 1000L * 1000L; // 10ms
+		private static final float DAMPEN_FACTOR = 0.9f; // don't change: 0.9f is exactly right!
+
+		public RunningAvg(int slotCount) {
+			this.slots = new long[slotCount];
+			this.offset = 0;
+		}
+
+		public void init(long value) {
+			while (this.offset < this.slots.length) {
+				this.slots[this.offset++] = value;
+			}
+		}
+
+		public void add(long value) {
+			this.slots[this.offset++ % this.slots.length] = value;
+			this.offset %= this.slots.length;
+		}
+
+		public long avg() {
+			long sum = 0;
+			for (int i = 0; i < this.slots.length; i++) {
+				sum += this.slots[i];
+			}
+			return sum / this.slots.length;
+		}
+		
+		public void dampenForLowResTicker() {
+			if (this.avg() > DAMPEN_THRESHOLD) {
+				for (int i = 0; i < this.slots.length; i++) {
+					this.slots[i] *= DAMPEN_FACTOR;
+				}
+			}
+		}
+	}
+}

--- a/jme3-lwjgl3/src/main/java/com/jme3/util/LWJGLBufferAllocator.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/util/LWJGLBufferAllocator.java
@@ -140,7 +140,7 @@ public class LWJGLBufferAllocator implements BufferAllocator {
 
     static {
         CLEAN_THREAD.setDaemon(true);
-        CLEAN_THREAD.setName("Thread to free LWJGL byte buffers");
+        CLEAN_THREAD.setName("LWJGL Deallocator");
         CLEAN_THREAD.start();
     }
 

--- a/jme3-vr/src/main/java/com/jme3/input/lwjgl/GlfwKeyInputVR.java
+++ b/jme3-vr/src/main/java/com/jme3/input/lwjgl/GlfwKeyInputVR.java
@@ -143,4 +143,11 @@ public class GlfwKeyInputVR implements KeyInput {
     public long getInputTimeNanos() {
         return (long) (glfwGetTime() * 1000000000);
     }
+
+    @Override
+    public String getKeyName(int jmeKey){
+        int glfwkey=GlfwKeyMap.fromJmeKeyCode(jmeKey);
+        return glfwGetKeyName(glfwkey,0);
+    }
+
 }

--- a/jme3-vr/src/main/java/com/jme3/input/lwjgl/GlfwKeyInputVR.java
+++ b/jme3-vr/src/main/java/com/jme3/input/lwjgl/GlfwKeyInputVR.java
@@ -145,9 +145,9 @@ public class GlfwKeyInputVR implements KeyInput {
     }
 
     @Override
-    public String getKeyName(int jmeKey){
-        int glfwkey=GlfwKeyMap.fromJmeKeyCode(jmeKey);
-        return glfwGetKeyName(glfwkey,0);
+    public String getKeyName(int jmeKey) {
+        int glfwkey = GlfwKeyMap.fromJmeKeyCode(jmeKey);
+        return glfwGetKeyName(glfwkey, 0);
     }
 
 }


### PR DESCRIPTION
In this PR i am going to address the issues that are still stopping us from using lwjgl3 as default backend.

I'll report important changes below:

## Better FPS limiter
Ported the Sync class from lwjgl2 to provide a more accurate fps limiter
Fix for #1455


## InputManager.getKeyName
Workaround for #942

-------------------

The following will be addressed in a future PR
##~~Removed AWT calls from the core~~
~~The AWT context causes glfw to behave weirdly or break in some platforms. 
I moved all the classes that need an awt context into a dedicated package to be adapted for lwjgl3 or outright removed in the future. I removed the SettingsDialog calls from the core, and refactored it to be self contained in its own class. 
Now the splash screen needs to be launched manually after creating the AppSettings, to reproduce the old jme behaviour the code will look like this~~
```java
        AppSettings settings=new AppSettings(true);
        
        if(!AWTSettingsDialog.showDialog(settings))return; // Splash screen

        app.setSettings(settings);
        app.start();
```

~~Some image loaders still depend on awt, i am not sure if this is a problem, but i guess they can be reworked to use a standalone solution.~~

## ~~STB based image loader~~
~~I added an alternative to AWTLoader using this pure java port of stb_image `https://github.com/StbJava/StbImageJava`. 
We could of course use the bindings for the official stb_image.h, but the pure java code is more portable. The library is pretty small with no dependencies and under public domain but there is only a private bintray repo for it, so i just copied it in the engine. It seems to be working fine.~~