### PR TITLE
Improve MorphTrack API

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -99,14 +99,14 @@ public class MorphTrack implements AnimTrack<float[]> {
      * @throws IllegalArgumentException if weights is an empty array or if
      *         the number of weights violates the frame count constraint
      */
-    public void setKeyframesWeight(float[] weights){
+    public void setKeyframesWeight(float[] weights) {
         if (times == null) {
             throw new IllegalStateException("MorphTrack doesn't have any time for key frames, please call setTimes first");
         }
         if (weights.length == 0) {
             throw new IllegalArgumentException("MorphTrack with no weight keyframes!");
         }
-        if(times.length * nbMorphTargets != weights.length){
+        if (times.length * nbMorphTargets != weights.length) {
             throw new IllegalArgumentException("weights.length must equal nbMorphTargets * times.length");
         }
 
@@ -148,10 +148,10 @@ public class MorphTrack implements AnimTrack<float[]> {
      *                 -- do not modify after passing it to this setter)
      */
     public void setKeyframes(float[] times, float[] weights) {
-        if(times != null){
+        if (times != null) {
             setTimes(times);
         }
-        if(weights != null){
+        if (weights != null) {
             setKeyframesWeight(weights);
         }
     }
@@ -159,7 +159,7 @@ public class MorphTrack implements AnimTrack<float[]> {
     /**
      * @return the number of morph targets
      */
-    public int getNbMorphTargets(){
+    public int getNbMorphTargets() {
         return nbMorphTargets;
     }
 
@@ -173,8 +173,8 @@ public class MorphTrack implements AnimTrack<float[]> {
      * @throws IllegalArgumentException if the number of weights and the new
      *         number of morph targets violate the frame count constraint
      */
-    public void setNbMorphTargets(float[] weights, int nbMorphTargets){
-        if(times.length * nbMorphTargets != weights.length){
+    public void setNbMorphTargets(float[] weights, int nbMorphTargets) {
+        if (times.length * nbMorphTargets != weights.length) {
             throw new IllegalArgumentException("weights.length must equal nbMorphTargets * times.length");
         }
         this.nbMorphTargets = nbMorphTargets;

--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -101,10 +101,13 @@ public class MorphTrack implements AnimTrack<float[]> {
         if (weights.length == 0) {
             throw new RuntimeException("MorphTrack with no weight keyframes!");
         }
+        if(times.length * nbMorphTargets != weights.length){
+            throw new RuntimeException("weights.length must equal nbMorphTargets * times.length");
+        }
 
         this.weights = weights;
 
-        assert times != null && times.length == weights.length * nbMorphTargets;
+        assert times.length * nbMorphTargets == weights.length;
     }
 
     /**
@@ -165,8 +168,11 @@ public class MorphTrack implements AnimTrack<float[]> {
      * @param nbMorphTargets the desired number of morph targets
      */
     public void setNbMorphTargets(float[] weights, int nbMorphTargets){
-        setKeyframesWeight(weights);
+        if(times.length * nbMorphTargets != weights.length){
+            throw new RuntimeException("weights.length must equal nbMorphTargets * times.length");
+        }
         this.nbMorphTargets = nbMorphTargets;
+        setKeyframesWeight(weights);
     }
 
     @Override
@@ -285,6 +291,5 @@ public class MorphTrack implements AnimTrack<float[]> {
         this.target = cloner.clone(target);
         // Note: interpolator, times, and weights are not cloned
     }
-
 
 }

--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -165,7 +165,7 @@ public class MorphTrack implements AnimTrack<float[]> {
      * @param nbMorphTargets the desired number of morph targets
      */
     public void setNbMorphTargets(float[] weights, int nbMorphTargets){
-        setWeights(weights);
+        setKeyframesWeight(weights);
         this.nbMorphTargets = nbMorphTargets;
     }
 

--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -89,6 +89,25 @@ public class MorphTrack implements AnimTrack<float[]> {
     }
 
     /**
+     * Set the weight for this morph track
+     *
+     * @param weights  the weights of the morphs for each frame (alias created
+     *                 -- do not modify after passing it to this setter)
+     */
+    public void setKeyframesWeight(float[] weights){
+        if (times == null) {
+            throw new RuntimeException("MorphTrack doesn't have any time for key frames, please call setTimes first");
+        }
+        if (weights.length == 0) {
+            throw new RuntimeException("MorphTrack with no weight keyframes!");
+        }
+
+        this.weights = weights;
+
+        assert times != null && times.length == weights.length;
+    }
+
+    /**
      * returns the arrays of time for this track
      *
      * @return the pre-existing array -- do not modify
@@ -113,24 +132,33 @@ public class MorphTrack implements AnimTrack<float[]> {
 
 
     /**
-     * Set the weight for this morph track
+     * Sets the weights for this morph track
      *
-     * @param times    a float array with the time of each frame (alias created
-     *                 -- do not modify after passing it to this setter)
-     * @param weights  the weights of the morphs for each frame (alias created
-     *                 -- do not modify after passing it to this setter)
+     * @param times        a float array with the time of each frame
+     * @param weights      the weight for each frame
      */
     public void setKeyframes(float[] times, float[] weights) {
-        setTimes(times);
-        if (weights != null) {
-            if (times == null) {
-                throw new RuntimeException("MorphTrack doesn't have any time for key frames, please call setTimes first");
-            }
-
-            this.weights = weights;
-
-            assert times.length == weights.length;
+        if(times != null){
+            setTimes(times);
         }
+        if(weights != null){
+            setKeyframesWeight(weights);
+        }
+    }
+
+    /**
+     * @return the desired number of morph targets
+     */
+    public int getNbMorphTargets(){
+        return nbMorphTargets;
+    }
+
+    /**
+     * Sets the desired number of morph targets
+     * @param nbMorphTargets the desired number of morph targets
+     */
+    public void setNbMorphTargets(int nbMorphTargets){
+        this.nbMorphTargets = nbMorphTargets;
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -104,7 +104,7 @@ public class MorphTrack implements AnimTrack<float[]> {
 
         this.weights = weights;
 
-        assert times != null && times.length == weights.length;
+        assert times != null && times.length == weights.length * nbMorphTargets;
     }
 
     /**
@@ -132,10 +132,13 @@ public class MorphTrack implements AnimTrack<float[]> {
 
 
     /**
-     * Sets the weights for this morph track
+     * Sets the times and weights for this morph track. Note that the number of weights
+     * must equal the number of frames times the number of morph targets.
      *
-     * @param times        a float array with the time of each frame
-     * @param weights      the weight for each frame
+     * @param times        a float array with the time of each frame (alias created
+     *                     -- do not modify after passing it to this setter)
+     * @param weights      the weight for each frame (alias created
+     *                     -- do not modify after passing it to this setter)
      */
     public void setKeyframes(float[] times, float[] weights) {
         if(times != null){
@@ -154,10 +157,15 @@ public class MorphTrack implements AnimTrack<float[]> {
     }
 
     /**
-     * Sets the desired number of morph targets
+     * Sets the desired number of morph targets and the corresponding weights.
+     * Note that the number of weights must equal the number of frames times the number of morph targets.
+     *
+     * @param weights        the weight for each frame (alias created
+     *                       -- do not modify after passing it to this setter)
      * @param nbMorphTargets the desired number of morph targets
      */
-    public void setNbMorphTargets(int nbMorphTargets){
+    public void setNbMorphTargets(float[] weights, int nbMorphTargets){
+        setWeights(weights);
         this.nbMorphTargets = nbMorphTargets;
     }
 

--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -65,13 +65,12 @@ public class MorphTrack implements AnimTrack<float[]> {
     /**
      * Creates a morph track with the given Geometry as a target
      *
-     * @param target   the desired target (alias created)
+     * @param target   the target (alias created)
      * @param times    a float array with the time of each frame (alias created
      *                 -- do not modify after passing it to this constructor)
      * @param weights  the morphs for each frames (alias created -- do not
      *                 modify after passing it to this constructor)
-     * @param nbMorphTargets
-     *                 the desired number of morph targets
+     * @param nbMorphTargets the number of morph targets
      */
     public MorphTrack(Geometry target, float[] times, float[] weights, int nbMorphTargets) {
         this.target = target;
@@ -89,7 +88,7 @@ public class MorphTrack implements AnimTrack<float[]> {
     }
 
     /**
-     * Set the weight for this morph track. Note that the number of weights
+     * Set the weights for this morph track. Note that the number of weights
      * must equal the number of frames times the number of morph targets.
      *
      * @param weights  the weights of the morphs for each frame (alias created
@@ -157,19 +156,19 @@ public class MorphTrack implements AnimTrack<float[]> {
     }
 
     /**
-     * @return the desired number of morph targets
+     * @return the number of morph targets
      */
     public int getNbMorphTargets(){
         return nbMorphTargets;
     }
 
     /**
-     * Sets the desired number of morph targets and the corresponding weights.
+     * Sets the number of morph targets and the corresponding weights.
      * Note that the number of weights must equal the number of frames times the number of morph targets.
      *
      * @param weights        the weight for each frame (alias created
      *                       -- do not modify after passing it to this setter)
-     * @param nbMorphTargets the desired number of morph targets
+     * @param nbMorphTargets the number of morph targets
      * @throws IllegalArgumentException if the number of weights and the new
      *         number of morph targets violate the frame count constraint
      */

--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -89,20 +89,25 @@ public class MorphTrack implements AnimTrack<float[]> {
     }
 
     /**
-     * Set the weight for this morph track
+     * Set the weight for this morph track. Note that the number of weights
+     * must equal the number of frames times the number of morph targets.
      *
      * @param weights  the weights of the morphs for each frame (alias created
      *                 -- do not modify after passing it to this setter)
+     *
+     * @throws IllegalStateException if this track does not have times set
+     * @throws IllegalArgumentException if weights is an empty array or if
+     *         the number of weights violates the frame count constraint
      */
     public void setKeyframesWeight(float[] weights){
         if (times == null) {
-            throw new RuntimeException("MorphTrack doesn't have any time for key frames, please call setTimes first");
+            throw new IllegalStateException("MorphTrack doesn't have any time for key frames, please call setTimes first");
         }
         if (weights.length == 0) {
-            throw new RuntimeException("MorphTrack with no weight keyframes!");
+            throw new IllegalArgumentException("MorphTrack with no weight keyframes!");
         }
         if(times.length * nbMorphTargets != weights.length){
-            throw new RuntimeException("weights.length must equal nbMorphTargets * times.length");
+            throw new IllegalArgumentException("weights.length must equal nbMorphTargets * times.length");
         }
 
         this.weights = weights;
@@ -122,10 +127,11 @@ public class MorphTrack implements AnimTrack<float[]> {
      *
      * @param times  the keyframes times (alias created -- do not modify after
      *               passing it to this setter)
+     * @throws IllegalArgumentException if times is empty
      */
     public void setTimes(float[] times) {
         if (times.length == 0) {
-            throw new RuntimeException("TransformTrack with no keyframes!");
+            throw new IllegalArgumentException("TransformTrack with no keyframes!");
         }
         this.times = times;
         length = times[times.length - 1] - times[0];
@@ -164,10 +170,12 @@ public class MorphTrack implements AnimTrack<float[]> {
      * @param weights        the weight for each frame (alias created
      *                       -- do not modify after passing it to this setter)
      * @param nbMorphTargets the desired number of morph targets
+     * @throws IllegalArgumentException if the number of weights and the new
+     *         number of morph targets violate the frame count constraint
      */
     public void setNbMorphTargets(float[] weights, int nbMorphTargets){
         if(times.length * nbMorphTargets != weights.length){
-            throw new RuntimeException("weights.length must equal nbMorphTargets * times.length");
+            throw new IllegalArgumentException("weights.length must equal nbMorphTargets * times.length");
         }
         this.nbMorphTargets = nbMorphTargets;
         setKeyframesWeight(weights);

--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -106,8 +106,6 @@ public class MorphTrack implements AnimTrack<float[]> {
         }
 
         this.weights = weights;
-
-        assert times.length * nbMorphTargets == weights.length;
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -65,12 +65,13 @@ public class MorphTrack implements AnimTrack<float[]> {
     /**
      * Creates a morph track with the given Geometry as a target
      *
-     * @param target   the target (alias created)
+     * @param target   the desired target (alias created)
      * @param times    a float array with the time of each frame (alias created
      *                 -- do not modify after passing it to this constructor)
      * @param weights  the morphs for each frames (alias created -- do not
      *                 modify after passing it to this constructor)
-     * @param nbMorphTargets the number of morph targets
+     * @param nbMorphTargets
+     *                 the desired number of morph targets
      */
     public MorphTrack(Geometry target, float[] times, float[] weights, int nbMorphTargets) {
         this.target = target;
@@ -141,10 +142,10 @@ public class MorphTrack implements AnimTrack<float[]> {
      * Sets the times and weights for this morph track. Note that the number of weights
      * must equal the number of frames times the number of morph targets.
      *
-     * @param times        a float array with the time of each frame (alias created
-     *                     -- do not modify after passing it to this setter)
-     * @param weights      the weight for each frame (alias created
-     *                     -- do not modify after passing it to this setter)
+     * @param times    a float array with the time of each frame (alias created
+     *                 -- do not modify after passing it to this setter)
+     * @param weights  the weights of the morphs for each frame (alias created
+     *                 -- do not modify after passing it to this setter)
      */
     public void setKeyframes(float[] times, float[] weights) {
         if(times != null){
@@ -166,9 +167,9 @@ public class MorphTrack implements AnimTrack<float[]> {
      * Sets the number of morph targets and the corresponding weights.
      * Note that the number of weights must equal the number of frames times the number of morph targets.
      *
-     * @param weights        the weight for each frame (alias created
+     * @param weights        the weights for each frame (alias created
      *                       -- do not modify after passing it to this setter)
-     * @param nbMorphTargets the number of morph targets
+     * @param nbMorphTargets the desired number of morph targets
      * @throws IllegalArgumentException if the number of weights and the new
      *         number of morph targets violate the frame count constraint
      */

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -121,10 +121,11 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Sets the keyframes times for this Joint track
      *
      * @param times the keyframes times
+     * @throws IllegalArgumentException if times is empty
      */
     public void setTimes(float[] times) {
         if (times.length == 0) {
-            throw new RuntimeException("TransformTrack with no keyframes!");
+            throw new IllegalArgumentException("TransformTrack with no keyframes!");
         }
         this.times = times;
         length = times[times.length - 1] - times[0];
@@ -134,13 +135,15 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Set the translations for this joint track
      *
      * @param translations the translation of the bone for each frame
+     * @throws IllegalStateException if this track does not have times set
+     * @throws IllegalArgumentException if the translations array is empty
      */
     public void setKeyframesTranslation(Vector3f[] translations) {
         if (times == null) {
-            throw new RuntimeException("TransformTrack doesn't have any time for key frames, please call setTimes first");
+            throw new IllegalStateException("TransformTrack doesn't have any time for key frames, please call setTimes first");
         }
         if (translations.length == 0) {
-            throw new RuntimeException("TransformTrack with no translation keyframes!");
+            throw new IllegalArgumentException("TransformTrack with no translation keyframes!");
         }
         this.translations = new CompactVector3Array();
         this.translations.add(translations);
@@ -153,13 +156,15 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Set the scales for this joint track
      *
      * @param scales the scales of the bone for each frame
+     * @throws IllegalStateException if this track does not have times set
+     * @throws IllegalArgumentException if the scales array is empty
      */
     public void setKeyframesScale(Vector3f[] scales) {
         if (times == null) {
-            throw new RuntimeException("TransformTrack doesn't have any time for key frames, please call setTimes first");
+            throw new IllegalStateException("TransformTrack doesn't have any time for key frames, please call setTimes first");
         }
         if (scales.length == 0) {
-            throw new RuntimeException("TransformTrack with no scale keyframes!");
+            throw new IllegalArgumentException("TransformTrack with no scale keyframes!");
         }
         this.scales = new CompactVector3Array();
         this.scales.add(scales);
@@ -172,13 +177,15 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Set the rotations for this joint track
      *
      * @param rotations the rotations of the bone for each frame
+     * @throws IllegalStateException if this track does not have times set
+     * @throws IllegalArgumentException if the rotations array is empty
      */
     public void setKeyframesRotation(Quaternion[] rotations) {
         if (times == null) {
-            throw new RuntimeException("TransformTrack doesn't have any time for key frames, please call setTimes first");
+            throw new IllegalStateException("TransformTrack doesn't have any time for key frames, please call setTimes first");
         }
         if (rotations.length == 0) {
-            throw new RuntimeException("TransformTrack with no rotation keyframes!");
+            throw new IllegalArgumentException("TransformTrack with no rotation keyframes!");
         }
         this.rotations = new CompactQuaternionArray();
         this.rotations.add(rotations);

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -121,11 +121,10 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Sets the keyframes times for this Joint track
      *
      * @param times the keyframes times
-     * @throws IllegalArgumentException if times is empty
      */
     public void setTimes(float[] times) {
         if (times.length == 0) {
-            throw new IllegalArgumentException("TransformTrack with no keyframes!");
+            throw new RuntimeException("TransformTrack with no keyframes!");
         }
         this.times = times;
         length = times[times.length - 1] - times[0];
@@ -135,15 +134,13 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Set the translations for this joint track
      *
      * @param translations the translation of the bone for each frame
-     * @throws IllegalStateException if this track does not have times set
-     * @throws IllegalArgumentException if the translations array is empty
      */
     public void setKeyframesTranslation(Vector3f[] translations) {
         if (times == null) {
-            throw new IllegalStateException("TransformTrack doesn't have any time for key frames, please call setTimes first");
+            throw new RuntimeException("TransformTrack doesn't have any time for key frames, please call setTimes first");
         }
         if (translations.length == 0) {
-            throw new IllegalArgumentException("TransformTrack with no translation keyframes!");
+            throw new RuntimeException("TransformTrack with no translation keyframes!");
         }
         this.translations = new CompactVector3Array();
         this.translations.add(translations);
@@ -156,15 +153,13 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Set the scales for this joint track
      *
      * @param scales the scales of the bone for each frame
-     * @throws IllegalStateException if this track does not have times set
-     * @throws IllegalArgumentException if the scales array is empty
      */
     public void setKeyframesScale(Vector3f[] scales) {
         if (times == null) {
-            throw new IllegalStateException("TransformTrack doesn't have any time for key frames, please call setTimes first");
+            throw new RuntimeException("TransformTrack doesn't have any time for key frames, please call setTimes first");
         }
         if (scales.length == 0) {
-            throw new IllegalArgumentException("TransformTrack with no scale keyframes!");
+            throw new RuntimeException("TransformTrack with no scale keyframes!");
         }
         this.scales = new CompactVector3Array();
         this.scales.add(scales);
@@ -177,15 +172,13 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Set the rotations for this joint track
      *
      * @param rotations the rotations of the bone for each frame
-     * @throws IllegalStateException if this track does not have times set
-     * @throws IllegalArgumentException if the rotations array is empty
      */
     public void setKeyframesRotation(Quaternion[] rotations) {
         if (times == null) {
-            throw new IllegalStateException("TransformTrack doesn't have any time for key frames, please call setTimes first");
+            throw new RuntimeException("TransformTrack doesn't have any time for key frames, please call setTimes first");
         }
         if (rotations.length == 0) {
-            throw new IllegalArgumentException("TransformTrack with no rotation keyframes!");
+            throw new RuntimeException("TransformTrack with no rotation keyframes!");
         }
         this.rotations = new CompactQuaternionArray();
         this.rotations.add(rotations);


### PR DESCRIPTION
The MorphTrack's current API has some inconsistencies with TransformTrack's API and some limitations as well (no ability to get/set the desired number of morph targets). This patch makes MorphTrack's API consistent with TransformTrack's API and adds a getter/setter for the number of morph targets.