### PR TITLE
Refactors the context restart code.

### DIFF
--- a/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java
+++ b/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java
@@ -69,6 +69,7 @@ public abstract class SimpleApplication extends LegacyApplication {
     public static final String INPUT_MAPPING_CAMERA_POS = DebugKeysAppState.INPUT_MAPPING_CAMERA_POS;
     public static final String INPUT_MAPPING_MEMORY = DebugKeysAppState.INPUT_MAPPING_MEMORY;
     public static final String INPUT_MAPPING_HIDE_STATS = "SIMPLEAPP_HideStats";
+    public static final String INPUT_RESTART_CONTEXT = "SIMPLEAPP_Restart";
 
     protected Node rootNode = new Node("Root Node");
     protected Node guiNode = new Node("Gui Node");
@@ -92,6 +93,8 @@ public abstract class SimpleApplication extends LegacyApplication {
                 if (stateManager.getState(StatsAppState.class) != null) {
                     stateManager.getState(StatsAppState.class).toggleStats();
                 }
+            }else if (name.equals(INPUT_RESTART_CONTEXT)){
+                restart();
             }
         }
     }
@@ -219,6 +222,7 @@ public abstract class SimpleApplication extends LegacyApplication {
 
             if (context.getType() == Type.Display) {
                 inputManager.addMapping(INPUT_MAPPING_EXIT, new KeyTrigger(KeyInput.KEY_ESCAPE));
+                inputManager.addMapping(INPUT_RESTART_CONTEXT, new KeyTrigger(KeyInput.KEY_TAB));
             }
 
             if (stateManager.getState(StatsAppState.class) != null) {
@@ -227,6 +231,7 @@ public abstract class SimpleApplication extends LegacyApplication {
             }
 
             inputManager.addListener(actionListener, INPUT_MAPPING_EXIT);
+            inputManager.addListener(actionListener, INPUT_RESTART_CONTEXT);
         }
 
         if (stateManager.getState(StatsAppState.class) != null) {

--- a/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java
+++ b/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java
@@ -69,7 +69,6 @@ public abstract class SimpleApplication extends LegacyApplication {
     public static final String INPUT_MAPPING_CAMERA_POS = DebugKeysAppState.INPUT_MAPPING_CAMERA_POS;
     public static final String INPUT_MAPPING_MEMORY = DebugKeysAppState.INPUT_MAPPING_MEMORY;
     public static final String INPUT_MAPPING_HIDE_STATS = "SIMPLEAPP_HideStats";
-    public static final String INPUT_RESTART_CONTEXT = "SIMPLEAPP_Restart";
 
     protected Node rootNode = new Node("Root Node");
     protected Node guiNode = new Node("Gui Node");
@@ -93,8 +92,6 @@ public abstract class SimpleApplication extends LegacyApplication {
                 if (stateManager.getState(StatsAppState.class) != null) {
                     stateManager.getState(StatsAppState.class).toggleStats();
                 }
-            }else if (name.equals(INPUT_RESTART_CONTEXT)){
-                restart();
             }
         }
     }
@@ -222,7 +219,6 @@ public abstract class SimpleApplication extends LegacyApplication {
 
             if (context.getType() == Type.Display) {
                 inputManager.addMapping(INPUT_MAPPING_EXIT, new KeyTrigger(KeyInput.KEY_ESCAPE));
-                inputManager.addMapping(INPUT_RESTART_CONTEXT, new KeyTrigger(KeyInput.KEY_TAB));
             }
 
             if (stateManager.getState(StatsAppState.class) != null) {
@@ -231,7 +227,6 @@ public abstract class SimpleApplication extends LegacyApplication {
             }
 
             inputManager.addListener(actionListener, INPUT_MAPPING_EXIT);
-            inputManager.addListener(actionListener, INPUT_RESTART_CONTEXT);
         }
 
         if (stateManager.getState(StatsAppState.class) != null) {

--- a/jme3-examples/src/main/java/jme3test/renderer/TestContextRestart.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestContextRestart.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2009-2021 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package jme3test.renderer;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.input.KeyInput;
+import com.jme3.input.controls.ActionListener;
+import com.jme3.input.controls.KeyTrigger;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.FastMath;
+import com.jme3.math.Quaternion;
+import com.jme3.renderer.RenderManager;
+import com.jme3.renderer.ViewPort;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.control.AbstractControl;
+import com.jme3.scene.shape.Box;
+import com.jme3.system.AppSettings;
+
+/**
+ * Tests how gamma correction works after a context restart.
+ *
+ * @author Markil 3
+ */
+public class TestContextRestart extends SimpleApplication {
+    public static void main(String[] args) {
+        TestContextRestart app = new TestContextRestart();
+        AppSettings settings = new AppSettings(true);
+        settings.setGammaCorrection(true);
+        // Still need to see why setting this to anything higher than OPENGL2 causes the screen to blank in redisplay.
+        settings.setRenderer(AppSettings.LWJGL_OPENGL32);
+        app.setSettings(settings);
+        app.start();
+    }
+
+    @Override
+    public void simpleInitApp() {
+        for (int i = 0, l = 256; i < l; i += 8) {
+            Geometry box = new Geometry("Box" + i, new Box(10, 200, 10));
+            Material mat = new Material(this.assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+            mat.setColor("Color", new ColorRGBA((float) i / 255F, 0, 0, 1));
+            box.setMaterial(mat);
+            box.setLocalTranslation(-2.5F * (l / 2 - i), 0, -700);
+            box.addControl(new AbstractControl() {
+                @Override
+                protected void controlUpdate(float tpf) {
+                    float[] angles = this.getSpatial().getLocalRotation().toAngles(new float[3]);
+                    angles[0] = angles[0] + (FastMath.PI / 500F);
+                    this.getSpatial().setLocalRotation(new Quaternion().fromAngles(angles));
+                }
+
+                @Override
+                protected void controlRender(RenderManager rm, ViewPort vp) {
+
+                }
+            });
+            this.rootNode.attachChild(box);
+        }
+
+        this.viewPort.setBackgroundColor(ColorRGBA.Yellow);
+
+        this.flyCam.setEnabled(false);
+        this.inputManager.setCursorVisible(true);
+    }
+}

--- a/jme3-examples/src/main/java/jme3test/renderer/TestContextRestart.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestContextRestart.java
@@ -47,39 +47,60 @@ import com.jme3.scene.shape.Box;
 import com.jme3.system.AppSettings;
 
 /**
- * Tests how gamma correction works after a context restart.
+ * Tests whether gamma correction works after a context restart. This test
+ * generates a series of boxes, each one with a slightly different shade from
+ * the other. If the boxes look the same before and after the restart, that
+ * means that gamma correction is working properly.
+ * <p>
+ * Note that for testing, it may be helpful to bypass the test chooser and run
+ * this class directly, since it can be easier to define your own settings
+ * beforehand. Of course, it should still workif all you need to test is the
+ * gamma correction, as long as you enable it in the settings dialog.
+ * </p>
  *
  * @author Markil 3
  */
-public class TestContextRestart extends SimpleApplication {
-    public static void main(String[] args) {
+public class TestContextRestart extends SimpleApplication
+{
+    public static final String INPUT_RESTART_CONTEXT = "SIMPLEAPP_Restart";
+
+    public static void main(String[] args)
+    {
         TestContextRestart app = new TestContextRestart();
         AppSettings settings = new AppSettings(true);
         settings.setGammaCorrection(true);
-        // Still need to see why setting this to anything higher than OPENGL2 causes the screen to blank in redisplay.
-        settings.setRenderer(AppSettings.LWJGL_OPENGL32);
+//        settings.setRenderer(AppSettings.LWJGL_OPENGL32);
         app.setSettings(settings);
         app.start();
     }
 
     @Override
-    public void simpleInitApp() {
-        for (int i = 0, l = 256; i < l; i += 8) {
+    public void simpleInitApp()
+    {
+        for (int i = 0, l = 256; i < l; i += 8)
+        {
             Geometry box = new Geometry("Box" + i, new Box(10, 200, 10));
-            Material mat = new Material(this.assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+            Material mat = new Material(this.assetManager,
+                    "Common/MatDefs/Misc/Unshaded.j3md");
             mat.setColor("Color", new ColorRGBA((float) i / 255F, 0, 0, 1));
             box.setMaterial(mat);
             box.setLocalTranslation(-2.5F * (l / 2 - i), 0, -700);
-            box.addControl(new AbstractControl() {
+            box.addControl(new AbstractControl()
+            {
                 @Override
-                protected void controlUpdate(float tpf) {
-                    float[] angles = this.getSpatial().getLocalRotation().toAngles(new float[3]);
+                protected void controlUpdate(float tpf)
+                {
+                    float[] angles = this.getSpatial()
+                            .getLocalRotation()
+                            .toAngles(new float[3]);
                     angles[0] = angles[0] + (FastMath.PI / 500F);
-                    this.getSpatial().setLocalRotation(new Quaternion().fromAngles(angles));
+                    this.getSpatial()
+                            .setLocalRotation(new Quaternion().fromAngles(angles));
                 }
 
                 @Override
-                protected void controlRender(RenderManager rm, ViewPort vp) {
+                protected void controlRender(RenderManager rm, ViewPort vp)
+                {
 
                 }
             });
@@ -90,5 +111,19 @@ public class TestContextRestart extends SimpleApplication {
 
         this.flyCam.setEnabled(false);
         this.inputManager.setCursorVisible(true);
+
+        inputManager.addMapping(INPUT_RESTART_CONTEXT, new KeyTrigger(
+                KeyInput.KEY_TAB));
+        this.inputManager.addListener(new ActionListener()
+        {
+            @Override
+            public void onAction(String name, boolean isPressed, float tpf)
+            {
+                if (name.equals(INPUT_RESTART_CONTEXT))
+                {
+                    restart();
+                }
+            }
+        }, INPUT_RESTART_CONTEXT);
     }
 }

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -251,41 +251,51 @@ public abstract class LwjglContext implements JmeContext {
         return samples;
     }
 
+    protected void reinitContext() {
+        initContext(false);
+    }
+
     protected void initContextFirstTime() {
+        initContext(true);
+    }
+
+    private void initContext(boolean first) {
         if (!GLContext.getCapabilities().OpenGL20) {
             throw new RendererException("OpenGL 2.0 or higher is "
                     + "required for jMonkeyEngine");
         }
-        
+
         int vers[] = getGLVersion(settings.getRenderer());
         if (vers != null) {
-            GL gl = new LwjglGL();
-            GLExt glext = new LwjglGLExt();
-            GLFbo glfbo;
-            
-            if (GLContext.getCapabilities().OpenGL30) {
-                glfbo = new LwjglGLFboGL3();
-            } else {
-                glfbo = new LwjglGLFboEXT();
+            if (first) {
+                GL gl = new LwjglGL();
+                GLExt glext = new LwjglGLExt();
+                GLFbo glfbo;
+
+                if (GLContext.getCapabilities().OpenGL30) {
+                    glfbo = new LwjglGLFboGL3();
+                } else {
+                    glfbo = new LwjglGLFboEXT();
+                }
+
+                if (settings.getBoolean("GraphicsDebug")) {
+                    gl = (GL) GLDebug.createProxy(gl, gl, GL.class, GL2.class, GL3.class, GL4.class);
+                    glext = (GLExt) GLDebug.createProxy(gl, glext, GLExt.class);
+                    glfbo = (GLFbo) GLDebug.createProxy(gl, glfbo, GLFbo.class);
+                }
+                if (settings.getBoolean("GraphicsTiming")) {
+                    GLTimingState timingState = new GLTimingState();
+                    gl = (GL) GLTiming.createGLTiming(gl, timingState, GL.class, GL2.class, GL3.class, GL4.class);
+                    glext = (GLExt) GLTiming.createGLTiming(glext, timingState, GLExt.class);
+                    glfbo = (GLFbo) GLTiming.createGLTiming(glfbo, timingState, GLFbo.class);
+                }
+                if (settings.getBoolean("GraphicsTrace")) {
+                    gl = (GL) GLTracer.createDesktopGlTracer(gl, GL.class, GL2.class, GL3.class, GL4.class);
+                    glext = (GLExt) GLTracer.createDesktopGlTracer(glext, GLExt.class);
+                    glfbo = (GLFbo) GLTracer.createDesktopGlTracer(glfbo, GLFbo.class);
+                }
+                renderer = new GLRenderer(gl, glext, glfbo);
             }
-            
-            if (settings.getBoolean("GraphicsDebug")) {
-                gl = (GL) GLDebug.createProxy(gl, gl, GL.class, GL2.class, GL3.class, GL4.class);
-                glext = (GLExt) GLDebug.createProxy(gl, glext, GLExt.class);
-                glfbo = (GLFbo) GLDebug.createProxy(gl, glfbo, GLFbo.class);
-            }
-            if (settings.getBoolean("GraphicsTiming")) {
-                GLTimingState timingState = new GLTimingState();
-                gl = (GL) GLTiming.createGLTiming(gl, timingState, GL.class, GL2.class, GL3.class, GL4.class);
-                glext = (GLExt) GLTiming.createGLTiming(glext, timingState, GLExt.class);
-                glfbo = (GLFbo) GLTiming.createGLTiming(glfbo, timingState, GLFbo.class);
-            }
-            if (settings.getBoolean("GraphicsTrace")) {
-                gl = (GL) GLTracer.createDesktopGlTracer(gl, GL.class, GL2.class, GL3.class, GL4.class);
-                glext = (GLExt) GLTracer.createDesktopGlTracer(glext, GLExt.class);
-                glfbo = (GLFbo) GLTracer.createDesktopGlTracer(glfbo, GLFbo.class);
-            }
-            renderer = new GLRenderer(gl, glext, glfbo);
             renderer.initialize();
         } else {
             throw new UnsupportedOperationException("Unsupported renderer: " + settings.getRenderer());
@@ -296,19 +306,20 @@ public abstract class LwjglContext implements JmeContext {
         renderer.setMainFrameBufferSrgb(settings.isGammaCorrection());
         renderer.setLinearizeSrgbImages(settings.isGammaCorrection());
 
-        // Init input
-        if (keyInput != null) {
-            keyInput.initialize();
-        }
+        if (first) {
+            // Init input
+            if (keyInput != null) {
+                keyInput.initialize();
+            }
 
-        if (mouseInput != null) {
-            mouseInput.initialize();
-        }
+            if (mouseInput != null) {
+                mouseInput.initialize();
+            }
 
-        if (joyInput != null) {
-            joyInput.initialize();
+            if (joyInput != null) {
+                joyInput.initialize();
+            }
         }
-        
     }
 
     @SuppressWarnings("unchecked")

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -308,8 +308,8 @@ public abstract class LwjglContext implements JmeContext {
                     glfbo = (GLFbo) GLTracer.createDesktopGlTracer(glfbo, GLFbo.class);
                 }
                 renderer = new GLRenderer(gl, glext, glfbo);
+                renderer.initialize();
             }
-            renderer.initialize();
         } else {
             throw new UnsupportedOperationException("Unsupported renderer: " + settings.getRenderer());
         }

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
@@ -185,6 +185,11 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
                 logger.log(Level.SEVERE, "Failed to set display settings!", ex);
             }
             listener.reshape(settings.getWidth(), settings.getHeight());
+            if (renderable.get()) {
+                reinitContext();
+            } else {
+                assert getType() == Type.Canvas;
+            }
             logger.fine("Display restarted.");
         } else if (Display.wasResized()) {
             int newWidth = Display.getWidth();

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -174,7 +174,15 @@ public abstract class LwjglContext implements JmeContext {
         return samples;
     }
 
+    protected void reinitContext() {
+        initContext(false);
+    }
+
     protected void initContextFirstTime() {
+        initContext(true);
+    }
+
+    protected void initContext(boolean first) {
 
         final String renderer = settings.getRenderer();
         final GLCapabilities capabilities = createCapabilities(!renderer.equals(AppSettings.LWJGL_OPENGL2));
@@ -185,36 +193,38 @@ public abstract class LwjglContext implements JmeContext {
             throw new UnsupportedOperationException("Unsupported renderer: " + renderer);
         }
 
-        GL gl = new LwjglGL();
-        GLExt glext = new LwjglGLExt();
-        GLFbo glfbo;
+        if (first) {
+            GL gl = new LwjglGL();
+            GLExt glext = new LwjglGLExt();
+            GLFbo glfbo;
 
-        if (capabilities.OpenGL30) {
-            glfbo = new LwjglGLFboGL3();
-        } else {
-            glfbo = new LwjglGLFboEXT();
+            if (capabilities.OpenGL30) {
+                glfbo = new LwjglGLFboGL3();
+            } else {
+                glfbo = new LwjglGLFboEXT();
+            }
+
+            if (settings.getBoolean("GraphicsDebug")) {
+                gl = (GL) GLDebug.createProxy(gl, gl, GL.class, GL2.class, GL3.class, GL4.class);
+                glext = (GLExt) GLDebug.createProxy(gl, glext, GLExt.class);
+                glfbo = (GLFbo) GLDebug.createProxy(gl, glfbo, GLFbo.class);
+            }
+
+            if (settings.getBoolean("GraphicsTiming")) {
+                GLTimingState timingState = new GLTimingState();
+                gl = (GL) GLTiming.createGLTiming(gl, timingState, GL.class, GL2.class, GL3.class, GL4.class);
+                glext = (GLExt) GLTiming.createGLTiming(glext, timingState, GLExt.class);
+                glfbo = (GLFbo) GLTiming.createGLTiming(glfbo, timingState, GLFbo.class);
+            }
+
+            if (settings.getBoolean("GraphicsTrace")) {
+                gl = (GL) GLTracer.createDesktopGlTracer(gl, GL.class, GL2.class, GL3.class, GL4.class);
+                glext = (GLExt) GLTracer.createDesktopGlTracer(glext, GLExt.class);
+                glfbo = (GLFbo) GLTracer.createDesktopGlTracer(glfbo, GLFbo.class);
+            }
+
+            this.renderer = new GLRenderer(gl, glext, glfbo);
         }
-
-        if (settings.getBoolean("GraphicsDebug")) {
-            gl = (GL) GLDebug.createProxy(gl, gl, GL.class, GL2.class, GL3.class, GL4.class);
-            glext = (GLExt) GLDebug.createProxy(gl, glext, GLExt.class);
-            glfbo = (GLFbo) GLDebug.createProxy(gl, glfbo, GLFbo.class);
-        }
-
-        if (settings.getBoolean("GraphicsTiming")) {
-            GLTimingState timingState = new GLTimingState();
-            gl = (GL) GLTiming.createGLTiming(gl, timingState, GL.class, GL2.class, GL3.class, GL4.class);
-            glext = (GLExt) GLTiming.createGLTiming(glext, timingState, GLExt.class);
-            glfbo = (GLFbo) GLTiming.createGLTiming(glfbo, timingState, GLFbo.class);
-        }
-
-        if (settings.getBoolean("GraphicsTrace")) {
-            gl = (GL) GLTracer.createDesktopGlTracer(gl, GL.class, GL2.class, GL3.class, GL4.class);
-            glext = (GLExt) GLTracer.createDesktopGlTracer(glext, GLExt.class);
-            glfbo = (GLFbo) GLTracer.createDesktopGlTracer(glfbo, GLFbo.class);
-        }
-
-        this.renderer = new GLRenderer(gl, glext, glfbo);
         this.renderer.initialize();
 
         if (capabilities.GL_ARB_debug_output && settings.getBoolean("GraphicsDebug")) {
@@ -224,36 +234,38 @@ public abstract class LwjglContext implements JmeContext {
         this.renderer.setMainFrameBufferSrgb(settings.isGammaCorrection());
         this.renderer.setLinearizeSrgbImages(settings.isGammaCorrection());
 
-        // Init input
-        if (keyInput != null) {
-            keyInput.initialize();
-        }
-
-        if (mouseInput != null) {
-            mouseInput.initialize();
-        }
-
-        if (joyInput != null) {
-            joyInput.initialize();
-        }
-
-        GLFW.glfwSetJoystickCallback(new GLFWJoystickCallback() {
-            @Override
-            public void invoke(int jid, int event) {
-
-                // Invoke the disconnected event before we reload the joysticks or we lose the reference to it.
-                // Invoke the connected event after we reload the joysticks to obtain the reference to it.
-
-                if ( event == GLFW.GLFW_CONNECTED ) {
-                    joyInput.reloadJoysticks();
-                    joyInput.fireJoystickConnectedEvent(jid);
-                }
-                else {
-                    joyInput.fireJoystickDisconnectedEvent(jid);
-                    joyInput.reloadJoysticks();
-                }
+        if (first) {
+            // Init input
+            if (keyInput != null) {
+                keyInput.initialize();
             }
-        });
+
+            if (mouseInput != null) {
+                mouseInput.initialize();
+            }
+
+            if (joyInput != null) {
+                joyInput.initialize();
+            }
+
+            GLFW.glfwSetJoystickCallback(new GLFWJoystickCallback() {
+                @Override
+                public void invoke(int jid, int event) {
+
+                    // Invoke the disconnected event before we reload the joysticks or we lose the reference to it.
+                    // Invoke the connected event after we reload the joysticks to obtain the reference to it.
+
+                    if ( event == GLFW.GLFW_CONNECTED ) {
+                        joyInput.reloadJoysticks();
+                        joyInput.fireJoystickConnectedEvent(jid);
+                    }
+                    else {
+                        joyInput.fireJoystickDisconnectedEvent(jid);
+                        joyInput.reloadJoysticks();
+                    }
+                }
+            });
+        }
 
         renderable.set(true);
     }

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -175,7 +175,7 @@ public abstract class LwjglContext implements JmeContext {
     }
 
     /**
-     * Reinitializes the relevent details of the context. For internal use only.
+     * Reinitializes the relevant details of the context. For internal use only.
      */
     protected void reinitContext() {
         initContext(false);

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -576,7 +576,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, "Failed to set display settings!", ex);
         }
-        // Re-enable gamma correction
+        // Reinitialize context flags and such
         reinitContext();
 
         // We need to reinit the mouse and keyboard input as they are tied to a window handle

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -576,6 +576,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, "Failed to set display settings!", ex);
         }
+        // Re-enable gamma correction
+        reinitContext();
 
         // We need to reinit the mouse and keyboard input as they are tied to a window handle
         if (keyInput != null && keyInput.isInitialized()) {


### PR DESCRIPTION
https://hub.jmonkeyengine.org/t/white-screen-on-context-restart/43866/28?u=markil3
Now most of the code that goes into initializing the renderer is now repeated every time. This is accomplished by moving most of the logic from the initContextFirstTime() methods into a new initContext(boolean) method. On the first boot, the code ultimately executes the same way. However, every context restart calls initContext(false) now as well. This will repeat all the code from before save for the creation of the GL and Renderer instances as well as input initialization.

At the moment, SimpleApplication now has a new default binding for the TAB key that restarts the context. This is to make it easier to test various examples, and I plan on removing it before we actually merge it.

This should solve issues #844 and #1445. This commit should also replace PR #1524.