### PR TITLE
address issue #1528 (distinguish ARM macOS/Windows from other platforms)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/system/JmeSystemDelegate.java
+++ b/jme3-core/src/main/java/com/jme3/system/JmeSystemDelegate.java
@@ -168,7 +168,11 @@ public abstract class JmeSystemDelegate {
         String arch = System.getProperty("os.arch").toLowerCase();
         boolean is64 = is64Bit(arch);
         if (os.contains("windows")) {
-            return is64 ? Platform.Windows64 : Platform.Windows32;
+            if (arch.startsWith("arm") || arch.startsWith("aarch")) {
+                return is64 ? Platform.Windows_ARM64 : Platform.Windows_ARM32;
+            } else {
+                return is64 ? Platform.Windows64 : Platform.Windows32;
+            }
         } else if (os.contains("linux") || os.contains("freebsd") 
                 || os.contains("sunos") || os.contains("unix")) {
             if (arch.startsWith("arm") || arch.startsWith("aarch")) {

--- a/jme3-core/src/main/java/com/jme3/system/JmeSystemDelegate.java
+++ b/jme3-core/src/main/java/com/jme3/system/JmeSystemDelegate.java
@@ -179,6 +179,8 @@ public abstract class JmeSystemDelegate {
         } else if (os.contains("mac os x") || os.contains("darwin")) {
             if (arch.startsWith("ppc")) {
                 return is64 ? Platform.MacOSX_PPC64 : Platform.MacOSX_PPC32;
+            } else if (arch.startsWith("aarch")) {
+                return Platform.MacOSX_ARM64; // no 32-bit version
             } else {
                 return is64 ? Platform.MacOSX64 : Platform.MacOSX32;
             }

--- a/jme3-core/src/main/java/com/jme3/system/Platform.java
+++ b/jme3-core/src/main/java/com/jme3/system/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -73,6 +73,11 @@ public enum Platform {
      */
     MacOSX64(true),
     
+    /**
+     * Apple Mac OS X 64-bit ARM
+     */
+    MacOSX_ARM64(true),
+
     /**
      * Apple Mac OS X 32 bit PowerPC
      */

--- a/jme3-core/src/main/java/com/jme3/system/Platform.java
+++ b/jme3-core/src/main/java/com/jme3/system/Platform.java
@@ -34,15 +34,25 @@ package com.jme3.system;
 public enum Platform {
 
     /**
-     * Microsoft Windows 32 bit
+     * Microsoft Windows 32-bit AMD/Intel
      */
     Windows32,
     
     /**
-     * Microsoft Windows 64 bit
+     * Microsoft Windows 64-bit AMD/Intel
      */
     Windows64(true),
     
+    /**
+     * Microsoft Windows 32-bit ARM
+     */
+    Windows_ARM32,
+
+    /**
+     * Microsoft Windows 64-bit ARM
+     */
+    Windows_ARM64(true),
+
     /**
      * Linux 32-bit Intel
      */


### PR DESCRIPTION
We want to be able to distinguish ARM Macs from X86/PPC Macs so that, as soon as LWJGL v3.3 released, JME can also support such platforms.