### PR TITLE
solve issue #1542 (crash in TestAppStates)

### DIFF
--- a/jme3-examples/src/main/java/jme3test/app/state/TestAppStates.java
+++ b/jme3-examples/src/main/java/jme3test/app/state/TestAppStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,6 +37,7 @@ import com.jme3.niftygui.NiftyJmeDisplay;
 import com.jme3.scene.Spatial;
 import com.jme3.system.AppSettings;
 import com.jme3.system.JmeContext;
+import jme3test.niftygui.StartScreenController;
 
 public class TestAppStates extends LegacyApplication {
 
@@ -70,10 +71,12 @@ public class TestAppStates extends LegacyApplication {
         state.getRootNode().attachChild(model);
 
         NiftyJmeDisplay niftyDisplay = new NiftyJmeDisplay(assetManager,
-                                                           inputManager,
-                                                           audioRenderer,
-                                                           guiViewPort);
-        niftyDisplay.getNifty().fromXml("Interface/Nifty/HelloJme.xml", "start");
+                inputManager,
+                audioRenderer,
+                guiViewPort);
+        StartScreenController startScreen = new StartScreenController(this);
+        niftyDisplay.getNifty().fromXml("Interface/Nifty/HelloJme.xml", "start",
+                startScreen);
         guiViewPort.addProcessor(niftyDisplay);
     }
 

--- a/jme3-examples/src/main/java/jme3test/niftygui/StartScreenController.java
+++ b/jme3-examples/src/main/java/jme3test/niftygui/StartScreenController.java
@@ -29,50 +29,64 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package jme3test.niftygui;
 
-import com.jme3.app.SimpleApplication;
-import com.jme3.material.Material;
-import com.jme3.niftygui.NiftyJmeDisplay;
-import com.jme3.scene.Geometry;
-import com.jme3.scene.shape.Box;
+import com.jme3.app.Application;
 import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.screen.Screen;
+import de.lessvoid.nifty.screen.ScreenController;
 
-public class TestNiftyGui extends SimpleApplication {
+/**
+ * A ScreenController for the "start" screen defined in
+ * "Interfaces/Nifty/HelloJme.xml", which is used in the TestAppStates and
+ * TestNiftyGui applications.
+ */
+public class StartScreenController implements ScreenController {
 
-    private Nifty nifty;
+    final private Application application;
 
-    public static void main(String[] args){
-        TestNiftyGui app = new TestNiftyGui();
-        app.setPauseOnLostFocus(false);
-        app.start();
+    /**
+     * Instantiate a ScreenController for the specified Application.
+     *
+     * @param app the Application
+     */
+    public StartScreenController(Application app) {
+        this.application = app;
     }
 
+    /**
+     * Nifty invokes this method when the screen gets enabled for the first
+     * time.
+     *
+     * @param nifty (not null)
+     * @param screen (not null)
+     */
     @Override
-    public void simpleInitApp() {
-        Box b = new Box(1, 1, 1);
-        Geometry geom = new Geometry("Box", b);
-        Material mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
-        mat.setTexture("ColorMap", assetManager.loadTexture("Interface/Logo/Monkey.jpg"));
-        geom.setMaterial(mat);
-        rootNode.attachChild(geom);
+    public void bind(Nifty nifty, Screen screen) {
+        System.out.println("bind(" + screen.getScreenId() + ")");
+    }
 
-        NiftyJmeDisplay niftyDisplay = NiftyJmeDisplay.newNiftyJmeDisplay(
-                assetManager,
-                inputManager,
-                audioRenderer,
-                guiViewPort);
-        nifty = niftyDisplay.getNifty();
-        StartScreenController startScreen = new StartScreenController(this);
-        nifty.fromXml("Interface/Nifty/HelloJme.xml", "start", startScreen);
+    /**
+     * Nifty invokes this method each time the screen starts up.
+     */
+    @Override
+    public void onStartScreen() {
+        System.out.println("onStartScreen");
+    }
 
-        // attach the nifty display to the gui view port as a processor
-        guiViewPort.addProcessor(niftyDisplay);
+    /**
+     * Nifty invokes this method each time the screen shuts down.
+     */
+    @Override
+    public void onEndScreen() {
+        System.out.println("onEndScreen");
+    }
 
-        // disable the fly cam
-//        flyCam.setEnabled(false);
-//        flyCam.setDragToRotate(true);
-        inputManager.setCursorVisible(true);
+    /**
+     * Stop the Application. Nifty invokes this method (via reflection) after
+     * the user clicks on the flashing orange panel.
+     */
+    public void quit() {
+        application.stop();
     }
 }

--- a/jme3-testdata/src/main/resources/Interface/Nifty/HelloJme.xml
+++ b/jme3-testdata/src/main/resources/Interface/Nifty/HelloJme.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nifty>
-  <screen id="start" controller="jme3test.niftygui.TestNiftyGui">
+  <screen id="start" controller="jme3test.niftygui.StartScreenController">
     <layer id="layer" backgroundColor="#0000" childLayout="center">
       <panel id="panel" height="25%" width="35%" align="center" valign="center" backgroundColor="#f60f" childLayout="center" visibleToMouse="true">
         <interact onClick="quit()"/>


### PR DESCRIPTION
Several things were broken here.

It was inappropriate for `TestAppStates` to use a default screen controller with "HelloJme.xml", because of course that screen controller does not implement the "quit()" method referenced in "HelloJme.xml". Also, "HelloJme.xml" specifies that the controller for its "start" screen should be an instance of `TestNiftyGui`. Furthermore, the "end" screen of "HelloJme.xml" is empty and therefore useless.

In order for `TestAppStates` and `TestNiftyGui` to cleanly share "HelloJme.xml", I added a class `StartScreenController` to serve as a screen controller for both apps.

I also deleted the "end" screen and re-purposed `quit()` to cleanly terminate the application.