### PR TITLE
Fix for lighting vertex shader when used with Fog and InstancedNode.

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/Lighting.vert
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/Lighting.vert
@@ -186,6 +186,6 @@ void main(){
     #endif
 
     #ifdef USE_FOG
-    fog_distance = distance(g_CameraPosition, (g_WorldMatrix * modelSpacePos).xyz);
+    fog_distance = distance(g_CameraPosition, (TransformWorld(modelSpacePos)).xyz);
     #endif
 }


### PR DESCRIPTION
Fix for lighting vertex shader compile error when used with Fog and InstancedNode.  All credit to sailsman63 for the actual fix.  

More info:  https://hub.jmonkeyengine.org/t/shader-compile-error-with-instancednode-lighting-material-and-linearfog/44124/2