### PR TITLE
resolve issue #1461 (protect no-arg Camera constructor)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/Camera.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Camera.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -207,7 +207,7 @@ public class Camera implements Savable, Cloneable {
     /**
      * Serialization only. Do not use.
      */
-    public Camera() {
+    protected Camera() {
         worldPlane = new Plane[MAX_WORLD_PLANES];
         for (int i = 0; i < MAX_WORLD_PLANES; i++) {
             worldPlane[i] = new Plane();

--- a/jme3-vr/src/main/java/com/jme3/app/VRApplication.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VRApplication.java
@@ -251,7 +251,7 @@ public abstract class VRApplication implements Application, SystemListener {
         
         guiNode.setQueueBucket(Bucket.Gui);
         guiNode.setCullHint(CullHint.Never);
-        dummyCam = new Camera();
+        dummyCam = new Camera(0, 0);
         
         initStateManager();
 

--- a/jme3-vr/src/main/java/com/jme3/app/VREnvironment.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VREnvironment.java
@@ -384,7 +384,7 @@ public class VREnvironment {
     				if ((settings != null) && (settings.getWidth() != 0) && (settings.getHeight() != 0)){
     		        	dummyCam = new Camera(settings.getWidth(), settings.getHeight());
     		        } else {
-    		        	dummyCam = new Camera();
+    		        	dummyCam = new Camera(0, 0);
     		        }
     			}
     		} else {


### PR DESCRIPTION
Protect the no-arg constructor and use a different constructor to instantiate dummy cameras in jme3-vr.