### PR TITLE
Adds getters/setters for Camera field of view and aspect ratio

### DIFF
--- a/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
+++ b/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
@@ -382,7 +382,10 @@ public class FlyByCamera implements AnalogListener, ActionListener {
      * @param value zoom amount
      */
     protected void zoomCamera(float value){
-        cam.setFov(cam.getFov() + value * 0.1F * zoomSpeed);
+        float newFov = cam.getFov() + value * 0.1F * zoomSpeed;
+        if (newFov > 0) {
+            cam.setFov(newFov);
+        }
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
+++ b/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
@@ -382,7 +382,7 @@ public class FlyByCamera implements AnalogListener, ActionListener {
      * @param value zoom amount
      */
     protected void zoomCamera(float value){
-        cam.setFov(cam.getFov() - value * 0.1F * zoomSpeed);
+        cam.setFov(cam.getFov() + value * 0.1F * zoomSpeed);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
+++ b/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
@@ -382,28 +382,7 @@ public class FlyByCamera implements AnalogListener, ActionListener {
      * @param value zoom amount
      */
     protected void zoomCamera(float value){
-        // derive fovY value
-        float h = cam.getFrustumTop();
-        float w = cam.getFrustumRight();
-        float aspect = w / h;
-
-        float near = cam.getFrustumNear();
-
-        float fovY = FastMath.atan(h / near)
-                / (FastMath.DEG_TO_RAD * .5f);
-        float newFovY = fovY + value * 0.1f * zoomSpeed;
-        if (newFovY > 0f) {
-            // Don't let the FOV go zero or negative.
-            fovY = newFovY;
-        }
-
-        h = FastMath.tan( fovY * FastMath.DEG_TO_RAD * .5f) * near;
-        w = h * aspect;
-
-        cam.setFrustumTop(h);
-        cam.setFrustumBottom(-h);
-        cam.setFrustumLeft(-w);
-        cam.setFrustumRight(w);
+        cam.setFov(cam.getFov() - value * 0.1F * zoomSpeed);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/renderer/Camera.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Camera.java
@@ -586,8 +586,7 @@ public class Camera implements Savable, Cloneable {
      * @return Frame of view angle along the Y in degrees, or 0 if the camera is in orthogonal mode.
      */
     public float getFov() {
-        if (!this.parallelProjection)
-        {
+        if (!this.parallelProjection) {
             float fovY = frustumTop / frustumNear;
             fovY = FastMath.atan(fovY);
             fovY /= 0.5F * FastMath.DEG_TO_RAD;
@@ -603,12 +602,10 @@ public class Camera implements Savable, Cloneable {
      * @param fovY   Frame of view angle along the Y in degrees. This must be greater than 0.
      */
     public void setFov(float fovY) {
-        if (fovY <= 0)
-        {
+        if (fovY <= 0) {
             throw new IllegalArgumentException("Field of view must be greater than 0");
         }
-        if (this.parallelProjection)
-        {
+        if (this.parallelProjection) {
             throw new IllegalArgumentException("Cannot set field of view on orthogonal camera");
         }
         float h = FastMath.tan(fovY * FastMath.DEG_TO_RAD * .5f) * frustumNear;

--- a/jme3-core/src/main/java/com/jme3/renderer/Camera.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Camera.java
@@ -600,10 +600,14 @@ public class Camera implements Savable, Cloneable {
      * Sets the field of view when the camera is in perspective mode. Note that this method has no
      * effect when the camera is in orthogonal mode.
      *
-     * @param fovY   Frame of view angle along the Y in degrees.
+     * @param fovY   Frame of view angle along the Y in degrees. This must be greater than 0.
      */
     public void setFov(float fovY) {
-        if (!this.parallelProjection && fovY > 0) {
+        if (fovY <= 0)
+        {
+            throw new IllegalArgumentException("Field of view must be greater than 0");
+        }
+        if (!this.parallelProjection) {
             float h = FastMath.tan(fovY * FastMath.DEG_TO_RAD * .5f) * frustumNear;
             float w = h * getAspect();
             frustumLeft = -w;

--- a/jme3-core/src/main/java/com/jme3/renderer/Camera.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Camera.java
@@ -153,7 +153,6 @@ public class Camera implements Savable, Cloneable {
      */
     protected float frustumBottom;
     private float currentFov;
-    private float currentAspect;
     //Temporary values computed in onFrustumChange that are needed if a
     //call is made to onFrameChange.
     protected float[] coeffLeft;
@@ -459,8 +458,8 @@ public class Camera implements Savable, Cloneable {
         if (fixAspect) {
             float h = height * (viewPortTop - viewPortBottom);
             float w = width * (viewPortRight - viewPortLeft);
-            currentAspect = w / h;
-            frustumRight = frustumTop * currentAspect;
+            float aspectRatio = w / h;
+            frustumRight = frustumTop * aspectRatio;
             frustumLeft = -frustumRight;
             onFrustumChange();
         }
@@ -600,7 +599,7 @@ public class Camera implements Savable, Cloneable {
     public void setFov(float fovY) {
         if (!this.parallelProjection && fovY > 0) {
             float h = FastMath.tan(fovY * FastMath.DEG_TO_RAD * .5f) * frustumNear;
-            float w = h * currentAspect;
+            float w = h * (width / height);
             currentFov = fovY;
             frustumLeft = -w;
             frustumRight = w;
@@ -616,26 +615,7 @@ public class Camera implements Savable, Cloneable {
      * @return Width:Height ratio, or -1 if the camera is in orthogonal mode.
      */
     public float getAspect() {
-        return !this.parallelProjection ? currentAspect : -1;
-    }
-
-    /**
-     * Sets the aspect ratio when the camera is in perspective mode. Note that this method has no
-     * effect when the camera is in orthogonal mode.
-     *
-     * @param aspect Width:Height ratio
-     */
-    public void setAspect(float aspect) {
-        if (!this.parallelProjection && aspect != 0) {
-            float h = FastMath.tan(currentFov * FastMath.DEG_TO_RAD * .5f) * frustumNear;
-            float w = h * aspect;
-            currentAspect = aspect;
-            frustumLeft = -w;
-            frustumRight = w;
-            frustumBottom = -h;
-            frustumTop = h;
-            onFrustumChange();
-        }
+        return !this.parallelProjection ? (width / height) : -1;
     }
 
     /**
@@ -834,7 +814,6 @@ public class Camera implements Savable, Cloneable {
         float h = FastMath.tan(fovY * FastMath.DEG_TO_RAD * .5f) * near;
         float w = h * aspect;
         currentFov = fovY;
-        currentAspect = aspect;
         frustumLeft = -w;
         frustumRight = w;
         frustumBottom = -h;

--- a/jme3-core/src/main/java/com/jme3/renderer/Camera.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Camera.java
@@ -607,15 +607,17 @@ public class Camera implements Savable, Cloneable {
         {
             throw new IllegalArgumentException("Field of view must be greater than 0");
         }
-        if (!this.parallelProjection) {
-            float h = FastMath.tan(fovY * FastMath.DEG_TO_RAD * .5f) * frustumNear;
-            float w = h * getAspect();
-            frustumLeft = -w;
-            frustumRight = w;
-            frustumBottom = -h;
-            frustumTop = h;
-            onFrustumChange();
+        if (this.parallelProjection)
+        {
+            throw new IllegalArgumentException("Cannot set field of view on orthogonal camera");
         }
+        float h = FastMath.tan(fovY * FastMath.DEG_TO_RAD * .5f) * frustumNear;
+        float w = h * getAspect();
+        frustumLeft = -w;
+        frustumRight = w;
+        frustumBottom = -h;
+        frustumTop = h;
+        onFrustumChange();
     }
 
     /**

--- a/jme3-examples/src/main/java/jme3test/renderer/TestAspectFov.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestAspectFov.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2009-2021 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package jme3test.renderer;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.asset.plugins.HttpZipLocator;
+import com.jme3.bullet.control.RigidBodyControl;
+import com.jme3.bullet.util.CollisionShapeFactory;
+import com.jme3.font.BitmapText;
+import com.jme3.input.KeyInput;
+import com.jme3.input.controls.ActionListener;
+import com.jme3.input.controls.AnalogListener;
+import com.jme3.input.controls.KeyTrigger;
+import com.jme3.light.AmbientLight;
+import com.jme3.light.DirectionalLight;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Spatial;
+import com.jme3.scene.shape.Box;
+import com.jme3.util.TempVars;
+
+/**
+ * Tests the setting of the FOV and aspect ratios.
+ *
+ * @author Markil 3
+ */
+public class TestAspectFov extends SimpleApplication implements ActionListener, AnalogListener {
+    final String FOV_IN = "fovIn", FOV_OUT = "fovOut", ASPECT_IN = "aspectIn", ASPECT_OUT = "aspectOut";
+    final float[] ratios = new float[]{2F / 1F, 3F / 1F, 4F / 3F, 5F / 4F, 16F / 9F, 1F / 2F, 1F / 3F, 3F / 4F, 4F / 5F, 9F / 16F};
+    private int ratioIndex = 0;
+    private BitmapText header, fov, aspect;
+
+    public static void main(String[] args) {
+        new TestAspectFov().start();
+    }
+
+    @Override
+    public void simpleInitApp() {
+        header = new BitmapText(this.guiFont);
+        header.setText("Adjust FOV with R/F, adjust Aspect Ratio with T/G");
+        guiNode.attachChild(header);
+        fov = new BitmapText(this.guiFont);
+        guiNode.attachChild(fov);
+        aspect = new BitmapText(this.guiFont);
+        guiNode.attachChild(aspect);
+
+        viewPort.setBackgroundColor(new ColorRGBA(0.7f, 0.8f, 1f, 1f));
+        flyCam.setMoveSpeed(100);
+
+        // We add light so we see the scene
+        AmbientLight al = new AmbientLight();
+        al.setColor(ColorRGBA.White.mult(1.3f));
+        rootNode.addLight(al);
+
+        DirectionalLight dl = new DirectionalLight();
+        dl.setColor(ColorRGBA.White);
+        dl.setDirection(new Vector3f(2.8f, -2.8f, -2.8f).normalizeLocal());
+        rootNode.addLight(dl);
+
+        assetManager.registerLocator("https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/jmonkeyengine/town.zip",
+                HttpZipLocator.class);
+        Spatial sceneModel = assetManager.loadModel("main.scene");
+        sceneModel.setLocalScale(2f);
+
+        rootNode.attachChild(sceneModel);
+
+        inputManager.addMapping(FOV_IN, new KeyTrigger(KeyInput.KEY_R));
+        inputManager.addMapping(FOV_OUT, new KeyTrigger(KeyInput.KEY_F));
+        inputManager.addMapping(ASPECT_IN, new KeyTrigger(KeyInput.KEY_T));
+        inputManager.addMapping(ASPECT_OUT, new KeyTrigger(KeyInput.KEY_G));
+        inputManager.addListener(this, FOV_IN, FOV_OUT, ASPECT_IN, ASPECT_OUT);
+    }
+
+    @Override
+    public void update() {
+        TempVars vars = TempVars.get();
+        super.update();
+        header.setLocalTranslation(0, cam.getHeight(), 0);
+        vars.vect1.set(header.getLocalTranslation());
+        vars.vect1.subtractLocal(0, header.getLineHeight(), 0);
+        fov.setLocalTranslation(vars.vect1);
+        fov.setText("FOV: " + cam.getFov());
+        vars.vect1.subtractLocal(0, fov.getLineHeight(), 0);
+        aspect.setLocalTranslation(vars.vect1);
+        aspect.setText("Aspect Ratio: " + cam.getAspect());
+        vars.release();
+    }
+
+    @Override
+    public void onAction(String name, boolean pressed, float tpf) {
+        if (pressed) {
+            switch (name) {
+                case ASPECT_IN:
+                    ratioIndex--;
+                    if (ratioIndex < 0) {
+                        ratioIndex = ratios.length - 1;
+                    }
+                    cam.setAspect(ratios[ratioIndex]);
+                    break;
+                case ASPECT_OUT:
+                    ratioIndex = (ratioIndex + 1) % ratios.length;
+                    cam.setAspect(ratios[ratioIndex]);
+                    break;
+            }
+        }
+    }
+
+    @Override
+    public void onAnalog(String name, float value, float tpf) {
+        switch (name) {
+            case FOV_IN:
+                cam.setFov(cam.getFov() - tpf * 10);
+                break;
+            case FOV_OUT:
+                cam.setFov(cam.getFov() + tpf * 10);
+                break;
+        }
+    }
+}

--- a/jme3-examples/src/main/java/jme3test/renderer/TestAspectFov.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestAspectFov.java
@@ -50,7 +50,8 @@ import com.jme3.util.TempVars;
  * @author Markil 3
  */
 public class TestAspectFov extends SimpleApplication implements AnalogListener {
-    final String FOV_IN = "fovIn", FOV_OUT = "fovOut";
+    private static final String FOV_IN = "fovIn";
+    private static final String FOV_OUT = "fovOut";
     private BitmapText header, fov;
 
     public static void main(String[] args) {

--- a/jme3-examples/src/main/java/jme3test/renderer/TestAspectFov.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestAspectFov.java
@@ -33,21 +33,15 @@ package jme3test.renderer;
 
 import com.jme3.app.SimpleApplication;
 import com.jme3.asset.plugins.HttpZipLocator;
-import com.jme3.bullet.control.RigidBodyControl;
-import com.jme3.bullet.util.CollisionShapeFactory;
 import com.jme3.font.BitmapText;
 import com.jme3.input.KeyInput;
-import com.jme3.input.controls.ActionListener;
 import com.jme3.input.controls.AnalogListener;
 import com.jme3.input.controls.KeyTrigger;
 import com.jme3.light.AmbientLight;
 import com.jme3.light.DirectionalLight;
-import com.jme3.material.Material;
 import com.jme3.math.ColorRGBA;
 import com.jme3.math.Vector3f;
-import com.jme3.scene.Geometry;
 import com.jme3.scene.Spatial;
-import com.jme3.scene.shape.Box;
 import com.jme3.util.TempVars;
 
 /**
@@ -55,11 +49,9 @@ import com.jme3.util.TempVars;
  *
  * @author Markil 3
  */
-public class TestAspectFov extends SimpleApplication implements ActionListener, AnalogListener {
-    final String FOV_IN = "fovIn", FOV_OUT = "fovOut", ASPECT_IN = "aspectIn", ASPECT_OUT = "aspectOut";
-    final float[] ratios = new float[]{2F / 1F, 3F / 1F, 4F / 3F, 5F / 4F, 16F / 9F, 1F / 2F, 1F / 3F, 3F / 4F, 4F / 5F, 9F / 16F};
-    private int ratioIndex = 0;
-    private BitmapText header, fov, aspect;
+public class TestAspectFov extends SimpleApplication implements AnalogListener {
+    final String FOV_IN = "fovIn", FOV_OUT = "fovOut";
+    private BitmapText header, fov;
 
     public static void main(String[] args) {
         new TestAspectFov().start();
@@ -68,12 +60,10 @@ public class TestAspectFov extends SimpleApplication implements ActionListener, 
     @Override
     public void simpleInitApp() {
         header = new BitmapText(this.guiFont);
-        header.setText("Adjust FOV with R/F, adjust Aspect Ratio with T/G");
+        header.setText("Adjust FOV with R/F or with mouse scroll");
         guiNode.attachChild(header);
         fov = new BitmapText(this.guiFont);
         guiNode.attachChild(fov);
-        aspect = new BitmapText(this.guiFont);
-        guiNode.attachChild(aspect);
 
         viewPort.setBackgroundColor(new ColorRGBA(0.7f, 0.8f, 1f, 1f));
         flyCam.setMoveSpeed(100);
@@ -97,13 +87,14 @@ public class TestAspectFov extends SimpleApplication implements ActionListener, 
 
         inputManager.addMapping(FOV_IN, new KeyTrigger(KeyInput.KEY_R));
         inputManager.addMapping(FOV_OUT, new KeyTrigger(KeyInput.KEY_F));
-        inputManager.addMapping(ASPECT_IN, new KeyTrigger(KeyInput.KEY_T));
-        inputManager.addMapping(ASPECT_OUT, new KeyTrigger(KeyInput.KEY_G));
-        inputManager.addListener(this, FOV_IN, FOV_OUT, ASPECT_IN, ASPECT_OUT);
+        inputManager.addListener(this, FOV_IN, FOV_OUT);
     }
 
     @Override
     public void update() {
+        /*
+         * Updates the labels
+         */
         TempVars vars = TempVars.get();
         super.update();
         header.setLocalTranslation(0, cam.getHeight(), 0);
@@ -112,28 +103,7 @@ public class TestAspectFov extends SimpleApplication implements ActionListener, 
         fov.setLocalTranslation(vars.vect1);
         fov.setText("FOV: " + cam.getFov());
         vars.vect1.subtractLocal(0, fov.getLineHeight(), 0);
-        aspect.setLocalTranslation(vars.vect1);
-        aspect.setText("Aspect Ratio: " + cam.getAspect());
         vars.release();
-    }
-
-    @Override
-    public void onAction(String name, boolean pressed, float tpf) {
-        if (pressed) {
-            switch (name) {
-                case ASPECT_IN:
-                    ratioIndex--;
-                    if (ratioIndex < 0) {
-                        ratioIndex = ratios.length - 1;
-                    }
-                    cam.setAspect(ratios[ratioIndex]);
-                    break;
-                case ASPECT_OUT:
-                    ratioIndex = (ratioIndex + 1) % ratios.length;
-                    cam.setAspect(ratios[ratioIndex]);
-                    break;
-            }
-        }
     }
 
     @Override

--- a/jme3-examples/src/main/java/jme3test/renderer/TestAspectFov.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestAspectFov.java
@@ -109,13 +109,18 @@ public class TestAspectFov extends SimpleApplication implements AnalogListener {
 
     @Override
     public void onAnalog(String name, float value, float tpf) {
+        final float CHANGE_VALUE = tpf * 10;
+        float newFov = cam.getFov();
         switch (name) {
             case FOV_IN:
-                cam.setFov(cam.getFov() - tpf * 10);
+                newFov -= CHANGE_VALUE;
                 break;
             case FOV_OUT:
-                cam.setFov(cam.getFov() + tpf * 10);
+                newFov += CHANGE_VALUE;
                 break;
+        }
+        if (newFov > 0 && newFov != cam.getFov()) {
+            cam.setFov(newFov);
         }
     }
 }


### PR DESCRIPTION
As discussed in https://hub.jmonkeyengine.org/t/getter-setter-methods-for-attribute-fieldofview-in-the-class-camera-java-in-jme-3-4/44426/9 and mentioned in #1491, I added getter and setter methods for the field of view for perspective cameras (calling these methods on an orthogonal camera has no effect). These can be easily tested on any example that uses the FlyByCamera (i.e., 90% of them), but I added a new test for it just the same that actually displays the current FOV.