### PR TITLE
Fix for lighting vertex shader when used with Fog and InstancedNode.

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/SPLighting.vert
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/SPLighting.vert
@@ -195,6 +195,6 @@ void main(){
     #endif
 
     #ifdef USE_FOG
-    fog_distance = distance(g_CameraPosition, (g_WorldMatrix * modelSpacePos).xyz);
+    fog_distance = distance(g_CameraPosition, (TransformWorld(modelSpacePos)).xyz);
     #endif
 }


### PR DESCRIPTION
Same fix as before, but in SPLighting.vert for SinglePassLighting (spotted by Ali_RS).
More info:  https://hub.jmonkeyengine.org/t/shader-compile-error-with-instancednode-lighting-material-and-linearfog/44124/2