### PR TITLE
Fix the issue #1349

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/FastMath.java
+++ b/jme3-core/src/main/java/com/jme3/math/FastMath.java
@@ -943,10 +943,10 @@ final public class FastMath {
         if (store == null) {
             store = new Vector3f();
         }
-        store.z = sphereCoords.x * FastMath.sin(sphereCoords.z);
-        float a = sphereCoords.x * FastMath.cos(sphereCoords.z);
-        store.x = a * FastMath.cos(sphereCoords.y);
-        store.y = a * FastMath.sin(sphereCoords.y);
+        store.y = sphereCoords.x * FastMath.sin(sphereCoords.y);
+        float a = sphereCoords.x * FastMath.cos(sphereCoords.y);
+        store.x = a * FastMath.cos(sphereCoords.z);
+        store.z = a * FastMath.sin(sphereCoords.z);
 
         return store;
     }

--- a/jme3-core/src/main/java/com/jme3/math/FastMath.java
+++ b/jme3-core/src/main/java/com/jme3/math/FastMath.java
@@ -933,7 +933,7 @@ final public class FastMath {
      * Z as up) and stores the results in the store var.
      *
      * @param sphereCoords the input spherical coordinates: x=distance from
-     * origin, y=longitude in radians, z=latitude in radians (not null,
+     * origin, y=latitude in radians, z=longitude in radians (not null,
      * unaffected)
      * @param store storage for the result (modified if not null)
      * @return the Cartesian coordinates (either store or a new vector)

--- a/jme3-core/src/test/java/com/jme3/math/FastMathTest.java
+++ b/jme3-core/src/test/java/com/jme3/math/FastMathTest.java
@@ -227,7 +227,6 @@ public class FastMathTest {
         assertEquals(in0.z, out0.z, 1e-5f);
     }
 
-    @Ignore // test fails due to issue #1349
     @Test
     public void testCartesianZToSpherical() {
         final Vector3f cartCoords = new Vector3f(1.1f, 5.8f, 8.1f);


### PR DESCRIPTION
This pull request is to solve the issue #1349.
According to the definition of each axis and the process to get x, y, and z of Spherical coordinates from the method cartesianZToSpherical, the method sphericalToCartesianZ should be modified.