### PR TITLE
cleanup of scene processors that don't implement profiling

### DIFF
--- a/jme3-android/src/main/java/com/jme3/app/state/VideoRecorderAppState.java
+++ b/jme3-android/src/main/java/com/jme3/app/state/VideoRecorderAppState.java
@@ -232,7 +232,6 @@ public class VideoRecorderAppState extends AbstractAppState {
         private LinkedBlockingQueue<WorkItem> usedItems = new LinkedBlockingQueue<>();
         private MjpegFileWriter writer;
         private boolean fastMode = true;
-        private AppProfiler prof;
 
         public void addImage(Renderer renderer, FrameBuffer out) {
             if (freeItems == null) {
@@ -331,7 +330,7 @@ public class VideoRecorderAppState extends AbstractAppState {
 
         @Override
         public void setProfiler(AppProfiler profiler) {
-            this.prof = profiler;
+            // not implemented
         }
     }
 

--- a/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ScreenshotAppState.java
@@ -311,6 +311,7 @@ public class ScreenshotAppState extends AbstractAppState implements ActionListen
 
     @Override
     public void setProfiler(AppProfiler profiler) {
+        // not implemented
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/post/HDRRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/post/HDRRenderer.java
@@ -62,8 +62,6 @@ public class HDRRenderer implements SceneProcessor {
     private RenderManager renderManager;
     private ViewPort viewPort;
     private static final Logger logger = Logger.getLogger(HDRRenderer.class.getName());
-    private AppProfiler prof;
-
     private Camera fbCam = new Camera(1, 1);
 
     private FrameBuffer msFB;
@@ -429,7 +427,7 @@ public class HDRRenderer implements SceneProcessor {
 
     @Override
     public void setProfiler(AppProfiler profiler) {
-        this.prof = profiler;
+        // not implemented
     }
 
 }

--- a/jme3-core/src/main/java/com/jme3/shadow/BasicShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/BasicShadowRenderer.java
@@ -76,7 +76,6 @@ public class BasicShadowRenderer implements SceneProcessor {
 
     protected GeometryList lightReceivers = new GeometryList(new OpaqueComparator());
     protected GeometryList shadowOccluders = new GeometryList(new OpaqueComparator());
-    private AppProfiler prof;
 
     /**
      * Creates a BasicShadowRenderer
@@ -231,7 +230,7 @@ public class BasicShadowRenderer implements SceneProcessor {
 
     @Override
     public void setProfiler(AppProfiler profiler) {
-        this.prof = profiler;
+        // not implemented
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/shadow/PssmShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/PssmShadowRenderer.java
@@ -76,8 +76,6 @@ import java.util.List;
 @Deprecated
 public class PssmShadowRenderer implements SceneProcessor {
 
-    private AppProfiler prof;
-
     /**
      * <code>FilterMode</code> specifies how shadows are filtered
      * @deprecated use {@link EdgeFilteringMode}
@@ -734,7 +732,7 @@ public class PssmShadowRenderer implements SceneProcessor {
 
     @Override
     public void setProfiler(AppProfiler profiler) {
-        this.prof = profiler;
+        // not implemented
     }
 
     /**

--- a/jme3-desktop/src/main/java/com/jme3/app/state/VideoRecorderAppState.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/VideoRecorderAppState.java
@@ -222,7 +222,6 @@ public class VideoRecorderAppState extends AbstractAppState {
         private LinkedBlockingQueue<WorkItem> freeItems;
         private LinkedBlockingQueue<WorkItem> usedItems = new LinkedBlockingQueue<>();
         private MjpegFileWriter writer;
-        private AppProfiler prof;
 
         public void addImage(Renderer renderer, FrameBuffer out) {
             if (freeItems == null) {
@@ -312,7 +311,7 @@ public class VideoRecorderAppState extends AbstractAppState {
 
         @Override
         public void setProfiler(AppProfiler profiler) {
-            this.prof = profiler;
+            // not implemented
         }
     }
 

--- a/jme3-desktop/src/main/java/com/jme3/system/AWTFrameProcessor.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/AWTFrameProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -186,8 +186,7 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
 
 	@Override
 	public void setProfiler(AppProfiler profiler) {
-		// TODO Auto-generated method stub
-
+            // not implemented
 	}
 
 	@Override

--- a/jme3-effects/src/main/java/com/jme3/water/ReflectionProcessor.java
+++ b/jme3-effects/src/main/java/com/jme3/water/ReflectionProcessor.java
@@ -110,6 +110,7 @@ public class ReflectionProcessor implements SceneProcessor {
 
     @Override
     public void setProfiler(AppProfiler profiler) {
+        // not implemented
     }
 
     /**

--- a/jme3-effects/src/main/java/com/jme3/water/SimpleWaterProcessor.java
+++ b/jme3-effects/src/main/java/com/jme3/water/SimpleWaterProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -120,8 +120,6 @@ public class SimpleWaterProcessor implements SceneProcessor {
     private float distortionScale = 0.2f;
     private float distortionMix = 0.5f;
     private float texScale = 1f;
-    private AppProfiler prof;
-
 
     /**
      * Creates a SimpleWaterProcessor
@@ -227,7 +225,7 @@ public class SimpleWaterProcessor implements SceneProcessor {
 
     @Override
     public void setProfiler(AppProfiler profiler) {
-        this.prof = profiler;
+        // not implemented
     }
 
     //debug only : displays maps
@@ -593,7 +591,6 @@ public class SimpleWaterProcessor implements SceneProcessor {
 
         RenderManager rm;
         ViewPort vp;
-        private AppProfiler prof;
 
         @Override
         public void initialize(RenderManager rm, ViewPort vp) {
@@ -630,7 +627,7 @@ public class SimpleWaterProcessor implements SceneProcessor {
 
         @Override
         public void setProfiler(AppProfiler profiler) {
-            this.prof = profiler;
+            // not implemented
         }
     }
 }

--- a/jme3-examples/src/main/java/jme3test/post/TestMultiRenderTarget.java
+++ b/jme3-examples/src/main/java/jme3test/post/TestMultiRenderTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -242,7 +242,7 @@ public class TestMultiRenderTarget extends SimpleApplication implements ScenePro
 
     @Override
     public void setProfiler(AppProfiler profiler) {
-
+        // not implemented
     }
 
 }

--- a/jme3-examples/src/main/java/jme3test/post/TestRenderToMemory.java
+++ b/jme3-examples/src/main/java/jme3test/post/TestRenderToMemory.java
@@ -264,7 +264,7 @@ public class TestRenderToMemory extends SimpleApplication implements SceneProces
 
     @Override
     public void setProfiler(AppProfiler profiler) {
-
+        // not implemented
     }
 
 


### PR DESCRIPTION
When a `SceneProcessor` doesn't implement profiling, delete the unused private `prof` field and document the empty code block in the `setProfiler()` method.