### PR TITLE
Use BufferedWriter

### DIFF
--- a/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MExporter.java
+++ b/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MExporter.java
@@ -10,13 +10,13 @@ import com.jme3.export.OutputCapsule;
 import com.jme3.export.Savable;
 import com.jme3.material.Material;
 import com.jme3.material.MaterialDef;
-
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Saves a Material to a j3m file with proper formatting.
@@ -50,13 +50,14 @@ public class J3MExporter implements JmeExporter {
             throw new IllegalArgumentException("J3MExporter can only save com.jme3.material.Material class");
         }
 
-        OutputStreamWriter out = new OutputStreamWriter(f, Charset.forName("UTF-8"));
+        try (OutputStreamWriter out = new OutputStreamWriter(f, StandardCharsets.UTF_8);
+                BufferedWriter writer = new BufferedWriter(out)) {
 
-        rootCapsule.clear();
-        object.write(this);
-        rootCapsule.writeToStream(out);
+            rootCapsule.clear();
+            object.write(this);
+            rootCapsule.writeToStream(writer);
 
-        out.flush();
+        }
     }
 
     @Override

--- a/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MExporter.java
+++ b/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MExporter.java
@@ -10,7 +10,7 @@ import com.jme3.export.OutputCapsule;
 import com.jme3.export.Savable;
 import com.jme3.material.Material;
 import com.jme3.material.MaterialDef;
-import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -50,20 +50,20 @@ public class J3MExporter implements JmeExporter {
             throw new IllegalArgumentException("J3MExporter can only save com.jme3.material.Material class");
         }
 
