### PR TITLE
AnimEvent: solve bug where onStop() kills prior event on the same layer

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/AnimComposer.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AnimComposer.java
@@ -457,6 +457,37 @@ public class AnimComposer extends AbstractControl {
     }
 
     /**
+     * Access the manager of the named layer.
+     *
+     * @param layerName the name of the layer to access
+     * @return the current manager (typically an AnimEvent) or null for none
+     */
+    public Object getLayerManager(String layerName) {
+        Layer layer = layers.get(layerName);
+        if (layer == null) {
+            throw new IllegalArgumentException("Unknown layer " + layerName);
+        }
+
+        return layer.manager;
+    }
+
+    /**
+     * Assign a manager to the named layer.
+     *
+     * @param layerName the name of the layer to modify
+     * @param manager the desired manager (typically an AnimEvent) or null for
+     * none
+     */
+    public void setLayerManager(String layerName, Object manager) {
+        Layer layer = layers.get(layerName);
+        if (layer == null) {
+            throw new IllegalArgumentException("Unknown layer " + layerName);
+        }
+
+        layer.manager = manager;
+    }
+
+    /**
      * Create a shallow clone for the JME cloner.
      *
      * @return a new instance
@@ -539,6 +570,7 @@ public class AnimComposer extends AbstractControl {
         private Action currentAction;
         private AnimationMask mask;
         private double time;
+        private Object manager;
 
         public Layer(AnimComposer ac) {
             this.ac = ac;

--- a/jme3-core/src/main/java/com/jme3/cinematic/events/AnimEvent.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/events/AnimEvent.java
@@ -150,7 +150,12 @@ public class AnimEvent extends AbstractCinematicEvent {
     @Override
     public void onStop() {
         logger.log(Level.INFO, "");
-        composer.removeCurrentAction(layerName);
+
+        Action currentAction = composer.getCurrentAction(layerName);
+        Action eventAction = composer.action(actionName);
+        if (currentAction == eventAction) {
+            composer.removeCurrentAction(layerName);
+        }
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/cinematic/events/AnimEvent.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/events/AnimEvent.java
@@ -120,8 +120,11 @@ public class AnimEvent extends AbstractCinematicEvent {
     public void onPause() {
         logger.log(Level.SEVERE, "");
 
-        Action eventAction = composer.action(actionName);
-        eventAction.setSpeed(0f);
+        Object layerManager = composer.getLayerManager(layerName);
+        if (layerManager == this) {
+            Action eventAction = composer.action(actionName);
+            eventAction.setSpeed(0f);
+        }
     }
 
     /**
@@ -142,6 +145,7 @@ public class AnimEvent extends AbstractCinematicEvent {
             composer.setTime(layerName, 0.0);
         }
         eventAction.setSpeed(speed);
+        composer.setLayerManager(layerName, this);
     }
 
     /**
@@ -151,10 +155,10 @@ public class AnimEvent extends AbstractCinematicEvent {
     public void onStop() {
         logger.log(Level.INFO, "");
 
-        Action currentAction = composer.getCurrentAction(layerName);
-        Action eventAction = composer.getAction(actionName);
-        if (currentAction == eventAction) {
+        Object layerManager = composer.getLayerManager(layerName);
+        if (layerManager == this) {
             composer.removeCurrentAction(layerName);
+            composer.setLayerManager(layerName, null);
         }
     }
 

--- a/jme3-core/src/main/java/com/jme3/cinematic/events/AnimEvent.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/events/AnimEvent.java
@@ -152,7 +152,7 @@ public class AnimEvent extends AbstractCinematicEvent {
         logger.log(Level.INFO, "");
 
         Action currentAction = composer.getCurrentAction(layerName);
-        Action eventAction = composer.action(actionName);
+        Action eventAction = composer.getAction(actionName);
         if (currentAction == eventAction) {
             composer.removeCurrentAction(layerName);
         }

--- a/jme3-examples/src/main/java/jme3test/animation/TestJaime.java
+++ b/jme3-examples/src/main/java/jme3test/animation/TestJaime.java
@@ -159,10 +159,19 @@ public class TestJaime  extends SimpleApplication {
         AnimClip forwardClip = af.buildAnimation(jaime);
         AnimComposer composer = jaime.getControl(AnimComposer.class);
         composer.addAnimClip(forwardClip);
+        /*
+         * Add a clip that warps the model to its starting position.
+         */
+        AnimFactory af2 = new AnimFactory(0.01f, "StartingPosition", 30f);
+        af2.addTimeTranslation(0f, new Vector3f(0f, 0f, -3f));
+        AnimClip startClip = af2.buildAnimation(jaime);
+        composer.addAnimClip(startClip);
 
         composer.makeLayer("SpatialLayer", null);
         String boneLayer = AnimComposer.DEFAULT_LAYER;
 
+        cinematic.addCinematicEvent(0f,
+                new AnimEvent(composer, "StartingPosition", "SpatialLayer"));
         cinematic.enqueueCinematicEvent(
                 new AnimEvent(composer, "Idle", boneLayer));
         float jumpStart = cinematic.enqueueCinematicEvent(


### PR DESCRIPTION
This solves a bug seen in `TestJaime` where anim events in the `Cinematic` were occasionally suppressed. This happened when 2 events were scheduled to play consecutively on the same layer and the later event's `onStart()` was invoked before the earlier event's `onStop()`. In this situation `onStop()` would remove the wrong action from the layer.