### PR TITLE
Light control fix

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
@@ -39,8 +39,6 @@ import com.jme3.light.DirectionalLight;
 import com.jme3.light.Light;
 import com.jme3.light.PointLight;
 import com.jme3.light.SpotLight;
-import com.jme3.math.Matrix4f;
-import com.jme3.math.Quaternion;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.ViewPort;

--- a/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
@@ -161,19 +161,21 @@ public class LightControl extends AbstractControl {
      */
     private void lightToSpatial(Light light) {
         TempVars vars = TempVars.get();
+        boolean rot = false, trans = false;
 
         if (light instanceof PointLight) {
             PointLight pLight = (PointLight) light;
             vars.vect1.set(pLight.getPosition());
-            spatial.getLocalRotation().mult(Vector3f.UNIT_Z, vars.vect2);
+            trans = true;
         } else if (light instanceof DirectionalLight) {
             DirectionalLight dLight = (DirectionalLight) light;
-            vars.vect1.set(spatial.getLocalTranslation());
             vars.vect2.set(dLight.getDirection()).negateLocal();
+            rot = true;
         } else if (light instanceof SpotLight) {
             SpotLight sLight = (SpotLight) light;
             vars.vect1.set(sLight.getPosition());
             vars.vect2.set(sLight.getDirection()).negateLocal();
+            trans = rot = true;
         }
         if (spatial.getParent() != null) {
             spatial.getParent().getLocalToWorldMatrix(vars.tempMat4).invertLocal();
@@ -181,9 +183,14 @@ public class LightControl extends AbstractControl {
             vars.tempMat4.translateVect(vars.vect1);
             vars.tempMat4.rotateVect(vars.vect2);
         }
-        vars.quat1.lookAt(vars.vect2, Vector3f.UNIT_Y);
-        spatial.setLocalRotation(vars.quat1);
-        spatial.setLocalTranslation(vars.vect1);
+
+        if (rot) {
+            vars.quat1.lookAt(vars.vect2, Vector3f.UNIT_Y);
+            spatial.setLocalRotation(vars.quat1);
+        }
+        if (trans) {
+            spatial.setLocalTranslation(vars.vect1);
+        }
         vars.release();
     }
 

--- a/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
@@ -51,6 +51,7 @@ import java.io.IOException;
  * This Control maintains a reference to a Camera,
  * which will be synched with the position (worldTranslation)
  * of the current spatial.
+ *
  * @author tim
  */
 public class LightControl extends AbstractControl {
@@ -130,26 +131,17 @@ public class LightControl extends AbstractControl {
     private void spatialToLight(Light light) {
 
         final Vector3f worldTranslation = spatial.getWorldTranslation();
+        Vector3f worldDirection = spatial.getWorldRotation().mult(Vector3f.UNIT_Z).negateLocal();
 
         if (light instanceof PointLight) {
             ((PointLight) light).setPosition(worldTranslation);
-            return;
-        }
-
-        final TempVars vars = TempVars.get();
-        final Vector3f vec = vars.vect1;
-
-        if (light instanceof DirectionalLight) {
-            ((DirectionalLight) light).setDirection(vec.set(worldTranslation).multLocal(-1.0f));
-        }
-
-        if (light instanceof SpotLight) {
+        } else if (light instanceof DirectionalLight) {
+            ((DirectionalLight) light).setDirection(worldDirection);
+        } else if (light instanceof SpotLight) {
             final SpotLight spotLight = (SpotLight) light;
             spotLight.setPosition(worldTranslation);
-            spotLight.setDirection(spatial.getWorldRotation().multLocal(vec.set(Vector3f.UNIT_Y).multLocal(-1)));
+            spotLight.setDirection(worldDirection);
         }
-
-        vars.release();
     }
 
     private void lightToSpatial(Light light) {

--- a/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
@@ -137,8 +137,12 @@ public class LightControl extends AbstractControl {
      * @author pspeed42
      */
     private void spatialToLight(Light light) {
-        final Vector3f worldTranslation = spatial.getWorldTranslation();
-        final Vector3f worldDirection = spatial.getWorldRotation().mult(Vector3f.UNIT_Z).negateLocal();
+        TempVars vars = TempVars.get();
+
+        final Vector3f worldTranslation = vars.vect1;
+        worldTranslation.set(spatial.getWorldTranslation());
+        final Vector3f worldDirection = vars.vect2;
+        spatial.getWorldRotation().mult(Vector3f.UNIT_Z, worldDirection).negateLocal();
 
         if (light instanceof PointLight) {
             ((PointLight) light).setPosition(worldTranslation);
@@ -149,6 +153,7 @@ public class LightControl extends AbstractControl {
             spotLight.setPosition(worldTranslation);
             spotLight.setDirection(worldDirection);
         }
+        vars.release();
     }
 
     /**

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControl2Directional.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControl2Directional.java
@@ -1,0 +1,130 @@
+package jme3test.light;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.light.AmbientLight;
+import com.jme3.light.DirectionalLight;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.FastMath;
+import com.jme3.math.Quaternion;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Node;
+import com.jme3.scene.control.LightControl;
+import com.jme3.scene.shape.Cylinder;
+import com.jme3.scene.shape.Dome;
+import com.jme3.scene.shape.Sphere;
+
+/**
+ * Similar to {@link TestLightControlDirectional}, except that the spatial is controlled by the light this
+ * time.
+ *
+ * @author Markil 3
+ */
+public class TestLightControl2Directional extends SimpleApplication {
+    private final Vector3f rotAxis = new Vector3f(Vector3f.UNIT_X);
+    private final float[] angles = new float[3];
+
+    public static void main(String[] args) {
+        TestLightControl2Directional app = new TestLightControl2Directional();
+        app.start();
+    }
+
+    Node lightNode;
+    DirectionalLight direction;
+    Geometry lightMdl;
+
+    public void setupLighting() {
+        AmbientLight al = new AmbientLight();
+        al.setColor(ColorRGBA.White.mult(2f));
+        rootNode.addLight(al);
+
+        direction = new DirectionalLight();
+        direction.setColor(ColorRGBA.White.mult(10));
+        rootNode.addLight(direction);
+
+
+//        PointLight pl=new PointLight();
+//      pl.setPosition(new Vector3f(77.70334f, 34.013165f, 27.1017f));
+//      pl.setRadius(1000);
+//      pl.setColor(ColorRGBA.White.mult(2));
+//      rootNode.addLight(pl);
+        lightMdl = new Geometry("Light", new Dome(Vector3f.ZERO, 2, 32, 5, false));
+        lightMdl.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
+        lightMdl.setLocalTranslation(new Vector3f(0, 0, 0));
+        lightMdl.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / 2F, 0, 0));
+        rootNode.attachChild(lightMdl);
+
+        /*
+         * We need this Dome doesn't have a "floor."
+         */
+        Geometry lightFloor = new Geometry("LightFloor", new Cylinder(2, 32, 5, .1F, true));
+        lightFloor.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
+        lightFloor.getMaterial().setColor("Color", ColorRGBA.White);
+//        lightFloor.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / 2F, 0, 0));
+
+        lightNode = new Node();
+        lightNode.addControl(new LightControl(direction, LightControl.ControlDirection.LightToSpatial));
+//        lightNode.setLocalTranslation(-5, 0, 0);
+        lightNode.attachChild(lightMdl);
+        lightNode.attachChild(lightFloor);
+
+        /*
+         * Offset the light node to check global stuff
+         */
+        Node axis = new Node();
+        axis.setLocalTranslation(5, -3, 2.5F);
+        axis.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / -4F, FastMath.PI / 2F, 0));
+        axis.attachChild(lightNode);
+        rootNode.attachChild(lightNode);
+    }
+
+    public void setupDome() {
+        Geometry dome = new Geometry("Dome", new Sphere(16, 32, 30, false, true));
+        dome.setMaterial(new Material(this.assetManager, "Common/MatDefs/Light/PBRLighting.j3md"));
+        dome.setLocalTranslation(new Vector3f(0, 0, 0));
+        rootNode.attachChild(dome);
+    }
+
+    @Override
+    public void simpleInitApp() {
+        flyCam.setMoveSpeed(30);
+
+        setupLighting();
+        setupDome();
+    }
+
+    @Override
+    public void simpleUpdate(float tpf) {
+        final Vector3f INIT_DIR = Vector3f.UNIT_Z.negate();
+        /*
+         * In Radians per second
+         */
+        final float ROT_SPEED = FastMath.PI * 2;
+        /*
+         * 360 degree rotation
+         */
+        final float FULL_ROT = FastMath.PI * 2;
+        super.simpleUpdate(tpf);
+        angles[0] += rotAxis.x * ROT_SPEED * tpf;
+        angles[1] += rotAxis.y * ROT_SPEED * tpf;
+        angles[2] += rotAxis.z * ROT_SPEED * tpf;
+        direction.setDirection(new Quaternion().fromAngles(angles).mult(INIT_DIR));
+        if (angles[0] >= FULL_ROT || angles[1] >= FULL_ROT || angles[2] >= FULL_ROT) {
+            direction.setDirection(INIT_DIR);
+            angles[0] = 0;
+            angles[1] = 0;
+            angles[2] = 0;
+            if (rotAxis.x > 0 && rotAxis.y == 0 && rotAxis.z == 0) {
+                rotAxis.set(0, 1, 0);
+            } else if (rotAxis.y > 0 && rotAxis.x == 0 && rotAxis.z == 0) {
+                rotAxis.set(0, 0, 1);
+            } else if (rotAxis.z > 0 && rotAxis.x == 0 && rotAxis.y == 0) {
+                rotAxis.set(FastMath.nextRandomFloat() % 1, FastMath.nextRandomFloat() % 1, FastMath.nextRandomFloat() % 1);
+            } else {
+                rotAxis.set(1, 0, 0);
+            }
+        }
+//        lightNode.lookAt(Vector3f.ZERO, Vector3f.UNIT_Y);
+    }
+}

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControl2Directional.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControl2Directional.java
@@ -27,7 +27,6 @@ public class TestLightControl2Directional extends SimpleApplication {
 
     private Node lightNode;
     private DirectionalLight direction;
-    private Geometry lightMdl;
 
     public static void main(String[] args) {
         TestLightControl2Directional app = new TestLightControl2Directional();
@@ -35,6 +34,7 @@ public class TestLightControl2Directional extends SimpleApplication {
     }
 
     public void setupLighting() {
+        Geometry lightMdl;
         AmbientLight al = new AmbientLight();
         al.setColor(ColorRGBA.White.mult(2f));
         rootNode.addLight(al);

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControl2Directional.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControl2Directional.java
@@ -25,14 +25,14 @@ public class TestLightControl2Directional extends SimpleApplication {
     private final Vector3f rotAxis = new Vector3f(Vector3f.UNIT_X);
     private final float[] angles = new float[3];
 
+    private Node lightNode;
+    private DirectionalLight direction;
+    private Geometry lightMdl;
+
     public static void main(String[] args) {
         TestLightControl2Directional app = new TestLightControl2Directional();
         app.start();
     }
-
-    Node lightNode;
-    DirectionalLight direction;
-    Geometry lightMdl;
 
     public void setupLighting() {
         AmbientLight al = new AmbientLight();

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControl2Directional.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControl2Directional.java
@@ -105,11 +105,17 @@ public class TestLightControl2Directional extends SimpleApplication {
          * 360 degree rotation
          */
         final float FULL_ROT = FastMath.PI * 2;
-        super.simpleUpdate(tpf);
         angles[0] += rotAxis.x * ROT_SPEED * tpf;
         angles[1] += rotAxis.y * ROT_SPEED * tpf;
         angles[2] += rotAxis.z * ROT_SPEED * tpf;
         direction.setDirection(new Quaternion().fromAngles(angles).mult(INIT_DIR));
+        super.simpleUpdate(tpf);
+        /*
+         * Make sure they are equal.
+         */
+        if (FastMath.abs(direction.getDirection().normalize().subtractLocal(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).negateLocal().normalizeLocal()).lengthSquared()) > .1F) {
+            System.err.printf("Rotation not equal: is %s (%s), needs to be %s (%f)\n", lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), lightNode.getLocalRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), direction.getDirection().normalize(), FastMath.abs(direction.getDirection().normalize().subtract(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal()).lengthSquared()));
+        }
         if (angles[0] >= FULL_ROT || angles[1] >= FULL_ROT || angles[2] >= FULL_ROT) {
             direction.setDirection(INIT_DIR);
             angles[0] = 0;
@@ -125,6 +131,5 @@ public class TestLightControl2Directional extends SimpleApplication {
                 rotAxis.set(1, 0, 0);
             }
         }
-//        lightNode.lookAt(Vector3f.ZERO, Vector3f.UNIT_Y);
     }
 }

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControl2Directional.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControl2Directional.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2012 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package jme3test.light;
 
 import com.jme3.app.SimpleApplication;
@@ -14,6 +45,7 @@ import com.jme3.scene.control.LightControl;
 import com.jme3.scene.shape.Cylinder;
 import com.jme3.scene.shape.Dome;
 import com.jme3.scene.shape.Sphere;
+import com.jme3.util.TempVars;
 
 /**
  * Similar to {@link TestLightControlDirectional}, except that the spatial is controlled by the light this
@@ -43,12 +75,6 @@ public class TestLightControl2Directional extends SimpleApplication {
         direction.setColor(ColorRGBA.White.mult(10));
         rootNode.addLight(direction);
 
-
-//        PointLight pl=new PointLight();
-//      pl.setPosition(new Vector3f(77.70334f, 34.013165f, 27.1017f));
-//      pl.setRadius(1000);
-//      pl.setColor(ColorRGBA.White.mult(2));
-//      rootNode.addLight(pl);
         lightMdl = new Geometry("Light", new Dome(Vector3f.ZERO, 2, 32, 5, false));
         lightMdl.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
         lightMdl.setLocalTranslation(new Vector3f(0, 0, 0));
@@ -61,21 +87,12 @@ public class TestLightControl2Directional extends SimpleApplication {
         Geometry lightFloor = new Geometry("LightFloor", new Cylinder(2, 32, 5, .1F, true));
         lightFloor.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
         lightFloor.getMaterial().setColor("Color", ColorRGBA.White);
-//        lightFloor.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / 2F, 0, 0));
 
         lightNode = new Node();
         lightNode.addControl(new LightControl(direction, LightControl.ControlDirection.LightToSpatial));
-//        lightNode.setLocalTranslation(-5, 0, 0);
         lightNode.attachChild(lightMdl);
         lightNode.attachChild(lightFloor);
 
-        /*
-         * Offset the light node to check global stuff
-         */
-        Node axis = new Node();
-        axis.setLocalTranslation(5, -3, 2.5F);
-        axis.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / -4F, FastMath.PI / 2F, 0));
-        axis.attachChild(lightNode);
         rootNode.attachChild(lightNode);
     }
 
@@ -88,6 +105,8 @@ public class TestLightControl2Directional extends SimpleApplication {
 
     @Override
     public void simpleInitApp() {
+        this.cam.setLocation(new Vector3f(-50, 20, 50));
+        this.cam.lookAt(Vector3f.ZERO, Vector3f.UNIT_Y);
         flyCam.setMoveSpeed(30);
 
         setupLighting();
@@ -100,22 +119,35 @@ public class TestLightControl2Directional extends SimpleApplication {
         /*
          * In Radians per second
          */
-        final float ROT_SPEED = FastMath.PI * 2;
+        final float ROT_SPEED = FastMath.PI / 2;
         /*
          * 360 degree rotation
          */
         final float FULL_ROT = FastMath.PI * 2;
+
+        TempVars vars = TempVars.get();
+        Vector3f lightDirection = vars.vect2, nodeDirection = vars.vect3;
+        float length;
+
         angles[0] += rotAxis.x * ROT_SPEED * tpf;
         angles[1] += rotAxis.y * ROT_SPEED * tpf;
         angles[2] += rotAxis.z * ROT_SPEED * tpf;
         direction.setDirection(new Quaternion().fromAngles(angles).mult(INIT_DIR));
         super.simpleUpdate(tpf);
+
         /*
          * Make sure they are equal.
          */
-        if (FastMath.abs(direction.getDirection().normalize().subtractLocal(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).negateLocal().normalizeLocal()).lengthSquared()) > .1F) {
-            System.err.printf("Rotation not equal: is %s (%s), needs to be %s (%f)\n", lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), lightNode.getLocalRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), direction.getDirection().normalize(), FastMath.abs(direction.getDirection().normalize().subtract(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal()).lengthSquared()));
+        lightDirection.set(direction.getDirection());
+        lightDirection.normalizeLocal();
+        lightNode.getWorldRotation().mult(Vector3f.UNIT_Z, nodeDirection);
+        nodeDirection.negateLocal().normalizeLocal();
+        length = lightDirection.subtract(nodeDirection, vars.vect4).lengthSquared();
+        length = FastMath.abs(length);
+        if (length > .1F) {
+            System.err.printf("Rotation not equal: is %s, needs to be %s (%f)\n", nodeDirection, lightDirection, length);
         }
+
         if (angles[0] >= FULL_ROT || angles[1] >= FULL_ROT || angles[2] >= FULL_ROT) {
             direction.setDirection(INIT_DIR);
             angles[0] = 0;
@@ -131,5 +163,7 @@ public class TestLightControl2Directional extends SimpleApplication {
                 rotAxis.set(1, 0, 0);
             }
         }
+
+        vars.release();
     }
 }

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControl2Spot.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControl2Spot.java
@@ -109,11 +109,20 @@ public class TestLightControl2Spot extends SimpleApplication {
          * 360 degree rotation
          */
         final float FULL_ROT = FastMath.PI * 2;
-        super.simpleUpdate(tpf);
         angles[0] += rotAxis.x * ROT_SPEED * tpf;
         angles[1] += rotAxis.y * ROT_SPEED * tpf;
         angles[2] += rotAxis.z * ROT_SPEED * tpf;
         spot.setDirection(new Quaternion().fromAngles(angles).mult(INIT_DIR));
+        super.simpleUpdate(tpf);
+        /*
+         * Make sure they are equal.
+         */
+        if (spot.getPosition().subtract(lightNode.getWorldTranslation()).lengthSquared() > 0.1F) {
+            System.err.printf("Translation not equal: is %s (%s), needs to be %s\n", lightNode.getWorldTranslation(), lightNode.getLocalTranslation(), spot.getPosition());
+        }
+        if (FastMath.abs(spot.getDirection().normalize().subtractLocal(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).negateLocal().normalizeLocal()).lengthSquared()) > .1F) {
+            System.err.printf("Rotation not equal: is %s (%s), needs to be %s (%f)\n", lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), lightNode.getLocalRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), spot.getDirection().normalize(), FastMath.abs(spot.getDirection().normalize().subtract(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal()).lengthSquared()));
+        }
         if (angles[0] >= FULL_ROT || angles[1] >= FULL_ROT || angles[2] >= FULL_ROT) {
             spot.setDirection(INIT_DIR);
             angles[0] = 0;
@@ -128,18 +137,6 @@ public class TestLightControl2Spot extends SimpleApplication {
             } else {
                 rotAxis.set(1, 0, 0);
             }
-        }
-        /*
-         * Make sure they are equal.
-         */
-        if (spot.getPosition().subtract(lightNode.getWorldTranslation()).lengthSquared() > 0.1F) {
-            System.out.printf("Translation not equal: is %s (%s), needs to be %s\n", lightNode.getWorldTranslation(), lightNode.getLocalTranslation(), spot.getPosition());
-        }
-        /*
-         * This causes warnings if I don't use at least 4, but the values are close enough that I don't really care.
-         */
-        if (spot.getDirection().normalize().subtract(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal()).lengthSquared() > 4F) {
-            System.out.printf("Rotation not equal: is %s (%s), needs to be %s\n", lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), lightNode.getLocalRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), spot.getDirection().normalize());
         }
     }
 }

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControl2Spot.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControl2Spot.java
@@ -2,7 +2,6 @@ package jme3test.light;
 
 import com.jme3.app.SimpleApplication;
 import com.jme3.light.AmbientLight;
