### PR TITLE
delete deprecated setters that are currently no-ops

### DIFF
--- a/jme3-core/src/main/java/com/jme3/animation/Bone.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Bone.java
@@ -664,16 +664,6 @@ public final class Bone implements Savable, JmeCloneable {
     }
 
     /**
-     * 
-     * @param translation -
-     * @param rotation -
-     * @deprecated use {@link #setUserTransformsInModelSpace(com.jme3.math.Vector3f, com.jme3.math.Quaternion) }
-     */
-    @Deprecated
-    public void setUserTransformsWorld(Vector3f translation, Quaternion rotation) {
-        
-    }
-    /**
      * Sets the transforms of this bone in model space (relative to the root bone)
      * 
      * Must update all bones in skeleton for this to work.

--- a/jme3-core/src/main/java/com/jme3/light/LightProbe.java
+++ b/jme3-core/src/main/java/com/jme3/light/LightProbe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -207,17 +207,6 @@ public class LightProbe extends Light implements Savable {
     @Deprecated
     public BoundingVolume getBounds() {
         return new BoundingSphere(area.getRadius(), ((SphereProbeArea)area).getCenter());
-    }
-
-    /**
-     * Sets the bounds of this LightProbe
-     * Note that for now only BoundingSphere is supported and this method will
-     * throw an UnsupportedOperationException with any other BoundingVolume type
-     * @param bounds the bounds of the LightProbe
-     * @deprecated
-     */
-    @Deprecated
-    public void setBounds(BoundingVolume bounds) {
     }
 
     public ProbeArea getArea() {

--- a/jme3-core/src/main/java/com/jme3/material/RenderState.java
+++ b/jme3-core/src/main/java/com/jme3/material/RenderState.java
@@ -705,33 +705,6 @@ public class RenderState implements Cloneable, Savable {
     }
 
     /**
-     * @deprecated Does nothing. Point sprite is already enabled by default for
-     * all supported platforms. jME3 does not support rendering conventional
-     * point clouds.
-     */
-    @Deprecated
-    public void setPointSprite(boolean pointSprite) {
-    }
-
-    /**
-     * @deprecated Does nothing. To use alpha test, set the
-     * <code>AlphaDiscardThreshold</code> material parameter.
-     * @param alphaFallOff does nothing
-     */
-    @Deprecated
-    public void setAlphaFallOff(float alphaFallOff) {
-    }
-
-    /**
-     * @deprecated Does nothing. To use alpha test, set the
-     * <code>AlphaDiscardThreshold</code> material parameter.
-     * @param alphaTest does nothing
-     */
-    @Deprecated
-    public void setAlphaTest(boolean alphaTest) {
-    }
-
-    /**
      * Enable writing color.
      *
      * <p>When color write is enabled, the result of a fragment shader, the
@@ -980,13 +953,6 @@ public class RenderState implements Cloneable, Savable {
     }
 
     /**
-     * @deprecated
-     */
-    @Deprecated
-    public void setAlphaFunc(TestFunction alphaFunc) {
-    }
-
-    /**
      * Sets the mesh line width.
      * Use this in conjunction with {@link #setWireframe(boolean)} or with a mesh in
      * {@link com.jme3.scene.Mesh.Mode#Lines} mode.
@@ -1232,7 +1198,6 @@ public class RenderState implements Cloneable, Savable {
     /**
      * @return true
      * @deprecated Always returns true since point sprite is always enabled.
-     * @see #setPointSprite(boolean)
      */
     @Deprecated
     public boolean isPointSprite() {

--- a/jme3-core/src/main/java/com/jme3/renderer/RenderContext.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -87,9 +87,6 @@ public class RenderContext {
      */
     public float polyOffsetUnits;
 
-    /**
-     * @see Mesh#setPointSize(float)
-     */
     public float pointSize;
 
     /**

--- a/jme3-core/src/main/java/com/jme3/renderer/RenderContext.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderContext.java
@@ -35,7 +35,6 @@ import java.lang.ref.WeakReference;
 
 import com.jme3.material.RenderState;
 import com.jme3.math.ColorRGBA;
-import com.jme3.scene.Mesh;
 import com.jme3.scene.VertexBuffer;
 import com.jme3.shader.Shader;
 import com.jme3.texture.FrameBuffer;

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,8 +57,6 @@ import java.util.ArrayList;
  * Meshes may contain three types of geometric primitives:
  * <ul>
  * <li>Points - Every vertex represents a single point in space.
- * Points can also be used for {@link RenderState#setPointSprite(boolean) point
- * sprite} mode.</li>
  * <li>Lines - 2 vertices represent a line segment, with the width specified
  * via {@link Material#getAdditionalRenderState()} and {@link RenderState#setLineWidth(float)}.</li>
  * <li>Triangles - 3 vertices represent a solid triangle primitive. </li>
@@ -613,22 +611,10 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
      * determined in the vertex shader.
      *
      * @return <code>1.0</code>
-     *
-     * @see #setPointSize(float)
      */
     @Deprecated
     public float getPointSize() {
         return 1.0f;
-    }
-
-    /**
-     * @deprecated Does nothing, since the size of {@link Mode#Points points} is
-     * determined via the vertex shader's <code>gl_PointSize</code> output.
-     *
-     * @param pointSize ignored
-     */
-    @Deprecated
-    public void setPointSize(float pointSize) {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -223,12 +223,6 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
     public boolean isFlushQueues() {
         return shadowRenderer.isFlushQueues();
     }
-
-    /**
-     * setFlushQueues does nothing now and is kept only for backward compatibility
-     */
-    @Deprecated
-    public void setFlushQueues(boolean flushQueues) {}
 
     /**
      * sets the shadow compare mode see {@link CompareMode} for more info

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
@@ -769,12 +769,6 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable,
     public boolean isFlushQueues() { return false; }
 
     /**
-     * setFlushQueues does nothing now and is kept only for backward compatibility
-     */
-    @Deprecated
-    public void setFlushQueues(boolean flushQueues) {}
-
-    /**
      * returns the pre shadows pass render state.
      * use it to adjust the RenderState parameters of the pre shadow pass.
      * Note that this will be overridden if the preShadow technique in the material has a ForcedRenderState

--- a/jme3-core/src/main/java/com/jme3/texture/Image.java
+++ b/jme3-core/src/main/java/com/jme3/texture/Image.java
@@ -959,13 +959,6 @@ public class Image extends NativeObject implements Savable /*, Cloneable*/ {
      * @deprecated This feature is no longer used by the engine
      */
     @Deprecated
-    public void setEfficentData(Object efficientData){
-    }
-
-    /**
-     * @deprecated This feature is no longer used by the engine
-     */
-    @Deprecated
     public Object getEfficentData(){
         return null;
     }

--- a/jme3-core/src/plugins/java/com/jme3/material/plugins/J3MLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/material/plugins/J3MLoader.java
@@ -488,7 +488,7 @@ public class J3MLoader implements AssetLoader {
         }else if (split[0].equals("DepthFunc")){
             renderState.setDepthFunc(RenderState.TestFunction.valueOf(split[1]));
         }else if (split[0].equals("AlphaFunc")){
-            renderState.setAlphaFunc(RenderState.TestFunction.valueOf(split[1]));
+            // ignore for backwards compatbility
         }else if (split[0].equals("LineWidth")){
             renderState.setLineWidth(Float.parseFloat(split[1]));
         } else {

--- a/jme3-vr/src/main/java/com/jme3/shadow/AbstractShadowFilterVR.java
+++ b/jme3-vr/src/main/java/com/jme3/shadow/AbstractShadowFilterVR.java
@@ -1,7 +1,7 @@
 package com.jme3.shadow;
 
 /*
- * Copyright (c) 2009-2019 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -232,14 +232,6 @@ public abstract class AbstractShadowFilterVR<T extends AbstractShadowRendererVR>
     public boolean isFlushQueues() {
         return shadowRenderer.isFlushQueues();
     }
-
-    /**
-     * setFlushQueues does nothing now and is kept only for backward compatibility.
-     * @param flushQueues can be <code>true</code> or <code>false</code>.
-     * @deprecated does nothing now and is kept only for backward compatibility.
-     */
-    @Deprecated
-    public void setFlushQueues(boolean flushQueues) {}
 
     /**
      * Sets the shadow compare mode (see {@link CompareMode} for more info).

--- a/jme3-vr/src/main/java/com/jme3/shadow/AbstractShadowRendererVR.java
+++ b/jme3-vr/src/main/java/com/jme3/shadow/AbstractShadowRendererVR.java
@@ -756,15 +756,6 @@ public abstract class AbstractShadowRendererVR implements SceneProcessor, Savabl
     public boolean isFlushQueues() { return false; }
 
     /**
-     * This method does nothing now and is kept only for backward compatibility.
-     * @param flushQueues any boolean.
-     * @deprecated This method does nothing now and is kept only for backward compatibility.
-     */
-    @Deprecated
-    public void setFlushQueues(boolean flushQueues) {}
-
-
-    /**
      * Returns the pre shadows pass render state.
      * use it to adjust the RenderState parameters of the pre shadow pass.
      * Note that this will be overridden if the preShadow technique in the material has a ForcedRenderState


### PR DESCRIPTION
Many classes, fields, and methods were deprecated in v3.3 and earlier releases. Few (if any) of them have been deleted.  Many deprecated classes and method still work, so developers may be tempted to ignore deprecation warnings.

This PR deletes previously deprecated *setter* methods that are currently no-ops. Such methods are hazards because they fail silently. Developers might use them without realizing they are no longer implemented.