### PR TITLE
TransformTrack: protect the no-arg constructor

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -63,7 +63,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Serialization-only. Do not use.
      */
-    public TransformTrack() {
+    protected TransformTrack() {
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -197,7 +197,9 @@ public class TransformTrack implements AnimTrack<Transform> {
      * @param scales       the scale of the bone for each frame
      */
     public void setKeyframes(float[] times, Vector3f[] translations, Quaternion[] rotations, Vector3f[] scales) {
-        setTimes(times);
+        if (times != null) {
+            setTimes(times);
+        }
         if (translations != null) {
             setKeyframesTranslation(translations);
         }

--- a/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SkeletonLoader.java
+++ b/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SkeletonLoader.java
@@ -93,8 +93,7 @@ public class SkeletonLoader extends DefaultHandler implements AssetLoader {
             assert elementStack.peek().equals("tracks");
             String jointName = SAXUtil.parseString(attribs.getValue("bone"));
             joint = nameToJoint.get(jointName);
-            track = new TransformTrack();
-            track.setTarget(joint);
+            track = new TransformTrack(joint, null, null, null, null);
         } else if (qName.equals("boneparent")) {
             assert elementStack.peek().equals("bonehierarchy");
             String jointName = attribs.getValue("bone");


### PR DESCRIPTION
Even though Nehon's documentation made it clear that the no-arg constructor for `TransformTrack` was ONLY for serialization, he used it anyway in the Ogre XML loader. Owing to this contradiction, PR #1228 skipped this class.

After studying `TransformTrack` more closely, I'm convinced that the no-arg constructor is needed ONLY for serialization. In the spirit of PR #1228, this PR would protect it against accidental misuse.

Forum discussion at https://hub.jmonkeyengine.org/t/question-about-new-animation-system-part-3-engine-v-3-4-0-beta1/44546/9