-import com.jme3.light.DirectionalLight;
 import com.jme3.light.SpotLight;
 import com.jme3.material.Material;
 import com.jme3.math.ColorRGBA;
@@ -26,14 +25,14 @@ public class TestLightControl2Spot extends SimpleApplication {
     private final Vector3f rotAxis = new Vector3f(Vector3f.UNIT_X);
     private final float[] angles = new float[3];
 
+    private Node lightNode;
+    private SpotLight spot;
+    private Geometry lightMdl;
+
     public static void main(String[] args) {
         TestLightControl2Spot app = new TestLightControl2Spot();
         app.start();
     }
-
-    Node lightNode;
-    SpotLight spot;
-    Geometry lightMdl;
 
     public void setupLighting() {
         AmbientLight al = new AmbientLight();

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControl2Spot.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControl2Spot.java
@@ -1,0 +1,145 @@
+package jme3test.light;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.light.AmbientLight;
+import com.jme3.light.DirectionalLight;
+import com.jme3.light.SpotLight;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.FastMath;
+import com.jme3.math.Quaternion;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Node;
+import com.jme3.scene.control.LightControl;
+import com.jme3.scene.shape.Cylinder;
+import com.jme3.scene.shape.Dome;
+import com.jme3.scene.shape.Sphere;
+
+/**
+ * Similar to {@link TestLightControlSpot}, except that the spatial is controlled by the light this
+ * time.
+ *
+ * @author Markil 3
+ */
+public class TestLightControl2Spot extends SimpleApplication {
+    private final Vector3f rotAxis = new Vector3f(Vector3f.UNIT_X);
+    private final float[] angles = new float[3];
+
+    public static void main(String[] args) {
+        TestLightControl2Spot app = new TestLightControl2Spot();
+        app.start();
+    }
+
+    Node lightNode;
+    SpotLight spot;
+    Geometry lightMdl;
+
+    public void setupLighting() {
+        AmbientLight al = new AmbientLight();
+        al.setColor(ColorRGBA.White.mult(2f));
+        rootNode.addLight(al);
+
+        spot = new SpotLight();
+        spot.setSpotRange(1000);
+        spot.setSpotInnerAngle(5 * FastMath.DEG_TO_RAD);
+        spot.setSpotOuterAngle(10 * FastMath.DEG_TO_RAD);
+        spot.setColor(ColorRGBA.White.mult(10));
+        rootNode.addLight(spot);
+
+
+//        PointLight pl=new PointLight();
+//      pl.setPosition(new Vector3f(77.70334f, 34.013165f, 27.1017f));
+//      pl.setRadius(1000);
+//      pl.setColor(ColorRGBA.White.mult(2));
+//      rootNode.addLight(pl);
+        lightMdl = new Geometry("Light", new Dome(Vector3f.ZERO, 2, 32, 5, false));
+        lightMdl.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
+        lightMdl.setLocalTranslation(new Vector3f(0, 0, 0));
+        lightMdl.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / 2F, 0, 0));
+        rootNode.attachChild(lightMdl);
+
+        /*
+         * We need this Dome doesn't have a "floor."
+         */
+        Geometry lightFloor = new Geometry("LightFloor", new Cylinder(2, 32, 5, .1F, true));
+        lightFloor.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
+        lightFloor.getMaterial().setColor("Color", ColorRGBA.White);
+//        lightFloor.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / 2F, 0, 0));
+
+        lightNode = new Node();
+        lightNode.addControl(new LightControl(spot, LightControl.ControlDirection.LightToSpatial));
+//        lightNode.setLocalTranslation(-5, 0, 0);
+        lightNode.attachChild(lightMdl);
+        lightNode.attachChild(lightFloor);
+
+        /*
+         * Offset the light node to check global stuff
+         */
+        Node axis = new Node();
+        axis.setLocalTranslation(5, -3, 2.5F);
+        axis.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / -4F, FastMath.PI / 2F, 0));
+        axis.attachChild(lightNode);
+        rootNode.attachChild(lightNode);
+    }
+
+    public void setupDome() {
+        Geometry dome = new Geometry("Dome", new Sphere(16, 32, 30, false, true));
+        dome.setMaterial(new Material(this.assetManager, "Common/MatDefs/Light/PBRLighting.j3md"));
+        dome.setLocalTranslation(new Vector3f(0, 0, 0));
+        rootNode.attachChild(dome);
+    }
+
+    @Override
+    public void simpleInitApp() {
+        flyCam.setMoveSpeed(30);
+
+        setupLighting();
+        setupDome();
+    }
+
+    @Override
+    public void simpleUpdate(float tpf) {
+        final Vector3f INIT_DIR = Vector3f.UNIT_Z.negate();
+        /*
+         * In Radians per second
+         */
+        final float ROT_SPEED = FastMath.PI * 2;
+        /*
+         * 360 degree rotation
+         */
+        final float FULL_ROT = FastMath.PI * 2;
+        super.simpleUpdate(tpf);
+        angles[0] += rotAxis.x * ROT_SPEED * tpf;
+        angles[1] += rotAxis.y * ROT_SPEED * tpf;
+        angles[2] += rotAxis.z * ROT_SPEED * tpf;
+        spot.setDirection(new Quaternion().fromAngles(angles).mult(INIT_DIR));
+        if (angles[0] >= FULL_ROT || angles[1] >= FULL_ROT || angles[2] >= FULL_ROT) {
+            spot.setDirection(INIT_DIR);
+            angles[0] = 0;
+            angles[1] = 0;
+            angles[2] = 0;
+            if (rotAxis.x > 0 && rotAxis.y == 0 && rotAxis.z == 0) {
+                rotAxis.set(0, 1, 0);
+            } else if (rotAxis.y > 0 && rotAxis.x == 0 && rotAxis.z == 0) {
+                rotAxis.set(0, 0, 1);
+            } else if (rotAxis.z > 0 && rotAxis.x == 0 && rotAxis.y == 0) {
+                rotAxis.set(FastMath.nextRandomFloat() % 1, FastMath.nextRandomFloat() % 1, FastMath.nextRandomFloat() % 1);
+            } else {
+                rotAxis.set(1, 0, 0);
+            }
+        }
+        /*
+         * Make sure they are equal.
+         */
+        if (spot.getPosition().subtract(lightNode.getWorldTranslation()).lengthSquared() > 0.1F) {
+            System.out.printf("Translation not equal: is %s (%s), needs to be %s\n", lightNode.getWorldTranslation(), lightNode.getLocalTranslation(), spot.getPosition());
+        }
+        /*
+         * This causes warnings if I don't use at least 4, but the values are close enough that I don't really care.
+         */
+        if (spot.getDirection().normalize().subtract(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal()).lengthSquared() > 4F) {
+            System.out.printf("Rotation not equal: is %s (%s), needs to be %s\n", lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), lightNode.getLocalRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), spot.getDirection().normalize());
+        }
+    }
+}

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControl2Spot.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControl2Spot.java
@@ -27,7 +27,6 @@ public class TestLightControl2Spot extends SimpleApplication {
 
     private Node lightNode;
     private SpotLight spot;
-    private Geometry lightMdl;
 
     public static void main(String[] args) {
         TestLightControl2Spot app = new TestLightControl2Spot();
@@ -35,6 +34,7 @@ public class TestLightControl2Spot extends SimpleApplication {
     }
 
     public void setupLighting() {
+        Geometry lightMdl;
         AmbientLight al = new AmbientLight();
         al.setColor(ColorRGBA.White.mult(2f));
         rootNode.addLight(al);

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControl2Spot.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControl2Spot.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2012 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package jme3test.light;
 
 import com.jme3.app.SimpleApplication;
@@ -14,6 +45,7 @@ import com.jme3.scene.control.LightControl;
 import com.jme3.scene.shape.Cylinder;
 import com.jme3.scene.shape.Dome;
 import com.jme3.scene.shape.Sphere;
+import com.jme3.util.TempVars;
 
 /**
  * Similar to {@link TestLightControlSpot}, except that the spatial is controlled by the light this
@@ -46,12 +78,6 @@ public class TestLightControl2Spot extends SimpleApplication {
         spot.setColor(ColorRGBA.White.mult(10));
         rootNode.addLight(spot);
 
-
-//        PointLight pl=new PointLight();
-//      pl.setPosition(new Vector3f(77.70334f, 34.013165f, 27.1017f));
-//      pl.setRadius(1000);
-//      pl.setColor(ColorRGBA.White.mult(2));
-//      rootNode.addLight(pl);
         lightMdl = new Geometry("Light", new Dome(Vector3f.ZERO, 2, 32, 5, false));
         lightMdl.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
         lightMdl.setLocalTranslation(new Vector3f(0, 0, 0));
@@ -64,21 +90,12 @@ public class TestLightControl2Spot extends SimpleApplication {
         Geometry lightFloor = new Geometry("LightFloor", new Cylinder(2, 32, 5, .1F, true));
         lightFloor.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
         lightFloor.getMaterial().setColor("Color", ColorRGBA.White);
-//        lightFloor.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / 2F, 0, 0));
 
         lightNode = new Node();
         lightNode.addControl(new LightControl(spot, LightControl.ControlDirection.LightToSpatial));
-//        lightNode.setLocalTranslation(-5, 0, 0);
         lightNode.attachChild(lightMdl);
         lightNode.attachChild(lightFloor);
 
-        /*
-         * Offset the light node to check global stuff
-         */
-        Node axis = new Node();
-        axis.setLocalTranslation(5, -3, 2.5F);
-        axis.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / -4F, FastMath.PI / 2F, 0));
-        axis.attachChild(lightNode);
         rootNode.attachChild(lightNode);
     }
 
