### PR TITLE
Fixed for windows and linux hack for mac threading

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -89,6 +89,8 @@ import java.util.logging.Logger;
 public abstract class LwjglContext implements JmeContext {
 
     private static final Logger logger = Logger.getLogger(LwjglContext.class.getName());
+    
+    protected static final String THREAD_NAME = "jME3 Main";
 
     static {
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -461,9 +461,19 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             return;
         }
 
-        // NOTE: this is required for Mac OS X!
-        mainThread = Thread.currentThread();
-        run();
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("mac os x") || os.contains("darwin")){
+            // NOTE: this is required for Mac OS X!
+            mainThread = Thread.currentThread();
+            run();
+
+        } else {
+            new Thread(this, THREAD_NAME).start();
+
+            if (waitFor) {
+                waitFor(true);
+            }    
+        }
     }
 
     /**


### PR DESCRIPTION
I believe the function was broken 5 years ago to "satisfy a Mac problem?" - it does not spawn a new asynchronous thread or obey the waitFor parameter as was originally intended.

I was not sure what to do, I don't have a Mac, so I put in a conditional - probably someone who has mac hardware could fix this the right case for the single use case.