### PR TITLE
Workflow updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -243,7 +243,7 @@ jobs:
         shell: bash
         run: |
           # Build
-          ./gradlew -PuseCommitHashAsVersionName=true -PskipPrebuildLibraries=true build
+          ./gradlew -i -PuseCommitHashAsVersionName=true -PskipPrebuildLibraries=true build
           
           if [ "${{ matrix.deploy }}" = "true" ];
           then  

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,9 +181,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04,windows-2019,macOS-latest]
+        os: [ubuntu-18.04,ubuntu-20.04,windows-2019,macOS-latest]
         jdk: [8.x.x,11.x.x]
         include:
+          - os: ubuntu-20.04
+            osName: linux-next
           - os: ubuntu-18.04
             osName: linux
             deploy: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
     name: Build on ${{ matrix.osName }} jdk${{ matrix.jdk }}
     runs-on: ${{ matrix.os }}    
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-18.04,windows-2019,macOS-latest]
         jdk: [8.x.x,11.x.x]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,6 @@ jobs:
           
           # Build
           ./gradlew  -PuseCommitHashAsVersionName=true --no-daemon  -PbuildNativeProjects=true -Dmaven.repo.local="$PWD/dist/maven" \
-          build \
           :jme3-bullet-native:build
                   
       # Upload natives to be used later by the BuildJMonkey job


### PR DESCRIPTION
This came out of some of the testing I did regarding the [failing Github Actions builds.](https://hub.jmonkeyengine.org/t/jme-github-actions-failing/44180?u=sailsman63)

Hopefully, these changes will make troubleshooting such issues a little simpler in the future:

- The original failure erroneously seemed to be originating in the "Build Natives" step, though it was actually an error the Java build step. It is *not* necessary to build the full engine at this stage, as the result was merely discarded and then repeated during the OS matrix phase a little further down. I suspect that the line that caused this to happen was not intentional in the first place.
- When a single part of a build matrix fails, we really should let all variants complete, rather than bailing early. This allows us to get as much data out of a build run as we can by comparing and contrasting the error messages
    - Also should improve on "Can't reproduce on my Machine" issues - We'll at least know which platforms are seeing the issue in the first place
- On occasion, JME swallows exceptions and only logs the error. Bumping the gradle build to log level INFO will get us more of these types of errors. The downside is a larger build log to comb through, but if the build is green, do we really care? And if it's not, the info can be useful.