### PR TITLE
avoid an NPE in GltfLoader.findChildren()

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -1086,11 +1086,10 @@ public class GltfLoader implements AssetLoader {
 
     private void findChildren(int nodeIndex) throws IOException {
         JointWrapper jw = fetchFromCache("nodes", nodeIndex, JointWrapper.class);
-        
-        if(jw == null) {
+        if (jw == null) {
             return;
         }
-        
+
         JsonObject nodeData = nodes.get(nodeIndex).getAsJsonObject();
         JsonArray children = nodeData.getAsJsonArray("children");
 

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -1087,6 +1087,8 @@ public class GltfLoader implements AssetLoader {
     private void findChildren(int nodeIndex) throws IOException {
         JointWrapper jw = fetchFromCache("nodes", nodeIndex, JointWrapper.class);
         if (jw == null) {
+            logger.log(Level.WARNING,
+                    "No JointWrapper found for nodeIndex={0}.", nodeIndex);
             return;
         }
 

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -1086,6 +1086,12 @@ public class GltfLoader implements AssetLoader {
 
     private void findChildren(int nodeIndex) throws IOException {
         JointWrapper jw = fetchFromCache("nodes", nodeIndex, JointWrapper.class);
+        
+        //Check if jw node exist or leave the function
+        if(jw == null){
+            return;
+        }
+        
         JsonObject nodeData = nodes.get(nodeIndex).getAsJsonObject();
         JsonArray children = nodeData.getAsJsonArray("children");
 

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -1087,8 +1087,7 @@ public class GltfLoader implements AssetLoader {
     private void findChildren(int nodeIndex) throws IOException {
         JointWrapper jw = fetchFromCache("nodes", nodeIndex, JointWrapper.class);
         
-        //Check if jw node exist or leave the function
-        if(jw == null){
+        if(jw == null) {
             return;
         }
         


### PR DESCRIPTION
null pointer exception if the GLTF file references a node that doesn't exist.
I got this problem while tring to convert my GLTF file, i got 440 animations on the file with 3 animation that have joint index missmatch.
Maybe it's better to log the errors detail so the user have all the information to correct the error