### PR TITLE
ignore return values from AnimMigrationUtils.migrate()

### DIFF
--- a/jme3-examples/src/main/java/jme3test/animation/TestJaime.java
+++ b/jme3-examples/src/main/java/jme3test/animation/TestJaime.java
@@ -101,7 +101,7 @@ public class TestJaime  extends SimpleApplication {
     
     public Node LoadModel() {
         Node jaime = (Node)assetManager.loadModel("Models/Jaime/Jaime.j3o");
-        jaime = (Node) AnimMigrationUtils.migrate(jaime);
+        AnimMigrationUtils.migrate(jaime);
         jaime.setShadowMode(RenderQueue.ShadowMode.CastAndReceive);
         rootNode.attachChild(jaime);
         return jaime;

--- a/jme3-examples/src/main/java/jme3test/model/anim/TestAttachmentsNode.java
+++ b/jme3-examples/src/main/java/jme3test/model/anim/TestAttachmentsNode.java
@@ -82,7 +82,7 @@ public class TestAttachmentsNode extends SimpleApplication
          * from the old animation system to the new one.
          */
         Spatial model = assetManager.loadModel("Models/Jaime/Jaime.j3o");
-        model = AnimMigrationUtils.migrate(model);
+        AnimMigrationUtils.migrate(model);
         /*
          * Play the "Idle" animation at half speed.
          */


### PR DESCRIPTION
Our best guidance for how to use `AnimMigrationUtils` is found in 5 example apps in jme3-test. However, 2 of those apps ( `TestJaime` and `TestAttachmentsNode`) assign return values from `migrate()` to local variables, giving the impression that the model might be converted by creating a new `Spatial`. 

In fact, `migrate()` converts models in place. Its return value is simply the argument. The assignments are redundant and also misleading, so this PR removes them from `TestJaime` and `TestAttachmentsNode`.