### PR TITLE
Allow use of a GlowColor with GlowMap

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/Glow.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/Glow.frag
@@ -17,10 +17,16 @@
 
 void main(){
     #ifdef HAS_GLOWMAP
+        #ifdef HAS_GLOWCOLOR
+           vec4 color = m_GlowColor;
+        #else
+           vec4 color = vec4(1.0);
+        #endif
+
         #if defined(NEED_TEXCOORD1) 
-           gl_FragColor = texture2D(m_GlowMap, texCoord1);
+           gl_FragColor = texture2D(m_GlowMap, texCoord1) * color;
         #else 
-           gl_FragColor = texture2D(m_GlowMap, texCoord);
+           gl_FragColor = texture2D(m_GlowMap, texCoord) * color;
         #endif
     #else
         #ifdef HAS_GLOWCOLOR


### PR DESCRIPTION
In the case of grayscale GlowMap, GlowColor can be used for changing color without manipulating glow texture.

Forum topic: https://hub.jmonkeyengine.org/t/glowcolor-unused-if-a-glowmap-is-specified/44002