### PR TITLE
resolve issue #1414 (checkSetParam warning while creating sky)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
+++ b/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
@@ -186,24 +186,32 @@ public class SkyFactory {
         sky.setCullHint(Spatial.CullHint.Never);
         sky.setModelBound(new BoundingSphere(Float.POSITIVE_INFINITY, Vector3f.ZERO));
 
-        Material skyMat = new Material(assetManager, "Common/MatDefs/Misc/Sky.j3md");
-        skyMat.setVector3("NormalScale", normalScale);
-        switch (envMapType){
-            case CubeMap : 
+        Material skyMat;
+        switch (envMapType) {
+            case CubeMap:
                 // make sure it's a cubemap
                 if (!(texture instanceof TextureCubeMap)) {
                     Image img = texture.getImage();
                     texture = new TextureCubeMap();
                     texture.setImage(img);
                 }
+                skyMat = new Material(assetManager,
+                        "Common/MatDefs/Misc/Sky.j3md");
                 break;
-            case SphereMap :     
+            case SphereMap:
+                skyMat = new Material(assetManager,
+                        "Common/MatDefs/Misc/SkyNonCube.j3md");
                 skyMat.setBoolean("SphereMap", true);
                 break;
-            case EquirectMap : 
+            case EquirectMap:
+                skyMat = new Material(assetManager,
+                        "Common/MatDefs/Misc/SkyNonCube.j3md");
                 skyMat.setBoolean("EquirectMap", true);
                 break;
+            default:
+                throw new IllegalArgumentException("envMapType=" + envMapType);
         }
+        skyMat.setVector3("NormalScale", normalScale);
         texture.setMagFilter(Texture.MagFilter.Bilinear);
         texture.setMinFilter(Texture.MinFilter.BilinearNoMipMaps);
         texture.setAnisotropicFilter(0);

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/SkyNonCube.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/SkyNonCube.j3md
@@ -1,0 +1,28 @@
+MaterialDef Sky Plane {
+    MaterialParameters {
+        Texture2D Texture
+        Boolean SphereMap
+        Boolean EquirectMap
+        Vector3 NormalScale
+    }
+    Technique {
+        VertexShader GLSL100 GLSL150:   Common/MatDefs/Misc/Sky.vert
+        FragmentShader GLSL100 GLSL150: Common/MatDefs/Misc/Sky.frag
+
+        WorldParameters {
+            ViewMatrix
+            ProjectionMatrix
+            WorldMatrixInverse
+        }
+
+        Defines {
+            SPHERE_MAP : SphereMap
+            EQUIRECT_MAP : EquirectMap
+        }
+
+        RenderState {
+            DepthWrite Off
+            DepthFunc Equal
+        }
+    }
+}


### PR DESCRIPTION
A solution using 2 different material definition assets:
 + "Common/MatDefs/Misc/Sky.j3md" for cube-mapped skies (tested using `TestHoveringTank`)
 + "Common/MatDefs/Misc/SkyNonCube.j3md" for sphere-mapped skies (tested using `TestEverything`) and equirect-mapped skies (tested using `RefEnv`)