### PR TITLE
GLRenderer: avoid NPE reported by Pavl_G

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -2852,7 +2852,8 @@ public final class GLRenderer implements Renderer {
         for (int i = 0; i < attribList.oldLen; i++) {
             int idx = attribList.oldList[i];
             gl.glDisableVertexAttribArray(idx);
-            if (context.boundAttribs[idx].get().isInstanced()) {
+            VertexBuffer buffer = context.boundAttribs[idx].get();
+            if (buffer != null && buffer.isInstanced()) {
                 glext.glVertexAttribDivisorARB(idx, 0);
             }
             context.boundAttribs[idx] = null;


### PR DESCRIPTION
This attempts to avoid the `NullPointerException` reported by Pavl_G at the Forum:
   https://hub.jmonkeyengine.org/t/engine-v3-4-0-beta-testing/44507/9

Since this appears to be related to #1408, I'd appreciate a review from @riccardobl

Stack trace from the reported crash:
```text
SEVERE: Uncaught exception thrown in Thread[jME3 Main,5,main]
java.lang.NullPointerException
	at com.jme3.renderer.opengl.GLRenderer.clearVertexAttribs(GLRenderer.java:2855)
	at com.jme3.renderer.opengl.GLRenderer.renderMeshDefault(GLRenderer.java:3188)
	at com.jme3.renderer.opengl.GLRenderer.renderMesh(GLRenderer.java:3219)
	at com.jme3.material.logic.DefaultTechniqueDefLogic.renderMeshFromGeometry(DefaultTechniqueDefLogic.java:72)
	at com.jme3.material.logic.SinglePassAndImageBasedLightingLogic.render(SinglePassAndImageBasedLightingLogic.java:268)
	at com.jme3.material.Technique.render(Technique.java:167)
	at com.jme3.material.Material.render(Material.java:1033)
	at com.jme3.renderer.RenderManager.renderGeometry(RenderManager.java:634)
	at com.jme3.renderer.queue.RenderQueue.renderGeometryList(RenderQueue.java:273)
	at com.jme3.renderer.queue.RenderQueue.renderQueue(RenderQueue.java:318)
	at com.jme3.renderer.RenderManager.renderViewPortQueues(RenderManager.java:918)
	at com.jme3.renderer.RenderManager.flushQueue(RenderManager.java:799)
	at com.jme3.renderer.RenderManager.renderViewPort(RenderManager.java:1128)
	at com.jme3.renderer.RenderManager.render(RenderManager.java:1180)
	at com.jme3.app.SimpleApplication.update(SimpleApplication.java:273)
	at com.jme3.system.lwjgl.LwjglWindow.runLoop(LwjglWindow.java:537)
	at com.jme3.system.lwjgl.LwjglWindow.run(LwjglWindow.java:624)
	at com.jme3.system.lwjgl.LwjglWindow.create(LwjglWindow.java:473)
	at com.jme3.app.LegacyApplication.start(LegacyApplication.java:491)
```