@@ -91,6 +108,8 @@ public class TestLightControl2Spot extends SimpleApplication {
 
     @Override
     public void simpleInitApp() {
+        this.cam.setLocation(new Vector3f(-50, 20, 50));
+        this.cam.lookAt(Vector3f.ZERO, Vector3f.UNIT_Y);
         flyCam.setMoveSpeed(30);
 
         setupLighting();
@@ -103,25 +122,41 @@ public class TestLightControl2Spot extends SimpleApplication {
         /*
          * In Radians per second
          */
-        final float ROT_SPEED = FastMath.PI * 2;
+        final float ROT_SPEED = FastMath.PI / 2;
         /*
          * 360 degree rotation
          */
         final float FULL_ROT = FastMath.PI * 2;
+
+        TempVars vars = TempVars.get();
+        Vector3f lightPosition = vars.vect1, lightDirection = vars.vect2, nodeDirection = vars.vect3;
+        float length;
+
         angles[0] += rotAxis.x * ROT_SPEED * tpf;
         angles[1] += rotAxis.y * ROT_SPEED * tpf;
         angles[2] += rotAxis.z * ROT_SPEED * tpf;
         spot.setDirection(new Quaternion().fromAngles(angles).mult(INIT_DIR));
         super.simpleUpdate(tpf);
+
         /*
          * Make sure they are equal.
          */
-        if (spot.getPosition().subtract(lightNode.getWorldTranslation()).lengthSquared() > 0.1F) {
+        lightPosition.set(spot.getPosition());
+        lightPosition.subtractLocal(lightNode.getWorldTranslation());
+        length = lightPosition.lengthSquared();
+        if (length > 0.1F) {
             System.err.printf("Translation not equal: is %s (%s), needs to be %s\n", lightNode.getWorldTranslation(), lightNode.getLocalTranslation(), spot.getPosition());
         }
-        if (FastMath.abs(spot.getDirection().normalize().subtractLocal(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).negateLocal().normalizeLocal()).lengthSquared()) > .1F) {
-            System.err.printf("Rotation not equal: is %s (%s), needs to be %s (%f)\n", lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), lightNode.getLocalRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), spot.getDirection().normalize(), FastMath.abs(spot.getDirection().normalize().subtract(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal()).lengthSquared()));
+        lightDirection.set(spot.getDirection());
+        lightDirection.normalizeLocal();
+        lightNode.getWorldRotation().mult(Vector3f.UNIT_Z, nodeDirection);
+        nodeDirection.negateLocal().normalizeLocal();
+        length = lightDirection.subtract(nodeDirection, vars.vect4).lengthSquared();
+        length = FastMath.abs(length);
+        if (length > .1F) {
+            System.err.printf("Rotation not equal: is %s, needs to be %s (%f)\n", nodeDirection, lightDirection, length);
         }
+
         if (angles[0] >= FULL_ROT || angles[1] >= FULL_ROT || angles[2] >= FULL_ROT) {
             spot.setDirection(INIT_DIR);
             angles[0] = 0;
@@ -137,5 +172,7 @@ public class TestLightControl2Spot extends SimpleApplication {
                 rotAxis.set(1, 0, 0);
             }
         }
+
+        vars.release();
     }
 }

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControlDirectional.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControlDirectional.java
@@ -26,14 +26,14 @@ public class TestLightControlDirectional extends SimpleApplication {
     private final Vector3f rotAxis = new Vector3f(Vector3f.UNIT_X);
     private final float[] angles = new float[3];
 
+    private Node lightNode;
+    private DirectionalLight direction;
+    private Geometry lightMdl;
+
     public static void main(String[] args) {
         TestLightControlDirectional app = new TestLightControlDirectional();
         app.start();
     }
-
-    Node lightNode;
-    DirectionalLight direction;
-    Geometry lightMdl;
 
     public void setupLighting() {
         AmbientLight al = new AmbientLight();

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControlDirectional.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControlDirectional.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2012 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package jme3test.light;
 
 import com.jme3.app.SimpleApplication;
@@ -14,6 +45,7 @@ import com.jme3.scene.control.LightControl;
 import com.jme3.scene.shape.Cylinder;
 import com.jme3.scene.shape.Dome;
 import com.jme3.scene.shape.Sphere;
+import com.jme3.util.TempVars;
 
 /**
  * Creates a directional light controlled by rotating a node. The light will shine on a surrounding sphere.
@@ -44,12 +76,6 @@ public class TestLightControlDirectional extends SimpleApplication {
         direction.setColor(ColorRGBA.White.mult(10));
         rootNode.addLight(direction);
 
-
-//        PointLight pl=new PointLight();
-//      pl.setPosition(new Vector3f(77.70334f, 34.013165f, 27.1017f));
-//      pl.setRadius(1000);
-//      pl.setColor(ColorRGBA.White.mult(2));
-//      rootNode.addLight(pl);
         lightMdl = new Geometry("Light", new Dome(Vector3f.ZERO, 2, 32, 5, false));
         lightMdl.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
         lightMdl.setLocalTranslation(new Vector3f(0, 0, 0));
@@ -62,11 +88,9 @@ public class TestLightControlDirectional extends SimpleApplication {
         Geometry lightFloor = new Geometry("LightFloor", new Cylinder(2, 32, 5, .1F, true));
         lightFloor.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
         lightFloor.getMaterial().setColor("Color", ColorRGBA.White);
-//        lightFloor.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / 2F, 0, 0));
 
         lightNode = new Node();
         lightNode.addControl(new LightControl(direction));
-//        lightNode.setLocalTranslation(-5, 0, 0);
         lightNode.attachChild(lightMdl);
         lightNode.attachChild(lightFloor);
         rootNode.attachChild(lightNode);
@@ -81,6 +105,8 @@ public class TestLightControlDirectional extends SimpleApplication {
 
     @Override
     public void simpleInitApp() {
+        this.cam.setLocation(new Vector3f(-50, 20, 50));
+        this.cam.lookAt(Vector3f.ZERO, Vector3f.UNIT_Y);
         flyCam.setMoveSpeed(30);
 
         setupLighting();
@@ -92,22 +118,35 @@ public class TestLightControlDirectional extends SimpleApplication {
         /*
          * In Radians per second
          */
-        final float ROT_SPEED = FastMath.PI * 2;
+        final float ROT_SPEED = FastMath.PI / 2;
         /*
          * 360 degree rotation
          */
         final float FULL_ROT = FastMath.PI * 2;
+
+        TempVars vars = TempVars.get();
+        Vector3f lightDirection = vars.vect2, nodeDirection = vars.vect3;
+        float length;
+
         angles[0] += rotAxis.x * ROT_SPEED * tpf;
         angles[1] += rotAxis.y * ROT_SPEED * tpf;
         angles[2] += rotAxis.z * ROT_SPEED * tpf;
         lightNode.setLocalRotation(new Quaternion().fromAngles(angles));
         super.simpleUpdate(tpf);
+
         /*
          * Make sure they are equal.
          */
-        if (FastMath.abs(direction.getDirection().normalize().subtractLocal(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).negateLocal().normalizeLocal()).lengthSquared()) > .1F) {
-            System.err.printf("Rotation not equal: is %s (%s), needs to be %s (%f)\n", lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), lightNode.getLocalRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), direction.getDirection().normalize(), FastMath.abs(direction.getDirection().normalize().subtract(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal()).lengthSquared()));
+        lightDirection.set(direction.getDirection());
+        lightDirection.normalize();
+        lightNode.getWorldRotation().mult(Vector3f.UNIT_Z, nodeDirection);
+        nodeDirection.negateLocal().normalizeLocal();
+        length = lightDirection.subtract(nodeDirection, vars.vect4).lengthSquared();
+        length = FastMath.abs(length);
+        if (length > .1F) {
+            System.err.printf("Rotation not equal: is %s, needs to be %s (%f)\n", nodeDirection, lightDirection, length);
         }
