### PR TITLE
suppress some warnings about unchecked conversions

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/MorphControl.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphControl.java
@@ -436,6 +436,7 @@ public class MorphControl extends AbstractControl implements Savable {
      * @throws IOException from the importer
      */
     @Override
+    @SuppressWarnings("unchecked")
     public void read(JmeImporter importer) throws IOException {
         super.read(importer);
         InputCapsule capsule = importer.getCapsule(this);
@@ -451,6 +452,7 @@ public class MorphControl extends AbstractControl implements Savable {
      * @throws IOException from the exporter
      */
     @Override
+    @SuppressWarnings("unchecked")
     public void write(JmeExporter exporter) throws IOException {
         super.write(exporter);
         OutputCapsule capsule = exporter.getCapsule(this);

--- a/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryExporter.java
+++ b/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryExporter.java
@@ -181,6 +181,7 @@ public class BinaryExporter implements JmeExporter {
      * @return A new instance that has been saved and loaded from the
      * original object.
      */
+    @SuppressWarnings("unchecked")
     public static <T extends Savable> T saveAndLoad(AssetManager assetManager, T object) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {

--- a/jme3-jbullet/src/test/java/com/jme3/jbullet/test/PreventBulletIssueRegressions.java
+++ b/jme3-jbullet/src/test/java/com/jme3/jbullet/test/PreventBulletIssueRegressions.java
@@ -74,6 +74,7 @@ public class PreventBulletIssueRegressions {
      * Test case for JME issue #889: disabled physics control gets added to a
      * physics space.
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testIssue889() throws IllegalAccessException, NoSuchFieldException {
         // throws are added so that we don't have to catch them just to assert them again.


### PR DESCRIPTION
Reducing the number of expected warnings increases the chances that new warnings will be noticed.