### PR TITLE
Add desaturation functionality to Unshaded.j3md

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.frag
@@ -48,7 +48,7 @@ void main(){
         }
     #endif
     
-    #ifdef DESATURATE
+    #ifdef DESATURATION
         vec3 gray = vec3(dot(vec3(0.2126,0.7152,0.0722), color.rgb));
         color.rgb = vec3(mix(color.rgb, gray, m_DesaturationValue));       
     #endif

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.frag
@@ -50,7 +50,7 @@ void main(){
     
     #ifdef DESATURATE
         vec3 gray = vec3(dot(vec3(0.2126,0.7152,0.0722), color.rgb));
-        color = vec4(mix(color.rgb, gray, m_DesaturationValue), 0.0);       
+        color.rgb = vec3(mix(color.rgb, gray, m_DesaturationValue));       
     #endif
 
     gl_FragColor = color;

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.frag
@@ -12,7 +12,9 @@ uniform vec4 m_Color;
 uniform sampler2D m_ColorMap;
 uniform sampler2D m_LightMap;
 
-uniform float m_DesaturationValue;
+#ifdef DESATURATION
+    uniform float m_DesaturationValue;
+#endif
 
 varying vec2 texCoord1;
 varying vec2 texCoord2;

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.frag
@@ -12,6 +12,8 @@ uniform vec4 m_Color;
 uniform sampler2D m_ColorMap;
 uniform sampler2D m_LightMap;
 
+uniform float m_DesaturationValue;
+
 varying vec2 texCoord1;
 varying vec2 texCoord2;
 
@@ -44,6 +46,11 @@ void main(){
         if(color.a < m_AlphaDiscardThreshold){
            discard;
         }
+    #endif
+    
+    #ifdef DESATURATE
+        vec3 gray = vec3(dot(vec3(0.2126,0.7152,0.0722), color.rgb));
+        color = vec4(mix(color.rgb, gray, m_DesaturationValue), 0.0);       
     #endif
 
     gl_FragColor = color;

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.j3md
@@ -59,6 +59,8 @@ MaterialDef Unshaded {
         Float ShadowMapSize
 
         Boolean BackfaceShadows: true
+        
+        Float DesaturationValue
     }
 
     Technique {
@@ -82,7 +84,8 @@ MaterialDef Unshaded {
             NUM_BONES : NumberOfBones
             DISCARD_ALPHA : AlphaDiscardThreshold
             NUM_MORPH_TARGETS: NumberOfMorphTargets
-            NUM_TARGETS_BUFFERS: NumberOfTargetsBuffers
+            NUM_TARGETS_BUFFERS: NumberOfTargetsBuffers            
+            DESATURATION : DesaturationValue
         }
     }
 

--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Unshaded.j3md
@@ -60,6 +60,7 @@ MaterialDef Unshaded {
 
         Boolean BackfaceShadows: true
         
+        // 1.0 indicates 100% desaturation
         Float DesaturationValue
     }
 


### PR DESCRIPTION
I added a small amount of code to the Unshaded.j3md and Unshaded.frag files to allow for desaturating the material's output color based on a float value, specifically for use in GUIs. 

Nearly all our GUI libraries use the Unshaded matdef for elements that are attached to the GUI node, and any custom gui elements will typically start from extending Unshaded if they need to do something in the shader, so adding this to Unshaded would alow all of our existent gui libraries to have desaturation functionality.
This should also not break any existing code, as nothing happens with this code unless the float value for desaturation gets defined for the material.

Following up on this thread https://hub.jmonkeyengine.org/t/how-to-desaturate-gui-element/43963