-        try (OutputStreamWriter out = new OutputStreamWriter(f, StandardCharsets.UTF_8);
-                BufferedWriter writer = new BufferedWriter(out)) {
+        try (OutputStreamWriter out = new OutputStreamWriter(f, StandardCharsets.UTF_8)) {
 
             rootCapsule.clear();
             object.write(this);
-            rootCapsule.writeToStream(writer);
+            rootCapsule.writeToStream(out);
 
         }
     }
 
     @Override
     public void save(Savable object, File f) throws IOException {
-        try (FileOutputStream fos = new FileOutputStream(f)) {
-            save(object, fos);
+        try (FileOutputStream fos = new FileOutputStream(f);
+                BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+            save(object, bos);
         }
     }
 

--- a/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MOutputCapsule.java
+++ b/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MOutputCapsule.java
@@ -16,7 +16,7 @@ import com.jme3.texture.Texture;
 import com.jme3.texture.Texture.WrapMode;
 import com.jme3.util.IntMap;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
@@ -40,7 +40,7 @@ public class J3MOutputCapsule implements OutputCapsule {
         parameters = new HashMap<>();
     }
 
-    public void writeToStream(OutputStreamWriter out) throws IOException {
+    public void writeToStream(Writer out) throws IOException {
         for (String key : parameters.keySet()) {
             out.write("      ");
             writeParameter(out, key, parameters.get(key));
@@ -48,7 +48,7 @@ public class J3MOutputCapsule implements OutputCapsule {
         }
     }
 
-    protected void writeParameter(OutputStreamWriter out, String name, String value) throws IOException {
+    protected void writeParameter(Writer out, String name, String value) throws IOException {
         out.write(name);
         out.write(" : ");
         out.write(value);

--- a/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MRenderStateOutputCapsule.java
+++ b/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MRenderStateOutputCapsule.java
@@ -8,17 +8,17 @@ package com.jme3.material.plugin.export.material;
 import com.jme3.export.OutputCapsule;
 import com.jme3.export.Savable;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.HashMap;
 
 /**
  *
  * @author tsr
  */
-public class J3MRenderStateOutputCapsule extends J3MOutputCapsule {    
+public class J3MRenderStateOutputCapsule extends J3MOutputCapsule {
     protected final static HashMap<String, String> NAME_MAP;
     protected String offsetUnit;
-    
+
     static {
         NAME_MAP = new HashMap<>();
         NAME_MAP.put( "wireframe", "Wireframe");
@@ -41,7 +41,7 @@ public class J3MRenderStateOutputCapsule extends J3MOutputCapsule {
     public OutputCapsule getCapsule(Savable object) {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
-    
+
     @Override
     public void clear() {
         super.clear();
@@ -49,34 +49,34 @@ public class J3MRenderStateOutputCapsule extends J3MOutputCapsule {
     }
 
     @Override
-    public void writeToStream(OutputStreamWriter out) throws IOException {
+    public void writeToStream(Writer out) throws IOException {
         out.write("    AdditionalRenderState {\n");
         super.writeToStream(out);
         out.write("    }\n");
-    }  
-    
+    }
+
     @Override
-    protected void writeParameter(OutputStreamWriter out, String name, String value) throws IOException {
+    protected void writeParameter(Writer out, String name, String value) throws IOException {
         out.write(name);
-        out.write(" ");        
+        out.write(" ");
         out.write(value);
-        
+
         if( "PolyOffset".equals(name) ) {
             out.write(" ");
             out.write(offsetUnit);
-        }        
+        }
     }
-    
+
     @Override
     protected void putParameter(String name, String value ) {
         if( "offsetUnits".equals(name) ) {
             offsetUnit = value;
             return;
         }
-        
+
         if( !NAME_MAP.containsKey(name) )
             return;
-        
+
         super.putParameter(NAME_MAP.get(name), value);
     }
 }

--- a/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MRootOutputCapsule.java
+++ b/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MRootOutputCapsule.java
@@ -9,7 +9,7 @@ import com.jme3.export.OutputCapsule;
 import com.jme3.export.Savable;
 
 import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.HashMap;
 
 /**
@@ -46,7 +46,7 @@ public class J3MRootOutputCapsule extends J3MOutputCapsule {
     }
 
     @Override
-    public void writeToStream(OutputStreamWriter out) throws IOException {
+    public void writeToStream(Writer out) throws IOException {
         out.write("Material " + name + " : " + materialDefinition + " {\n\n");
         if (isTransparent != null)
             out.write("    Transparent " + ((isTransparent) ? "On" : "Off") + "\n\n");

--- a/jme3-plugins/src/main/java/com/jme3/material/plugin/export/materialdef/J3mdExporter.java
+++ b/jme3-plugins/src/main/java/com/jme3/material/plugin/export/materialdef/J3mdExporter.java
@@ -6,7 +6,6 @@
 package com.jme3.material.plugin.export.materialdef;
 
 import com.jme3.material.*;
-
 import java.io.*;
 import java.util.List;
 
@@ -68,8 +67,9 @@ public class J3mdExporter {
 
 
     public void save(MaterialDef matDef, File f) throws IOException {
-        try (FileOutputStream fos = new FileOutputStream(f)) {
-            save(matDef, fos);
+        try (FileOutputStream fos = new FileOutputStream(f);
+                BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+            save(matDef, bos);
         }
     }
 

--- a/jme3-plugins/src/main/java/com/jme3/material/plugin/export/materialdef/J3mdMatParamWriter.java
+++ b/jme3-plugins/src/main/java/com/jme3/material/plugin/export/materialdef/J3mdMatParamWriter.java
@@ -7,13 +7,11 @@ package com.jme3.material.plugin.export.materialdef;
 
 import com.jme3.material.*;
 import com.jme3.math.*;
-import com.jme3.texture.image.ColorSpace;
-
-import java.io.*;
-
 import static com.jme3.shader.VarType.Vector2;
 import static com.jme3.shader.VarType.Vector3;
 import static com.jme3.shader.VarType.Vector4;
+import com.jme3.texture.image.ColorSpace;
+import java.io.*;
 
 /**
  * @author nehon
@@ -23,7 +21,7 @@ public class J3mdMatParamWriter {
     public J3mdMatParamWriter() {
     }
 
-    public void write(MatParam param, OutputStreamWriter out) throws IOException {
+    public void write(MatParam param, Writer out) throws IOException {
         out.write("        ");
         out.write(param.getVarType().name());
         out.write(" ");

--- a/jme3-plugins/src/main/java/com/jme3/material/plugin/export/materialdef/J3mdTechniqueDefWriter.java
+++ b/jme3-plugins/src/main/java/com/jme3/material/plugin/export/materialdef/J3mdTechniqueDefWriter.java
@@ -9,9 +9,8 @@ import com.jme3.material.MatParam;
 import com.jme3.material.RenderState;
 import com.jme3.material.TechniqueDef;
 import com.jme3.shader.*;
-
 import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.Collection;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -25,7 +24,7 @@ public class J3mdTechniqueDefWriter {
     public J3mdTechniqueDefWriter() {
     }
 
-    public void write(TechniqueDef techniqueDef, Collection<MatParam> matParams, OutputStreamWriter out) throws IOException {
+    public void write(TechniqueDef techniqueDef, Collection<MatParam> matParams, Writer out) throws IOException {
         out.write("    Technique");
         if(!techniqueDef.getName().equals("Default")) {
             out.write(" ");
@@ -93,7 +92,7 @@ public class J3mdTechniqueDefWriter {
         out.write("    }\n");
     }
 
-    private void writeDefines(TechniqueDef techniqueDef, Collection<MatParam> matParams, OutputStreamWriter out) throws IOException {
+    private void writeDefines(TechniqueDef techniqueDef, Collection<MatParam> matParams, Writer out) throws IOException {
         out.write("        Defines {\n");
 
         for (int i = 0; i < techniqueDef.getDefineNames().length; i++) {
@@ -110,7 +109,7 @@ public class J3mdTechniqueDefWriter {
         out.write("        }\n\n");
     }
 
-    private void writeShaderNodes(TechniqueDef techniqueDef, Collection<MatParam> matParams, OutputStreamWriter out) throws IOException {
+    private void writeShaderNodes(TechniqueDef techniqueDef, Collection<MatParam> matParams, Writer out) throws IOException {
         out.write("        VertexShaderNodes {\n");
         for (ShaderNode shaderNode : techniqueDef.getShaderNodes()) {
             if(shaderNode.getDefinition().getType() == Shader.ShaderType.Vertex){
@@ -128,7 +127,7 @@ public class J3mdTechniqueDefWriter {
         out.write("        }\n\n");
     }
 
-    private void writeWorldParams(TechniqueDef techniqueDef, OutputStreamWriter out) throws IOException {
+    private void writeWorldParams(TechniqueDef techniqueDef, Writer out) throws IOException {
         out.write("        WorldParameters {\n");
         for (UniformBinding uniformBinding : techniqueDef.getWorldBindings()) {
             out.write("            ");
@@ -138,7 +137,7 @@ public class J3mdTechniqueDefWriter {
         out.write("        }\n\n");
     }
 
-    private void writeShaders(TechniqueDef techniqueDef, OutputStreamWriter out) throws IOException {
+    private void writeShaders(TechniqueDef techniqueDef, Writer out) throws IOException {
         if (techniqueDef.getShaderProgramNames().size() > 0) {
             for (Shader.ShaderType shaderType : techniqueDef.getShaderProgramNames().keySet()) {
                 //   System.err.println(shaderType + " " +techniqueDef.getShaderProgramNames().get(shaderType) + " " +techniqueDef.getShaderProgramLanguage(shaderType))
@@ -154,7 +153,7 @@ public class J3mdTechniqueDefWriter {
         }
     }
 
-    private void writeShaderNode( OutputStreamWriter out, ShaderNode shaderNode, Collection<MatParam> matParams) throws IOException {
+    private void writeShaderNode(Writer out, ShaderNode shaderNode, Collection<MatParam> matParams) throws IOException {
         out.write("            ShaderNode ");
         out.write(shaderNode.getName());
         out.write(" {\n");
@@ -193,8 +192,7 @@ public class J3mdTechniqueDefWriter {
         out.write("            }\n");
     }
 
-    private void writeVariableMapping(final OutputStreamWriter out, final ShaderNode shaderNode,
-                                      final VariableMapping mapping, final Collection<MatParam> matParams)
+    private void writeVariableMapping(final Writer out, final ShaderNode shaderNode,                                      final VariableMapping mapping, final Collection<MatParam> matParams)
             throws IOException {
 
         final ShaderNodeVariable leftVar = mapping.getLeftVariable();
@@ -269,7 +267,7 @@ public class J3mdTechniqueDefWriter {
         return res;
     }
 
-    private void writeRenderStateAttribute(OutputStreamWriter out, String name, String value) throws IOException {
+    private void writeRenderStateAttribute(Writer out, String name, String value) throws IOException {
         out.write("            ");
         out.write(name);
         out.write(" ");
@@ -277,7 +275,7 @@ public class J3mdTechniqueDefWriter {
         out.write("\n");
     }
 
-    private void writeRenderState(RenderState rs, OutputStreamWriter out) throws IOException {
+    private void writeRenderState(RenderState rs, Writer out) throws IOException {
         RenderState defRs = RenderState.DEFAULT;
         if(rs.getBlendMode() != defRs.getBlendMode()) {
             writeRenderStateAttribute(out, "Blend", rs.getBlendMode().name());


### PR DESCRIPTION
Related to: https://github.com/jMonkeyEngine/jmonkeyengine/pull/1434

These we write 1100 files (namely the Material files, j3m). The speedup is on the error margin of the measurement. The reason being that the usage really limits to these really small files (500 bytes...). It still should be less writes on the disk.