### PR TITLE
TestAttachDriver: don't remove the SliderJoint more than once

### DIFF
--- a/jme3-examples/src/main/java/jme3test/bullet/TestAttachDriver.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestAttachDriver.java
@@ -275,8 +275,11 @@ public class TestAttachDriver extends SimpleApplication implements ActionListene
             }
         } else if (binding.equals("Space")) {
             if (value) {
-                getPhysicsSpace().remove(slider);
-                slider.destroy();
+                if (slider != null) {
+                    getPhysicsSpace().remove(slider);
+                    slider.destroy();
+                    slider = null;
+                }
                 vehicle.applyImpulse(jumpForce, Vector3f.ZERO);
             }
         } else if (binding.equals("Reset")) {


### PR DESCRIPTION
If you run the `TestAttachDriver` app (in jme3-examples) and press the spacebar twice, a diagnostic is issued:
```text
May 15, 2021 9:53:30 AM com.jme3.bullet.PhysicsSpace removeJoint
WARNING: Joint com.jme3.bullet.joints.SliderJoint@799f10e1 does not exist in PhysicsSpace, cannot remove.
```

The diagnostic indicates a bug in the app. This PR fixes the bug.