### PR TITLE
resolve issue #1447 (no setter for EnvironmentCamera background color)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/environment/EnvironmentCamera.java
+++ b/jme3-core/src/main/java/com/jme3/environment/EnvironmentCamera.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -197,6 +197,24 @@ public class EnvironmentCamera extends BaseAppState {
     }
 
     /**
+     * Alter the background color of an initialized EnvironmentCamera.
+     *
+     * @param bgColor the desired color (not null, unaffected, default is the
+     * background color of the application's default viewport)
+     */
+    public void setBackGroundColor(ColorRGBA bgColor) {
+        if (!isInitialized()) {
+            throw new IllegalStateException(
+                    "The EnvironmentCamera is uninitialized.");
+        }
+
+        backGroundColor.set(bgColor);
+        for (int i = 0; i < 6; ++i) {
+            viewports[i].setBackgroundColor(bgColor);
+        }
+    }
+
+    /**
      * Gets the size of environment cameras.
      *
      * @return the size of environment cameras.
@@ -260,7 +278,7 @@ public class EnvironmentCamera extends BaseAppState {
 
     @Override
     protected void initialize(Application app) {
-        this.backGroundColor = app.getViewPort().getBackgroundColor();
+        this.backGroundColor = app.getViewPort().getBackgroundColor().clone();
 
         final Camera[] cameras = new Camera[6];
         final Texture2D[] textures = new Texture2D[6];


### PR DESCRIPTION
Previously `EnvironmentCamera` didn't copy the default viewport's background color, but kept an alias to the pre-existing object. To avoid unintentionally altering the default viewport, it is necessary to clone the object.

`EnvironmentCamera` overrides the `backGroundColor` field during initialization, so setting it any sooner would have no effect. I decided to throw an `IllegalStateException` in that situation, to avert puzzling logic errors in apps. 