### PR TITLE
Ignore collision with InstancedGeometry

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedGeometry.java
+++ b/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedGeometry.java
@@ -32,6 +32,8 @@
 package com.jme3.scene.instancing;
 
 import com.jme3.bounding.BoundingVolume;
+import com.jme3.collision.Collidable;
+import com.jme3.collision.CollisionResults;
 import com.jme3.export.InputCapsule;
 import com.jme3.export.JmeExporter;
 import com.jme3.export.JmeImporter;
@@ -391,6 +393,11 @@ public class InstancedGeometry extends Geometry {
     public boolean checkCulling(Camera cam) {
         this.cam = cam;
         return super.checkCulling(cam);
+    }
+
+    @Override
+    public int collideWith(Collidable other, CollisionResults results) {
+        return 0; // Ignore collision
     }
 
     /**


### PR DESCRIPTION
This should fix the raycasting issue reported on the forum: https://hub.jmonkeyengine.org/t/npe-when-ray-casing-with-instancednode/44135