### PR TITLE
Joint: make 2 methods accessible to subclasses

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/Joint.java
+++ b/jme3-core/src/main/java/com/jme3/anim/Joint.java
@@ -169,7 +169,7 @@ public class Joint implements Savable, JmeCloneable, HasLocalTransform {
      *
      * @param outTransform
      */
-    void getOffsetTransform(Matrix4f outTransform) {
+    protected void getOffsetTransform(Matrix4f outTransform) {
         jointModelTransform.getOffsetTransform(outTransform, inverseModelBindMatrix);
     }
 
@@ -359,7 +359,7 @@ public class Joint implements Savable, JmeCloneable, HasLocalTransform {
      * @param targets    a list of geometries animated by this bone's skeleton (not
      *                   null, unaffected)
      */
-    Node getAttachmentsNode(int jointIndex, SafeArrayList<Geometry> targets) {
+    protected Node getAttachmentsNode(int jointIndex, SafeArrayList<Geometry> targets) {
         targetGeometry = null;
         /*
          * Search for a geometry animated by this particular bone.


### PR DESCRIPTION
Based on a proposal by Pavl_G at the Forum: https://hub.jmonkeyengine.org/t/question-about-new-animation-system-part-3-engine-v-3-4-0-beta1/44546/22

This makes `getAttachmentsNode()` and `getOffsetTransform()` accessible to subclasses. Currently these methods are used only in `SkinningControl` and `Armature` respectively.