### PR TITLE
Action: publicize the setLength() method

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/Action.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/Action.java
@@ -30,7 +30,13 @@ public abstract class Action implements JmeCloneable, Tween {
         return length;
     }
 
-    protected void setLength(double length) {
+    /**
+     * Alter the length (duration) of this Action.  This can be used to extend
+     * or truncate an Action.
+     *
+     * @param length the desired length (in unscaled seconds, default=0)
+     */
+    public void setLength(double length) {
         this.length = length;
     }
 


### PR DESCRIPTION
Sometimes (as in PR #1487) it would be convenient to directly alter the duration of an Action.