### PR TITLE
Wrap the input stream in BufferedInputStream

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/texture/plugins/AWTLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/texture/plugins/AWTLoader.java
@@ -41,6 +41,7 @@ import com.jme3.util.BufferUtils;
 import java.awt.Transparency;
 import java.awt.color.ColorSpace;
 import java.awt.image.*;
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -176,7 +177,7 @@ public class AWTLoader implements AssetLoader {
 
     public Image load(InputStream in, boolean flipY) throws IOException{
         ImageIO.setUseCache(false);
-        BufferedImage img = ImageIO.read(in);
+        BufferedImage img = ImageIO.read(new BufferedInputStream(in));
         if (img == null){
             return null;
         }

--- a/jme3-desktop/src/main/java/com/jme3/texture/plugins/AWTLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/texture/plugins/AWTLoader.java
@@ -177,7 +177,7 @@ public class AWTLoader implements AssetLoader {
 
     public Image load(InputStream in, boolean flipY) throws IOException{
         ImageIO.setUseCache(false);
-        BufferedImage img = ImageIO.read(new BufferedInputStream(in));
+        BufferedImage img = ImageIO.read(in);
         if (img == null){
             return null;
         }
@@ -188,18 +188,13 @@ public class AWTLoader implements AssetLoader {
     public Object load(AssetInfo info) throws IOException {
         if (ImageIO.getImageReadersBySuffix(info.getKey().getExtension()) != null){
             boolean flip = ((TextureKey) info.getKey()).isFlipY();
-            InputStream in = null;
-            try {
-                in = info.openStream();
-                Image img = load(in, flip);
+            try (InputStream in = info.openStream();
+                    BufferedInputStream bin = new BufferedInputStream(in)) {
+                Image img = load(bin, flip);
                 if (img == null){
                     throw new AssetLoadException("The given image cannot be loaded " + info.getKey());
                 }
                 return img;
-            } finally {
-                if (in != null){
-                    in.close();
-                }
             }
         }else{
             throw new AssetLoadException("The extension " + info.getKey().getExtension() + " is not supported");

--- a/jme3-desktop/src/main/java/com/jme3/texture/plugins/AWTLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/texture/plugins/AWTLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Introducing buffered stream for the ImageIO. Otherwise it reads in very small chunks and this is not desirable. Lots of calls. This is a performance improvement.

Old (starts with very small, and then proceeds with 512, maybe strides, dunno, variable read lengths):
![image](https://user-images.githubusercontent.com/8344766/135659314-0cb2afc5-1170-4d53-8bc2-65018861874d.png)

New:
![image](https://user-images.githubusercontent.com/8344766/135659333-874a48fd-cdbf-4735-a819-978c85b5b216.png)
