### PR TITLE
Fix spherical light probes always starting at 0,0,0

### DIFF
--- a/jme3-core/src/main/java/com/jme3/light/LightProbe.java
+++ b/jme3-core/src/main/java/com/jme3/light/LightProbe.java
@@ -231,9 +231,9 @@ public class LightProbe extends Light implements Savable {
                 break;
             case OrientedBox:
                 area = new OrientedBoxProbeArea(new Transform());
-                area.setCenter(position);
                 break;
         }
+        area.setCenter(position);
     }
 
     public AreaType getAreaType(){


### PR DESCRIPTION
When setting the type of a light probe to spherical, previously the center of the area wasn't set to the probe's position.

The code is untested, as I can't currently build the engine locally, so someone testing it would be welcome. The changes are minimal though, so chances of something breaking are small.