### PR TITLE
Add project license header information

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ allprojects {
     }
 }
 
+// Set the license for IDEs that understand this
+ext.license = file("$rootDir/license.txt")
+
 apply plugin: 'base'
 apply plugin: 'com.github.spotbugs'
 apply from: file('version.gradle')

--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,35 @@
+<#if licenseFirst??>
+${licenseFirst}
+</#if>
+${licensePrefix}Copyright (c) 2009-${date?date?string("yyyy")} jMonkeyEngine
+${licensePrefix}All rights reserved.
+${licensePrefix?replace(" +$", "", "r")}
+${licensePrefix}Redistribution and use in source and binary forms, with or without
+${licensePrefix}modification, are permitted provided that the following conditions are
+${licensePrefix}met:
+${licensePrefix?replace(" +$", "", "r")}
+${licensePrefix}* Redistributions of source code must retain the above copyright
+${licensePrefix}  notice, this list of conditions and the following disclaimer.
+${licensePrefix?replace(" +$", "", "r")}
+${licensePrefix}* Redistributions in binary form must reproduce the above copyright
+${licensePrefix}  notice, this list of conditions and the following disclaimer in the
+${licensePrefix}  documentation and/or other materials provided with the distribution.
+${licensePrefix?replace(" +$", "", "r")}
+${licensePrefix}* Neither the name of 'jMonkeyEngine' nor the names of its contributors
+${licensePrefix}  may be used to endorse or promote products derived from this software
+${licensePrefix}  without specific prior written permission.
+${licensePrefix?replace(" +$", "", "r")}
+${licensePrefix}THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+${licensePrefix}"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+${licensePrefix}TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+${licensePrefix}PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+${licensePrefix}CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+${licensePrefix}EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+${licensePrefix}PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+${licensePrefix}PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+${licensePrefix}LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+${licensePrefix}NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+${licensePrefix}SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+<#if licenseLast??>
+${licenseLast}
+</#if>


### PR DESCRIPTION
Since you have been adding those IDE specific settings... here is one from the home team :)

This re-adds the once deleted license.txt and adds it as the project license in Gradle properties. This works in Netbeans (jME SDK). Probably not in any other IDE. Whenever you add a new class file to any of the jME projects in NB, this license header will be added on top of the class.