### PR TITLE
Buffered mjpeg file writer

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -478,7 +478,7 @@ public class MjpegFileWriter implements AutoCloseable {
             ind.add(new AVIIndex(dwOffset, dwSize));
         }
 
-        public byte[] toBytes() throws Exception {
+        public byte[] toBytes() throws IOException {
             cb = 16 * ind.size();
 
             ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
This optimizes the VideoRecorderAppState video file writing.

- The old version writes really small chunks, 4 bytes, even 1 byte chunks at times, PER FRAME!
- The new version uses buffer (8192 bytes) to write bigger chunks
- In reality much of the data written at a time (the individual frames) is a bigger chunk than 8192 -> written at one go
- Implements AutoCloseable, in my mind this is logical. Like writing a ZIP file etc. similar API

Basically this improves performance by eliminating some of the system calls.

New:
![image](https://user-images.githubusercontent.com/8344766/127681754-2900571f-2f1f-4f85-ab85-05f8124c4548.png)

Old:
![image](https://user-images.githubusercontent.com/8344766/127681992-144d4070-9f78-4e53-87ee-87f9db9db955.png)
