### PR TITLE
TransformTrack: add null checks to getTranslations() and getRotations()

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -83,10 +83,10 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * return the array of rotations of this track
      *
-     * @return an array
+     * @return an array, or null if no rotations
      */
     public Quaternion[] getRotations() {
-        return rotations.toObjectArray();
+        return rotations == null ? null : rotations.toObjectArray();
     }
 
     /**
@@ -110,10 +110,10 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * returns the array of translations of this track
      *
-     * @return an array
+     * @return an array, or null if no translations
      */
     public Vector3f[] getTranslations() {
-        return translations.toObjectArray();
+        return translations == null ? null : translations.toObjectArray();
     }
 
 


### PR DESCRIPTION
As noted [at the Forum](https://hub.jmonkeyengine.org/t/question-about-new-animation-system-part-3-engine-v-3-4-0-beta1/44546/9), it's easy to create a `TransformTrack` without any translations or rotations. Since there are null checks in `getDataAtTime()`, such tracks can be useful. However, the `getTranslations()` and `getRotations()` methods lack null checks, leading to NPEs when applied to such tracks.

This PR would avoid NPEs on tracks without any translations or rotations.