### PR TITLE
[M]Fix issue#1436

### DIFF
--- a/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryInputCapsule.java
+++ b/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryInputCapsule.java
@@ -37,11 +37,11 @@ import com.jme3.export.SavableClassUtil;
 import com.jme3.util.BufferUtils;
 import com.jme3.util.IntMap;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashMap;
@@ -1023,7 +1023,7 @@ final class BinaryInputCapsule implements InputCapsule {
             bytes[x] =  content[index++];
         }
 
-        return new String(bytes, "UTF8");
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     protected String[] readStringArray(byte[] content) throws IOException {

--- a/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryOutputCapsule.java
+++ b/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryOutputCapsule.java
@@ -41,6 +41,7 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -684,8 +685,7 @@ final class BinaryOutputCapsule implements OutputCapsule {
             write(NULL_OBJECT);
             return;
         }
-        // write our output as UTF-8. Java misspells UTF-8 as UTF8 for official use in java.lang
-        byte[] bytes = value.getBytes("UTF8");
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
         write(bytes.length);
         baos.write(bytes);
     }


### PR DESCRIPTION
Fix the code error when checking UTF-8 data

let content = [0xE4, 0x8A, 0xBC], let `b = 0xE4` (1110 0100)

See this part:
````java
                if (b < 0x80) {
                    // good
                }
                else if ((b & 0xC0) == 0xC0) {//   (0xE4 & 0xC0) == 0xC0     =====>  true
                    utf8State = UTF8_2BYTE;
                }
                else if ((b & 0xE0) == 0xE0) {//   (0xE4 & 0xE0) == 0xE0      =====>  true
                    utf8State = UTF8_3BYTE_1;
                }
                else {
                    utf8State = UTF8_ILLEGAL;
                }
````

3 bytes UTF-8 data while always be treated as 2 bytes UTF-8 data.