+
         if (angles[0] >= FULL_ROT || angles[1] >= FULL_ROT || angles[2] >= FULL_ROT) {
             lightNode.setLocalRotation(Quaternion.DIRECTION_Z);
             angles[0] = 0;
@@ -123,5 +162,7 @@ public class TestLightControlDirectional extends SimpleApplication {
                 rotAxis.set(1, 0, 0);
             }
         }
+
+        vars.release();
     }
 }

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControlDirectional.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControlDirectional.java
@@ -28,7 +28,6 @@ public class TestLightControlDirectional extends SimpleApplication {
 
     private Node lightNode;
     private DirectionalLight direction;
-    private Geometry lightMdl;
 
     public static void main(String[] args) {
         TestLightControlDirectional app = new TestLightControlDirectional();
@@ -36,6 +35,7 @@ public class TestLightControlDirectional extends SimpleApplication {
     }
 
     public void setupLighting() {
+        Geometry lightMdl;
         AmbientLight al = new AmbientLight();
         al.setColor(ColorRGBA.White.mult(2f));
         rootNode.addLight(al);

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControlDirectional.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControlDirectional.java
@@ -97,11 +97,17 @@ public class TestLightControlDirectional extends SimpleApplication {
          * 360 degree rotation
          */
         final float FULL_ROT = FastMath.PI * 2;
-        super.simpleUpdate(tpf);
         angles[0] += rotAxis.x * ROT_SPEED * tpf;
         angles[1] += rotAxis.y * ROT_SPEED * tpf;
         angles[2] += rotAxis.z * ROT_SPEED * tpf;
         lightNode.setLocalRotation(new Quaternion().fromAngles(angles));
+        super.simpleUpdate(tpf);
+        /*
+         * Make sure they are equal.
+         */
+        if (FastMath.abs(direction.getDirection().normalize().subtractLocal(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).negateLocal().normalizeLocal()).lengthSquared()) > .1F) {
+            System.err.printf("Rotation not equal: is %s (%s), needs to be %s (%f)\n", lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), lightNode.getLocalRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), direction.getDirection().normalize(), FastMath.abs(direction.getDirection().normalize().subtract(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal()).lengthSquared()));
+        }
         if (angles[0] >= FULL_ROT || angles[1] >= FULL_ROT || angles[2] >= FULL_ROT) {
             lightNode.setLocalRotation(Quaternion.DIRECTION_Z);
             angles[0] = 0;
@@ -117,6 +123,5 @@ public class TestLightControlDirectional extends SimpleApplication {
                 rotAxis.set(1, 0, 0);
             }
         }
-//        lightNode.lookAt(Vector3f.ZERO, Vector3f.UNIT_Y);
     }
 }

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControlDirectional.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControlDirectional.java
@@ -1,0 +1,122 @@
+package jme3test.light;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.light.AmbientLight;
+import com.jme3.light.DirectionalLight;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.FastMath;
+import com.jme3.math.Quaternion;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Node;
+import com.jme3.scene.control.LightControl;
+import com.jme3.scene.shape.Cylinder;
+import com.jme3.scene.shape.Dome;
+import com.jme3.scene.shape.Sphere;
+
+/**
+ * Creates a directional light controlled by rotating a node. The light will shine on a surrounding sphere.
+ * The light will rotate upon each axis before working on a random axis and then reverting to the x
+ * axis.
+ *
+ * @author Markil 3
+ */
+public class TestLightControlDirectional extends SimpleApplication {
+    private final Vector3f rotAxis = new Vector3f(Vector3f.UNIT_X);
+    private final float[] angles = new float[3];
+
+    public static void main(String[] args) {
+        TestLightControlDirectional app = new TestLightControlDirectional();
+        app.start();
+    }
+
+    Node lightNode;
+    DirectionalLight direction;
+    Geometry lightMdl;
+
+    public void setupLighting() {
+        AmbientLight al = new AmbientLight();
+        al.setColor(ColorRGBA.White.mult(2f));
+        rootNode.addLight(al);
+
+        direction = new DirectionalLight();
+        direction.setColor(ColorRGBA.White.mult(10));
+        rootNode.addLight(direction);
+
+
+//        PointLight pl=new PointLight();
+//      pl.setPosition(new Vector3f(77.70334f, 34.013165f, 27.1017f));
+//      pl.setRadius(1000);
+//      pl.setColor(ColorRGBA.White.mult(2));
+//      rootNode.addLight(pl);
+        lightMdl = new Geometry("Light", new Dome(Vector3f.ZERO, 2, 32, 5, false));
+        lightMdl.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
+        lightMdl.setLocalTranslation(new Vector3f(0, 0, 0));
+        lightMdl.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / 2F, 0, 0));
+        rootNode.attachChild(lightMdl);
+
+        /*
+         * We need this Dome doesn't have a "floor."
+         */
+        Geometry lightFloor = new Geometry("LightFloor", new Cylinder(2, 32, 5, .1F, true));
+        lightFloor.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
+        lightFloor.getMaterial().setColor("Color", ColorRGBA.White);
+//        lightFloor.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / 2F, 0, 0));
+
+        lightNode = new Node();
+        lightNode.addControl(new LightControl(direction));
+//        lightNode.setLocalTranslation(-5, 0, 0);
+        lightNode.attachChild(lightMdl);
+        lightNode.attachChild(lightFloor);
+        rootNode.attachChild(lightNode);
+    }
+
+    public void setupDome() {
+        Geometry dome = new Geometry("Dome", new Sphere(16, 32, 30, false, true));
+        dome.setMaterial(new Material(this.assetManager, "Common/MatDefs/Light/PBRLighting.j3md"));
+        dome.setLocalTranslation(new Vector3f(0, 0, 0));
+        rootNode.attachChild(dome);
+    }
+
+    @Override
+    public void simpleInitApp() {
+        flyCam.setMoveSpeed(30);
+
+        setupLighting();
+        setupDome();
+    }
+
+    @Override
+    public void simpleUpdate(float tpf) {
+        /*
+         * In Radians per second
+         */
+        final float ROT_SPEED = FastMath.PI * 2;
+        /*
+         * 360 degree rotation
+         */
+        final float FULL_ROT = FastMath.PI * 2;
+        super.simpleUpdate(tpf);
+        angles[0] += rotAxis.x * ROT_SPEED * tpf;
+        angles[1] += rotAxis.y * ROT_SPEED * tpf;
+        angles[2] += rotAxis.z * ROT_SPEED * tpf;
+        lightNode.setLocalRotation(new Quaternion().fromAngles(angles));
+        if (angles[0] >= FULL_ROT || angles[1] >= FULL_ROT || angles[2] >= FULL_ROT) {
+            lightNode.setLocalRotation(Quaternion.DIRECTION_Z);
+            angles[0] = 0;
+            angles[1] = 0;
+            angles[2] = 0;
+            if (rotAxis.x > 0 && rotAxis.y == 0 && rotAxis.z == 0) {
+                rotAxis.set(0, 1, 0);
+            } else if (rotAxis.y > 0 && rotAxis.x == 0 && rotAxis.z == 0) {
+                rotAxis.set(0, 0, 1);
+            } else if (rotAxis.z > 0 && rotAxis.x == 0 && rotAxis.y == 0) {
+                rotAxis.set(FastMath.nextRandomFloat() % 1, FastMath.nextRandomFloat() % 1, FastMath.nextRandomFloat() % 1);
+            } else {
+                rotAxis.set(1, 0, 0);
+            }
+        }
+//        lightNode.lookAt(Vector3f.ZERO, Vector3f.UNIT_Y);
+    }
+}

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControlSpot.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControlSpot.java
@@ -1,0 +1,126 @@
+package jme3test.light;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.light.AmbientLight;
+import com.jme3.light.SpotLight;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.FastMath;
+import com.jme3.math.Quaternion;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Node;
+import com.jme3.scene.control.LightControl;
+import com.jme3.scene.shape.Cylinder;
+import com.jme3.scene.shape.Dome;
+import com.jme3.scene.shape.Sphere;
+
+/**
+ * Creates a spot light controlled by rotating a node. The light will shine on a surrounding sphere.
+ * The light will rotate upon each axis before working on a random axis and then reverting to the x
+ * axis.
+ *
+ * @author Markil 3
+ */
+public class TestLightControlSpot extends SimpleApplication {
+    private final Vector3f rotAxis = new Vector3f(Vector3f.UNIT_X);
+    private final float[] angles = new float[3];
+
+    public static void main(String[] args) {
+        TestLightControlSpot app = new TestLightControlSpot();
+        app.start();
+    }
+
+    Node lightNode;
+    SpotLight spot;
+    Geometry lightMdl;
+
+    public void setupLighting() {
+        AmbientLight al = new AmbientLight();
+        al.setColor(ColorRGBA.White.mult(2f));
+        rootNode.addLight(al);
+
+        spot = new SpotLight();
+
+        spot.setSpotRange(1000);
+        spot.setSpotInnerAngle(5 * FastMath.DEG_TO_RAD);
+        spot.setSpotOuterAngle(10 * FastMath.DEG_TO_RAD);
+        spot.setColor(ColorRGBA.White.mult(10));
+        rootNode.addLight(spot);
+
+
+//        PointLight pl=new PointLight();
+//      pl.setPosition(new Vector3f(77.70334f, 34.013165f, 27.1017f));
+//      pl.setRadius(1000);
+//      pl.setColor(ColorRGBA.White.mult(2));
+//      rootNode.addLight(pl);
+        lightMdl = new Geometry("Light", new Dome(Vector3f.ZERO, 2, 32, 5, false));
+        lightMdl.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
+        lightMdl.setLocalTranslation(new Vector3f(0, 0, 0));
+        lightMdl.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / 2F, 0, 0));
+        rootNode.attachChild(lightMdl);
+
+        /*
+         * We need this Dome doesn't have a "floor."
+         */
+        Geometry lightFloor = new Geometry("LightFloor", new Cylinder(2, 32, 5, .1F, true));
+        lightFloor.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
+        lightFloor.getMaterial().setColor("Color", ColorRGBA.White);
+//        lightFloor.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / 2F, 0, 0));
+
+        lightNode = new Node();
+        lightNode.addControl(new LightControl(spot));
+//        lightNode.setLocalTranslation(-5, 0, 0);
+        lightNode.attachChild(lightMdl);
+        lightNode.attachChild(lightFloor);
+        rootNode.attachChild(lightNode);
+    }
+
+    public void setupDome() {
+        Geometry dome = new Geometry("Dome", new Sphere(16, 32, 30, false, true));
+        dome.setMaterial(new Material(this.assetManager, "Common/MatDefs/Light/PBRLighting.j3md"));
+        dome.setLocalTranslation(new Vector3f(0, 0, 0));
+        rootNode.attachChild(dome);
+    }
+
+    @Override
+    public void simpleInitApp() {
+        flyCam.setMoveSpeed(30);
+
+        setupLighting();
+        setupDome();
+    }
+
+    @Override
+    public void simpleUpdate(float tpf) {
+        /*
+         * In Radians per second
+         */
+        final float ROT_SPEED = FastMath.PI * 2;
+        /*
+         * 360 degree rotation
+         */
+        final float FULL_ROT = FastMath.PI * 2;
+        super.simpleUpdate(tpf);
+        angles[0] += rotAxis.x * ROT_SPEED * tpf;
+        angles[1] += rotAxis.y * ROT_SPEED * tpf;
+        angles[2] += rotAxis.z * ROT_SPEED * tpf;
+        lightNode.setLocalRotation(new Quaternion().fromAngles(angles));
+        if (angles[0] >= FULL_ROT || angles[1] >= FULL_ROT || angles[2] >= FULL_ROT) {
+            lightNode.setLocalRotation(Quaternion.DIRECTION_Z);
+            angles[0] = 0;
+            angles[1] = 0;
+            angles[2] = 0;
+            if (rotAxis.x > 0 && rotAxis.y == 0 && rotAxis.z == 0) {
+                rotAxis.set(0, 1, 0);
+            } else if (rotAxis.y > 0 && rotAxis.x == 0 && rotAxis.z == 0) {
+                rotAxis.set(0, 0, 1);
+            } else if (rotAxis.z > 0 && rotAxis.x == 0 && rotAxis.y == 0) {
+                rotAxis.set(FastMath.nextRandomFloat() % 1, FastMath.nextRandomFloat() % 1, FastMath.nextRandomFloat() % 1);
+            } else {
+                rotAxis.set(1, 0, 0);
+            }
+        }
+//        lightNode.lookAt(Vector3f.ZERO, Vector3f.UNIT_Y);
+    }
+}

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControlSpot.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControlSpot.java
@@ -28,7 +28,6 @@ public class TestLightControlSpot extends SimpleApplication {
 
     private Node lightNode;
     private SpotLight spot;
-    private Geometry lightMdl;
 
     public static void main(String[] args) {
         TestLightControlSpot app = new TestLightControlSpot();
@@ -36,6 +35,7 @@ public class TestLightControlSpot extends SimpleApplication {
     }
 
     public void setupLighting() {
+        Geometry lightMdl;
         AmbientLight al = new AmbientLight();
         al.setColor(ColorRGBA.White.mult(2f));
         rootNode.addLight(al);

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControlSpot.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControlSpot.java
@@ -101,11 +101,20 @@ public class TestLightControlSpot extends SimpleApplication {
          * 360 degree rotation
          */
         final float FULL_ROT = FastMath.PI * 2;
-        super.simpleUpdate(tpf);
         angles[0] += rotAxis.x * ROT_SPEED * tpf;
         angles[1] += rotAxis.y * ROT_SPEED * tpf;
         angles[2] += rotAxis.z * ROT_SPEED * tpf;
         lightNode.setLocalRotation(new Quaternion().fromAngles(angles));
+        super.simpleUpdate(tpf);
+        /*
+         * Make sure they are equal.
+         */
+        if (spot.getPosition().subtract(lightNode.getWorldTranslation()).lengthSquared() > 0.1F) {
+            System.err.printf("Translation not equal: is %s (%s), needs to be %s\n", lightNode.getWorldTranslation(), lightNode.getLocalTranslation(), spot.getPosition());
+        }
+        if (FastMath.abs(spot.getDirection().normalize().subtractLocal(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).negateLocal().normalizeLocal()).lengthSquared()) > .1F) {
+            System.err.printf("Rotation not equal: is %s (%s), needs to be %s (%f)\n", lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), lightNode.getLocalRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), spot.getDirection().normalize(), FastMath.abs(spot.getDirection().normalize().subtract(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal()).lengthSquared()));
+        }
         if (angles[0] >= FULL_ROT || angles[1] >= FULL_ROT || angles[2] >= FULL_ROT) {
             lightNode.setLocalRotation(Quaternion.DIRECTION_Z);
             angles[0] = 0;
@@ -121,6 +130,5 @@ public class TestLightControlSpot extends SimpleApplication {
                 rotAxis.set(1, 0, 0);
             }
         }
-//        lightNode.lookAt(Vector3f.ZERO, Vector3f.UNIT_Y);
     }
 }

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControlSpot.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControlSpot.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2012 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package jme3test.light;
 
 import com.jme3.app.SimpleApplication;
