### PR TITLE
Fading ParticleEmitter's start and end color

### DIFF
--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -1192,6 +1192,9 @@ public class ParticleEmitter extends Geometry {
                 currentStartColor.interpolateLocal(startColorToFadeTo, timeSlerpPct);
             }            
         }
+        else{
+            currentStartColor.set(getStartColor());
+        } 
 
         
         //color fading for end color
@@ -1207,7 +1210,7 @@ public class ParticleEmitter extends Geometry {
             }
         }
         else{
-            currentStartColor.set(getStartColor());
+            currentEndColor.set(getEndColor());
         }
     }
     

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -1286,6 +1286,17 @@ public class ParticleEmitter extends Geometry {
         oc.write(rotateSpeed, "rotateSpeed", 0);
 
         oc.write(particleInfluencer, "influencer", DEFAULT_INFLUENCER);
+        
+        oc.write(startColorToFadeTo, "startColorToFadeTo", new ColorRGBA());
+        oc.write(initialStartColorToFadeFrom, "initialStartColorToFadeFrom", new ColorRGBA());
+        oc.write(totalStartColorFadeDuration, "totalStartColorFadeDuration", 0);
+        oc.write(startColorFadeDuration, "startColorFadeDuration", 0);
+        
+        oc.write(endColorToFadeTo, "endColorToFadeTo", new ColorRGBA());
+        oc.write(initialEndColorToFadeFrom, "initialEndColorToFadeFrom", new ColorRGBA());
+        oc.write(totalEndColorFadeDuration, "totalEndColorFadeDuration", 0);
+        oc.write(endColorFadeDuration, "endColorFadeDuration", 0);
+        
     }
 
     @Override
