### PR TITLE
renaming Java identifiers

### DIFF
--- a/jme3-android/src/main/java/com/jme3/app/state/VideoRecorderAppState.java
+++ b/jme3-android/src/main/java/com/jme3/app/state/VideoRecorderAppState.java
@@ -227,7 +227,7 @@ public class VideoRecorderAppState extends AbstractAppState {
         private int width;
         private int height;
         private RenderManager renderManager;
-        private boolean isInitilized = false;
+        private boolean isInitialized = false;
         private LinkedBlockingQueue<WorkItem> freeItems;
         private LinkedBlockingQueue<WorkItem> usedItems = new LinkedBlockingQueue<>();
         private MjpegFileWriter writer;
@@ -273,7 +273,7 @@ public class VideoRecorderAppState extends AbstractAppState {
             this.width = camera.getWidth();
             this.height = camera.getHeight();
             this.renderManager = rm;
-            this.isInitilized = true;
+            this.isInitialized = true;
             if (freeItems == null) {
                 freeItems = new LinkedBlockingQueue<WorkItem>();
                 for (int i = 0; i < numCpus; i++) {
@@ -288,7 +288,7 @@ public class VideoRecorderAppState extends AbstractAppState {
 
         @Override
         public boolean isInitialized() {
-            return this.isInitilized;
+            return this.isInitialized;
         }
 
         @Override

--- a/jme3-core/src/main/java/com/jme3/anim/Armature.java
+++ b/jme3-core/src/main/java/com/jme3/anim/Armature.java
@@ -53,7 +53,7 @@ public class Armature implements JmeCloneable, Savable {
      * Contains the skinning matrices, multiplying it by a vertex effected by a bone
      * will cause it to go to the animated position.
      */
-    private transient Matrix4f[] skinningMatrices;
+    private transient Matrix4f[] skinningMatrixes;
     private Class<? extends JointModelTransform> modelTransformClass = SeparateJointModelTransform.class;
 
     /**
@@ -103,9 +103,9 @@ public class Armature implements JmeCloneable, Savable {
     }
 
     private void createSkinningMatrices() {
-        skinningMatrices = new Matrix4f[jointList.length];
-        for (int i = 0; i < skinningMatrices.length; i++) {
-            skinningMatrices[i] = new Matrix4f();
+        skinningMatrixes = new Matrix4f[jointList.length];
+        for (int i = 0; i < skinningMatrixes.length; i++) {
+            skinningMatrixes[i] = new Matrix4f();
         }
     }
 
@@ -261,9 +261,9 @@ public class Armature implements JmeCloneable, Savable {
      */
     public Matrix4f[] computeSkinningMatrices() {
         for (int i = 0; i < jointList.length; i++) {
-            jointList[i].getOffsetTransform(skinningMatrices[i]);
+            jointList[i].getOffsetTransform(skinningMatrixes[i]);
         }
-        return skinningMatrices;
+        return skinningMatrixes;
     }
 
     /**
@@ -289,7 +289,7 @@ public class Armature implements JmeCloneable, Savable {
     public void cloneFields(Cloner cloner, Object original) {
         this.rootJoints = cloner.clone(rootJoints);
         this.jointList = cloner.clone(jointList);
-        this.skinningMatrices = cloner.clone(skinningMatrices);
+        this.skinningMatrixes = cloner.clone(skinningMatrixes);
         for (Joint joint : jointList) {
             instantiateJointModelTransform(joint);
         }

--- a/jme3-core/src/main/java/com/jme3/anim/Armature.java
+++ b/jme3-core/src/main/java/com/jme3/anim/Armature.java
@@ -53,7 +53,7 @@ public class Armature implements JmeCloneable, Savable {
      * Contains the skinning matrices, multiplying it by a vertex effected by a bone
      * will cause it to go to the animated position.
      */
-    private transient Matrix4f[] skinningMatrixes;
+    private transient Matrix4f[] skinningMatrices;
     private Class<? extends JointModelTransform> modelTransformClass = SeparateJointModelTransform.class;
 
     /**
@@ -78,7 +78,7 @@ public class Armature implements JmeCloneable, Savable {
         for (int i = jointList.length - 1; i >= 0; i--) {
             Joint joint = jointList[i];
             joint.setId(i);
-            instanciateJointModelTransform(joint);
+            instantiateJointModelTransform(joint);
             if (joint.getParent() == null) {
                 rootJointList.add(joint);
             }
@@ -103,9 +103,9 @@ public class Armature implements JmeCloneable, Savable {
     }
 
     private void createSkinningMatrices() {
-        skinningMatrixes = new Matrix4f[jointList.length];
-        for (int i = 0; i < skinningMatrixes.length; i++) {
-            skinningMatrixes[i] = new Matrix4f();
+        skinningMatrices = new Matrix4f[jointList.length];
+        for (int i = 0; i < skinningMatrices.length; i++) {
+            skinningMatrices[i] = new Matrix4f();
         }
     }
 
@@ -124,11 +124,11 @@ public class Armature implements JmeCloneable, Savable {
             return;
         }
         for (Joint joint : jointList) {
-            instanciateJointModelTransform(joint);
+            instantiateJointModelTransform(joint);
         }
     }
 
-    private void instanciateJointModelTransform(Joint joint) {
+    private void instantiateJointModelTransform(Joint joint) {
         try {
             joint.setJointModelTransform(modelTransformClass.newInstance());
         } catch (InstantiationException | IllegalAccessException e) {
@@ -261,9 +261,9 @@ public class Armature implements JmeCloneable, Savable {
      */
     public Matrix4f[] computeSkinningMatrices() {
         for (int i = 0; i < jointList.length; i++) {
-            jointList[i].getOffsetTransform(skinningMatrixes[i]);
+            jointList[i].getOffsetTransform(skinningMatrices[i]);
         }
-        return skinningMatrixes;
+        return skinningMatrices;
     }
 
     /**
@@ -289,9 +289,9 @@ public class Armature implements JmeCloneable, Savable {
     public void cloneFields(Cloner cloner, Object original) {
         this.rootJoints = cloner.clone(rootJoints);
         this.jointList = cloner.clone(jointList);
-        this.skinningMatrixes = cloner.clone(skinningMatrixes);
+        this.skinningMatrices = cloner.clone(skinningMatrices);
         for (Joint joint : jointList) {
-            instanciateJointModelTransform(joint);
+            instantiateJointModelTransform(joint);
         }
     }
 
@@ -325,7 +325,7 @@ public class Armature implements JmeCloneable, Savable {
         int i = 0;
         for (Joint joint : jointList) {
             joint.setId(i++);
-            instanciateJointModelTransform(joint);
+            instantiateJointModelTransform(joint);
         }
         createSkinningMatrices();
 

--- a/jme3-core/src/main/java/com/jme3/animation/Skeleton.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Skeleton.java
@@ -60,7 +60,7 @@ public final class Skeleton implements Savable, JmeCloneable {
      * Contains the skinning matrices, multiplying it by a vertex affected by a bone
      * will cause it to go to the animated position.
      */
-    private transient Matrix4f[] skinningMatrixes;
+    private transient Matrix4f[] skinningMatrices;
 
     /**
      * Creates a skeleton from a bone list. 
@@ -138,13 +138,13 @@ public final class Skeleton implements Savable, JmeCloneable {
     public void cloneFields( Cloner cloner, Object original ) {
         this.rootBones = cloner.clone(rootBones);
         this.boneList = cloner.clone(boneList);
-        this.skinningMatrixes = cloner.clone(skinningMatrixes);    
+        this.skinningMatrices = cloner.clone(skinningMatrices);
     }
 
     private void createSkinningMatrices() {
-        skinningMatrixes = new Matrix4f[boneList.length];
-        for (int i = 0; i < skinningMatrixes.length; i++) {
-            skinningMatrixes[i] = new Matrix4f();
+        skinningMatrices = new Matrix4f[boneList.length];
+        for (int i = 0; i < skinningMatrices.length; i++) {
+            skinningMatrices[i] = new Matrix4f();
         }
     }
 
@@ -273,10 +273,10 @@ public final class Skeleton implements Savable, JmeCloneable {
     public Matrix4f[] computeSkinningMatrices() {
         TempVars vars = TempVars.get();
         for (int i = 0; i < boneList.length; i++) {
-            boneList[i].getOffsetTransform(skinningMatrixes[i], vars.quat1, vars.vect1, vars.vect2, vars.tempMat3);
+            boneList[i].getOffsetTransform(skinningMatrices[i], vars.quat1, vars.vect1, vars.vect2, vars.tempMat3);
         }
         vars.release();
-        return skinningMatrixes;
+        return skinningMatrices;
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/animation/Skeleton.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Skeleton.java
@@ -60,7 +60,7 @@ public final class Skeleton implements Savable, JmeCloneable {
      * Contains the skinning matrices, multiplying it by a vertex affected by a bone
      * will cause it to go to the animated position.
      */
-    private transient Matrix4f[] skinningMatrices;
+    private transient Matrix4f[] skinningMatrixes;
 
     /**
      * Creates a skeleton from a bone list. 
@@ -138,13 +138,13 @@ public final class Skeleton implements Savable, JmeCloneable {
     public void cloneFields( Cloner cloner, Object original ) {
         this.rootBones = cloner.clone(rootBones);
         this.boneList = cloner.clone(boneList);
-        this.skinningMatrices = cloner.clone(skinningMatrices);
+        this.skinningMatrixes = cloner.clone(skinningMatrixes);
     }
 
     private void createSkinningMatrices() {
-        skinningMatrices = new Matrix4f[boneList.length];
-        for (int i = 0; i < skinningMatrices.length; i++) {
-            skinningMatrices[i] = new Matrix4f();
+        skinningMatrixes = new Matrix4f[boneList.length];
+        for (int i = 0; i < skinningMatrixes.length; i++) {
+            skinningMatrixes[i] = new Matrix4f();
         }
     }
 
@@ -273,10 +273,10 @@ public final class Skeleton implements Savable, JmeCloneable {
     public Matrix4f[] computeSkinningMatrices() {
         TempVars vars = TempVars.get();
         for (int i = 0; i < boneList.length; i++) {
-            boneList[i].getOffsetTransform(skinningMatrices[i], vars.quat1, vars.vect1, vars.vect2, vars.tempMat3);
+            boneList[i].getOffsetTransform(skinningMatrixes[i], vars.quat1, vars.vect1, vars.vect2, vars.tempMat3);
         }
         vars.release();
-        return skinningMatrices;
+        return skinningMatrixes;
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/cinematic/MotionPath.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/MotionPath.java
@@ -131,13 +131,13 @@ public class MotionPath implements Savable {
             }
             switch (spline.getType()) {
                 case CatmullRom:
-                    debugNode.attachChild(CreateCatmullRomPath());
+                    debugNode.attachChild(createCatmullRomPath());
                     break;
                 case Linear:
-                    debugNode.attachChild(CreateLinearPath());
+                    debugNode.attachChild(createLinearPath());
                     break;
                 default:
-                    debugNode.attachChild(CreateLinearPath());
+                    debugNode.attachChild(createLinearPath());
                     break;
             }
 
@@ -145,7 +145,7 @@ public class MotionPath implements Savable {
         }
     }
 
-    private Geometry CreateLinearPath() {
+    private Geometry createLinearPath() {
 
         Material mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
         mat.getAdditionalRenderState().setWireframe(true);
@@ -155,7 +155,7 @@ public class MotionPath implements Savable {
         return lineGeometry;
     }
 
-    private Geometry CreateCatmullRomPath() {
+    private Geometry createCatmullRomPath() {
 
         Material mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
         mat.getAdditionalRenderState().setWireframe(true);

--- a/jme3-core/src/main/java/com/jme3/environment/generation/IrradianceSphericalHarmonicsGenerator.java
+++ b/jme3-core/src/main/java/com/jme3/environment/generation/IrradianceSphericalHarmonicsGenerator.java
@@ -91,9 +91,9 @@ public class IrradianceSphericalHarmonicsGenerator extends RunnableWithProgress 
             }
         });
         try {
-            Vector3f[] shCoeffs = EnvMapUtils.getSphericalHarmonicsCoefficents(sourceMap);
-            EnvMapUtils.prepareShCoefs(shCoeffs);
-            store.setShCoeffs(shCoeffs);
+            Vector3f[] shCoefficients = EnvMapUtils.getSphericalHarmonicsCoefficents(sourceMap);
+            EnvMapUtils.prepareShCoefs(shCoefficients);
+            store.setShCoeffs(shCoefficients);
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/jme3-core/src/main/java/com/jme3/light/DefaultLightFilter.java
+++ b/jme3-core/src/main/java/com/jme3/light/DefaultLightFilter.java
@@ -43,14 +43,14 @@ public final class DefaultLightFilter implements LightFilter {
 
     private Camera camera;
     private final HashSet<Light> processedLights = new HashSet<>();
-    private LightProbeBlendingStrategy probeBlendStrat;
+    private LightProbeBlendingStrategy probeBlendStrategy;
 
     public DefaultLightFilter() {
-        probeBlendStrat = new WeightedProbeBlendingStrategy();
+        probeBlendStrategy = new WeightedProbeBlendingStrategy();
     }
 
-    public DefaultLightFilter(LightProbeBlendingStrategy probeBlendStrat) {
-        this.probeBlendStrat = probeBlendStrat;
+    public DefaultLightFilter(LightProbeBlendingStrategy probeBlendStrategy) {
+        this.probeBlendStrategy = probeBlendStrategy;
     }
     
     @Override
@@ -100,14 +100,14 @@ public final class DefaultLightFilter implements LightFilter {
                 }
                 
                 if (light.getType() == Light.Type.Probe) {
-                    probeBlendStrat.registerProbe((LightProbe) light);
+                    probeBlendStrategy.registerProbe((LightProbe) light);
                 } else {
                     filteredLightList.add(light);
                 }
                 
             }
             
-            probeBlendStrat.populateProbes(geometry, filteredLightList);
+            probeBlendStrategy.populateProbes(geometry, filteredLightList);
 
         } finally {
             vars.release();
@@ -115,7 +115,7 @@ public final class DefaultLightFilter implements LightFilter {
     }
 
     public void setLightProbeBlendingStrategy(LightProbeBlendingStrategy strategy){
-        probeBlendStrat = strategy;
+        probeBlendStrategy = strategy;
     }
 
 }

--- a/jme3-core/src/main/java/com/jme3/light/LightProbe.java
+++ b/jme3-core/src/main/java/com/jme3/light/LightProbe.java
@@ -73,7 +73,7 @@ public class LightProbe extends Light implements Savable {
     private static final Logger logger = Logger.getLogger(LightProbe.class.getName());
     public static final Matrix4f FALLBACK_MATRIX = new Matrix4f(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1);
 
-    private Vector3f[] shCoeffs;
+    private Vector3f[] shCoefficients;
     private TextureCubeMap prefilteredEnvMap;
     private ProbeArea area = new SphereProbeArea(Vector3f.ZERO, 1.0f);
     private boolean ready = false;
@@ -105,10 +105,10 @@ public class LightProbe extends Light implements Savable {
 
     /**
      * Sets the prefiltered environment map
-     * @param prefileteredEnvMap the prefiltered environment map
+     * @param prefilteredEnvMap the prefiltered environment map
      */
-    public void setPrefilteredMap(TextureCubeMap prefileteredEnvMap) {
-        this.prefilteredEnvMap = prefileteredEnvMap;
+    public void setPrefilteredMap(TextureCubeMap prefilteredEnvMap) {
+        this.prefilteredEnvMap = prefilteredEnvMap;
     }
 
     /**
@@ -163,7 +163,7 @@ public class LightProbe extends Light implements Savable {
     public void write(JmeExporter ex) throws IOException {
         super.write(ex);
         OutputCapsule oc = ex.getCapsule(this);
-        oc.write(shCoeffs, "shCoeffs", null);
+        oc.write(shCoefficients, "shCoeffs", null);
         oc.write(prefilteredEnvMap, "prefilteredEnvMap", null);
         oc.write(position, "position", null);
         oc.write(area, "area", new SphereProbeArea(Vector3f.ZERO, 1.0f));
@@ -193,9 +193,9 @@ public class LightProbe extends Light implements Savable {
             ready = false;
             logger.log(Level.WARNING, "LightProbe is missing parameters, it should be recomputed. Please use lightProbeFactory.updateProbe()");
         } else {
-            shCoeffs = new Vector3f[coeffs.length];
+            shCoefficients = new Vector3f[coeffs.length];
             for (int i = 0; i < coeffs.length; i++) {
-                shCoeffs[i] = (Vector3f) coeffs[i];
+                shCoefficients[i] = (Vector3f) coeffs[i];
             }
         }
     }
@@ -254,11 +254,11 @@ public class LightProbe extends Light implements Savable {
     }
 
     public Vector3f[] getShCoeffs() {
-        return shCoeffs;
+        return shCoefficients;
     }
 
-    public void setShCoeffs(Vector3f[] shCoeffs) {
-        this.shCoeffs = shCoeffs;
+    public void setShCoeffs(Vector3f[] shCoefficients) {
+        this.shCoefficients = shCoefficients;
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
+++ b/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
@@ -317,39 +317,39 @@ public final class ColorRGBA implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets this <code>ColorRGBA</code> to the interpolation by changeAmnt from
+     * Sets this <code>ColorRGBA</code> to the interpolation by changeAmount from
      * this to the finalColor:
-     * this=(1-changeAmnt)*this + changeAmnt * finalColor
+     * this=(1-changeAmount)*this + changeAmount * finalColor
      *
      * @param finalColor The final color to interpolate towards.
-     * @param changeAmnt An amount between 0.0 - 1.0 representing a percentage
+     * @param changeAmount An amount between 0.0 - 1.0 representing a percentage
      * change from this towards finalColor.
      * @return this ColorRGBA
      */
-    public ColorRGBA interpolateLocal(ColorRGBA finalColor, float changeAmnt) {
-        this.r = (1 - changeAmnt) * this.r + changeAmnt * finalColor.r;
-        this.g = (1 - changeAmnt) * this.g + changeAmnt * finalColor.g;
-        this.b = (1 - changeAmnt) * this.b + changeAmnt * finalColor.b;
-        this.a = (1 - changeAmnt) * this.a + changeAmnt * finalColor.a;
+    public ColorRGBA interpolateLocal(ColorRGBA finalColor, float changeAmount) {
+        this.r = (1 - changeAmount) * this.r + changeAmount * finalColor.r;
+        this.g = (1 - changeAmount) * this.g + changeAmount * finalColor.g;
+        this.b = (1 - changeAmount) * this.b + changeAmount * finalColor.b;
+        this.a = (1 - changeAmount) * this.a + changeAmount * finalColor.a;
         return this;
     }
 
     /**
-     * Sets this <code>ColorRGBA</code> to the interpolation by changeAmnt from
+     * Sets this <code>ColorRGBA</code> to the interpolation by changeAmount from
      * beginColor to finalColor:
-     * this=(1-changeAmnt)*beginColor + changeAmnt * finalColor
+     * this=(1-changeAmount)*beginColor + changeAmount * finalColor
      *
-     * @param beginColor The beginning color (changeAmnt=0).
-     * @param finalColor The final color to interpolate towards (changeAmnt=1).
-     * @param changeAmnt An amount between 0.0 - 1.0 representing a percentage
+     * @param beginColor The beginning color (changeAmount=0).
+     * @param finalColor The final color to interpolate towards (changeAmount=1).
+     * @param changeAmount An amount between 0.0 - 1.0 representing a percentage
      *  change from beginColor towards finalColor.
      * @return this ColorRGBA
      */
-    public ColorRGBA interpolateLocal(ColorRGBA beginColor, ColorRGBA finalColor, float changeAmnt) {
-        this.r = (1 - changeAmnt) * beginColor.r + changeAmnt * finalColor.r;
-        this.g = (1 - changeAmnt) * beginColor.g + changeAmnt * finalColor.g;
-        this.b = (1 - changeAmnt) * beginColor.b + changeAmnt * finalColor.b;
-        this.a = (1 - changeAmnt) * beginColor.a + changeAmnt * finalColor.a;
+    public ColorRGBA interpolateLocal(ColorRGBA beginColor, ColorRGBA finalColor, float changeAmount) {
+        this.r = (1 - changeAmount) * beginColor.r + changeAmount * finalColor.r;
+        this.g = (1 - changeAmount) * beginColor.g + changeAmount * finalColor.g;
+        this.b = (1 - changeAmount) * beginColor.b + changeAmount * finalColor.b;
+        this.a = (1 - changeAmount) * beginColor.a + changeAmount * finalColor.a;
         return this;
     }
 

--- a/jme3-core/src/main/java/com/jme3/math/CurveAndSurfaceMath.java
+++ b/jme3-core/src/main/java/com/jme3/math/CurveAndSurfaceMath.java
@@ -66,14 +66,14 @@ public class CurveAndSurfaceMath {
         List<Float> knots = nurbSpline.getKnots();
         int controlPointAmount = controlPoints.size();
         store.set(Vector3f.ZERO);
-        float delimeter = 0;
+        float delimiter = 0;
         for (int i = 0; i < controlPointAmount; ++i) {
             float val = weights[i] * CurveAndSurfaceMath.computeBaseFunctionValue(i, nurbSpline.getBasisFunctionDegree(), u, knots);
             store.addLocal(nurbSpline.getControlPoints().get(i)
                     .mult(val));
-            delimeter += val;
+            delimiter += val;
         }
-        store.divideLocal(delimeter);
+        store.divideLocal(delimiter);
     }
 
     /**
@@ -95,7 +95,7 @@ public class CurveAndSurfaceMath {
     public static void interpolate(float u, float v, List<List<Vector4f>> controlPoints, List<Float>[] knots,
             int basisUFunctionDegree, int basisVFunctionDegree, Vector3f store) {
         store.set(Vector3f.ZERO);
-        float delimeter = 0;
+        float delimiter = 0;
         int vControlPointsAmount = controlPoints.size();
         int uControlPointsAmount = controlPoints.get(0).size();
         for (int i = 0; i < vControlPointsAmount; ++i) {
@@ -105,10 +105,10 @@ public class CurveAndSurfaceMath {
                         * CurveAndSurfaceMath.computeBaseFunctionValue(i, basisVFunctionDegree, v, knots[1])
                         * CurveAndSurfaceMath.computeBaseFunctionValue(j, basisUFunctionDegree, u, knots[0]);
                 store.addLocal(controlPoint.x * val, controlPoint.y * val, controlPoint.z * val);
-                delimeter += val;
+                delimiter += val;
             }
         }
-        store.divideLocal(delimeter);
+        store.divideLocal(delimiter);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/math/Vector4f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector4f.java
@@ -792,37 +792,37 @@ public final class Vector4f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Sets this vector to the interpolation by changeAmnt from this to the finalVec
-     * this=(1-changeAmnt)*this + changeAmnt * finalVec
+     * Sets this vector to the interpolation by changeAmount from this to the finalVec
+     * this=(1-changeAmount)*this + changeAmount * finalVec
      *
      * @param finalVec The final vector to interpolate towards
-     * @param changeAmnt An amount between 0.0 - 1.0 representing a percentage
+     * @param changeAmount An amount between 0.0 - 1.0 representing a percentage
      *  change from this towards finalVec
      * @return this
      */
-    public Vector4f interpolateLocal(Vector4f finalVec, float changeAmnt) {
-        this.x = (1 - changeAmnt) * this.x + changeAmnt * finalVec.x;
-        this.y = (1 - changeAmnt) * this.y + changeAmnt * finalVec.y;
-        this.z = (1 - changeAmnt) * this.z + changeAmnt * finalVec.z;
-        this.w = (1 - changeAmnt) * this.w + changeAmnt * finalVec.w;
+    public Vector4f interpolateLocal(Vector4f finalVec, float changeAmount) {
+        this.x = (1 - changeAmount) * this.x + changeAmount * finalVec.x;
+        this.y = (1 - changeAmount) * this.y + changeAmount * finalVec.y;
+        this.z = (1 - changeAmount) * this.z + changeAmount * finalVec.z;
+        this.w = (1 - changeAmount) * this.w + changeAmount * finalVec.w;
         return this;
     }
 
     /**
-     * Sets this vector to the interpolation by changeAmnt from beginVec to finalVec
-     * this=(1-changeAmnt)*beginVec + changeAmnt * finalVec
+     * Sets this vector to the interpolation by changeAmount from beginVec to finalVec
+     * this=(1-changeAmount)*beginVec + changeAmount * finalVec
      *
-     * @param beginVec the beginning vector (changeAmnt=0)
+     * @param beginVec the beginning vector (changeAmount=0)
      * @param finalVec The final vector to interpolate towards
-     * @param changeAmnt An amount between 0.0 - 1.0 representing a percentage
+     * @param changeAmount An amount between 0.0 - 1.0 representing a percentage
      *  change from beginVec towards finalVec
      * @return this
      */
-    public Vector4f interpolateLocal(Vector4f beginVec, Vector4f finalVec, float changeAmnt) {
-        this.x = (1 - changeAmnt) * beginVec.x + changeAmnt * finalVec.x;
-        this.y = (1 - changeAmnt) * beginVec.y + changeAmnt * finalVec.y;
-        this.z = (1 - changeAmnt) * beginVec.z + changeAmnt * finalVec.z;
-        this.w = (1 - changeAmnt) * beginVec.w + changeAmnt * finalVec.w;
+    public Vector4f interpolateLocal(Vector4f beginVec, Vector4f finalVec, float changeAmount) {
+        this.x = (1 - changeAmount) * beginVec.x + changeAmount * finalVec.x;
+        this.y = (1 - changeAmount) * beginVec.y + changeAmount * finalVec.y;
+        this.z = (1 - changeAmount) * beginVec.z + changeAmount * finalVec.z;
+        this.w = (1 - changeAmount) * beginVec.w + changeAmount * finalVec.w;
         return this;
     }
 

--- a/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
@@ -85,7 +85,7 @@ public class RenderManager {
     private int viewX, viewY, viewWidth, viewHeight;
     private final Matrix4f orthoMatrix = new Matrix4f();
     private final LightList filteredLightList = new LightList(null);
-    private boolean handleTranlucentBucket = true;
+    private boolean handleTranslucentBucket = true;
     private AppProfiler prof;
     private LightFilter lightFilter = new DefaultLightFilter();
     private TechniqueDef.LightMode preferredLightMode = TechniqueDef.LightMode.MultiPass;
@@ -506,7 +506,7 @@ public class RenderManager {
      * @see #setHandleTranslucentBucket(boolean) 
      */
     public boolean isHandleTranslucentBucket() {
-        return handleTranlucentBucket;
+        return handleTranslucentBucket;
     }
 
     /**
@@ -518,7 +518,7 @@ public class RenderManager {
      * be rendered.
      */
     public void setHandleTranslucentBucket(boolean handleTranslucentBucket) {
-        this.handleTranlucentBucket = handleTranslucentBucket;
+        this.handleTranslucentBucket = handleTranslucentBucket;
     }
 
     /**
@@ -949,7 +949,7 @@ public class RenderManager {
         if (prof!=null) prof.vpStep(VpStep.RenderBucket, vp, Bucket.Translucent);
         
         RenderQueue rq = vp.getQueue();
-        if (!rq.isQueueEmpty(Bucket.Translucent) && handleTranlucentBucket) {
+        if (!rq.isQueueEmpty(Bucket.Translucent) && handleTranslucentBucket) {
             rq.renderQueue(Bucket.Translucent, this, vp.getCamera(), true);
         }
     }

--- a/jme3-core/src/main/java/com/jme3/scene/AssetLinkNode.java
+++ b/jme3-core/src/main/java/com/jme3/scene/AssetLinkNode.java
@@ -190,11 +190,11 @@ public class AssetLinkNode extends Node {
 
     @Override
     public void write(JmeExporter e) throws IOException {
-        SafeArrayList<Spatial> childs = children;
+        SafeArrayList<Spatial> childList = children;
         children = new SafeArrayList<>(Spatial.class);
         super.write(e);
         OutputCapsule capsule = e.getCapsule(this);
         capsule.writeSavableArrayList(assetLoaderKeys, "assetLoaderKeyList", null);
-        children = childs;
+        children = childList;
     }
 }

--- a/jme3-core/src/main/java/com/jme3/shader/ShaderGenerator.java
+++ b/jme3-core/src/main/java/com/jme3/shader/ShaderGenerator.java
@@ -296,12 +296,12 @@ public abstract class ShaderGenerator {
      * @see ShaderNode#getDefinition()
      * @see ShaderNodeDefinition#getType()
      * 
-     * @param nodeDecalarationSource the declaration part of the node
+     * @param nodeDeclarationSource the declaration part of the node
      * @param source the StringBuilder to append generated code.
      * @param shaderNode the shaderNode.
      * @param info the ShaderGenerationInfo.
      */
-    protected abstract void generateDeclarativeSection(StringBuilder source, ShaderNode shaderNode, String nodeDecalarationSource, ShaderGenerationInfo info);
+    protected abstract void generateDeclarativeSection(StringBuilder source, ShaderNode shaderNode, String nodeDeclarationSource, ShaderGenerationInfo info);
 
     /**
      * generates the start of the shader main section. this method is

--- a/jme3-core/src/main/java/com/jme3/util/JmeFormatter.java
+++ b/jme3-core/src/main/java/com/jme3/util/JmeFormatter.java
@@ -46,13 +46,13 @@ import java.util.logging.LogRecord;
 public class JmeFormatter extends Formatter {
 
     final private Date calendar = new Date();
-    final private String lineSeperator;
+    final private String lineSeparator;
     final private MessageFormat format;
     final private Object args[] = new Object[1];
     final private StringBuffer store = new StringBuffer();
 
     public JmeFormatter(){
-        lineSeperator = System.getProperty("line.separator");
+        lineSeparator = System.getProperty("line.separator");
         format = new MessageFormat("{0,time}");
     }
 
@@ -74,7 +74,7 @@ public class JmeFormatter extends Formatter {
         sb.append(record.getLevel().getLocalizedName()).append(" ");
         sb.append(clazz).append(" ");
         sb.append(store.toString()).append(" ");
-        sb.append(formatMessage(record)).append(lineSeperator);
+        sb.append(formatMessage(record)).append(lineSeparator);
 
         if (record.getThrown() != null) {
             try {

--- a/jme3-core/src/main/java/com/jme3/util/TangentBinormalGenerator.java
+++ b/jme3-core/src/main/java/com/jme3/util/TangentBinormalGenerator.java
@@ -276,7 +276,7 @@ public class TangentBinormalGenerator {
     private static List<VertexData> splitVertices(Mesh mesh, List<VertexData> vertexData, boolean splitMirorred) {
         int nbVertices = mesh.getBuffer(Type.Position).getNumElements();
         List<VertexData> newVertices = new ArrayList<>();
-        Map<Integer, Integer> indiceMap = new HashMap<>();
+        Map<Integer, Integer> indexMap = new HashMap<>();
         FloatBuffer normalBuffer = mesh.getFloatBuffer(Type.Normal);
 
         for (int i = 0; i < vertexData.size(); i++) {
@@ -309,7 +309,7 @@ public class TangentBinormalGenerator {
                 
                 newVertices.add(newVert);
                 //keep vertex index to fix the index buffers later
-                indiceMap.put(nbVertices, i);
+                indexMap.put(nbVertices, i);
                 for (TriangleData tri : newVert.triangles) {
                     for (int j = 0; j < tri.index.length; j++) {
                         if(tri.index[j] == i){
@@ -362,7 +362,7 @@ public class TangentBinormalGenerator {
                         int index = vertexData.size();                      
                         newVerts.position(vertexData.size() * vb.getNumComponents());
                         for (int j = 0; j < newVertices.size(); j++) {
-                            int oldInd = indiceMap.get(index) ;
+                            int oldInd = indexMap.get(index) ;
                             for (int i = 0; i < vb.getNumComponents(); i++) {                                
                                     putValue(vb.getFormat(), newVerts, buffer, oldInd* vb.getNumComponents() + i);
                             }                            

--- a/jme3-core/src/main/java/com/jme3/util/mikktspace/MikktspaceTangentGenerator.java
+++ b/jme3-core/src/main/java/com/jme3/util/mikktspace/MikktspaceTangentGenerator.java
@@ -898,8 +898,8 @@ public class MikktspaceTangentGenerator {
                     assert (iNrActiveGroups < iNrMaxGroups);
                     pTriInfos[f].assignedGroup[i] = new Group(); 
                     pGroups[iNrActiveGroups] = pTriInfos[f].assignedGroup[i];
-                    pTriInfos[f].assignedGroup[i].vertexRepresentitive = vert_index;
-                    pTriInfos[f].assignedGroup[i].orientPreservering = (pTriInfos[f].flag & ORIENT_PRESERVING) != 0;
+                    pTriInfos[f].assignedGroup[i].vertexRepresentative = vert_index;
+                    pTriInfos[f].assignedGroup[i].orientationPreserving = (pTriInfos[f].flag & ORIENT_PRESERVING) != 0;
                     pTriInfos[f].assignedGroup[i].nrFaces = 0;
                     
                     ++iNrActiveGroups;
@@ -962,7 +962,7 @@ public class MikktspaceTangentGenerator {
         TriInfo pMyTriInfo = psTriInfos[iMyTriIndex];
 
         // track down vertex
-        final int iVertRep = pGroup.vertexRepresentitive;
+        final int iVertRep = pGroup.vertexRepresentative;
         int index = 3 * iMyTriIndex;
         int i = -1;
         if (piTriListIn[index] == iVertRep) {
@@ -988,12 +988,12 @@ public class MikktspaceTangentGenerator {
                     && pMyTriInfo.assignedGroup[1] == null
                     && pMyTriInfo.assignedGroup[2] == null) {
                 pMyTriInfo.flag &= (~ORIENT_PRESERVING);
-                pMyTriInfo.flag |= (pGroup.orientPreservering ? ORIENT_PRESERVING : 0);
+                pMyTriInfo.flag |= (pGroup.orientationPreserving ? ORIENT_PRESERVING : 0);
             }
         }
         {
             final boolean bOrient = (pMyTriInfo.flag & ORIENT_PRESERVING) != 0;
-            if (bOrient != pGroup.orientPreservering) {
+            if (bOrient != pGroup.orientationPreserving) {
                 return false;
             }
         }
@@ -1060,7 +1060,7 @@ public class MikktspaceTangentGenerator {
                 assert (index >= 0 && index < 3);
 
                 iVertIndex = piTriListIn[f * 3 + index];
-                assert (iVertIndex == pGroup.vertexRepresentitive);
+                assert (iVertIndex == pGroup.vertexRepresentative);
 
                 // is normalized already
                 n = getNormal(mikkTSpace, iVertIndex);
@@ -1131,7 +1131,7 @@ public class MikktspaceTangentGenerator {
                     System.arraycopy(tmp_group.triMembers, 0, pIndices, 0, iMembers);
                     //memcpy(pIndices, tmp_group.pTriMembers, iMembers*sizeof(int));
                     pSubGroupTspace[iUniqueSubGroups]
-                            = evalTspace(tmp_group.triMembers, iMembers, piTriListIn, pTriInfos, mikkTSpace, pGroup.vertexRepresentitive);
+                            = evalTspace(tmp_group.triMembers, iMembers, piTriListIn, pTriInfos, mikkTSpace, pGroup.vertexRepresentative);
                     ++iUniqueSubGroups;
                 }
 
@@ -1141,16 +1141,16 @@ public class MikktspaceTangentGenerator {
                     final int iVert = pTriInfos[f].vertNum[index];
                     TSpace pTS_out = psTspace[iOffs + iVert];
                     assert (pTS_out.counter < 2);
-                    assert (((pTriInfos[f].flag & ORIENT_PRESERVING) != 0) == pGroup.orientPreservering);
+                    assert (((pTriInfos[f].flag & ORIENT_PRESERVING) != 0) == pGroup.orientationPreserving);
                     if (pTS_out.counter == 1) {
                         pTS_out.set(avgTSpace(pTS_out, pSubGroupTspace[l]));
                         pTS_out.counter = 2;  // update counter
-                        pTS_out.orient = pGroup.orientPreservering;
+                        pTS_out.orient = pGroup.orientationPreserving;
                     } else {
                         assert (pTS_out.counter == 0);
                         pTS_out.set(pSubGroupTspace[l]);
                         pTS_out.counter = 1;  // update counter
-                        pTS_out.orient = pGroup.orientPreservering;
+                        pTS_out.orient = pGroup.orientationPreserving;
                     }
                 }
             }
@@ -1673,8 +1673,8 @@ public class MikktspaceTangentGenerator {
     private static class Group {
         int nrFaces;
         List<Integer> faceIndices = new ArrayList<>();
-        int vertexRepresentitive;
-        boolean orientPreservering;
+        int vertexRepresentative;
+        boolean orientationPreserving;
     }
 
     private static class TriInfo {

--- a/jme3-desktop/src/main/java/com/jme3/app/state/VideoRecorderAppState.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/VideoRecorderAppState.java
@@ -218,7 +218,7 @@ public class VideoRecorderAppState extends AbstractAppState {
         private int width;
         private int height;
         private RenderManager renderManager;
-        private boolean isInitilized = false;
+        private boolean isInitialized = false;
         private LinkedBlockingQueue<WorkItem> freeItems;
         private LinkedBlockingQueue<WorkItem> usedItems = new LinkedBlockingQueue<>();
         private MjpegFileWriter writer;
@@ -258,7 +258,7 @@ public class VideoRecorderAppState extends AbstractAppState {
             this.width = camera.getWidth();
             this.height = camera.getHeight();
             this.renderManager = rm;
-            this.isInitilized = true;
+            this.isInitialized = true;
             if (freeItems == null) {
                 freeItems = new LinkedBlockingQueue<WorkItem>();
                 for (int i = 0; i < numCpus; i++) {
@@ -273,7 +273,7 @@ public class VideoRecorderAppState extends AbstractAppState {
 
         @Override
         public boolean isInitialized() {
-            return this.isInitilized;
+            return this.isInitialized;
         }
 
         @Override

--- a/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
@@ -605,7 +605,7 @@ public final class NativeLibraryLoader {
             loadedAsFileName = fileNameInJar;
         }
         
-        File extactionDirectory = getExtractionFolder();
+        File extractionDirectory = getExtractionFolder();
         URLConnection conn;
         InputStream in;
         
@@ -618,7 +618,7 @@ public final class NativeLibraryLoader {
                                            "'. Error: " + ex, ex);
         }
         
-        File targetFile = new File(extactionDirectory, loadedAsFileName);
+        File targetFile = new File(extractionDirectory, loadedAsFileName);
         OutputStream out = null;
         try {
             if (targetFile.exists()) {
@@ -663,10 +663,10 @@ public final class NativeLibraryLoader {
             // lwjgl and jinput handle loading by themselves.
             if (name.equals("lwjgl") || name.equals("lwjgl3")) {
                 System.setProperty("org.lwjgl.librarypath", 
-                                   extactionDirectory.getAbsolutePath());
+                                   extractionDirectory.getAbsolutePath());
             } else if (name.equals("jinput")) {
                 System.setProperty("net.java.games.input.librarypath", 
-                                   extactionDirectory.getAbsolutePath());
+                                   extractionDirectory.getAbsolutePath());
             } else {
                 // all other libraries (openal, bulletjme, custom)
                 // will load directly in here.

--- a/jme3-effects/src/main/java/com/jme3/post/filters/BloomFilter.java
+++ b/jme3-effects/src/main/java/com/jme3/post/filters/BloomFilter.java
@@ -87,7 +87,7 @@ public class BloomFilter extends Filter {
     private Pass preGlowPass;
     private Pass extractPass;
     private Pass horizontalBlur = new Pass();
-    private Pass verticalalBlur = new Pass();
+    private Pass verticalBlur = new Pass();
     private Material extractMat;
     private Material vBlurMat;
     private Material hBlurMat;
@@ -97,8 +97,8 @@ public class BloomFilter extends Filter {
     private ViewPort viewPort;
 
     private AssetManager assetManager;
-    private int initalWidth;
-    private int initalHeight;
+    private int initialWidth;
+    private int initialHeight;
     
     /**
      * Creates a Bloom filter
@@ -123,8 +123,8 @@ public class BloomFilter extends Filter {
         this.viewPort = vp;
 
         this.assetManager = manager;
-        this.initalWidth = w;
-        this.initalHeight = h;
+        this.initialWidth = w;
+        this.initialHeight = h;
                 
         screenWidth = (int) Math.max(1, (w / downSamplingFactor));
         screenHeight = (int) Math.max(1, (h / downSamplingFactor));
@@ -175,7 +175,7 @@ public class BloomFilter extends Filter {
 
         //configuring vertical blur pass
         vBlurMat = new Material(manager, "Common/MatDefs/Blur/VGaussianBlur.j3md");
-        verticalalBlur = new Pass() {
+        verticalBlur = new Pass() {
 
             @Override
             public void beforeRender() {
@@ -185,18 +185,18 @@ public class BloomFilter extends Filter {
             }
         };
 
-        verticalalBlur.init(renderManager.getRenderer(), screenWidth, screenHeight, Format.RGBA8, Format.Depth, 1, vBlurMat);
-        postRenderPasses.add(verticalalBlur);
+        verticalBlur.init(renderManager.getRenderer(), screenWidth, screenHeight, Format.RGBA8, Format.Depth, 1, vBlurMat);
+        postRenderPasses.add(verticalBlur);
 
 
         //final material
         material = new Material(manager, "Common/MatDefs/Post/BloomFinal.j3md");
-        material.setTexture("BloomTex", verticalalBlur.getRenderedTexture());
+        material.setTexture("BloomTex", verticalBlur.getRenderedTexture());
     }
 
 
     protected void reInitFilter() {
-        initFilter(assetManager, renderManager, viewPort, initalWidth, initalHeight);
+        initFilter(assetManager, renderManager, viewPort, initialWidth, initialHeight);
     }
     
     @Override

--- a/jme3-effects/src/main/java/com/jme3/post/filters/LightScatteringFilter.java
+++ b/jme3-effects/src/main/java/com/jme3/post/filters/LightScatteringFilter.java
@@ -60,7 +60,7 @@ public class LightScatteringFilter extends Filter {
     private float blurStart = 0.02f;
     private float blurWidth = 0.9f;
     private float lightDensity = 1.4f;
-    private boolean adaptative = true;
+    private boolean adaptive = true;
     Vector3f viewLightPos = new Vector3f();
     private boolean display = true;
     private float innerLightDensity;
@@ -104,7 +104,7 @@ public class LightScatteringFilter extends Filter {
     protected void postQueue(RenderQueue queue) {
         getClipCoordinates(lightPosition, screenLightPos, viewPort.getCamera());
         viewPort.getCamera().getViewMatrix().mult(lightPosition, viewLightPos);        
-        if (adaptative) {
+        if (adaptive) {
             float densityX = 1f - FastMath.clamp(FastMath.abs(screenLightPos.x - 0.5f), 0, 1);
             float densityY = 1f - FastMath.clamp(FastMath.abs(screenLightPos.y - 0.5f), 0, 1);
             innerLightDensity = lightDensity * densityX * densityY;
@@ -234,7 +234,7 @@ public class LightScatteringFilter extends Filter {
         oc.write(blurStart, "blurStart", 0.02f);
         oc.write(blurWidth, "blurWidth", 0.9f);
         oc.write(lightDensity, "lightDensity", 1.4f);
-        oc.write(adaptative, "adaptative", true);
+        oc.write(adaptive, "adaptative", true);
     }
 
     @Override
@@ -246,6 +246,6 @@ public class LightScatteringFilter extends Filter {
         blurStart = ic.readFloat("blurStart", 0.02f);
         blurWidth = ic.readFloat("blurWidth", 0.9f);
         lightDensity = ic.readFloat("lightDensity", 1.4f);
-        adaptative = ic.readBoolean("adaptative", true);
+        adaptive = ic.readBoolean("adaptative", true);
     }
 }

--- a/jme3-examples/src/main/java/jme3test/TestChooser.java
+++ b/jme3-examples/src/main/java/jme3test/TestChooser.java
@@ -96,12 +96,12 @@ public class TestChooser extends JDialog {
      * @return classes vector, list of all the classes in a given package (must
      *         be found in classpath).
      */
-    private Vector<Class> find(String pckgname, boolean recursive,
+    private Vector<Class> find(String packageName, boolean recursive,
             Vector<Class> classes) {
         URL url;
 
         // Translate the package name into an absolute path
-        String name = pckgname;
+        String name = packageName;
         if (!name.startsWith("/")) {
             name = "/" + name;
         }
@@ -111,7 +111,7 @@ public class TestChooser extends JDialog {
         // URL url = UPBClassLoader.get().getResource(name);
         url = this.getClass().getResource(name);
         // URL url = ClassLoader.getSystemClassLoader().getResource(name);
-        pckgname = pckgname + ".";
+        packageName = packageName + ".";
 
         File directory;
         try {
@@ -123,7 +123,7 @@ public class TestChooser extends JDialog {
         if (directory.exists()) {
             logger.fine("Searching for Demo classes in \""
                     + directory.getName() + "\".");
-            addAllFilesInDirectory(directory, classes, pckgname, recursive);
+            addAllFilesInDirectory(directory, classes, packageName, recursive);
         } else {
             try {
                 // It does not work with the filesystem: we must
@@ -145,10 +145,10 @@ public class TestChooser extends JDialog {
                 }
             } catch (IOException e) {
                 logger.logp(Level.SEVERE, this.getClass().toString(),
-                        "find(pckgname, recursive, classes)", "Exception", e);
+                        "find(packageName, recursive, classes)", "Exception", e);
             } catch (Exception e) {
                 logger.logp(Level.SEVERE, this.getClass().toString(),
-                        "find(pckgname, recursive, classes)", "Exception", e);
+                        "find(packageName, recursive, classes)", "Exception", e);
             }
         }
         return classes;

--- a/jme3-examples/src/main/java/jme3test/bullet/TestFancyCar.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestFancyCar.java
@@ -123,10 +123,10 @@ public class TestFancyCar extends SimpleApplication implements ActionListener {
         //Load model and get chassis Geometry
         carNode = (Node) assetManager.loadModel("Models/Ferrari/Car.scene");
         carNode.setShadowMode(ShadowMode.Cast);
-        Geometry chasis = findGeom(carNode, "Car");
+        Geometry chassis = findGeom(carNode, "Car");
 
         //Create a hull collision shape for the chassis
-        CollisionShape carHull = CollisionShapeFactory.createDynamicMeshShape(chasis);
+        CollisionShape carHull = CollisionShapeFactory.createDynamicMeshShape(chassis);
 
         //Create a vehicle control
         player = new VehicleControl(carHull, mass);

--- a/jme3-examples/src/main/java/jme3test/games/RollingTheMonkey.java
+++ b/jme3-examples/src/main/java/jme3test/games/RollingTheMonkey.java
@@ -220,8 +220,8 @@ public class RollingTheMonkey extends SimpleApplication implements ActionListene
         Quaternion rotation = new Quaternion();
         Vector3f translation = new Vector3f(0.0f, PICKUP_SIZE * 1.5f, -PICKUP_RADIUS);
         int index = 0;
-        float ammount = FastMath.TWO_PI / PICKUP_COUNT;
-        for(float angle = 0; angle < FastMath.TWO_PI; angle += ammount) {
+        float amount = FastMath.TWO_PI / PICKUP_COUNT;
+        for(float angle = 0; angle < FastMath.TWO_PI; angle += amount) {
             Geometry pickUp = new Geometry("pickUp" + (index++), new Box(PICKUP_SIZE,PICKUP_SIZE, PICKUP_SIZE));
             pickUp.setShadowMode(ShadowMode.CastAndReceive);
             pickUp.setMaterial(materialYellow);

--- a/jme3-examples/src/main/java/jme3test/games/WorldOfInception.java
+++ b/jme3-examples/src/main/java/jme3test/games/WorldOfInception.java
@@ -484,15 +484,15 @@ public class WorldOfInception extends SimpleApplication implements AnalogListene
 
         public String getCoordinates() {
             InceptionLevel cur = this;
-            StringBuilder strb = new StringBuilder();
-            strb.insert(0, this.getPlayerPosition());
-            strb.insert(0, this.getPositionInParent() + " / ");
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.insert(0, this.getPlayerPosition());
+            stringBuilder.insert(0, this.getPositionInParent() + " / ");
             cur = cur.getParent();
             while (cur != null) {
-                strb.insert(0, cur.getPositionInParent() + " / ");
+                stringBuilder.insert(0, cur.getPositionInParent() + " / ");
                 cur = cur.getParent();
             }
-            return strb.toString();
+            return stringBuilder.toString();
         }
     }
 

--- a/jme3-examples/src/main/java/jme3test/material/TestParallax.java
+++ b/jme3-examples/src/main/java/jme3test/material/TestParallax.java
@@ -115,13 +115,13 @@ public class TestParallax extends SimpleApplication {
             @Override
             public void onAnalog(String name, float value, float tpf) {
                 if ("heightUP".equals(name)) {
-                    parallaxHeigh += 0.01;
-                    mat.setFloat("ParallaxHeight", parallaxHeigh);
+                    parallaxHeight += 0.01;
+                    mat.setFloat("ParallaxHeight", parallaxHeight);
                 }
                 if ("heightDown".equals(name)) {
-                    parallaxHeigh -= 0.01;
-                    parallaxHeigh = Math.max(parallaxHeigh, 0);
-                    mat.setFloat("ParallaxHeight", parallaxHeigh);
+                    parallaxHeight -= 0.01;
+                    parallaxHeight = Math.max(parallaxHeight, 0);
+                    mat.setFloat("ParallaxHeight", parallaxHeight);
                 }
 
             }
@@ -141,7 +141,7 @@ public class TestParallax extends SimpleApplication {
         }, "toggleSteep");
         inputManager.addMapping("toggleSteep", new KeyTrigger(KeyInput.KEY_SPACE));
     }
-    private float parallaxHeigh = 0.05f;
+    private float parallaxHeight = 0.05f;
     private boolean steep = false;
 
     @Override

--- a/jme3-examples/src/main/java/jme3test/material/TestParallaxPBR.java
+++ b/jme3-examples/src/main/java/jme3test/material/TestParallaxPBR.java
@@ -119,13 +119,13 @@ public class TestParallaxPBR extends SimpleApplication {
             @Override
             public void onAnalog(String name, float value, float tpf) {
                 if ("heightUP".equals(name)) {
-                    parallaxHeigh += 0.01;
+                    parallaxHeight += 0.01;
                     mat.setFloat("ParallaxHeight", parallaxHeigh);
                 }
                 if ("heightDown".equals(name)) {
-                    parallaxHeigh -= 0.01;
-                    parallaxHeigh = Math.max(parallaxHeigh, 0);
-                    mat.setFloat("ParallaxHeight", parallaxHeigh);
+                    parallaxHeight -= 0.01;
+                    parallaxHeight = Math.max(parallaxHeight, 0);
+                    mat.setFloat("ParallaxHeight", parallaxHeight);
                 }
 
             }
@@ -145,7 +145,7 @@ public class TestParallaxPBR extends SimpleApplication {
         }, "toggleSteep");
         inputManager.addMapping("toggleSteep", new KeyTrigger(KeyInput.KEY_SPACE));
     }
-    private float parallaxHeigh = 0.05f;
+    private float parallaxHeight = 0.05f;
     private boolean steep = false;
 
     @Override

--- a/jme3-examples/src/main/java/jme3test/material/TestParallaxPBR.java
+++ b/jme3-examples/src/main/java/jme3test/material/TestParallaxPBR.java
@@ -120,7 +120,7 @@ public class TestParallaxPBR extends SimpleApplication {
             public void onAnalog(String name, float value, float tpf) {
                 if ("heightUP".equals(name)) {
                     parallaxHeight += 0.01;
-                    mat.setFloat("ParallaxHeight", parallaxHeigh);
+                    mat.setFloat("ParallaxHeight", parallaxHeight);
                 }
                 if ("heightDown".equals(name)) {
                     parallaxHeight -= 0.01;

--- a/jme3-examples/src/main/java/jme3test/opencl/TestContextSwitching.java
+++ b/jme3-examples/src/main/java/jme3test/opencl/TestContextSwitching.java
@@ -59,7 +59,7 @@ public class TestContextSwitching extends SimpleApplication implements ScreenCon
     private static String selectedPlatform;
     private static String selectedDevice;
     private Context clContext;
-    private static List<? extends Platform> availabePlatforms;
+    private static List<? extends Platform> availablePlatforms;
     private Buffer testBuffer;
     private boolean bufferCreated;
 
@@ -119,7 +119,7 @@ public class TestContextSwitching extends SimpleApplication implements ScreenCon
         updateInfos();
         
         platformListBox.clear();
-        for (Platform p : availabePlatforms) {
+        for (Platform p : availablePlatforms) {
             platformListBox.addItem(p.getName());
         }
         platformListBox.selectItem(selectedPlatform);
@@ -165,7 +165,7 @@ public class TestContextSwitching extends SimpleApplication implements ScreenCon
     private void changePlatform(String platform) {
         selectedPlatform = platform;
         Platform p = null;
-        for (Platform p2 : availabePlatforms) {
+        for (Platform p2 : availablePlatforms) {
             if (p2.getName().equals(selectedPlatform)) {
                 p = p2;
                 break;
@@ -212,7 +212,7 @@ public class TestContextSwitching extends SimpleApplication implements ScreenCon
         
         @Override
         public List<? extends Device> chooseDevices(List<? extends Platform> platforms) {
-            availabePlatforms = platforms;
+            availablePlatforms = platforms;
             
             Platform platform = null;
             for (Platform p : platforms) {

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
@@ -395,10 +395,10 @@ public class PhysicsSpace {
 
     public void distributeEvents() {
         //add collision callbacks
-        int clistsize = collisionListeners.size();
+        int cListSize = collisionListeners.size();
         while( collisionEvents.isEmpty() == false ) {
             PhysicsCollisionEvent physicsCollisionEvent = collisionEvents.pop();
-            for(int i=0;i<clistsize;i++) {
+            for(int i=0;i<cListSize;i++) {
                 collisionListeners.get(i).collision(physicsCollisionEvent);
             }
             //recycle events

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/joints/PhysicsJoint.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/joints/PhysicsJoint.java
@@ -87,12 +87,12 @@ public abstract class PhysicsJoint implements Savable {
     }
 
     /**
-     * toggles collisions between linked bodys<br>
-     * joint has to be removed from and added to PhyiscsSpace to apply this.
-     * @param collisionBetweenLinkedBodys set to false to have no collisions between linked bodys
+     * toggles collisions between linked bodies<br>
+     * joint has to be removed from and added to PhysicsSpace to apply this.
+     * @param collisionBetweenLinkedBodies set to false to have no collisions between linked bodies
      */
-    public void setCollisionBetweenLinkedBodys(boolean collisionBetweenLinkedBodys) {
-        this.collisionBetweenLinkedBodys = collisionBetweenLinkedBodys;
+    public void setCollisionBetweenLinkedBodys(boolean collisionBetweenLinkedBodies) {
+        this.collisionBetweenLinkedBodys = collisionBetweenLinkedBodies;
     }
 
     public PhysicsRigidBody getBodyA() {

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/util/Converter.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/util/Converter.java
@@ -259,11 +259,11 @@ public class Converter {
         jmeMesh.setBuffer(Type.Index, 3, BufferUtils.createShortBuffer(mesh.numTriangles * 3));
         jmeMesh.setBuffer(Type.Position, 3, BufferUtils.createFloatBuffer(mesh.numVertices * 3));
 
-        IndexBuffer indicess = jmeMesh.getIndexBuffer();
+        IndexBuffer indices = jmeMesh.getIndexBuffer();
         FloatBuffer vertices = jmeMesh.getFloatBuffer(Type.Position);
 
         for (int i = 0; i < mesh.numTriangles * 3; i++) {
-            indicess.put(i, mesh.triangleIndexBase.getInt(i * 4));
+            indices.put(i, mesh.triangleIndexBase.getInt(i * 4));
         }
 
         for (int i = 0; i < mesh.numVertices * 3; i++) {

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/util/DebugShapeFactory.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/util/DebugShapeFactory.java
@@ -188,16 +188,16 @@ public class DebugShapeFactory {
         vertices.limit(numberOfFloats);
 
         // Loop variables
-        final IntArrayList hullIndicies = hull.getIndexPointer();
+        final IntArrayList hullIndices = hull.getIndexPointer();
         final List<Vector3f> hullVertices = hull.getVertexPointer();
         Vector3f vertexA, vertexB, vertexC;
         int index = 0;
 
         for (int i = 0; i < numberOfTriangles; i++) {
             // Grab the data for this triangle from the hull
-            vertexA = hullVertices.get(hullIndicies.get(index++));
-            vertexB = hullVertices.get(hullIndicies.get(index++));
-            vertexC = hullVertices.get(hullIndicies.get(index++));
+            vertexA = hullVertices.get(hullIndices.get(index++));
+            vertexB = hullVertices.get(hullIndices.get(index++));
+            vertexC = hullVertices.get(hullIndices.get(index++));
 
             // Put the verticies into the vertex buffer
             vertices.put(vertexA.x).put(vertexA.y).put(vertexA.z);

--- a/jme3-lwjgl/src/main/java/com/jme3/opencl/lwjgl/Utils.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/opencl/lwjgl/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -112,11 +112,11 @@ public class Utils {
     }
     public static void checkError(int error, String callName) {
         if (error != CL10.CL_SUCCESS) {
-            String errname = getErrorName(error);
-            if (errname == null) {
-                errname = "UNKNOWN";
+            String errorName = getErrorName(error);
+            if (errorName == null) {
+                errorName = "UNKNOWN";
             }
-            throw new OpenCLException("OpenCL error in " + callName + ": " + errname + " (0x" + Integer.toHexString(error) + ")", error);
+            throw new OpenCLException("OpenCL error in " + callName + ": " + errorName + " (0x" + Integer.toHexString(error) + ")", error);
         }
     }
     

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -397,10 +397,10 @@ public abstract class LwjglContext implements JmeContext {
         if (chooser == null) {
             chooser = new DefaultPlatformChooser();
         }
-        List<? extends Device> choosenDevices = chooser.chooseDevices(platforms);
-        List<CLDevice> devices = new ArrayList<>(choosenDevices.size());
+        List<? extends Device> chosenDevices = chooser.chooseDevices(platforms);
+        List<CLDevice> devices = new ArrayList<>(chosenDevices.size());
         LwjglPlatform platform = null;
-        for (Device d : choosenDevices) {
+        for (Device d : chosenDevices) {
             if (!(d instanceof LwjglDevice)) {
                 logger.log(Level.SEVERE, "attempt to return a custom Device implementation from PlatformChooser: {0}", d);
                 return;
@@ -420,12 +420,12 @@ public abstract class LwjglContext implements JmeContext {
         }
         clPlatform = platform;
         logger.log(Level.INFO, "chosen platform: {0}", platform.getName());
-        logger.log(Level.INFO, "chosen devices: {0}", choosenDevices);
+        logger.log(Level.INFO, "chosen devices: {0}", chosenDevices);
         
         //create context
         try {
             CLContext c = CLContext.create(platform.getPlatform(), devices, null, Display.getDrawable(), null);
-            clContext = new com.jme3.opencl.lwjgl.LwjglContext(c, (List<LwjglDevice>) choosenDevices);
+            clContext = new com.jme3.opencl.lwjgl.LwjglContext(c, (List<LwjglDevice>) chosenDevices);
         } catch (LWJGLException ex) {
             logger.log(Level.SEVERE, "Unable to create OpenCL context", ex);
             return;

--- a/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/Utils.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2016 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -108,11 +108,11 @@ public class Utils {
     }
     public static void checkError(int error, String callName) {
         if (error != CL10.CL_SUCCESS) {
-            String errname = getErrorName(error);
-            if (errname == null) {
-                errname = "UNKNOWN";
+            String errorName = getErrorName(error);
+            if (errorName == null) {
+                errorName = "UNKNOWN";
             }
-            throw new OpenCLException("OpenCL error in " + callName + ": " + errname + " (0x" + Integer.toHexString(error) + ")", error);
+            throw new OpenCLException("OpenCL error in " + callName + ": " + errorName + " (0x" + Integer.toHexString(error) + ")", error);
         }
     }
     

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -380,8 +380,8 @@ public abstract class LwjglContext implements JmeContext {
             chooser = new DefaultPlatformChooser();
         }
 
-        final List<? extends Device> choosenDevices = chooser.chooseDevices(platforms);
-        final Optional<? extends Device> unsupportedDevice = choosenDevices.stream()
+        final List<? extends Device> chosenDevices = chooser.chooseDevices(platforms);
+        final Optional<? extends Device> unsupportedDevice = chosenDevices.stream()
                 .filter(dev -> !(dev instanceof LwjglDevice))
                 .findAny();
 
@@ -391,7 +391,7 @@ public abstract class LwjglContext implements JmeContext {
             return;
         }
 
-        final Set<LwjglPlatform> lwjglPlatforms = choosenDevices.stream()
+        final Set<LwjglPlatform> lwjglPlatforms = chosenDevices.stream()
                 .map(LwjglDevice.class::cast)
                 .map(LwjglDevice::getPlatform)
                 .collect(toSet());
@@ -401,7 +401,7 @@ public abstract class LwjglContext implements JmeContext {
             return;
         }
 
-        final long[] deviceIds = choosenDevices.stream()
+        final long[] deviceIds = chosenDevices.stream()
                 .map(LwjglDevice.class::cast)
                 .mapToLong(LwjglDevice::getDevice)
                 .toArray();
@@ -416,12 +416,12 @@ public abstract class LwjglContext implements JmeContext {
                 .orElseThrow(() -> new RuntimeException("not found a platform"));
 
         logger.log(Level.INFO, "chosen platform: {0}", platform.getName());
-        logger.log(Level.INFO, "chosen devices: {0}", choosenDevices);
+        logger.log(Level.INFO, "chosen devices: {0}", chosenDevices);
         
         // create context
         try {
             long context = createContext(platform.getPlatform(), deviceIds, window);
-            clContext = new com.jme3.opencl.lwjgl.LwjglContext(context, (List<LwjglDevice>) choosenDevices);
+            clContext = new com.jme3.opencl.lwjgl.LwjglContext(context, (List<LwjglDevice>) chosenDevices);
         } catch (final Exception ex) {
             logger.log(Level.SEVERE, "Unable to create OpenCL context", ex);
             return;

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneLoader.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneLoader.java
@@ -72,7 +72,7 @@ public class SceneLoader implements AssetLoader {
 	// Scene objects
 	private Map<Long, FbxObject> allObjects = new HashMap<>(); // All supported FBX objects
 	private Map<Long, FbxSkin> skinMap = new HashMap<>(); // Skin for bone clusters
-	private Map<Long, FbxObject> alayerMap = new HashMap<>(); // Animation layers
+	private Map<Long, FbxObject> aLayerMap = new HashMap<>(); // Animation layers
 	public Map<Long, FbxNode> modelMap = new HashMap<>(); // Nodes
 	private Map<Long, FbxNode> limbMap = new HashMap<>(); // Nodes that are actually bones
 	private Map<Long, FbxBindPose> bindMap = new HashMap<>(); // Node bind poses
@@ -197,7 +197,7 @@ public class SceneLoader implements AssetLoader {
 			case "AnimationLayer":
 				FbxObject layer = new FbxObject(this, e);
 				obj = layer;
-				alayerMap.put(layer.id, layer);
+				aLayerMap.put(layer.id, layer);
 				break;
 			case "AnimationCurve":
 				obj = new FbxAnimCurve(this, e);
@@ -304,8 +304,8 @@ public class SceneLoader implements AssetLoader {
 			return;
 		if(animList == null || animList.list.size() == 0) {
 			animList = new AnimationList();
-			for(long layerId : alayerMap.keySet()) {
-				FbxObject layer = alayerMap.get(layerId);
+			for(long layerId : aLayerMap.keySet()) {
+				FbxObject layer = aLayerMap.get(layerId);
 				animList.add(layer.name, layer.name, 0, -1);
 			}
 		}
@@ -319,8 +319,8 @@ public class SceneLoader implements AssetLoader {
 			Animation anim = new Animation(animInfo.name, length);
 			// Search source layer for animation nodes
 			long sourceLayerId = 0L;
-			for(long layerId : alayerMap.keySet()) {
-				FbxObject layer = alayerMap.get(layerId);
+			for(long layerId : aLayerMap.keySet()) {
+				FbxObject layer = aLayerMap.get(layerId);
 				if(layer.name.equals(animInfo.layerName)) {
 					sourceLayerId = layerId;
 					break;
@@ -448,7 +448,7 @@ public class SceneLoader implements AssetLoader {
 		// Clear objects
 		allObjects.clear();
 		skinMap.clear();
-		alayerMap.clear();
+		aLayerMap.clear();
 		modelMap.clear();
 		limbMap.clear();
 		bindMap.clear();

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/objects/FbxMesh.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/objects/FbxMesh.java
@@ -341,8 +341,8 @@ public class FbxMesh extends FbxObject {
 		}
 		if(vertices != null) {
 			// Unroll vertices data array
-			FloatBuffer posBuf = BufferUtils.createFloatBuffer(vCount * 3);
-			mesh.setBuffer(VertexBuffer.Type.Position, 3, posBuf);
+			FloatBuffer positionBuffer = BufferUtils.createFloatBuffer(vCount * 3);
+			mesh.setBuffer(VertexBuffer.Type.Position, 3, positionBuffer);
 			int srcCount = vertices.length / 3;
 			for(int i = 0; i < vCount; ++i) {
 				int index = vertexMap.get(i);
@@ -351,13 +351,13 @@ public class FbxMesh extends FbxObject {
 				float x = (float) vertices[3 * index + 0] / scene.unitSize * scene.xAxis; // XXX Why we should scale by unit size?
 				float y = (float) vertices[3 * index + 1] / scene.unitSize * scene.yAxis;
 				float z = (float) vertices[3 * index + 2] / scene.unitSize * scene.zAxis;
-				posBuf.put(x).put(y).put(z);
+				positionBuffer.put(x).put(y).put(z);
 			}
 		}
 		if(normals != null) {
 			// Unroll normals data array
-			FloatBuffer normBuf = BufferUtils.createFloatBuffer(vCount * 3);
-			mesh.setBuffer(VertexBuffer.Type.Normal, 3, normBuf);
+			FloatBuffer normalBuffer = BufferUtils.createFloatBuffer(vCount * 3);
+			mesh.setBuffer(VertexBuffer.Type.Normal, 3, normalBuffer);
 			List<Integer> mapping = null;
 			if(normalsMapping.equals("ByVertice"))
 				mapping = vertexMap;
@@ -373,13 +373,13 @@ public class FbxMesh extends FbxObject {
 				float x = (float) normals[3 * index + 0] * scene.xAxis;
 				float y = (float) normals[3 * index + 1] * scene.yAxis;
 				float z = (float) normals[3 * index + 2] * scene.zAxis;
-				normBuf.put(x).put(y).put(z);
+				normalBuffer.put(x).put(y).put(z);
 			}
 		}
 		if(tangents != null) {
 			// Unroll normals data array
-			FloatBuffer tanBuf = BufferUtils.createFloatBuffer(vCount * 4);
-			mesh.setBuffer(VertexBuffer.Type.Tangent, 4, tanBuf);
+			FloatBuffer tangentBuffer = BufferUtils.createFloatBuffer(vCount * 4);
+			mesh.setBuffer(VertexBuffer.Type.Tangent, 4, tangentBuffer);
 			List<Integer> mapping = null;
 			if(tangentsMapping.equals("ByVertice"))
 				mapping = vertexMap;
@@ -395,13 +395,13 @@ public class FbxMesh extends FbxObject {
 				float x = (float) tangents[3 * index + 0] * scene.xAxis;
 				float y = (float) tangents[3 * index + 1] * scene.yAxis;
 				float z = (float) tangents[3 * index + 2] * scene.zAxis;
-				tanBuf.put(x).put(y).put(z).put(-1.0f);
+				tangentBuffer.put(x).put(y).put(z).put(-1.0f);
 			}
 		}
 		if(binormals != null) {
 			// Unroll normals data array
-			FloatBuffer binormBuf = BufferUtils.createFloatBuffer(vCount * 3);
-			mesh.setBuffer(VertexBuffer.Type.Binormal, 3, binormBuf);
+			FloatBuffer binormalBuffer = BufferUtils.createFloatBuffer(vCount * 3);
+			mesh.setBuffer(VertexBuffer.Type.Binormal, 3, binormalBuffer);
 			List<Integer> mapping = null;
 			if(binormalsMapping.equals("ByVertice"))
 				mapping = vertexMap;
@@ -417,7 +417,7 @@ public class FbxMesh extends FbxObject {
 				float x = (float) binormals[3 * index + 0] * scene.xAxis;
 				float y = (float) binormals[3 * index + 1] * scene.yAxis;
 				float z = (float) binormals[3 * index + 2] * scene.zAxis;
-				binormBuf.put(x).put(y).put(z);
+				binormalBuffer.put(x).put(y).put(z);
 			}
 		}
 		for(int uvLayer = 0; uvLayer < uvs.size(); ++uvLayer) {
@@ -452,7 +452,7 @@ public class FbxMesh extends FbxObject {
 				}
 			}
 			// Unroll UV data array
-			FloatBuffer tcBuf = BufferUtils.createFloatBuffer(vCount * 2);
+			FloatBuffer uvBuffer = BufferUtils.createFloatBuffer(vCount * 2);
 			VertexBuffer.Type type = VertexBuffer.Type.TexCoord;
 			switch(uvLayer) {
 			case 1:
@@ -477,7 +477,7 @@ public class FbxMesh extends FbxObject {
 				type = VertexBuffer.Type.TexCoord8;
 				break;
 			}
-			mesh.setBuffer(type, 2, tcBuf);
+			mesh.setBuffer(type, 2, uvBuffer);
 			int srcCount = uv.length / 2;
 			for(int i = 0; i < vCount; ++i) {
 				int index = unIndexMap.get(i);
@@ -485,7 +485,7 @@ public class FbxMesh extends FbxObject {
 					throw new AssetLoadException("Invalid texcoord mapping. Unexpected lookup texcoord " + index + " from " + srcCount);
 				float u = (index >= 0) ? (float) uv[2 * index + 0] : 0;
 				float v = (index >= 0) ? (float) uv[2 * index + 1] : 0;
-				tcBuf.put(u).put(v);
+				uvBuffer.put(u).put(v);
 			}
 		}
 		List<Geometry> geometries = new ArrayList<>();

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/objects/FbxSkin.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/objects/FbxSkin.java
@@ -106,7 +106,7 @@ public class FbxSkin extends FbxObject {
 						boneWeightData.put(offset, (float) cluster.weights[i]);
 						boneIndicesData.put(offset, (byte) limb.boneIndex);
 					} else {
-						if((float) cluster.weights[i] > smalestW) { // If current weight more than smallest, discard smallest
+						if((float) cluster.weights[i] > smallestW) { // If current weight more than smallest, discard smallest
 							boneWeightData.put(smallestOffset, (float) cluster.weights[i]);
 							boneIndicesData.put(smallestOffset, (byte) limb.boneIndex);
 						}

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/objects/FbxSkin.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/objects/FbxSkin.java
@@ -90,16 +90,16 @@ public class FbxSkin extends FbxObject {
 					int v = dstVertices.get(j);
 					// Append bone index and weight to vertex
 					int offset;
-					int smalestOffset = 0;
+					int smallestOffset = 0;
 					float w = 0;
-					float smalestW = Float.MAX_VALUE;
+					float smallestW = Float.MAX_VALUE;
 					for(offset = v * 4; offset < v * 4 + 4; ++offset) {
 						w = boneWeightData.get(offset);
 						if(w == 0)
 							break;
-						if(w < smalestW) {
-							smalestW = w;
-							smalestOffset = offset;
+						if(w < smallestW) {
+							smallestW = w;
+							smallestOffset = offset;
 						}
 					}
 					if(w == 0) {
@@ -107,8 +107,8 @@ public class FbxSkin extends FbxObject {
 						boneIndicesData.put(offset, (byte) limb.boneIndex);
 					} else {
 						if((float) cluster.weights[i] > smalestW) { // If current weight more than smallest, discard smallest
-							boneWeightData.put(smalestOffset, (float) cluster.weights[i]);
-							boneIndicesData.put(smalestOffset, (byte) limb.boneIndex);
+							boneWeightData.put(smallestOffset, (float) cluster.weights[i]);
+							boneIndicesData.put(smallestOffset, (byte) limb.boneIndex);
 						}
 						bonesLimitExceeded++;
 					}

--- a/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/MaterialLoader.java
+++ b/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/MaterialLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,7 +63,7 @@ public class MaterialLoader implements AssetLoader {
     private Texture[] textures = new Texture[4];
     private String texName;
     private String matName;
-    private float shinines;
+    private float shininess;
     private boolean vcolor = false;
     private boolean blend = false;
     private boolean twoSide = false;
@@ -247,11 +247,11 @@ public class MaterialLoader implements AssetLoader {
             if (subsplit.length >= 5){
                 // using 5 float values
                 specular.a = unknown;
-                shinines = Float.parseFloat(subsplit[4]);
+                shininess = Float.parseFloat(subsplit[4]);
             }else{
                 // using 4 float values
                 specular.a = 1f;
-                shinines = unknown;
+                shininess = unknown;
             }
         }else if (keyword.equals("texture_unit")){
             readTextureUnit(statement);
@@ -363,8 +363,8 @@ public class MaterialLoader implements AssetLoader {
         }
 
         if (!noLight){
-            if (shinines > 0f) {
-                mat.setFloat("Shininess", shinines);
+            if (shininess > 0f) {
+                mat.setFloat("Shininess", shininess);
             } else {
                 mat.setFloat("Shininess", 16f); // set shininess to some value anyway..
             }
@@ -432,7 +432,7 @@ public class MaterialLoader implements AssetLoader {
         diffuse = null;
         specular = null;
         emissive = null;
-        shinines = 0f;
+        shininess = 0f;
         vcolor = false;
         blend = false;
         texUnit = 0;

--- a/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/MeshLoader.java
+++ b/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/MeshLoader.java
@@ -294,8 +294,8 @@ public class MeshLoader extends DefaultHandler implements AssetLoader {
         mesh = sharedMesh;
     }
 
-    private void startGeometry(String vertexcount) throws SAXException {
-        vertCount = parseInt(vertexcount);
+    private void startGeometry(String vertexCount) throws SAXException {
+        vertCount = parseInt(vertexCount);
     }
 
     /**

--- a/jme3-vr/src/main/java/com/jme3/app/VRApplication.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VRApplication.java
@@ -172,7 +172,7 @@ public abstract class VRApplication implements Application, SystemListener {
     private VRAPI VRhardware            = null;
     private VRGuiManager guiManager     = null;
     private OpenVRMouseManager mouseManager = null;
-    private OpenVRViewManager viewmanager   = null;
+    private OpenVRViewManager viewManager = null;
     
     private String OS;
      
@@ -259,7 +259,7 @@ public abstract class VRApplication implements Application, SystemListener {
         guiManager = new VRGuiManager(null);
         
         // Create a new view manager.
-        viewmanager = new OpenVRViewManager(null);
+        viewManager = new OpenVRViewManager(null);
         
         // Create a new mouse manager.
         mouseManager = new OpenVRMouseManager(null);
@@ -312,7 +312,7 @@ public abstract class VRApplication implements Application, SystemListener {
      * @return the VR view manager.
      */
     public OpenVRViewManager getVRViewManager() {
-        return viewmanager;
+        return viewManager;
     }
     
     /**
@@ -357,7 +357,7 @@ public abstract class VRApplication implements Application, SystemListener {
      */
     public void setResolutionMultiplier(float val) {
         resMult = val;
-        if( viewmanager != null ) viewmanager.setResolutionMultiplier(resMult);
+        if( viewManager != null ) viewManager.setResolutionMultiplier(resMult);
     }
     
     
@@ -399,7 +399,7 @@ public abstract class VRApplication implements Application, SystemListener {
     */
     @Override
     public Camera getCamera() {
-        if( isInVR() && viewmanager != null && viewmanager.getLeftCamera() != null ) {
+        if( isInVR() && viewManager != null && viewManager.getLeftCamera() != null ) {
             return dummyCam;
         }
         return cam;
@@ -841,7 +841,7 @@ public abstract class VRApplication implements Application, SystemListener {
      */
     public void moveScreenProcessingToVR() {
         if( isInVR() ) {
-        	viewmanager.moveScreenProcessingToEyes();
+        	viewManager.moveScreenProcessingToEyes();
         }
     }
     
@@ -1037,7 +1037,7 @@ public abstract class VRApplication implements Application, SystemListener {
      * @see #getFinalObserverPosition()
      */
     public Quaternion getFinalObserverRotation() {
-        if( viewmanager == null ) {
+        if( viewManager == null ) {
             if( observer == null ) {
                 return getCamera().getRotation();
             } else return observer.getWorldRotation();
@@ -1056,7 +1056,7 @@ public abstract class VRApplication implements Application, SystemListener {
      * @see #getFinalObserverRotation()
      */
     public Vector3f getFinalObserverPosition() {
-        if( viewmanager == null ) {
+        if( viewManager == null ) {
             if( observer == null ) {
                 return getCamera().getLocation();
             } else return observer.getWorldTranslation();            
@@ -1077,7 +1077,7 @@ public abstract class VRApplication implements Application, SystemListener {
      * @see #getVRHeightAdjustment()
      */
     public void setVRHeightAdjustment(float amount) {
-        if( viewmanager != null ) viewmanager.setHeightAdjustment(amount);
+        if( viewManager != null ) viewManager.setHeightAdjustment(amount);
     }
     
     /**
@@ -1086,7 +1086,7 @@ public abstract class VRApplication implements Application, SystemListener {
      * @see #setVRHeightAdjustment(float)
      */
     public float getVRHeightAdjustment() {
-        if( viewmanager != null ) return viewmanager.getHeightAdjustment();
+        if( viewManager != null ) return viewManager.getHeightAdjustment();
         return 0f;
     }
       
@@ -1096,8 +1096,8 @@ public abstract class VRApplication implements Application, SystemListener {
      * @see #getRightViewPort()
      */
     public ViewPort getLeftViewPort() {
-        if( viewmanager == null ) return getViewPort();
-        return viewmanager.getLeftViewPort();
+        if( viewManager == null ) return getViewPort();
+        return viewManager.getLeftViewPort();
     }
     
     /**
@@ -1106,8 +1106,8 @@ public abstract class VRApplication implements Application, SystemListener {
      * @see #getLeftViewPort()
      */
     public ViewPort getRightViewPort() {
-        if( viewmanager == null ) return getViewPort();
-        return viewmanager.getRightViewPort();
+        if( viewManager == null ) return getViewPort();
+        return viewManager.getRightViewPort();
     }
     
     
@@ -1116,11 +1116,11 @@ public abstract class VRApplication implements Application, SystemListener {
      * @param clr the background color.
      */
     public void setBackgroundColors(ColorRGBA clr) {
-        if( viewmanager == null ) {
+        if( viewManager == null ) {
             getViewPort().setBackgroundColor(clr);
-        } else if( viewmanager.getLeftViewPort() != null ) {
-        	viewmanager.getLeftViewPort().setBackgroundColor(clr);
-            if( viewmanager.getRightViewPort() != null ) viewmanager.getRightViewPort().setBackgroundColor(clr);
+        } else if( viewManager.getLeftViewPort() != null ) {
+        	viewManager.getLeftViewPort().setBackgroundColor(clr);
+            if( viewManager.getRightViewPort() != null ) viewManager.getRightViewPort().setBackgroundColor(clr);
         }
     }
     
@@ -1179,8 +1179,8 @@ public abstract class VRApplication implements Application, SystemListener {
         stateManager.render(renderManager);
         
         // update VR pose & cameras
-        if( viewmanager != null ) {
-        	viewmanager.update(tpf);    
+        if( viewManager != null ) {
+        	viewManager.update(tpf);
         } else if( observer != null ) {
             getCamera().setFrame(observer.getWorldTranslation(), observer.getWorldRotation());
         }
@@ -1203,8 +1203,8 @@ public abstract class VRApplication implements Application, SystemListener {
         stateManager.postRender();
         
         // update compositor?
-        if( viewmanager != null ) {
-        	viewmanager.postRender();
+        if( viewManager != null ) {
+        	viewManager.postRender();
         }
     }
 
@@ -1371,8 +1371,8 @@ public abstract class VRApplication implements Application, SystemListener {
             }
             
             //FIXME: WARNING !!
-            viewmanager = new OpenVRViewManager(null);
-            viewmanager.setResolutionMultiplier(resMult);
+            viewManager = new OpenVRViewManager(null);
+            viewManager.setResolutionMultiplier(resMult);
             inputManager.addMapping(RESET_HMD, new KeyTrigger(KeyInput.KEY_F9));
             setLostFocusBehavior(LostFocusBehavior.Disabled);
         } else {
@@ -1381,25 +1381,25 @@ public abstract class VRApplication implements Application, SystemListener {
             guiViewPort.attachScene(guiNode);
         }
         
-        if( viewmanager != null ) {
-        	viewmanager.initialize();
+        if( viewManager != null ) {
+        	viewManager.initialize();
         }
         
         simpleInitApp();
         
         // any filters created, move them now
-        if( viewmanager != null ) {
-        	viewmanager.moveScreenProcessingToEyes();
+        if( viewManager != null ) {
+        	viewManager.moveScreenProcessingToEyes();
             
             // print out camera information
             if( isInVR() ) {
                 logger.info("VR Initialization Information");
-                if( viewmanager.getLeftCamera() != null ){ 
-                  logger.info("camLeft: " + viewmanager.getLeftCamera().toString());
+                if( viewManager.getLeftCamera() != null ){
+                  logger.info("camLeft: " + viewManager.getLeftCamera().toString());
                 }
                 
-                if( viewmanager.getRightCamera() != null ){ 
-                  logger.info("camRight: " + viewmanager.getRightCamera().toString());
+                if( viewManager.getRightCamera() != null ){
+                  logger.info("camRight: " + viewManager.getRightCamera().toString());
                 }
             }
         }

--- a/jme3-vr/src/main/java/com/jme3/app/VREnvironment.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VREnvironment.java
@@ -39,7 +39,7 @@ public class VREnvironment {
     private VRAPI hardware              = null;
     private VRGuiManager guiManager     = null;
     private VRMouseManager mouseManager = null;
-    private VRViewManager viewmanager   = null;
+    private VRViewManager viewManager = null;
     
     private VRBounds bounds             = null;
     
@@ -132,7 +132,7 @@ public class VREnvironment {
 	 * @return the VR view manager.
 	 */
 	public VRViewManager getVRViewManager() {
-	    return viewmanager;
+	    return viewManager;
 	}
 	
 	/**
@@ -190,8 +190,8 @@ public class VREnvironment {
      * @see #getVRHeightAdjustment()
      */
     public void setVRHeightAdjustment(float amount) {
-        if( viewmanager != null ){
-        	viewmanager.setHeightAdjustment(amount);
+        if( viewManager != null ){
+        	viewManager.setHeightAdjustment(amount);
         }
     }
     
@@ -201,8 +201,8 @@ public class VREnvironment {
      * @see #setVRHeightAdjustment(float)
      */
     public float getVRHeightAdjustment() {
-        if( viewmanager != null ){
-        	return viewmanager.getHeightAdjustment();
+        if( viewManager != null ){
+        	return viewManager.getHeightAdjustment();
         }
         return 0f;
     }
@@ -405,15 +405,15 @@ public class VREnvironment {
     	this.application = application;
     	this.app         = appState;
     	
-    	// Instanciate view manager
+    	// Instantiate view manager
     	if (vrBinding == VRConstants.SETTING_VRAPI_OPENVR_VALUE){
-    		viewmanager = new OpenVRViewManager(this);
+    		viewManager = new OpenVRViewManager(this);
     	} else if (vrBinding == VRConstants.SETTING_VRAPI_OSVR_VALUE){
-    		viewmanager = new OSVRViewManager(this);
+    		viewManager = new OSVRViewManager(this);
     	} else if (vrBinding == VRConstants.SETTING_VRAPI_OCULUSVR_VALUE) {
-    		viewmanager = new OculusViewManager(this);
+    		viewManager = new OculusViewManager(this);
     	} else if (vrBinding == VRConstants.SETTING_VRAPI_OPENVR_LWJGL_VALUE) {
-    		viewmanager = new LWJGLOpenVRViewManager(this);
+    		viewManager = new LWJGLOpenVRViewManager(this);
     	} else {
     		logger.severe("Cannot instanciate view manager, unknown VRAPI type: "+vrBinding);
     	}


### PR DESCRIPTION
This PR renames local variables, method arguments, private fields, and such in the Java code. In most cases the old names contained typos or spelling errors. A few names violated coding conventions (see issue #1587, for instance) or were abbreviated to the brink of becoming unintelligible.

There's plenty of room for further work along these lines.