### PR TITLE
Add note to javadoc for Quaternion lookAt method

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -1405,7 +1405,9 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * <code>lookAt</code> is a convenience method for auto-setting the
      * quaternion based on a direction and an up vector. It computes
      * the rotation to transform the z-axis to point into 'direction'
-     * and the y-axis to 'up'.
+     * and the y-axis to 'up'.  Note that the results will be invalid
+     * if a zero length direction vector (0,0,0) is supplied, or if the 
+     * direction and up vectors are parallel.
      *
      * @param direction
      *            where to look at in terms of local coordinates


### PR DESCRIPTION
Adds a small note to the javadoc for Quaternion.lookAt, to explain that the method may produce invalid results under some circumstances.