### PR TITLE
privatize package-private loggers

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/tween/Tweens.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/Tweens.java
@@ -47,7 +47,7 @@ import java.util.logging.Logger;
  */
 public class Tweens {
 
-    static Logger log = Logger.getLogger(Tweens.class.getName());
+    private static final Logger log = Logger.getLogger(Tweens.class.getName());
 
     private static final CurveFunction SMOOTH = new SmoothStep();
     private static final CurveFunction SINE = new Sine();

--- a/jme3-core/src/main/java/com/jme3/app/state/BaseAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/BaseAppState.java
@@ -73,7 +73,7 @@ import java.util.logging.Logger;
  */
 public abstract class BaseAppState implements AppState {
 
-    static final Logger log = Logger.getLogger(BaseAppState.class.getName());
+    private static final Logger log = Logger.getLogger(BaseAppState.class.getName());
 
     private Application app;
     private boolean initialized;

--- a/jme3-core/src/main/java/com/jme3/app/state/ConstantVerifierState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/ConstantVerifierState.java
@@ -52,7 +52,7 @@ import static java.lang.Float.NEGATIVE_INFINITY;
  */
 public class ConstantVerifierState extends BaseAppState {
 
-    static final Logger log = Logger.getLogger(BaseAppState.class.getName());
+    private static final Logger log = Logger.getLogger(BaseAppState.class.getName());
 
     // Note: I've used actual constructed objects for the good values
     //       instead of clone just to better catch cases where the values

--- a/jme3-core/src/main/java/com/jme3/util/clone/Cloner.java
+++ b/jme3-core/src/main/java/com/jme3/util/clone/Cloner.java
@@ -99,7 +99,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class Cloner {
 
-    final static Logger log = Logger.getLogger(Cloner.class.getName());
+    private static final Logger log = Logger.getLogger(Cloner.class.getName());
 
     /**
      *  Keeps track of the objects that have been cloned so far.

--- a/jme3-networking/src/main/java/com/jme3/network/base/DefaultClient.java
+++ b/jme3-networking/src/main/java/com/jme3/network/base/DefaultClient.java
@@ -57,7 +57,7 @@ import java.util.logging.Logger;
  */
 public class DefaultClient implements Client
 {
-    static final Logger log = Logger.getLogger(DefaultClient.class.getName());
+    private static final Logger log = Logger.getLogger(DefaultClient.class.getName());
     
     // First two channels are reserved for reliable and
     // unreliable.  Note: channels are endpoint specific so these

--- a/jme3-networking/src/main/java/com/jme3/network/base/DefaultServer.java
+++ b/jme3-networking/src/main/java/com/jme3/network/base/DefaultServer.java
@@ -58,7 +58,7 @@ import java.util.logging.Logger;
  */
 public class DefaultServer implements Server
 {
-    static final Logger log = Logger.getLogger(DefaultServer.class.getName());
+    private static final Logger log = Logger.getLogger(DefaultServer.class.getName());
 
     // First two channels are reserved for reliable and
     // unreliable

--- a/jme3-networking/src/main/java/com/jme3/network/base/KernelAdapter.java
+++ b/jme3-networking/src/main/java/com/jme3/network/base/KernelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,7 +64,7 @@ import java.util.logging.Logger;
  */
 public class KernelAdapter extends Thread
 {
-    static Logger log = Logger.getLogger(KernelAdapter.class.getName());
+    private static final Logger log = Logger.getLogger(KernelAdapter.class.getName());
     
     private DefaultServer server; // this is unfortunate
     private Kernel kernel;

--- a/jme3-networking/src/main/java/com/jme3/network/base/MessageListenerRegistry.java
+++ b/jme3-networking/src/main/java/com/jme3/network/base/MessageListenerRegistry.java
@@ -50,7 +50,7 @@ import java.util.logging.Logger;
  */
 public class MessageListenerRegistry<S> implements MessageListener<S>
 {
-    static final Logger log = Logger.getLogger(MessageListenerRegistry.class.getName());
+    private static final Logger log = Logger.getLogger(MessageListenerRegistry.class.getName());
     
     private final List<MessageListener<? super S>> listeners = new CopyOnWriteArrayList<>();
     private final Map<Class,List<MessageListener<? super S>>> typeListeners 

--- a/jme3-networking/src/main/java/com/jme3/network/kernel/AbstractKernel.java
+++ b/jme3-networking/src/main/java/com/jme3/network/kernel/AbstractKernel.java
@@ -49,7 +49,7 @@ import java.util.logging.Logger;
  */
 public abstract class AbstractKernel implements Kernel
 {
-    static Logger log = Logger.getLogger(AbstractKernel.class.getName());
+    private static final Logger log = Logger.getLogger(AbstractKernel.class.getName());
 
     private AtomicLong nextId = new AtomicLong(1);
 

--- a/jme3-networking/src/main/java/com/jme3/network/kernel/tcp/SelectorKernel.java
+++ b/jme3-networking/src/main/java/com/jme3/network/kernel/tcp/SelectorKernel.java
@@ -56,7 +56,7 @@ import java.util.logging.Logger;
  */
 public class SelectorKernel extends AbstractKernel
 {
-    static Logger log = Logger.getLogger(SelectorKernel.class.getName());
+    private static final Logger log = Logger.getLogger(SelectorKernel.class.getName());
 
     private InetSocketAddress address;
     private SelectorThread thread;

--- a/jme3-networking/src/main/java/com/jme3/network/kernel/udp/UdpKernel.java
+++ b/jme3-networking/src/main/java/com/jme3/network/kernel/udp/UdpKernel.java
@@ -52,7 +52,7 @@ import java.util.logging.Logger;
  */
 public class UdpKernel extends AbstractKernel
 {
-    static Logger log = Logger.getLogger(UdpKernel.class.getName());
+    private static final Logger log = Logger.getLogger(UdpKernel.class.getName());
 
     private InetSocketAddress address;
     private HostThread thread;

--- a/jme3-networking/src/main/java/com/jme3/network/message/SerializerRegistrationsMessage.java
+++ b/jme3-networking/src/main/java/com/jme3/network/message/SerializerRegistrationsMessage.java
@@ -65,7 +65,7 @@ import java.util.logging.Logger;
 @Serializable
 public class SerializerRegistrationsMessage extends AbstractMessage {
 
-    static final Logger log = Logger.getLogger(SerializerRegistrationsMessage.class.getName());
+    private static final Logger log = Logger.getLogger(SerializerRegistrationsMessage.class.getName());
 
     public static final Set<Class> ignore = new HashSet<Class>();
     static {

--- a/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/FieldSerializer.java
+++ b/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/FieldSerializer.java
@@ -50,7 +50,7 @@ import java.util.logging.Logger;
  */
 public class FieldSerializer extends Serializer {
     
-    static final Logger log = Logger.getLogger(FieldSerializer.class.getName());
+    private static final Logger log = Logger.getLogger(FieldSerializer.class.getName());
 
     private static Map<Class, SavedField[]> savedFields = new HashMap<Class, SavedField[]>();
     private static Map<Class, Constructor> savedCtors = new HashMap<Class, Constructor>();

--- a/jme3-networking/src/main/java/com/jme3/network/service/AbstractHostedConnectionService.java
+++ b/jme3-networking/src/main/java/com/jme3/network/service/AbstractHostedConnectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 jMonkeyEngine
+ * Copyright (c) 2015-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,7 +57,7 @@ import java.util.logging.Logger;
  */
 public abstract class AbstractHostedConnectionService extends AbstractHostedService { 
  
-    static final Logger log = Logger.getLogger(AbstractHostedConnectionService.class.getName());
+    private static final Logger log = Logger.getLogger(AbstractHostedConnectionService.class.getName());
 
     private boolean autoHost;
     

--- a/jme3-networking/src/main/java/com/jme3/network/service/ServiceManager.java
+++ b/jme3-networking/src/main/java/com/jme3/network/service/ServiceManager.java
@@ -46,7 +46,7 @@ import java.util.logging.Logger;
  */
 public abstract class ServiceManager<T> {
 
-    static final Logger log = Logger.getLogger(ServiceManager.class.getName());
+    private static final Logger log = Logger.getLogger(ServiceManager.class.getName());
     
     private final List<Service<T>> services = new CopyOnWriteArrayList<>();
     private volatile boolean started = false;

--- a/jme3-networking/src/main/java/com/jme3/network/service/rmi/RmiHostedService.java
+++ b/jme3-networking/src/main/java/com/jme3/network/service/rmi/RmiHostedService.java
@@ -75,7 +75,7 @@ import java.util.logging.Logger;
  */
 public class RmiHostedService extends AbstractHostedService {
 
-    static final Logger log = Logger.getLogger(RpcHostedService.class.getName());
+    private static final Logger log = Logger.getLogger(RpcHostedService.class.getName());
     
     public static final String ATTRIBUTE_NAME = "rmi";
 

--- a/jme3-networking/src/main/java/com/jme3/network/service/rmi/RmiRegistry.java
+++ b/jme3-networking/src/main/java/com/jme3/network/service/rmi/RmiRegistry.java
@@ -54,7 +54,7 @@ import java.util.logging.Logger;
  */
 public class RmiRegistry {
 
-    static final Logger log = Logger.getLogger(RmiRegistry.class.getName());
+    private static final Logger log = Logger.getLogger(RmiRegistry.class.getName());
 
     // RPC IDs for calling our remote endpoint
     private static final short NEW_CLASS = 0;

--- a/jme3-networking/src/main/java/com/jme3/network/service/rpc/RpcConnection.java
+++ b/jme3-networking/src/main/java/com/jme3/network/service/rpc/RpcConnection.java
@@ -51,7 +51,7 @@ import java.util.logging.Logger;
  */
 public class RpcConnection {
 
-    static final Logger log = Logger.getLogger(RpcConnection.class.getName());
+    private static final Logger log = Logger.getLogger(RpcConnection.class.getName());
  
     /**
      *  The underlying connection upon which RPC call messages are sent

--- a/jme3-networking/src/main/java/com/jme3/network/service/rpc/RpcHostedService.java
+++ b/jme3-networking/src/main/java/com/jme3/network/service/rpc/RpcHostedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 jMonkeyEngine
+ * Copyright (c) 2015-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -66,7 +66,7 @@ public class RpcHostedService extends AbstractHostedConnectionService {
 
     private static final String ATTRIBUTE_NAME = "rpcSession";
 
-    static final Logger log = Logger.getLogger(RpcHostedService.class.getName());
+    private static final Logger log = Logger.getLogger(RpcHostedService.class.getName());
 
     private SessionDataDelegator delegator;
 

--- a/jme3-networking/src/main/java/com/jme3/network/service/serializer/ClientSerializerRegistrationsService.java
+++ b/jme3-networking/src/main/java/com/jme3/network/service/serializer/ClientSerializerRegistrationsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 jMonkeyEngine
+ * Copyright (c) 2015-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -51,7 +51,7 @@ import java.util.logging.Logger;
 public class ClientSerializerRegistrationsService extends AbstractClientService 
                                                   implements MessageListener<Client> {
                                                   
-    static final Logger log = Logger.getLogger(SerializerRegistrationsMessage.class.getName());
+    private static final Logger log = Logger.getLogger(SerializerRegistrationsMessage.class.getName());
 
     @Override
     protected void onInitialize( ClientServiceManager serviceManager ) {

--- a/jme3-networking/src/main/java/com/jme3/network/util/AbstractMessageDelegator.java
+++ b/jme3-networking/src/main/java/com/jme3/network/util/AbstractMessageDelegator.java
@@ -57,7 +57,7 @@ import java.util.logging.Logger;
 public abstract class AbstractMessageDelegator<S extends MessageConnection> 
                                 implements MessageListener<S> {
                                 
-    static final Logger log = Logger.getLogger(AbstractMessageDelegator.class.getName());                                
+    private static final Logger log = Logger.getLogger(AbstractMessageDelegator.class.getName());                                
                                 
     private Class delegateType;
     private Map<Class, Method> methods = new HashMap<>();

--- a/jme3-networking/src/main/java/com/jme3/network/util/SessionDataDelegator.java
+++ b/jme3-networking/src/main/java/com/jme3/network/util/SessionDataDelegator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 jMonkeyEngine
+ * Copyright (c) 2015-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,7 @@ import java.util.logging.Logger;
  */
 public class SessionDataDelegator extends AbstractMessageDelegator<HostedConnection> {
  
-    static final Logger log = Logger.getLogger(SessionDataDelegator.class.getName());
+    private static final Logger log = Logger.getLogger(SessionDataDelegator.class.getName());
     
     private String attributeName;
  


### PR DESCRIPTION
Many JME loggers are declared package-private (with no access modifier). Probably these should all be `public`, `protected`, or `private`. Of these choices, `public` seems the safest.

In a few cases, I added the `final` modifier as well.