### PR TITLE
un-deprecate LoopMode, since it's still needed for cinematic events

### DIFF
--- a/jme3-core/src/main/java/com/jme3/animation/LoopMode.java
+++ b/jme3-core/src/main/java/com/jme3/animation/LoopMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,6 @@ package com.jme3.animation;
  * <code>LoopMode</code> determines how animations repeat, or if they
  * do not repeat.
  */
-@Deprecated
 public enum LoopMode {
     /**
      * The animation will play repeatedly, when it reaches the end


### PR DESCRIPTION
The `LoopMode` enum is part of the "com.jme3.animation" package: the old animation system, which @Nehon deprecated in 2018 when he introduced the new system. However, `LoopMode` is also used extensively in the "com.jme3.cinematic" package, which is not deprecated.

As long as it has a legitimate use, `LoopMode` should not be deprecated.