### PR TITLE
Use BufferedOutputStream to achieve maximum throughput

### DIFF
--- a/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryExporter.java
+++ b/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryExporter.java
@@ -161,23 +161,23 @@ public class BinaryExporter implements JmeExporter {
 
     public static boolean debug = false;
     public static boolean useFastBufs = true;
-      
+
     public BinaryExporter() {
     }
 
     public static BinaryExporter getInstance() {
         return new BinaryExporter();
     }
-    
+
     /**
      * Saves the object into memory then loads it from memory.
-     * 
+     *
      * Used by tests to check if the persistence system is working.
-     * 
+     *
      * @param <T> The type of savable.
      * @param assetManager AssetManager to load assets from.
      * @param object The object to save and then load.
-     * @return A new instance that has been saved and loaded from the 
+     * @return A new instance that has been saved and loaded from the
      * original object.
      */
     public static <T extends Savable> T saveAndLoad(AssetManager assetManager, T object) {
@@ -203,11 +203,11 @@ public class BinaryExporter implements JmeExporter {
         contentTable.clear();
         locationTable.clear();
         contentKeys.clear();
-        
+
         // write signature and version
         os.write(ByteUtils.convertToBytes(FormatVersion.SIGNATURE));
         os.write(ByteUtils.convertToBytes(FormatVersion.VERSION));
-        
+
         int id = processBinarySavable(object);
 
         // write out tag table
@@ -216,7 +216,7 @@ public class BinaryExporter implements JmeExporter {
         int aliasSize = ((int) FastMath.log(classNum, 256) + 1); // make all
                                                                   // aliases a
                                                                   // fixed width
-        
+
         os.write(ByteUtils.convertToBytes(classNum));
         for (String key : classes.keySet()) {
             BinaryClassObject bco = classes.get(key);
@@ -226,20 +226,20 @@ public class BinaryExporter implements JmeExporter {
                     aliasSize);
             os.write(aliasBytes);
             classTableSize += aliasSize;
-            
+
             // jME3 NEW: Write class hierarchy version numbers
             os.write( bco.classHierarchyVersions.length );
             for (int version : bco.classHierarchyVersions){
                 os.write(ByteUtils.convertToBytes(version));
             }
             classTableSize += 1 + bco.classHierarchyVersions.length * 4;
-            
+
             // write classname size & classname
             byte[] classBytes = key.getBytes();
             os.write(ByteUtils.convertToBytes(classBytes.length));
             os.write(classBytes);
             classTableSize += 4 + classBytes.length;
-            
+
             // for each field, write alias, type, and name
             os.write(ByteUtils.convertToBytes(bco.nameFields.size()));
             for (String fieldName : bco.nameFields.keySet()) {
@@ -357,11 +357,9 @@ public class BinaryExporter implements JmeExporter {
             parentDirectory.mkdirs();
         }
 
-        FileOutputStream fos = new FileOutputStream(f);
-        try {
-            save(object, fos);
-        } finally {
-            fos.close();
+        try (FileOutputStream fos = new FileOutputStream(f);
+                BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+            save(object, bos);
         }
     }
 
@@ -375,12 +373,12 @@ public class BinaryExporter implements JmeExporter {
         bco.alias = generateTag();
         bco.nameFields = new HashMap<>();
         bco.classHierarchyVersions = SavableClassUtil.getSavableVersions(clazz);
-        
+
         classes.put(clazz.getName(), bco);
-            
+
         return bco;
     }
-    
+
     public int processBinarySavable(Savable object) throws IOException {
         if (object == null) {
             return -1;


### PR DESCRIPTION
Ah, sorry for the white space changes.

Well, I was heavily optimizing our OpenKeeper's file operations. Basically trying to convert it to NIO world instead of the old I/O libraries. The results are stunning. There was still this place where I was relying on jME to write out the converted assets. And here it is.

We are writing 2015 files (615 MB) of j3o models with this BinaryExporter. Files range from few kilobytes to anywhere around 8 megabytes.

**Before: 110 seconds
After: 23 seconds**

The time includes a lot of stuff really, but this is the effect of this little change. This is not NIO, instead the old I/O. Still the fastest way to write a file in Java. See for example https://www.happycoders.eu/java/how-to-write-files-quickly-and-easily/#Performance_overview_writing_files.

Dunno what you think about doing some NIO work. That means basically getting rid of File, replace it with Path, Paths and Files classes. That doesn't alone yield any performance improvements though, or at least measurable ones. Mainly API thing.