### PR TITLE
solve issue #1544 (diagnostic messages from TestMusicPlayer)

### DIFF
--- a/jme3-examples/src/main/java/jme3test/audio/TestMusicPlayer.java
+++ b/jme3-examples/src/main/java/jme3test/audio/TestMusicPlayer.java
@@ -206,6 +206,8 @@ public class TestMusicPlayer extends javax.swing.JFrame {
             }
 
             musicSource = new AudioNode(musicData, key);
+            // A positional AudioNode would prohibit stereo sound!
+            musicSource.setPositional(false);
             musicLength = musicData.getDuration();
             updateTime();
         }
@@ -264,18 +266,7 @@ public class TestMusicPlayer extends javax.swing.JFrame {
     }//GEN-LAST:event_btnFFActionPerformed
 
     private void sldBarStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_sldBarStateChanged
-        if (musicSource != null && !sldBar.getValueIsAdjusting()){
-            curTime = sldBar.getValue() / 100f;
-            if (curTime < 0)
-                curTime = 0;
-            
-            musicSource.setTimeOffset(curTime);
-//            if (musicSource.getStatus() == Status.Playing){
-//                musicSource.stop();               
-//                musicSource.play();
-//            }
-            updateTime();
-        }
+        // do nothing: OGG/Vorbis supports seeking, but only for time = 0!
     }//GEN-LAST:event_sldBarStateChanged
 
     /**


### PR DESCRIPTION
I didn't figure out how to remove the horizontal slider. I simply disabled it by turning `sldBarStateChanged()` into a no-op. That fixed the `UnsupportedOperationException`.

To fix the `IllegalStateException`, I configured the `AudioNode` to be in ambient mode instead of positional mode.