### PR TITLE
FieldSerializer: do not ignore final fields.

### DIFF
--- a/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/FieldSerializer.java
+++ b/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/FieldSerializer.java
@@ -98,7 +98,6 @@ public class FieldSerializer extends Serializer {
         for (Field field : fields) {
             int modifiers = field.getModifiers();
             if (Modifier.isTransient(modifiers)) continue;
-            if (Modifier.isFinal(modifiers)) continue;
             if (Modifier.isStatic(modifiers)) continue;
             if (field.isSynthetic()) continue;
             field.setAccessible(true);


### PR DESCRIPTION
This patch allows serializing final fields for sending over the network.

Note this is possible due to obtaining reflection access to the final field otherwise it will throw IllegalAccessException.

https://github.com/jMonkeyEngine/jmonkeyengine/blob/c3e06bd507cb22de81cf91e095dca4ca2f29b4e1/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/FieldSerializer.java#L104