### PR TITLE
Restart audio context if current device is "disconnected"

### DIFF
--- a/jme3-core/src/main/java/com/jme3/audio/openal/ALAudioRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/audio/openal/ALAudioRenderer.java
@@ -865,13 +865,13 @@ public class ALAudioRenderer implements AudioRenderer, Runnable {
     private void checkDevice() {
 
         // If the device is disconnected, pick a new one
-        if (isZombieDevice()) {
+        if (isDisconnected()) {
             logger.log(Level.INFO, "Current audio device disconnected.");
             restartAudioRenderer();
         }
     }
 
-    private boolean isZombieDevice() {
+    private boolean isDisconnected() {
         if (!supportDisconnect) {
             return false;
         }

--- a/jme3-core/src/main/java/com/jme3/audio/openal/ALC.java
+++ b/jme3-core/src/main/java/com/jme3/audio/openal/ALC.java
@@ -61,6 +61,7 @@ public interface ALC {
     public static final int ALC_ALL_DEVICES_SPECIFIER = 0x1013;
 
     //public static ALCCapabilities createCapabilities(long device);
+    public static final int ALC_CONNECTED = 0x313;
 
     /**
      * Creates an AL context.


### PR DESCRIPTION
Okay, finally something that it is worthy in my mind; recovering from audio failure! The implementation is based on: http://forum.lwjgl.org/index.php?topic=7081.msg37006#msg37006. Tested on Linux & Windows and seems to work.

To try it out:

- Use i.e. headphones when launching a jME app
- Disconnect headphones

New behavior in this case:

- The disconnection is detected fairly soon, audio renderer is re-created, creates some noise on the log
- Lost bytes in the buffer are not recovered :(
- New audio goes to the new default device

Old behavior in this case:

- No sound, ever, again
- Our app plays background tunes -> CPU spikes permanently as we start feeding audio to void
- Behavior of disconnected device is documented here: https://javadoc.lwjgl.org/org/lwjgl/openal/EXTDisconnect.html
- It kinda pretends to work

What this does **not** do:

- Replugging headphones doesn't change audio back to headphones -> we wont react to changes in default devices, only disconnected/broken
- I did try to also do this, but I couldn't detect this situation. At least with the headphones, the headphones was always the default whether they were plugged in or not. Probably works if the default device is changed by the user for real. But since the automatic headphone thing doesn't work, I don't see this as a must have (or a regular use case).