### PR TITLE
rename some method arguments for clarity

### DIFF
--- a/jme3-android-examples/src/main/java/org/jmonkeyengine/jme3androidexamples/MainActivity.java
+++ b/jme3-android-examples/src/main/java/org/jmonkeyengine/jme3androidexamples/MainActivity.java
@@ -364,7 +364,7 @@ public class MainActivity extends AppCompatActivity implements OnItemClickListen
         setSelection(-1);
     }
 
-    public void afterTextChanged(Editable edtbl) {
+    public void afterTextChanged(Editable editable) {
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/animation/Pose.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Pose.java
@@ -76,9 +76,9 @@ public final class Pose implements Savable, Cloneable {
      * Applies the offsets of this pose to the vertex buffer given by the blend factor.
      *
      * @param blend Blend factor, 0 = no change to vertex buffer, 1 = apply full offsets
-     * @param vertbuf Vertex buffer to apply this pose to
+     * @param vertexBuffer Vertex buffer to apply this pose to
      */
-    public void apply(float blend, FloatBuffer vertbuf){
+    public void apply(float blend, FloatBuffer vertexBuffer){
         for (int i = 0; i < indices.length; i++){
             Vector3f offset = offsets[i];
             int vertIndex   = indices[i];
@@ -86,13 +86,13 @@ public final class Pose implements Savable, Cloneable {
             tempVec.set(offset).multLocal(blend);
 
             // acquire vertex
-            BufferUtils.populateFromBuffer(tempVec2, vertbuf, vertIndex);
+            BufferUtils.populateFromBuffer(tempVec2, vertexBuffer, vertIndex);
 
             // add offset multiplied by factor
             tempVec2.addLocal(tempVec);
 
             // write modified vertex
-            BufferUtils.setInBuffer(tempVec2, vertbuf, vertIndex);
+            BufferUtils.setInBuffer(tempVec2, vertexBuffer, vertIndex);
         }
     }
     

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GL.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GL.java
@@ -281,22 +281,22 @@ public interface GL {
      * <p>
      * Specifies the weighting factors used by the blend equation, for both RGB and alpha functions and for all draw buffers.
      *
-     * @param sfactor the source weighting factor.
-     * @param dfactor the destination weighting factor.
+     * @param sFactor the source weighting factor.
+     * @param dFactor the destination weighting factor.
      */
-    public void glBlendFunc(int sfactor, int dfactor);
+    public void glBlendFunc(int sFactor, int dFactor);
 
     /**
      * <p><a target="_blank" href="http://docs.gl/gl4/glBlendFuncSeparate">Reference Page</a></p>
      * <p>
      * Specifies pixel arithmetic for RGB and alpha components separately.
      *
-     * @param sfactorRGB   how the red, green, and blue blending factors are computed. The initial value is GL_ONE.
-     * @param dfactorRGB   how the red, green, and blue destination blending factors are computed. The initial value is GL_ZERO.
-     * @param sfactorAlpha how the alpha source blending factor is computed. The initial value is GL_ONE.
-     * @param dfactorAlpha how the alpha destination blending factor is computed. The initial value is GL_ZERO.
+     * @param sFactorRGB   how the red, green, and blue blending factors are computed. The initial value is GL_ONE.
+     * @param dFactorRGB   how the red, green, and blue destination blending factors are computed. The initial value is GL_ZERO.
+     * @param sFactorAlpha how the alpha source blending factor is computed. The initial value is GL_ONE.
+     * @param dFactorAlpha how the alpha destination blending factor is computed. The initial value is GL_ZERO.
      */
-    public void glBlendFuncSeparate(int sfactorRGB, int dfactorRGB, int sfactorAlpha, int dfactorAlpha);
+    public void glBlendFuncSeparate(int sFactorRGB, int dFactorRGB, int sFactorAlpha, int dFactorAlpha);
 
     /**
      * <p><a target="_blank" href="http://docs.gl/gl4/glBufferData">Reference Page</a></p>

--- a/jme3-desktop/src/main/java/jme3tools/converters/ImageToAwt.java
+++ b/jme3-desktop/src/main/java/jme3tools/converters/ImageToAwt.java
@@ -375,7 +375,7 @@ public class ImageToAwt {
         }
     }
 
-    public static BufferedImage convert(Image image, boolean do16bit, boolean fullalpha, int mipLevel){
+    public static BufferedImage convert(Image image, boolean do16bit, boolean fullAlpha, int mipLevel){
         Format format = image.getFormat();
         DecodeParams p = params.get(image.getFormat());
         if (p == null)
@@ -411,7 +411,7 @@ public class ImageToAwt {
             out = new BufferedImage(width, height, BufferedImage.TYPE_BYTE_GRAY);
         }else if ( (rgb && alpha) || (luminance && alpha) ){
             if (do16bit){
-                if (fullalpha){
+                if (fullAlpha){
                     ColorModel model = AWTLoader.AWT_RGBA4444;
                     WritableRaster raster = model.createCompatibleWritableRaster(width, width);
                     out = new BufferedImage(model, raster, false, null);

--- a/jme3-ios/src/main/java/com/jme3/renderer/ios/IosGL.java
+++ b/jme3-ios/src/main/java/com/jme3/renderer/ios/IosGL.java
@@ -147,13 +147,13 @@ public class IosGL implements GL, GL2, GLES_30, GLExt, GLFbo {
     }
 
     @Override
-    public void glBlendFunc(int sfactor, int dfactor) {
-        JmeIosGLES.glBlendFunc(sfactor, dfactor);
+    public void glBlendFunc(int sFactor, int dFactor) {
+        JmeIosGLES.glBlendFunc(sFactor, dFactor);
     }
     
     @Override
-    public void glBlendFuncSeparate(int sfactorRGB, int dfactorRGB, int sfactorAlpha, int dfactorAlpha) {
-        JmeIosGLES.glBlendFuncSeparate(sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha);
+    public void glBlendFuncSeparate(int sFactorRGB, int dFactorRGB, int sFactorAlpha, int dFactorAlpha) {
+        JmeIosGLES.glBlendFuncSeparate(sFactorRGB, dFactorRGB, sFactorAlpha, dFactorAlpha);
     }
 
 
@@ -623,7 +623,7 @@ public class IosGL implements GL, GL2, GLES_30, GLExt, GLFbo {
     }
 
     @Override
-    public void glTexImage2DMultisample(int target, int samples, int internalformat, int width, int height, boolean fixedsamplelocations) {
+    public void glTexImage2DMultisample(int target, int samples, int internalformat, int width, int height, boolean fixedSampleLocations) {
         throw new UnsupportedOperationException("Multisample textures not available on iOS");
     }
 

--- a/jme3-lwjgl/src/main/java/com/jme3/opencl/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/opencl/lwjgl/LwjglContext.java
@@ -163,7 +163,7 @@ public class LwjglContext extends Context {
     }
 
     @Override
-    public Image bindImage(com.jme3.texture.Image image, Texture.Type textureType, int miplevel, MemoryAccess access) {
+    public Image bindImage(com.jme3.texture.Image image, Texture.Type textureType, int mipLevel, MemoryAccess access) {
         int imageID = image.getId();
         if (imageID == -1) {
             throw new IllegalArgumentException("image was not yet uploaded to the GPU");
@@ -171,7 +171,7 @@ public class LwjglContext extends Context {
         long memFlags = Utils.getMemoryAccessFlags(access);
         int textureTarget = convertTextureType(textureType);
         Utils.errorBuffer.rewind();
-        CLMem mem = CL12GL.clCreateFromGLTexture(context, memFlags, textureTarget, miplevel, imageID, Utils.errorBuffer);
+        CLMem mem = CL12GL.clCreateFromGLTexture(context, memFlags, textureTarget, mipLevel, imageID, Utils.errorBuffer);
         Utils.checkError(Utils.errorBuffer, "clCreateFromGLTexture");
         return new LwjglImage(mem);
     }

--- a/jme3-lwjgl/src/main/java/com/jme3/renderer/lwjgl/LwjglGLExt.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/renderer/lwjgl/LwjglGLExt.java
@@ -62,8 +62,8 @@ public final class LwjglGLExt implements GLExt {
     }
 
     @Override
-    public void glTexImage2DMultisample(int target, int samples, int internalformat, int width, int height, boolean fixedsamplelocations) {
-        ARBTextureMultisample.glTexImage2DMultisample(target, samples, internalformat, width, height, fixedsamplelocations);
+    public void glTexImage2DMultisample(int target, int samples, int internalformat, int width, int height, boolean fixedSampleLocations) {
+        ARBTextureMultisample.glTexImage2DMultisample(target, samples, internalformat, width, height, fixedSampleLocations);
     }
 
     @Override

--- a/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/LwjglContext.java
@@ -174,7 +174,7 @@ public class LwjglContext extends Context {
     }
 
     @Override
-    public Image bindImage(com.jme3.texture.Image image, Texture.Type textureType, int miplevel, MemoryAccess access) {
+    public Image bindImage(com.jme3.texture.Image image, Texture.Type textureType, int mipLevel, MemoryAccess access) {
         Utils.assertSharingPossible();
         int imageID = image.getId();
         if (imageID == -1) {
@@ -183,7 +183,7 @@ public class LwjglContext extends Context {
         long memFlags = Utils.getMemoryAccessFlags(access);
         int textureTarget = convertTextureType(textureType);
         Utils.errorBuffer.rewind();
-        long mem = CL12GL.clCreateFromGLTexture(context, memFlags, textureTarget, miplevel, imageID, Utils.errorBuffer);
+        long mem = CL12GL.clCreateFromGLTexture(context, memFlags, textureTarget, mipLevel, imageID, Utils.errorBuffer);
         Utils.checkError(Utils.errorBuffer, "clCreateFromGLTexture");
         return new LwjglImage(mem);
     }

--- a/jme3-lwjgl3/src/main/java/com/jme3/renderer/lwjgl/LwjglGL.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/renderer/lwjgl/LwjglGL.java
@@ -87,14 +87,14 @@ public class LwjglGL extends LwjglRender implements GL, GL2, GL3, GL4 {
     }
 
     @Override
-    public void glBlendFunc(final int sfactor, final int dfactor) {
-        GL11.glBlendFunc(sfactor, dfactor);
+    public void glBlendFunc(final int sFactor, final int dFactor) {
+        GL11.glBlendFunc(sFactor, dFactor);
     }
 
     @Override
-    public void glBlendFuncSeparate(final int sfactorRGB, final int dfactorRGB, final int sfactorAlpha,
-                                    final int dfactorAlpha) {
-        GL14.glBlendFuncSeparate(sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha);
+    public void glBlendFuncSeparate(final int sFactorRGB, final int dFactorRGB, final int sFactorAlpha,
+                                    final int dFactorAlpha) {
+        GL14.glBlendFuncSeparate(sFactorRGB, dFactorRGB, sFactorAlpha, dFactorAlpha);
     }
 
     @Override

--- a/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/MeshLoader.java
+++ b/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/MeshLoader.java
@@ -285,9 +285,9 @@ public class MeshLoader extends DefaultHandler implements AssetLoader {
         geoms.add(geom);
     }
 
-    private void startSharedGeom(String vertexcount) throws SAXException {
+    private void startSharedGeom(String vertexCount) throws SAXException {
         sharedMesh = new Mesh();
-        vertCount = parseInt(vertexcount);
+        vertCount = parseInt(vertexCount);
         usesSharedVerts = false;
 
         geom = null;


### PR DESCRIPTION
This PR renames method arguments in Java code, in order to clarify the purposes of those arguments. Mostly just better use of camelCase to indicate word boundaries.

There's plenty of room for further work along these lines.