### PR TITLE
FXAA.frag: read alpha value from texture instead of passing constant 1

### DIFF
--- a/jme3-effects/src/main/resources/Common/MatDefs/Post/FXAA.frag
+++ b/jme3-effects/src/main/resources/Common/MatDefs/Post/FXAA.frag
@@ -84,6 +84,6 @@ vec3 FxaaPixelShader(
 
 void main()
 {
-
-    gl_FragColor = vec4(FxaaPixelShader(posPos, m_Texture, g_ResolutionInverse), 1.0);
+    vec4 texVal = texture2D(m_Texture, texCoord);
+    gl_FragColor = vec4(FxaaPixelShader(posPos, m_Texture, g_ResolutionInverse), texVal.a);
 }


### PR DESCRIPTION
Forum post: https://hub.jmonkeyengine.org/t/fxaa-filter-removes-transparency/42577/4