### PR TITLE
TerrainQuad: serialize "patchSize" field.

### DIFF
--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1734,6 +1734,7 @@ public class TerrainQuad extends Node implements Terrain {
         offsetAmount = c.readFloat("offsetAmount", 0);
         quadrant = c.readInt("quadrant", 0);
         totalSize = c.readInt("totalSize", 0);
+        patchSize = c.readInt("patchSize", 0);
         //lodCalculator = (LodCalculator) c.readSavable("lodCalculator", createDefaultLodCalculator());
         //lodCalculatorFactory = (LodCalculatorFactory) c.readSavable("lodCalculatorFactory", null);
 
@@ -1750,6 +1751,7 @@ public class TerrainQuad extends Node implements Terrain {
         OutputCapsule c = e.getCapsule(this);
         c.write(size, "size", 0);
         c.write(totalSize, "totalSize", 0);
+        c.write(patchSize, "patchSize", 0);
         c.write(stepScale, "stepScale", null);
         c.write(offset, "offset", new Vector2f(0,0));
         c.write(offsetAmount, "offsetAmount", 0);

--- a/jme3-terrain/src/test/java/com/jme3/terrain/TestTerrainExporting.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/TestTerrainExporting.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jme3.terrain;
+
+import com.jme3.export.binary.BinaryExporter;
+import com.jme3.math.FastMath;
+import com.jme3.terrain.collision.BaseAWTTest;
+import com.jme3.terrain.geomipmap.TerrainQuad;
+import com.jme3.terrain.heightmap.AbstractHeightMap;
+import com.jme3.terrain.heightmap.ImageBasedHeightMap;
+import com.jme3.texture.Texture;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test saving/loading terrain.
+ *
+ * @author Ali-RS
+ */
+public class TestTerrainExporting extends BaseAWTTest {
+
+    /**
+     * Test saving/loading a TerrainQuad.
+     */
+    @Test
+    public void testTerrainExporting() {
+
+        Texture heightMapImage = getAssetManager().loadTexture("Textures/Terrain/splat/mountains512.png");
+        AbstractHeightMap map = new ImageBasedHeightMap(heightMapImage.getImage(), 0.25f);
+        map.load();
+
+        TerrainQuad terrain = new TerrainQuad("Terrain", 65, 513, map.getHeightMap());
+
+        TerrainQuad saveAndLoad = BinaryExporter.saveAndLoad(getAssetManager(), terrain);
+
+        Assert.assertEquals(513, saveAndLoad.getTotalSize());
+        Assert.assertEquals(65, saveAndLoad.getPatchSize());
+        Assert.assertArrayEquals(terrain.getHeightMap(), saveAndLoad.getHeightMap(), FastMath.ZERO_TOLERANCE);
+    }
+
+}


### PR DESCRIPTION
After loading a terrain from j3o, calling `TerrainQuad.getPatchSize()` will return 0, because "patchSize" is ignored when writing to file. This patch should fix it.