@@ -14,6 +45,7 @@ import com.jme3.scene.control.LightControl;
 import com.jme3.scene.shape.Cylinder;
 import com.jme3.scene.shape.Dome;
 import com.jme3.scene.shape.Sphere;
+import com.jme3.util.TempVars;
 
 /**
  * Creates a spot light controlled by rotating a node. The light will shine on a surrounding sphere.
@@ -48,12 +80,6 @@ public class TestLightControlSpot extends SimpleApplication {
         spot.setColor(ColorRGBA.White.mult(10));
         rootNode.addLight(spot);
 
-
-//        PointLight pl=new PointLight();
-//      pl.setPosition(new Vector3f(77.70334f, 34.013165f, 27.1017f));
-//      pl.setRadius(1000);
-//      pl.setColor(ColorRGBA.White.mult(2));
-//      rootNode.addLight(pl);
         lightMdl = new Geometry("Light", new Dome(Vector3f.ZERO, 2, 32, 5, false));
         lightMdl.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
         lightMdl.setLocalTranslation(new Vector3f(0, 0, 0));
@@ -66,11 +92,9 @@ public class TestLightControlSpot extends SimpleApplication {
         Geometry lightFloor = new Geometry("LightFloor", new Cylinder(2, 32, 5, .1F, true));
         lightFloor.setMaterial(assetManager.loadMaterial("Common/Materials/RedColor.j3m"));
         lightFloor.getMaterial().setColor("Color", ColorRGBA.White);
-//        lightFloor.setLocalRotation(new Quaternion().fromAngles(FastMath.PI / 2F, 0, 0));
 
         lightNode = new Node();
         lightNode.addControl(new LightControl(spot));
-//        lightNode.setLocalTranslation(-5, 0, 0);
         lightNode.attachChild(lightMdl);
         lightNode.attachChild(lightFloor);
         rootNode.attachChild(lightNode);
@@ -85,6 +109,8 @@ public class TestLightControlSpot extends SimpleApplication {
 
     @Override
     public void simpleInitApp() {
+        this.cam.setLocation(new Vector3f(-50, 20, 50));
+        this.cam.lookAt(Vector3f.ZERO, Vector3f.UNIT_Y);
         flyCam.setMoveSpeed(30);
 
         setupLighting();
@@ -96,25 +122,40 @@ public class TestLightControlSpot extends SimpleApplication {
         /*
          * In Radians per second
          */