@@ -1322,6 +1333,16 @@ public class ParticleEmitter extends Geometry {
         selectRandomImage = ic.readBoolean("selectRandomImage", false);
         randomAngle = ic.readBoolean("randomAngle", false);
         rotateSpeed = ic.readFloat("rotateSpeed", 0);
+        
+        startColorToFadeTo = (ColorRGBA) ic.readSavable("startColorToFadeTo", new ColorRGBA());
+        initialStartColorToFadeFrom = (ColorRGBA) ic.readSavable("initialStartColorToFadeFrom", new ColorRGBA());
+        totalStartColorFadeDuration = ic.readFloat("totalStartColorFadeDuration", 0);
+        startColorFadeDuration = ic.readFloat("startColorFadeDuration", 0);        
+        endColorToFadeTo = (ColorRGBA) ic.readSavable("endColorToFadeTo", new ColorRGBA());
+        initialEndColorToFadeFrom = (ColorRGBA) ic.readSavable("initialEndColorToFadeFrom", new ColorRGBA());
+        totalEndColorFadeDuration = ic.readFloat("totalEndColorFadeDuration", 0);
+        endColorFadeDuration = ic.readFloat("endColorFadeDuration", 0);
+    
 
         switch (meshType) {
             case Point:

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -1128,14 +1128,14 @@ public class ParticleEmitter extends Geometry {
     private float totalEndColorFadeDuration;
     private float endColorFadeDuration;    
     
-    public void fadeToStartColor(float fadeDuration, ColorRGBA newStartColor){
+    public void setFadeToStartColor(float fadeDuration, ColorRGBA newStartColor){
         totalStartColorFadeDuration = fadeDuration;  
         startColorFadeDuration = fadeDuration;
         startColorToFadeTo = newStartColor;        
         initialStartColorToFadeFrom = this.getStartColor().clone();
     }
     
-    public void fadeToEndColor(float fadeDuration, ColorRGBA newEndColor){
+    public void setFadeToEndColor(float fadeDuration, ColorRGBA newEndColor){
         totalEndColorFadeDuration = fadeDuration;
         endColorFadeDuration = fadeDuration;
         endColorToFadeTo = newEndColor;
@@ -1143,11 +1143,11 @@ public class ParticleEmitter extends Geometry {
     }
      
      //convenience method for fading both start and end color over the same duration
-    public void fadeToColors(float fadeDuration, ColorRGBA newStartColor, ColorRGBA newEndColor){
-        fadeToEndColor(fadeDuration, newEndColor);
-        fadeToStartColor(fadeDuration, newStartColor);
+    public void setFadeToColors(float fadeDuration, ColorRGBA newStartColor, ColorRGBA newEndColor){
+        setFadeToEndColor(fadeDuration, newEndColor);
+        setFadeToStartColor(fadeDuration, newStartColor);
     }  
-     public void updateColorFading(float tpf){
+    private void updateColorFading(float tpf){
         if(startColorFadeDuration > 0){
             startColorFadeDuration -= tpf;
             

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -1192,9 +1192,6 @@ public class ParticleEmitter extends Geometry {
                 currentStartColor.interpolateLocal(startColorToFadeTo, timeSlerpPct);
             }            
         }
-        else{
-            currentStartColor.set(getStartColor());
-        } 
 
         
         //color fading for end color
@@ -1208,9 +1205,6 @@ public class ParticleEmitter extends Geometry {
                 currentEndColor.set(initialEndColorToFadeFrom);
                 currentEndColor.interpolateLocal(endColorToFadeTo, timeSlerpPct);
             }
-        }
-        else{
-            currentEndColor.set(getEndColor());
         }
     }
     

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -1117,6 +1117,68 @@ public class ParticleEmitter extends Geometry {
 
         vars.release();
     }
+    
+    private ColorRGBA startColorToFadeTo;
+    private ColorRGBA initialStartColorToFadeFrom;
+    private float totalStartColorFadeDuration;
+    private float startColorFadeDuration;
+    
+    private ColorRGBA endColorToFadeTo;
+    private ColorRGBA initialEndColorToFadeFrom;
+    private float totalEndColorFadeDuration;
+    private float endColorFadeDuration;    
+    
+    public void fadeToStartColor(float fadeDuration, ColorRGBA newStartColor){
+        totalStartColorFadeDuration = fadeDuration;  
+        startColorFadeDuration = fadeDuration;
+        startColorToFadeTo = newStartColor;        
+        initialStartColorToFadeFrom = this.getStartColor().clone();
+    }
+    
+    public void fadeToEndColor(float fadeDuration, ColorRGBA newEndColor){
+        totalEndColorFadeDuration = fadeDuration;
+        endColorFadeDuration = fadeDuration;
+        endColorToFadeTo = newEndColor;
+        initialEndColorToFadeFrom = this.getEndColor().clone();
+    }
+     
+     //convenience method for fading both start and end color over the same duration
+    public void fadeToColors(float fadeDuration, ColorRGBA newStartColor, ColorRGBA newEndColor){
+        fadeToEndColor(fadeDuration, newEndColor);
+        fadeToStartColor(fadeDuration, newStartColor);
+    }  
+     public void updateColorFading(float tpf){
+        if(startColorFadeDuration > 0){
+            startColorFadeDuration -= tpf;
+            
+            if(startColorFadeDuration < 0){
+                setStartColor(startColorToFadeTo);
+            }else{
+                float timeSlerpPct = 1 - (startColorFadeDuration / totalStartColorFadeDuration);
+                
+                ColorRGBA slerpedStartColor = initialStartColorToFadeFrom.clone();
+                slerpedStartColor.interpolateLocal(startColorToFadeTo, timeSlerpPct);
+                setStartColor(slerpedStartColor);
+            }
+            
+        }
+        
+        //color fading for end color
+        if(endColorFadeDuration > 0){
+            endColorFadeDuration -= tpf;
+            if(endColorFadeDuration < 0){
+                setEndColor(endColorToFadeTo);
+            }else{
+                float timeSlerpPct =  1 - (endColorFadeDuration / totalEndColorFadeDuration);
+                
+                ColorRGBA slerpedEndColor = initialEndColorToFadeFrom.clone();
+                slerpedEndColor.interpolateLocal(endColorToFadeTo, timeSlerpPct);
+                setEndColor(slerpedEndColor);
+            }
+            
+        }
+    }
+    
 
     /**
      * Set to enable or disable the particle emitter
@@ -1148,6 +1210,7 @@ public class ParticleEmitter extends Geometry {
     public void updateFromControl(float tpf) {
         if (enabled) {
             this.updateParticleState(tpf);
+            this.updateColorFading(tpf);
         }
     }
 

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -109,6 +109,16 @@ public class ParticleEmitter extends Geometry {
     //variable that helps with computations
     private transient Vector3f temp = new Vector3f();
     private transient Vector3f lastPos;
+    
+    private ColorRGBA startColorToFadeTo = new ColorRGBA();
+    private ColorRGBA initialStartColorToFadeFrom  = new ColorRGBA();
+    private float totalStartColorFadeDuration;
+    private float startColorFadeDuration;        
+    private ColorRGBA endColorToFadeTo  = new ColorRGBA();
+    private ColorRGBA initialEndColorToFadeFrom  = new ColorRGBA();
+    private float totalEndColorFadeDuration;
+    private float endColorFadeDuration;   
+
 
     public static class ParticleEmitterControl implements Control, JmeCloneable {
 
@@ -1118,28 +1128,18 @@ public class ParticleEmitter extends Geometry {
         vars.release();
     }
     
-    private ColorRGBA startColorToFadeTo;
-    private ColorRGBA initialStartColorToFadeFrom;
-    private float totalStartColorFadeDuration;
-    private float startColorFadeDuration;
-    
-    private ColorRGBA endColorToFadeTo;
-    private ColorRGBA initialEndColorToFadeFrom;
-    private float totalEndColorFadeDuration;
-    private float endColorFadeDuration;    
-    
-    public void setFadeToStartColor(float fadeDuration, ColorRGBA newStartColor){
+    public void fadeToStartColor(float fadeDuration, ColorRGBA newStartColor){
         totalStartColorFadeDuration = fadeDuration;  
         startColorFadeDuration = fadeDuration;
-        startColorToFadeTo = newStartColor;        
-        initialStartColorToFadeFrom = this.getStartColor().clone();
+        startColorToFadeTo.set(newStartColor);
+        initialStartColorToFadeFrom.set(getStartColor());
     }
     
-    public void setFadeToEndColor(float fadeDuration, ColorRGBA newEndColor){
+    public void fadeToEndColor(float fadeDuration, ColorRGBA newEndColor){
         totalEndColorFadeDuration = fadeDuration;
         endColorFadeDuration = fadeDuration;
-        endColorToFadeTo = newEndColor;
-        initialEndColorToFadeFrom = this.getEndColor().clone();
+        endColorToFadeTo.set(newEndColor);
+        initialEndColorToFadeFrom.set(getEndColor());
     }
      
      //convenience method for fading both start and end color over the same duration
@@ -1147,6 +1147,16 @@ public class ParticleEmitter extends Geometry {
         setFadeToEndColor(fadeDuration, newEndColor);
         setFadeToStartColor(fadeDuration, newStartColor);
     }  
+    
+    public ColorRGBA getStartColorToFadeTo() {        return startColorToFadeTo;    }
+    public ColorRGBA getInitialStartColorToFadeFrom() {        return initialStartColorToFadeFrom;    }
+    public float getStartColorFadeDuration() {        return startColorFadeDuration;    }    
+    public float getTotalStartColorFadeDuration() {        return totalStartColorFadeDuration;    }
+    public ColorRGBA getEndColorToFadeTo() {        return endColorToFadeTo;    }    
+    public ColorRGBA getInitialEndColorToFadeFrom() {        return initialEndColorToFadeFrom;    }
+    public float getTotalEndColorFadeDuration() {        return totalEndColorFadeDuration;    }
+    public float getEndColorFadeDuration() {        return endColorFadeDuration;    }
+    
     private void updateColorFading(float tpf){
         if(startColorFadeDuration > 0){
             startColorFadeDuration -= tpf;

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -1128,14 +1128,14 @@ public class ParticleEmitter extends Geometry {
         vars.release();
     }
     
-    public void fadeToStartColor(float fadeDuration, ColorRGBA newStartColor){
+    public void setFadeToStartColor(float fadeDuration, ColorRGBA newStartColor){
         totalStartColorFadeDuration = fadeDuration;  
         startColorFadeDuration = fadeDuration;
         startColorToFadeTo.set(newStartColor);
         initialStartColorToFadeFrom.set(getStartColor());
     }
     
-    public void fadeToEndColor(float fadeDuration, ColorRGBA newEndColor){
+    public void setFadeToEndColor(float fadeDuration, ColorRGBA newEndColor){
         totalEndColorFadeDuration = fadeDuration;
         endColorFadeDuration = fadeDuration;
         endColorToFadeTo.set(newEndColor);

--- a/jme3-core/src/main/java/com/jme3/effect/controls/ParticleEmitterEffectsControl.java
+++ b/jme3-core/src/main/java/com/jme3/effect/controls/ParticleEmitterEffectsControl.java
@@ -178,9 +178,7 @@ public class ParticleEmitterEffectsControl extends AbstractControl implements Co
     
      @Override
     public void cloneFields(Cloner cloner, Object original) {
-        super.cloneFields(cloner, original); //To change body of generated methods, choose Tools | Templates.
-        
-         super.cloneFields(cloner, original);
+        super.cloneFields(cloner, original);
         
         this.startColorToFadeTo = cloner.clone(startColorToFadeTo);
         this.initialStartColorToFadeFrom = cloner.clone(initialStartColorToFadeFrom);
@@ -198,7 +196,7 @@ public class ParticleEmitterEffectsControl extends AbstractControl implements Co
         super.write(ex);
         
         OutputCapsule oc = ex.getCapsule(this);
-         oc.write(startColorToFadeTo, "startColorToFadeTo", new ColorRGBA());
+        oc.write(startColorToFadeTo, "startColorToFadeTo", new ColorRGBA());
         oc.write(initialStartColorToFadeFrom, "initialStartColorToFadeFrom", new ColorRGBA());
         oc.write(totalStartColorFadeDuration, "totalStartColorFadeDuration", 0);
         oc.write(startColorFadeDuration, "startColorFadeDuration", 0);

--- a/jme3-core/src/main/java/com/jme3/effect/controls/ParticleEmitterEffectsControl.java
+++ b/jme3-core/src/main/java/com/jme3/effect/controls/ParticleEmitterEffectsControl.java
@@ -221,9 +221,4 @@ public class ParticleEmitterEffectsControl extends AbstractControl implements Co
         totalEndColorFadeDuration = ic.readFloat("totalEndColorFadeDuration", 0);
         endColorFadeDuration = ic.readFloat("endColorFadeDuration", 0);
     }
-
-    
-    
-
-    
 }

--- a/jme3-core/src/main/java/com/jme3/effect/controls/ParticleEmitterEffectsControl.java
+++ b/jme3-core/src/main/java/com/jme3/effect/controls/ParticleEmitterEffectsControl.java
@@ -45,10 +45,7 @@ import com.jme3.scene.control.Control;
 import com.jme3.util.clone.Cloner;
 import java.io.IOException;
 
-/**
- *
- * @author ryan
- */
+
 public class ParticleEmitterEffectsControl extends AbstractControl implements Control{
     
     private ParticleEmitter particleEmitter;
@@ -146,7 +143,7 @@ public class ParticleEmitterEffectsControl extends AbstractControl implements Co
     protected void controlUpdate(float tpf) {
         if(enabled){
             updateColorFading(tpf);
-        }        
+        }   
     }
 
     @Override
@@ -169,6 +166,7 @@ public class ParticleEmitterEffectsControl extends AbstractControl implements Co
     @Override
     public void update(float tpf) {
         super.update(tpf);
+   
     }
 
     @Override
@@ -177,7 +175,7 @@ public class ParticleEmitterEffectsControl extends AbstractControl implements Co
     }
     
      @Override
-    public void cloneFields(Cloner cloner, Object original) {
+     public void cloneFields(Cloner cloner, Object original) {       
         super.cloneFields(cloner, original);
         
         this.startColorToFadeTo = cloner.clone(startColorToFadeTo);
@@ -196,6 +194,7 @@ public class ParticleEmitterEffectsControl extends AbstractControl implements Co
         super.write(ex);
         
         OutputCapsule oc = ex.getCapsule(this);
+        
         oc.write(startColorToFadeTo, "startColorToFadeTo", new ColorRGBA());
         oc.write(initialStartColorToFadeFrom, "initialStartColorToFadeFrom", new ColorRGBA());
         oc.write(totalStartColorFadeDuration, "totalStartColorFadeDuration", 0);

--- a/jme3-core/src/main/java/com/jme3/effect/controls/ParticleEmitterEffectsControl.java
+++ b/jme3-core/src/main/java/com/jme3/effect/controls/ParticleEmitterEffectsControl.java
@@ -1,0 +1,232 @@
+  
+/*
+ * Copyright (c) 2009-2012 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.effect;
+import com.jme3.effect.ParticleEmitter;
+import com.jme3.export.InputCapsule;
+import com.jme3.export.JmeExporter;
+import com.jme3.export.JmeImporter;
+import com.jme3.export.OutputCapsule;
+import com.jme3.math.ColorRGBA;
+import com.jme3.renderer.RenderManager;
+import com.jme3.renderer.ViewPort;
+import com.jme3.scene.Spatial;
+import com.jme3.scene.control.AbstractControl;
+import com.jme3.scene.control.Control;
+import com.jme3.util.clone.Cloner;
+import java.io.IOException;
+
+/**
+ *
+ * @author ryan
+ */
+public class ParticleEmitterEffectsControl extends AbstractControl implements Control{
+    
+    private ParticleEmitter particleEmitter;
+    
+    private ColorRGBA startColorToFadeTo = new ColorRGBA();
+    private ColorRGBA initialStartColorToFadeFrom  = new ColorRGBA();
+    private float totalStartColorFadeDuration;
+    private float startColorFadeDuration;        
+    private ColorRGBA endColorToFadeTo  = new ColorRGBA();
+    private ColorRGBA initialEndColorToFadeFrom  = new ColorRGBA();
+    private float totalEndColorFadeDuration;
+    private float endColorFadeDuration; 
+    
+    private ColorRGBA currentStartColor = new ColorRGBA(); //used internally to store the interpolated values in the fade process in the update loop
+    private ColorRGBA currentEndColor = new ColorRGBA();
+    
+
+    
+    public ParticleEmitter getParticlEmitter() {        return particleEmitter;    }
+    public ColorRGBA getStartColorToFadeTo() {        return startColorToFadeTo;    }
+    public ColorRGBA getInitialStartColorToFadeFrom() {        return initialStartColorToFadeFrom;    }
+    public float getStartColorFadeDuration() {        return startColorFadeDuration;    }    
+    public float getTotalStartColorFadeDuration() {        return totalStartColorFadeDuration;    }
+    public ColorRGBA getEndColorToFadeTo() {        return endColorToFadeTo;    }    
+    public ColorRGBA getInitialEndColorToFadeFrom() {        return initialEndColorToFadeFrom;    }
+    public float getTotalEndColorFadeDuration() {        return totalEndColorFadeDuration;    }
+    public float getEndColorFadeDuration() {        return endColorFadeDuration;    }
+    
+    public ParticleEmitterEffectsControl(ParticleEmitter particleEmitter) {
+        super();
+        
+        this.particleEmitter =  particleEmitter;
+        
+    }
+
+
+    
+    public void setFadeToStartColor(float fadeDuration, ColorRGBA newStartColor){
+        totalStartColorFadeDuration = fadeDuration;  
+        startColorFadeDuration = fadeDuration;
+        startColorToFadeTo.set(newStartColor);
+        initialStartColorToFadeFrom.set(particleEmitter.getStartColor());
+    }
+    
+    public void setFadeToEndColor(float fadeDuration, ColorRGBA newEndColor){
+        totalEndColorFadeDuration = fadeDuration;
+        endColorFadeDuration = fadeDuration;
+        endColorToFadeTo.set(newEndColor);
+        initialEndColorToFadeFrom.set(particleEmitter.getEndColor());
+    }
+     
+     //convenience method for fading both start and end color over the same duration
+    public void setFadeToColors(float fadeDuration, ColorRGBA newStartColor, ColorRGBA newEndColor){
+        setFadeToEndColor(fadeDuration, newEndColor);
+        setFadeToStartColor(fadeDuration, newStartColor);
+    }  
+    
+    
+
+
+    private void updateColorFading(float tpf){
+        
+        //color fading for start color
+        if(startColorFadeDuration > 0){
+            startColorFadeDuration -= tpf;
+            
+            if(startColorFadeDuration < 0){
+                particleEmitter.setStartColor(startColorToFadeTo);
+            }else{
+                float timeSlerpPct = 1 - (startColorFadeDuration / totalStartColorFadeDuration);
+                
+                currentStartColor.set(initialStartColorToFadeFrom);
+                currentStartColor.interpolateLocal(startColorToFadeTo, timeSlerpPct);
+                particleEmitter.setStartColor(currentStartColor);
+            }            
+        }        
+        
+        //color fading for end color
+        if(endColorFadeDuration > 0){
+            endColorFadeDuration -= tpf;
+            if(endColorFadeDuration < 0){
+                currentEndColor.set(endColorToFadeTo);
+            }else{
+                float timeSlerpPct =  1 - (endColorFadeDuration / totalEndColorFadeDuration);
+                
+                currentEndColor.set(initialEndColorToFadeFrom);
+                currentEndColor.interpolateLocal(endColorToFadeTo, timeSlerpPct);
+                particleEmitter.setEndColor(currentEndColor);
+            }
+        }
+
+    }
+
+    @Override
+    protected void controlUpdate(float tpf) {
+        if(enabled){
+            updateColorFading(tpf);
+        }        
+    }
+
+    @Override
+    protected void controlRender(RenderManager rm, ViewPort vp) {
+        
+    }
+
+    @Override
+    public Control cloneForSpatial(Spatial spatial) {
+        return super.cloneForSpatial(spatial);    
+    }
+    
+   
+
+    @Override
+    public void setSpatial(Spatial spatial) {
+        super.setSpatial(spatial);
+    }
+
+    @Override
+    public void update(float tpf) {
+        super.update(tpf);
+    }
+
+    @Override
+    public void render(RenderManager rm, ViewPort vp) {
+        super.render(rm, vp);
+    }
+    
+     @Override
+    public void cloneFields(Cloner cloner, Object original) {
+        super.cloneFields(cloner, original); //To change body of generated methods, choose Tools | Templates.
+        
+         super.cloneFields(cloner, original);
+        
+        this.startColorToFadeTo = cloner.clone(startColorToFadeTo);
+        this.initialStartColorToFadeFrom = cloner.clone(initialStartColorToFadeFrom);
+        this.totalStartColorFadeDuration = cloner.clone(totalStartColorFadeDuration);
+        this.startColorFadeDuration = cloner.clone(startColorFadeDuration);
+        
+        this.endColorToFadeTo = cloner.clone(endColorToFadeTo);
+        this.initialEndColorToFadeFrom = cloner.clone(initialEndColorToFadeFrom);
+        this.totalEndColorFadeDuration = cloner.clone(totalEndColorFadeDuration);
+        this.endColorFadeDuration = cloner.clone(endColorFadeDuration);
+    }
+
+    @Override
+    public void write(JmeExporter ex) throws IOException {
+        super.write(ex);
+        
+        OutputCapsule oc = ex.getCapsule(this);
+         oc.write(startColorToFadeTo, "startColorToFadeTo", new ColorRGBA());
+        oc.write(initialStartColorToFadeFrom, "initialStartColorToFadeFrom", new ColorRGBA());
+        oc.write(totalStartColorFadeDuration, "totalStartColorFadeDuration", 0);
+        oc.write(startColorFadeDuration, "startColorFadeDuration", 0);
+
+        oc.write(endColorToFadeTo, "endColorToFadeTo", new ColorRGBA());
+        oc.write(initialEndColorToFadeFrom, "initialEndColorToFadeFrom", new ColorRGBA());
+        oc.write(totalEndColorFadeDuration, "totalEndColorFadeDuration", 0);
+        oc.write(endColorFadeDuration, "endColorFadeDuration", 0);
+    }
+
+    @Override
+    public void read(JmeImporter im) throws IOException {
+        super.read(im);
+        
+        InputCapsule ic = im.getCapsule(this);
+        
+        startColorToFadeTo = (ColorRGBA) ic.readSavable("startColorToFadeTo", new ColorRGBA());
+        initialStartColorToFadeFrom = (ColorRGBA) ic.readSavable("initialStartColorToFadeFrom", new ColorRGBA());
+        totalStartColorFadeDuration = ic.readFloat("totalStartColorFadeDuration", 0);
+        startColorFadeDuration = ic.readFloat("startColorFadeDuration", 0);        
+        endColorToFadeTo = (ColorRGBA) ic.readSavable("endColorToFadeTo", new ColorRGBA());
+        initialEndColorToFadeFrom = (ColorRGBA) ic.readSavable("initialEndColorToFadeFrom", new ColorRGBA());
+        totalEndColorFadeDuration = ic.readFloat("totalEndColorFadeDuration", 0);
+        endColorFadeDuration = ic.readFloat("endColorFadeDuration", 0);
+    }
+
+    
+    
+
+    
+}

--- a/jme3-core/src/main/java/com/jme3/effect/controls/ParticleEmitterEffectsControl.java
+++ b/jme3-core/src/main/java/com/jme3/effect/controls/ParticleEmitterEffectsControl.java
@@ -30,7 +30,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.jme3.effect;
+package com.jme3.effect.controls;
 import com.jme3.effect.ParticleEmitter;
 import com.jme3.export.InputCapsule;
 import com.jme3.export.JmeExporter;


### PR DESCRIPTION
I added some code to allow fading a Particle Emitter's start and end color independently. Previously there was no way to easily fade a particle emitter in/out or to fade it to a different color - you could only set the start and end color. However, in order to smoothly fade out a particle emitter, the start color also needs to be able to be faded. So I added this code to smoothly fade the start and end color to a different color over a set duration in my own version of the ParticleEmitter in my project, and I thought that it might be useful to contribute to the core ParticleEmitter class. 

No existing code was removed, and I just added methods for initiating the color fading process, as well as some code to the update loop to handle the color fading process.