### PR TITLE
resolve issue #1551 (OpenGLExceptions in jme3-examples)

### DIFF
--- a/jme3-examples/src/main/java/jme3test/collision/TestMousePick.java
+++ b/jme3-examples/src/main/java/jme3test/collision/TestMousePick.java
@@ -60,7 +60,7 @@ public class TestMousePick extends SimpleApplication {
     @Override
     public void simpleInitApp() {
         flyCam.setEnabled(false);
-        initMark();       // a red sphere to mark the hit
+        initMark();
 
         /** create four colored boxes and a floor to shoot at: */
         shootables = new Node("Shootables");
@@ -127,20 +127,18 @@ public class TestMousePick extends SimpleApplication {
         return floor;
     }
 
-    /** A red ball that marks the last spot that was "hit" by the "shot". */
-    protected void initMark() {
+    /**
+     * A red arrow to mark the spot being picked.
+     */
+    private void initMark() {
         Arrow arrow = new Arrow(Vector3f.UNIT_Z.mult(2f));
-
-        //Sphere sphere = new Sphere(30, 30, 0.2f);
         mark = new Geometry("BOOM!", arrow);
-        //mark = new Geometry("BOOM!", sphere);
         Material mark_mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
-        mark_mat.getAdditionalRenderState().setLineWidth(3);
         mark_mat.setColor("Color", ColorRGBA.Red);
         mark.setMaterial(mark_mat);
     }
 
-    protected Spatial makeCharacter() {
+    private Spatial makeCharacter() {
         // load a character from jme3test-test-data
         Spatial golem = assetManager.loadModel("Models/Oto/Oto.mesh.xml");
         golem.scale(0.5f);

--- a/jme3-examples/src/main/java/jme3test/model/shape/TestDebugShapes.java
+++ b/jme3-examples/src/main/java/jme3test/model/shape/TestDebugShapes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,32 +50,31 @@ public class TestDebugShapes extends SimpleApplication {
         app.start();
     }
 
-    public Geometry putShape(Mesh shape, ColorRGBA color, float lineWidth){
+    private Geometry putShape(Mesh shape, ColorRGBA color) {
         Geometry g = new Geometry("shape", shape);
         Material mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
         mat.getAdditionalRenderState().setWireframe(true);
-        mat.getAdditionalRenderState().setLineWidth(lineWidth);
         mat.setColor("Color", color);
         g.setMaterial(mat);
         rootNode.attachChild(g);
         return g;
     }
 
-    public void putArrow(Vector3f pos, Vector3f dir, ColorRGBA color){
+    private void putArrow(Vector3f pos, Vector3f dir, ColorRGBA color){
         Arrow arrow = new Arrow(dir);
-        putShape(arrow, color, 4).setLocalTranslation(pos);
+        putShape(arrow, color).setLocalTranslation(pos);
     }
 
-    public void putBox(Vector3f pos, float size, ColorRGBA color){
-        putShape(new WireBox(size, size, size), color, 1).setLocalTranslation(pos);
+    private void putBox(Vector3f pos, float size, ColorRGBA color) {
+        putShape(new WireBox(size, size, size), color).setLocalTranslation(pos);
     }
 
-    public void putGrid(Vector3f pos, ColorRGBA color){
-        putShape(new Grid(6, 6, 0.2f), color, 1).center().move(pos);
+    private void putGrid(Vector3f pos, ColorRGBA color) {
+        putShape(new Grid(6, 6, 0.2f), color).center().move(pos);
     }
 
-    public void putSphere(Vector3f pos, ColorRGBA color){
-        putShape(new WireSphere(1), color, 1).setLocalTranslation(pos);
+    private void putSphere(Vector3f pos, ColorRGBA color) {
+        putShape(new WireSphere(1), color).setLocalTranslation(pos);
     }
 
     @Override


### PR DESCRIPTION
+ Removed uses of `setLineWidth()` from `TestDebugShapes` and `TestMousePick`.
+ Privatized methods with no uses outside those classes.
+ Corrected misleading comments and updated the copyright dates.