-        final float ROT_SPEED = FastMath.PI * 2;
+        final float ROT_SPEED = FastMath.PI / 2;
         /*
          * 360 degree rotation
          */
         final float FULL_ROT = FastMath.PI * 2;
+
+        TempVars vars = TempVars.get();
+        Vector3f lightPosition = vars.vect1, lightDirection = vars.vect2, nodeDirection = vars.vect3;
+        float length;
+
         angles[0] += rotAxis.x * ROT_SPEED * tpf;
         angles[1] += rotAxis.y * ROT_SPEED * tpf;
         angles[2] += rotAxis.z * ROT_SPEED * tpf;
         lightNode.setLocalRotation(new Quaternion().fromAngles(angles));
         super.simpleUpdate(tpf);
+
         /*
          * Make sure they are equal.
          */
-        if (spot.getPosition().subtract(lightNode.getWorldTranslation()).lengthSquared() > 0.1F) {
-            System.err.printf("Translation not equal: is %s (%s), needs to be %s\n", lightNode.getWorldTranslation(), lightNode.getLocalTranslation(), spot.getPosition());
+        lightPosition.set(spot.getPosition());
+        length = lightPosition.subtract(lightNode.getWorldTranslation(), vars.vect4).lengthSquared();
+        if (length > 0.1F) {
+            System.err.printf("Translation not equal: is %s, needs to be %s\n", lightNode.getWorldTranslation(), spot.getPosition());
         }
-        if (FastMath.abs(spot.getDirection().normalize().subtractLocal(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).negateLocal().normalizeLocal()).lengthSquared()) > .1F) {
-            System.err.printf("Rotation not equal: is %s (%s), needs to be %s (%f)\n", lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), lightNode.getLocalRotation().mult(Vector3f.UNIT_Z).normalizeLocal(), spot.getDirection().normalize(), FastMath.abs(spot.getDirection().normalize().subtract(lightNode.getWorldRotation().mult(Vector3f.UNIT_Z).normalizeLocal()).lengthSquared()));
+        lightDirection.set(spot.getDirection());
+        lightDirection.normalizeLocal();
+        lightNode.getWorldRotation().mult(Vector3f.UNIT_Z, nodeDirection);
+        nodeDirection.negateLocal().normalizeLocal();
+        length = lightDirection.subtract(nodeDirection, vars.vect4).lengthSquared();
+        length = FastMath.abs(length);
+        if (length > .1F) {
+            System.err.printf("Rotation not equal: is %s, needs to be %s (%f)\n", nodeDirection, lightDirection, length);
         }
