### PR TITLE
Fix title (and registry entry) for Settingsdialog

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/app/SettingsDialog.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/SettingsDialog.java
@@ -169,6 +169,7 @@ public final class SettingsDialog extends JFrame {
             logger.log(Level.WARNING,
                     "Failed to load settings", ex);
         }
+        registrySettings.setTitle(appTitle);
 
         if (loadSettings) {
             source.copyFrom(registrySettings);


### PR DESCRIPTION
...the developer probably want it to be named as its application