### PR TITLE
Updates The jme3-lwjgl module to use jinput 2.0.9 instead of the 2.0.…

### DIFF
--- a/jme3-lwjgl/build.gradle
+++ b/jme3-lwjgl/build.gradle
@@ -6,4 +6,10 @@ dependencies {
     compile project(':jme3-core')
     compile project(':jme3-desktop')
     compile 'org.lwjgl.lwjgl:lwjgl:2.9.3'
+    /*
+     * Upgrades the default jinput-2.0.5 to jinput-2.0.9 to fix a bug with gamepads on Linux.
+     * See https://hub.jmonkeyengine.org/t/linux-gamepad-input-on-jme3-lwjgl-splits-input-between-two-logical-gamepads
+     */
+    compile 'net.java.jinput:jinput:2.0.9'
+    compile 'net.java.jinput:jinput:2.0.9:natives-all'
 }


### PR DESCRIPTION
…5 suggested by LWJGL2.

This fixes a gamepad bug discussed in https://hub.jmonkeyengine.org/t/linux-gamepad-input-on-jme3-lwjgl-splits-input-between-two-logical-gamepads