+
         if (angles[0] >= FULL_ROT || angles[1] >= FULL_ROT || angles[2] >= FULL_ROT) {
             lightNode.setLocalRotation(Quaternion.DIRECTION_Z);
             angles[0] = 0;
@@ -130,5 +171,7 @@ public class TestLightControlSpot extends SimpleApplication {
                 rotAxis.set(1, 0, 0);
             }
         }
+
+        vars.release();
     }
 }

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControlSpot.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControlSpot.java
@@ -26,14 +26,14 @@ public class TestLightControlSpot extends SimpleApplication {
     private final Vector3f rotAxis = new Vector3f(Vector3f.UNIT_X);
     private final float[] angles = new float[3];
 
+    private Node lightNode;
+    private SpotLight spot;
+    private Geometry lightMdl;
+
     public static void main(String[] args) {
         TestLightControlSpot app = new TestLightControlSpot();
         app.start();
     }
-
-    Node lightNode;
-    SpotLight spot;
-    Geometry lightMdl;
 
     public void setupLighting() {
         AmbientLight al = new AmbientLight();


### PR DESCRIPTION
As @tlf30, @pspeed42 and I were working on #1443, it became apparent that the LightControl class wasn't entirely functional, particularly when it came to spot lights. This PR not only fixes that (including filling out the missing spotlight code in the lightToSpatial method), but also replaces some legacy code relating to directional lights from before version 3.
https://hub.jmonkeyengine.org/t/gltf-unlit-material-and-punctual-light-extensions/44132/29?u=markil3

Note that, when dealing with "world" coordinates when moving the spatial to the light, the rotations aren't always entirely accurate (the distance between the vectors can be as much as 4 units during testing). However, they appear close enough in debugging that I'm not concerned (Line 141 of TestLightControl2Spot).