### PR TITLE
Github Actions: Implement a "Mesa Compliance Testing"

### DIFF
--- a/.github/workflows/mesa-compliance.yml
+++ b/.github/workflows/mesa-compliance.yml
@@ -1,0 +1,46 @@
+name: Mesa Compliance Testing
+on:
+  - push
+  - pull_request
+
+jobs:
+  MesaTests:
+    name: Mesa Compliance Testing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: MeFisto94/jme3-testing
+      - uses: actions/checkout@v2
+        with:
+          path: engine
+
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@0.0.1
+      - name: Fetch Docker Image
+        run: sudo docker pull riccardoblb/buildenvs:javagl
+      - name: Prebuild Everything # This task is so we don't get the whole compilation output verbosely in the test tasks.
+        run: ./gradlew assemble
+
+      - name: Test on LWJGL3
+        run: |
+          chmod +x ci-runner.sh
+          NO_INTERRACTIVE=1 ./ci-runner.sh -Dmesa-llvm-ci=true tests-lwjgl3:test -i
+      - name: Upload lwjgl3 reports
+        uses: actions/upload-artifact@v1.0.0
+        if: always()
+        with:
+          name: reports-lwjgl3
+          path: tests-lwjgl3/build/reports
+
+      - name: Test on LWJGL2
+        if: always()
+        run: |
+          chmod +x ci-runner.sh
+          NO_INTERRACTIVE=1 ./ci-runner.sh -Dmesa-llvm-ci=true tests-lwjgl2:test -i
+      - name: Upload lwjgl2 reports
+        uses: actions/upload-artifact@v1.0.0
+        if: always()
+        with:
+          name: reports-lwjgl2
+          path: tests-lwjgl2/build/reports


### PR DESCRIPTION
using https://github.com/MeFisto94/jme3-testing that runs functional tests on a software renderer to validate rendering works correctly.

## Scope
This is only the tracking PR about the Github Actions integration of this feature. Anything related to the feature itself may happen on the hub topic https://hub.jmonkeyengine.org/t/help-testing-jmonkeyengine/42856 or the jme3-testing repository.

Note: Currently when merging the PR, none of the tests will work, because they all time out, which means app.stop isn't called correctly. This used to work on an older revision of the engine, maybe context changes have caused the issue, I will investigate it, but it's unrelated to this PR basically.

## Security
In theory jme3-testing and the buildenvs should use specific commit hashes to protect against their maintainers introducing evil code (or host them into the main organization, also from the aspect of it not disappearing), since this is a dedicated workflow, unrelated to releasing binaries or something, only the second aspect may be worth considering.

I'll move this PR in draft state until the issues in jme3-testing have been solved, feel free to comment on both this and jme3-testing in general. 