### PR TITLE
TestGltfLoading: scale down Zophrac model

### DIFF
--- a/jme3-examples/src/main/java/jme3test/model/TestGltfLoading.java
+++ b/jme3-examples/src/main/java/jme3test/model/TestGltfLoading.java
@@ -112,7 +112,7 @@ public class TestGltfLoading extends SimpleApplication {
 //        rootNode.addLight(pl1);
 
         //loadModel("Models/gltf/polly/project_polly.gltf", new Vector3f(0, 0, 0), 0.5f);
-        //loadModel("Models/gltf/zophrac/scene.gltf", new Vector3f(0, 0, 0), 0.1f);
+        //loadModel("Models/gltf/zophrac/scene.gltf", new Vector3f(0, 0, 0), 0.01f);
     //    loadModel("Models/gltf/scifigirl/scene.gltf", new Vector3f(0, -1, 0), 0.1f);
         //loadModel("Models/gltf/man/scene.gltf", new Vector3f(0, -1, 0), 0.1f);
        //loadModel("Models/gltf/torus/scene.gltf", new Vector3f(0, -1, 0), 0.1f);


### PR DESCRIPTION
in order to render the entire model without requiring the user to reposition the camera.

Requested in this comment: https://github.com/jMonkeyEngine/jmonkeyengine/issues/1089#issuecomment-929926676