### PR TITLE
Javadoc update, proposed fix for issue #1428

### DIFF
--- a/jme3-core/src/main/java/com/jme3/app/state/BaseAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/BaseAppState.java
@@ -44,10 +44,10 @@ import java.util.logging.Logger;
  *  management convenience than AbstractAppState, including methods
  *  for enable/disable/initialize state management.
  *  The abstract onEnable() and onDisable() methods are called
- *  appropriately during initialize(), terminate(), or setEnabled()
+ *  appropriately during initialize(), cleanup(), or setEnabled()
  *  depending on the mutual state of "initialized" and "enabled".
  *  
- *  <p>initialize() and terminate() can be used by subclasses to
+ *  <p>initialize() and cleanup() can be used by subclasses to
  *  manage resources that should exist the entire time that the 
  *  app state is attached.  This is useful for resources that might
  *  be expensive to create or load.</p>


### PR DESCRIPTION
The `terminate()` method does not exist, the correct one is `cleanup()`