### PR TITLE
avoid accessing static fields through instance variables

### DIFF
--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/KinematicRagdollControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/KinematicRagdollControl.java
@@ -283,7 +283,7 @@ public class KinematicRagdollControl extends AbstractPhysicsControl implements P
         }
         if(mode == Mode.IK){
             ikUpdate(tpf);
-        } else if (mode == mode.Ragdoll && targetModel.getLocalTranslation().equals(modelPosition)) {
+        } else if (mode == Mode.Ragdoll && targetModel.getLocalTranslation().equals(modelPosition)) {
             //if the ragdoll has the control of the skeleton, we update each bone with its position in physics world space.
             ragDollUpdate(tpf);
         } else {

--- a/jme3-core/src/main/java/com/jme3/cinematic/events/AnimationEvent.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/events/AnimationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -339,10 +339,10 @@ public class AnimationEvent extends AbstractCinematicEvent {
             channel.setAnim(animationName, blendTime);
         }
         float t = time;
-        if (loopMode == loopMode.Loop) {
+        if (loopMode == LoopMode.Loop) {
             t = t % channel.getAnimMaxTime();
         }
-        if (loopMode == loopMode.Cycle) {
+        if (loopMode == LoopMode.Cycle) {
             float parity = (float) Math.ceil(time / channel.getAnimMaxTime());
             if (parity > 0 && parity % 2 == 0) {
                 t = channel.getAnimMaxTime() - t % channel.getAnimMaxTime();

--- a/jme3-examples/src/main/java/jme3test/animation/TestCinematic.java
+++ b/jme3-examples/src/main/java/jme3test/animation/TestCinematic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,6 +37,7 @@ import com.jme3.cinematic.*;
 import com.jme3.cinematic.events.*;
 import com.jme3.font.BitmapText;
 import com.jme3.input.ChaseCamera;
+import com.jme3.input.KeyInput;
 import com.jme3.input.controls.ActionListener;
 import com.jme3.input.controls.KeyTrigger;
 import com.jme3.light.DirectionalLight;
@@ -242,9 +243,9 @@ public class TestCinematic extends SimpleApplication {
     }
 
     private void initInputs() {
-        inputManager.addMapping("togglePause", new KeyTrigger(keyInput.KEY_RETURN));
-        inputManager.addMapping("navFwd", new KeyTrigger(keyInput.KEY_RIGHT));
-        inputManager.addMapping("navBack", new KeyTrigger(keyInput.KEY_LEFT));
+        inputManager.addMapping("togglePause", new KeyTrigger(KeyInput.KEY_RETURN));
+        inputManager.addMapping("navFwd", new KeyTrigger(KeyInput.KEY_RIGHT));
+        inputManager.addMapping("navBack", new KeyTrigger(KeyInput.KEY_LEFT));
         ActionListener acl = new ActionListener() {
 
             @Override

--- a/jme3-examples/src/main/java/jme3test/helloworld/HelloInput.java
+++ b/jme3-examples/src/main/java/jme3test/helloworld/HelloInput.java
@@ -69,7 +69,7 @@ public class HelloInput extends SimpleApplication {
   /** Custom Keybinding: Map named actions to inputs. */
   private void initKeys() {
     /** You can map one or several inputs to one named mapping. */
-    inputManager.addMapping("Pause",  new KeyTrigger(keyInput.KEY_P));
+    inputManager.addMapping("Pause",  new KeyTrigger(KeyInput.KEY_P));
     inputManager.addMapping("Left",   new KeyTrigger(KeyInput.KEY_J));
     inputManager.addMapping("Right",  new KeyTrigger(KeyInput.KEY_K));
     inputManager.addMapping("Rotate", new KeyTrigger(KeyInput.KEY_SPACE), // spacebar!

--- a/jme3-examples/src/main/java/jme3test/input/TestCameraNode.java
+++ b/jme3-examples/src/main/java/jme3test/input/TestCameraNode.java
@@ -32,6 +32,7 @@
 package jme3test.input;
 
 import com.jme3.app.SimpleApplication;
+import com.jme3.input.KeyInput;
 import com.jme3.input.MouseInput;
 import com.jme3.input.controls.*;
 import com.jme3.material.Material;
@@ -102,10 +103,10 @@ public class TestCameraNode extends SimpleApplication implements AnalogListener,
   }
 
   public void registerInput() {
-    inputManager.addMapping("moveForward", new KeyTrigger(keyInput.KEY_UP), new KeyTrigger(keyInput.KEY_W));
-    inputManager.addMapping("moveBackward", new KeyTrigger(keyInput.KEY_DOWN), new KeyTrigger(keyInput.KEY_S));
-    inputManager.addMapping("moveRight", new KeyTrigger(keyInput.KEY_RIGHT), new KeyTrigger(keyInput.KEY_D));
-    inputManager.addMapping("moveLeft", new KeyTrigger(keyInput.KEY_LEFT), new KeyTrigger(keyInput.KEY_A));
+    inputManager.addMapping("moveForward", new KeyTrigger(KeyInput.KEY_UP), new KeyTrigger(KeyInput.KEY_W));
+    inputManager.addMapping("moveBackward", new KeyTrigger(KeyInput.KEY_DOWN), new KeyTrigger(KeyInput.KEY_S));
+    inputManager.addMapping("moveRight", new KeyTrigger(KeyInput.KEY_RIGHT), new KeyTrigger(KeyInput.KEY_D));
+    inputManager.addMapping("moveLeft", new KeyTrigger(KeyInput.KEY_LEFT), new KeyTrigger(KeyInput.KEY_A));
     inputManager.addMapping("toggleRotate", new MouseButtonTrigger(MouseInput.BUTTON_LEFT));
     inputManager.addMapping("rotateRight", new MouseAxisTrigger(MouseInput.AXIS_X, true));
     inputManager.addMapping("rotateLeft", new MouseAxisTrigger(MouseInput.AXIS_X, false));

--- a/jme3-examples/src/main/java/jme3test/input/TestChaseCamera.java
+++ b/jme3-examples/src/main/java/jme3test/input/TestChaseCamera.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,6 +33,7 @@ package jme3test.input;
 
 import com.jme3.app.SimpleApplication;
 import com.jme3.input.ChaseCamera;
+import com.jme3.input.KeyInput;
 import com.jme3.input.controls.ActionListener;
 import com.jme3.input.controls.AnalogListener;
 import com.jme3.input.controls.KeyTrigger;
@@ -108,11 +109,11 @@ public class TestChaseCamera extends SimpleApplication implements AnalogListener
   }
 
   public void registerInput() {
-    inputManager.addMapping("moveForward", new KeyTrigger(keyInput.KEY_UP), new KeyTrigger(keyInput.KEY_W));
-    inputManager.addMapping("moveBackward", new KeyTrigger(keyInput.KEY_DOWN), new KeyTrigger(keyInput.KEY_S));
-    inputManager.addMapping("moveRight", new KeyTrigger(keyInput.KEY_RIGHT), new KeyTrigger(keyInput.KEY_D));
-    inputManager.addMapping("moveLeft", new KeyTrigger(keyInput.KEY_LEFT), new KeyTrigger(keyInput.KEY_A));
-    inputManager.addMapping("displayPosition", new KeyTrigger(keyInput.KEY_P));
+    inputManager.addMapping("moveForward", new KeyTrigger(KeyInput.KEY_UP), new KeyTrigger(KeyInput.KEY_W));
+    inputManager.addMapping("moveBackward", new KeyTrigger(KeyInput.KEY_DOWN), new KeyTrigger(KeyInput.KEY_S));
+    inputManager.addMapping("moveRight", new KeyTrigger(KeyInput.KEY_RIGHT), new KeyTrigger(KeyInput.KEY_D));
+    inputManager.addMapping("moveLeft", new KeyTrigger(KeyInput.KEY_LEFT), new KeyTrigger(KeyInput.KEY_A));
+    inputManager.addMapping("displayPosition", new KeyTrigger(KeyInput.KEY_P));
     inputManager.addListener(this, "moveForward", "moveBackward", "moveRight", "moveLeft");
     inputManager.addListener(this, "displayPosition");
   }

--- a/jme3-examples/src/main/java/jme3test/input/TestJoystick.java
+++ b/jme3-examples/src/main/java/jme3test/input/TestJoystick.java
@@ -7,6 +7,7 @@ import com.jme3.font.BitmapText;
 import com.jme3.input.Joystick;
 import com.jme3.input.JoystickAxis;
 import com.jme3.input.JoystickButton;
+import com.jme3.input.MouseInput;
 import com.jme3.input.RawInputListener;
 import com.jme3.input.controls.ActionListener;
 import com.jme3.input.controls.MouseButtonTrigger;
@@ -84,7 +85,7 @@ public class TestJoystick extends SimpleApplication {
         
         // add action listener for mouse click 
         // to all easier custom mapping
-        inputManager.addMapping("mouseClick", new MouseButtonTrigger(mouseInput.BUTTON_LEFT));
+        inputManager.addMapping("mouseClick", new MouseButtonTrigger(MouseInput.BUTTON_LEFT));
         inputManager.addListener(new ActionListener() {
             @Override
             public void onAction(String name, boolean isPressed, float tpf) {

--- a/jme3-examples/src/main/java/jme3test/post/TestDepthOfField.java
+++ b/jme3-examples/src/main/java/jme3test/post/TestDepthOfField.java
@@ -34,6 +34,7 @@ package jme3test.post;
 import com.jme3.app.SimpleApplication;
 import com.jme3.collision.CollisionResult;
 import com.jme3.collision.CollisionResults;
+import com.jme3.input.KeyInput;
 import com.jme3.input.controls.ActionListener;
 import com.jme3.input.controls.AnalogListener;
 import com.jme3.input.controls.KeyTrigger;
@@ -164,13 +165,13 @@ public class TestDepthOfField extends SimpleApplication {
         }, "blurScaleUp", "blurScaleDown", "focusRangeUp", "focusRangeDown", "focusDistanceUp", "focusDistanceDown");
 
 
-        inputManager.addMapping("toggle", new KeyTrigger(keyInput.KEY_SPACE));
-        inputManager.addMapping("blurScaleUp", new KeyTrigger(keyInput.KEY_U));
-        inputManager.addMapping("blurScaleDown", new KeyTrigger(keyInput.KEY_J));
-        inputManager.addMapping("focusRangeUp", new KeyTrigger(keyInput.KEY_I));
-        inputManager.addMapping("focusRangeDown", new KeyTrigger(keyInput.KEY_K));
-        inputManager.addMapping("focusDistanceUp", new KeyTrigger(keyInput.KEY_O));
-        inputManager.addMapping("focusDistanceDown", new KeyTrigger(keyInput.KEY_L));
+        inputManager.addMapping("toggle", new KeyTrigger(KeyInput.KEY_SPACE));
+        inputManager.addMapping("blurScaleUp", new KeyTrigger(KeyInput.KEY_U));
+        inputManager.addMapping("blurScaleDown", new KeyTrigger(KeyInput.KEY_J));
+        inputManager.addMapping("focusRangeUp", new KeyTrigger(KeyInput.KEY_I));
+        inputManager.addMapping("focusRangeDown", new KeyTrigger(KeyInput.KEY_K));
+        inputManager.addMapping("focusDistanceUp", new KeyTrigger(KeyInput.KEY_O));
+        inputManager.addMapping("focusDistanceDown", new KeyTrigger(KeyInput.KEY_L));
 
     }
 

--- a/jme3-examples/src/main/java/jme3test/water/TestPostWaterLake.java
+++ b/jme3-examples/src/main/java/jme3test/water/TestPostWaterLake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,6 +34,7 @@ package jme3test.water;
 import com.jme3.app.SimpleApplication;
 import com.jme3.asset.plugins.HttpZipLocator;
 import com.jme3.asset.plugins.ZipLocator;
+import com.jme3.input.KeyInput;
 import com.jme3.input.controls.ActionListener;
 import com.jme3.input.controls.KeyTrigger;
 import com.jme3.light.DirectionalLight;
@@ -121,6 +122,6 @@ public class TestPostWaterLake extends SimpleApplication {
             }
         }, "HQ");
 
-        inputManager.addMapping("HQ", new KeyTrigger(keyInput.KEY_SPACE));
+        inputManager.addMapping("HQ", new KeyTrigger(KeyInput.KEY_SPACE));
     }
 }


### PR DESCRIPTION
As NetBeans likes to point out, "Java language allows access to static fields thru instance variables, however this is often misleading and harder to read."