### PR TITLE
visible methods and fields shouldn't depend on invisible classes

### DIFF
--- a/jme3-core/src/main/java/com/jme3/app/state/ConstantVerifierState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ConstantVerifierState.java
@@ -57,7 +57,7 @@ public class ConstantVerifierState extends BaseAppState {
     // Note: I've used actual constructed objects for the good values
     //       instead of clone just to better catch cases where the values
     //       might have been corrupted even before the app state was touched. -pspeed
-    public static final Checker[] DEFAULT_CHECKS = new Checker[] {
+    private static final Checker[] DEFAULT_CHECKS = new Checker[] {
             new Checker(Vector3f.ZERO, new Vector3f(0, 0, 0)),
             new Checker(Vector3f.NAN, new Vector3f(NaN, NaN, NaN)),
             new Checker(Vector3f.UNIT_X, new Vector3f(1, 0, 0)),
@@ -111,7 +111,7 @@ public class ConstantVerifierState extends BaseAppState {
      *  Creates a verifier app state that will check all of the specified
      *  checks and report errors using the specified error type.
      */
-    public ConstantVerifierState( ErrorType errorType, Checker... checkers ) {
+    private ConstantVerifierState( ErrorType errorType, Checker... checkers ) {
         this.errorType = errorType;
         this.checkers.addAll(Arrays.asList(checkers));
     }
@@ -126,10 +126,6 @@ public class ConstantVerifierState extends BaseAppState {
     
     public ErrorType getErrorType() {
         return errorType;
-    }
-    
-    protected SafeArrayList<Checker> getCheckers() {
-        return checkers;
     }
     
     @Override

--- a/jme3-core/src/main/java/com/jme3/font/BitmapFont.java
+++ b/jme3-core/src/main/java/com/jme3/font/BitmapFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -129,7 +129,7 @@ public class BitmapFont implements Savable {
      * @param sb
      * @return the line height
      */
-    public float getLineHeight(StringBlock sb) {
+    float getLineHeight(StringBlock sb) {
         return charSet.getLineHeight() * (sb.getSize() / charSet.getRenderedSize());
     }
 

--- a/jme3-core/src/main/java/com/jme3/input/JoystickCompatibilityMappings.java
+++ b/jme3-core/src/main/java/com/jme3/input/JoystickCompatibilityMappings.java
@@ -100,7 +100,7 @@ public class JoystickCompatibilityMappings {
      * @return The various axis remappings for the requested joystick, or null of there are none.
      * @author Markil3
      */
-    protected static Map<String, AxisData> getAxisMappings(String joystickName, boolean create) {
+    private static Map<String, AxisData> getAxisMappings(String joystickName, boolean create) {
         Map<String, AxisData> result = axisMappings.get(joystickName.trim());
         if (result == null && create) {
             result = new HashMap<String, AxisData>();
@@ -295,19 +295,6 @@ public class JoystickCompatibilityMappings {
         }
         logger.log(Level.FINE, "returning remapped:" + map.get(componentId));
         return map.get(componentId);
-    }
-
-    /**
-     * Returns a set of Joystick axis name remappings if they exist otherwise
-     * it returns an empty map.
-     *
-     * @author Markil3
-     */
-    public static Map<String, AxisData> getJoystickAxisMappings(String joystickName) {
-        Map<String, AxisData> result = getAxisMappings(joystickName.trim(), false);
-        if (result == null)
-            return Collections.emptyMap();
-        return Collections.unmodifiableMap(result);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedNode.java
+++ b/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedNode.java
@@ -173,7 +173,7 @@ public class InstancedNode extends GeometryGroupNode {
         }
     }
 
-    protected InstancedNodeControl control;
+    private InstancedNodeControl control;
 
     protected HashMap<Geometry, InstancedGeometry> igByGeom
             = new HashMap<>();

--- a/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryExporter.java
+++ b/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryExporter.java
@@ -34,6 +34,7 @@ package com.jme3.export.binary;
 import com.jme3.asset.AssetManager;
 import com.jme3.export.FormatVersion;
 import com.jme3.export.JmeExporter;
+import com.jme3.export.OutputCapsule;
 import com.jme3.export.Savable;
 import com.jme3.export.SavableClassUtil;
 import com.jme3.math.FastMath;
@@ -147,7 +148,7 @@ public class BinaryExporter implements JmeExporter {
     protected int aliasCount = 1;
     protected int idCount = 1;
 
-    protected IdentityHashMap<Savable, BinaryIdContentPair> contentTable
+    final private IdentityHashMap<Savable, BinaryIdContentPair> contentTable
              = new IdentityHashMap<>();
 
     protected HashMap<Integer, Integer> locationTable
@@ -323,12 +324,12 @@ public class BinaryExporter implements JmeExporter {
         }
     }
 
-    protected String getChunk(BinaryIdContentPair pair) {
+    private String getChunk(BinaryIdContentPair pair) {
         return new String(pair.getContent().bytes, 0, Math.min(64, pair
                 .getContent().bytes.length));
     }
 
-    protected int findPrevMatch(BinaryIdContentPair oldPair,
+    private int findPrevMatch(BinaryIdContentPair oldPair,
             ArrayList<BinaryIdContentPair> bucket) {
         if (bucket == null)
             return -1;
@@ -364,7 +365,7 @@ public class BinaryExporter implements JmeExporter {
     }
 
     @Override
-    public BinaryOutputCapsule getCapsule(Savable object) {
+    public OutputCapsule getCapsule(Savable object) {
         return contentTable.get(object).getContent();
     }
 
@@ -419,7 +420,7 @@ public class BinaryExporter implements JmeExporter {
         return bytes;
     }
 
-    protected BinaryIdContentPair generateIdContentPair(BinaryClassObject bco) {
+    private BinaryIdContentPair generateIdContentPair(BinaryClassObject bco) {
         BinaryIdContentPair pair = new BinaryIdContentPair(idCount++,
                 new BinaryOutputCapsule(this, bco));
         return pair;

--- a/jme3-examples/src/main/java/jme3test/gui/TestBitmapFontLayout.java
+++ b/jme3-examples/src/main/java/jme3test/gui/TestBitmapFontLayout.java
@@ -109,7 +109,7 @@ public class TestBitmapFontLayout extends SimpleApplication {
         }
     }
     
-    protected Texture renderAwtFont( TestConfig test, int width, int height, BitmapFont bitmapFont ) {
+    private Texture renderAwtFont( TestConfig test, int width, int height, BitmapFont bitmapFont ) {
  
         BitmapCharacterSet charset = bitmapFont.getCharSet();
           
@@ -156,7 +156,7 @@ public class TestBitmapFontLayout extends SimpleApplication {
         return new Texture2D(jmeImage);
     }
     
-    protected Node createVisual( TestConfig test ) {
+    private Node createVisual( TestConfig test ) {
         Node result = new Node(test.name);
         
         // For reasons I have trouble articulating, I want the visual's 0,0,0 to be

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/material/FbxMaterialProperties.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/material/FbxMaterialProperties.java
@@ -191,13 +191,4 @@ public class FbxMaterialProperties {
     public Object getProperty(String name) { 
         return propertyValueMap.get(name);
     }
-    
-    public static Type getPropertyType(String name) {
-        FBXMaterialProperty prop = propertyMetaMap.get(name);
-        if (prop == null) { 
-            return null;
-        } else {
-            return prop.type;
-        }
-    }
 }

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -509,7 +509,7 @@ public class GltfLoader implements AssetLoader {
         return buffs;
     }
 
-    public <R> R readAccessorData(int accessorIndex, Populator<R> populator) throws IOException {
+    private <R> R readAccessorData(int accessorIndex, Populator<R> populator) throws IOException {
 
         assertNotNull(accessors, "No accessor attribute in the gltf file");
 


### PR DESCRIPTION
Or as the Netbeans inspector puts it, "Having private or package private types in a package API is useless."

Some instances were resolved simply by reducing the visibility of the field or method. In one instance, a field was only assigned once, so the assignment was made final. In a few instances, the field or method could never be used anywhere, so it was deleted.