### PR TITLE
reformat source code of the SkyFactory class

### DIFF
--- a/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
+++ b/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
@@ -231,7 +231,7 @@ public class SkyFactory {
      * Create a sky using the given cubemap or spheremap texture.
      *
      * @param assetManager from which to load materials
-     * @param texture to use    *
+     * @param texture to use
      * @param sphereMap determines how the texture is used:<br>
      * <ul>
      * <li>true: The texture is a Texture2D with the pixels arranged for
@@ -430,7 +430,7 @@ public class SkyFactory {
      * @param north texture for the northern face of the cube
      * @param south texture for the southern face of the cube
      * @param up texture for the top face of the cube
-     * @param down texture for the bottom face of the cube     *
+     * @param down texture for the bottom face of the cube
      * @return a new spatial representing the sky, ready to be attached to the
      * scene graph
      */

--- a/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
+++ b/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
@@ -107,7 +107,8 @@ public class SkyFactory {
      * </ul>
      * @return a new spatial representing the sky, ready to be attached to the
      * scene graph
-     * @deprecated use {@link SkyFactory#createSky(com.jme3.asset.AssetManager, com.jme3.texture.Texture, com.jme3.math.Vector3f, com.jme3.util.SkyFactory.EnvMapType)}
+     * @deprecated use {@link SkyFactory#createSky(com.jme3.asset.AssetManager, com.jme3.texture.Texture,
+     * com.jme3.math.Vector3f, com.jme3.util.SkyFactory.EnvMapType)}
      */
     @Deprecated
     public static Spatial createSky(AssetManager assetManager, Texture texture,
@@ -156,12 +157,14 @@ public class SkyFactory {
      * frustum
      * @return a new spatial representing the sky, ready to be attached to the
      * scene graph
-     * @deprecated use {@link #createSky(com.jme3.asset.AssetManager, com.jme3.texture.Texture, com.jme3.math.Vector3f, com.jme3.util.SkyFactory.EnvMapType, float)}
+     * @deprecated use {@link #createSky(com.jme3.asset.AssetManager, com.jme3.texture.Texture,
+     * com.jme3.math.Vector3f, com.jme3.util.SkyFactory.EnvMapType, float)}
      */
     @Deprecated
     public static Spatial createSky(AssetManager assetManager, Texture texture,
             Vector3f normalScale, boolean sphereMap, int sphereRadius) {
-        return createSky(assetManager, texture, normalScale, sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap, sphereRadius);
+        return createSky(assetManager, texture, normalScale,
+                sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap, sphereRadius);
     }
 
     /**
@@ -243,11 +246,13 @@ public class SkyFactory {
      * </ul>
      * @return a new spatial representing the sky, ready to be attached to the
      * scene graph
-     * @deprecated use {@link SkyFactory#createSky(com.jme3.asset.AssetManager, com.jme3.texture.Texture, com.jme3.math.Vector3f, com.jme3.util.SkyFactory.EnvMapType)}
+     * @deprecated use {@link SkyFactory#createSky(com.jme3.asset.AssetManager, com.jme3.texture.Texture,
+     * com.jme3.math.Vector3f, com.jme3.util.SkyFactory.EnvMapType)}
      */
     @Deprecated
     public static Spatial createSky(AssetManager assetManager, Texture texture, boolean sphereMap) {
-        return createSky(assetManager, texture, Vector3f.UNIT_XYZ,  sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap);
+        return createSky(assetManager, texture, Vector3f.UNIT_XYZ,
+                sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap);
     }
 
     /**
@@ -266,7 +271,8 @@ public class SkyFactory {
      * </ul>
      * @return a new spatial representing the sky, ready to be attached to the
      * scene graph
-     * @deprecated use {@link #createSky(com.jme3.asset.AssetManager, java.lang.String, com.jme3.util.SkyFactory.EnvMapType)}
+     * @deprecated use {@link #createSky(com.jme3.asset.AssetManager, java.lang.String,
+     * com.jme3.util.SkyFactory.EnvMapType)}
      */
     @Deprecated
     public static Spatial createSky(AssetManager assetManager, String textureName, boolean sphereMap) {
@@ -408,7 +414,8 @@ public class SkyFactory {
 
         checkImagesForCubeMap(westImg, eastImg, northImg, southImg, upImg, downImg);
 
-        Image cubeImage = new Image(westImg.getFormat(), westImg.getWidth(), westImg.getHeight(), null, westImg.getColorSpace());
+        Image cubeImage = new Image(westImg.getFormat(), westImg.getWidth(), westImg.getHeight(),
+                null, westImg.getColorSpace());
 
         cubeImage.addData(westImg.getData(0));
         cubeImage.addData(eastImg.getData(0));
@@ -434,7 +441,8 @@ public class SkyFactory {
      * @return a new spatial representing the sky, ready to be attached to the
      * scene graph
      */
-    public static Spatial createSky(AssetManager assetManager, Texture west, Texture east, Texture north, Texture south, Texture up, Texture down) {
+    public static Spatial createSky(AssetManager assetManager,
+            Texture west, Texture east, Texture north, Texture south, Texture up, Texture down) {
         return createSky(assetManager, west, east, north, south, up, down, Vector3f.UNIT_XYZ);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
+++ b/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
@@ -58,7 +58,7 @@ public class SkyFactory {
     /**
      * The type of map fed to the shader 
      */
-    public enum EnvMapType{
+    public enum EnvMapType {
         /**
          * The env map is a cube map see {@link TextureCubeMap} or 6 separate images that form a cube map
          * The texture is either a {@link TextureCubeMap} or 6 {@link com.jme3.texture.Texture2D}. 
@@ -162,7 +162,7 @@ public class SkyFactory {
     @Deprecated
     public static Spatial createSky(AssetManager assetManager, Texture texture,
             Vector3f normalScale, boolean sphereMap, int sphereRadius) {
-        return createSky(assetManager, texture, normalScale, sphereMap?EnvMapType.SphereMap:EnvMapType.CubeMap, sphereRadius);
+        return createSky(assetManager, texture, normalScale, sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap, sphereRadius);
     }
     
      /**
@@ -248,7 +248,7 @@ public class SkyFactory {
     */  
     @Deprecated
     public static Spatial createSky(AssetManager assetManager, Texture texture, boolean sphereMap) {
-        return createSky(assetManager, texture, Vector3f.UNIT_XYZ,  sphereMap?EnvMapType.SphereMap:EnvMapType.CubeMap);
+        return createSky(assetManager, texture, Vector3f.UNIT_XYZ,  sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap);
     }
 
     /**
@@ -271,7 +271,7 @@ public class SkyFactory {
     */  
     @Deprecated
     public static Spatial createSky(AssetManager assetManager, String textureName, boolean sphereMap) {
-        return createSky(assetManager, textureName,  sphereMap?EnvMapType.SphereMap:EnvMapType.CubeMap);
+        return createSky(assetManager, textureName,  sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap);
     }
     
     /**
@@ -343,7 +343,7 @@ public class SkyFactory {
                 throw new IllegalArgumentException("Images must have same resolution");
             }
             ByteBuffer data2 = image.getData(0);
-            if (data2 != null){
+            if (data2 != null) {
                 if (data2.capacity() != size) {
                     throw new IllegalArgumentException("Images must have same size");
                 }

--- a/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
+++ b/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
@@ -165,7 +165,7 @@ public class SkyFactory {
         return createSky(assetManager, texture, normalScale, sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap, sphereRadius);
     }
     
-     /**
+    /**
      * Create a sky using the given cubemap or spheremap texture.
      *
      * @param assetManager from which to load materials
@@ -180,7 +180,7 @@ public class SkyFactory {
      * @return a new spatial representing the sky, ready to be attached to the
      * scene graph     
      */
-     public static Spatial createSky(AssetManager assetManager, Texture texture,
+    public static Spatial createSky(AssetManager assetManager, Texture texture,
             Vector3f normalScale, EnvMapType envMapType, float sphereRadius) {
         if (texture == null) {
             throw new IllegalArgumentException("texture cannot be null");
@@ -229,73 +229,73 @@ public class SkyFactory {
     }
      
     /**
-    * Create a sky using the given cubemap or spheremap texture.
-    *
-    * @param assetManager from which to load materials
-    * @param texture to use    *
-    * @param sphereMap determines how the texture is used:<br>
-    * <ul>
-    * <li>true: The texture is a Texture2D with the pixels arranged for
-    * <a href="http://en.wikipedia.org/wiki/Sphere_mapping">sphere
-    * mapping</a>.</li>
-    * <li>false: The texture is either a TextureCubeMap or Texture2D. If it is
-    * a Texture2D then the image is taken from it and is inserted into a
-    * TextureCubeMap</li>
-    * </ul> 
-    * @return a new spatial representing the sky, ready to be attached to the
-    * scene graph
-    * @deprecated use {@link SkyFactory#createSky(com.jme3.asset.AssetManager, com.jme3.texture.Texture, com.jme3.math.Vector3f, com.jme3.util.SkyFactory.EnvMapType)}
-    */  
+     * Create a sky using the given cubemap or spheremap texture.
+     *
+     * @param assetManager from which to load materials
+     * @param texture to use    *
+     * @param sphereMap determines how the texture is used:<br>
+     * <ul>
+     * <li>true: The texture is a Texture2D with the pixels arranged for
+     * <a href="http://en.wikipedia.org/wiki/Sphere_mapping">sphere
+     * mapping</a>.</li>
+     * <li>false: The texture is either a TextureCubeMap or Texture2D. If it is
+     * a Texture2D then the image is taken from it and is inserted into a
+     * TextureCubeMap</li>
+     * </ul> 
+     * @return a new spatial representing the sky, ready to be attached to the
+     * scene graph
+     * @deprecated use {@link SkyFactory#createSky(com.jme3.asset.AssetManager, com.jme3.texture.Texture, com.jme3.math.Vector3f, com.jme3.util.SkyFactory.EnvMapType)}
+     */  
     @Deprecated
     public static Spatial createSky(AssetManager assetManager, Texture texture, boolean sphereMap) {
         return createSky(assetManager, texture, Vector3f.UNIT_XYZ,  sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap);
     }
 
     /**
-    * Create a sky using the given cubemap or spheremap texture.
-    *
-    * @param assetManager from which to load materials
-    * @param textureName the path to the texture asset to use    
-    * @param sphereMap determines how the texture is used:<br>
-    * <ul>
-    * <li>true: The texture is a Texture2D with the pixels arranged for
-    * <a href="http://en.wikipedia.org/wiki/Sphere_mapping">sphere
-    * mapping</a>.</li>
-    * <li>false: The texture is either a TextureCubeMap or Texture2D. If it is
-    * a Texture2D then the image is taken from it and is inserted into a
-    * TextureCubeMap</li>
-    * </ul> 
-    * @return a new spatial representing the sky, ready to be attached to the
-    * scene graph
-    * @deprecated use {@link #createSky(com.jme3.asset.AssetManager, java.lang.String, com.jme3.util.SkyFactory.EnvMapType)}
-    */  
+     * Create a sky using the given cubemap or spheremap texture.
+     *
+     * @param assetManager from which to load materials
+     * @param textureName the path to the texture asset to use    
+     * @param sphereMap determines how the texture is used:<br>
+     * <ul>
+     * <li>true: The texture is a Texture2D with the pixels arranged for
+     * <a href="http://en.wikipedia.org/wiki/Sphere_mapping">sphere
+     * mapping</a>.</li>
+     * <li>false: The texture is either a TextureCubeMap or Texture2D. If it is
+     * a Texture2D then the image is taken from it and is inserted into a
+     * TextureCubeMap</li>
+     * </ul> 
+     * @return a new spatial representing the sky, ready to be attached to the
+     * scene graph
+     * @deprecated use {@link #createSky(com.jme3.asset.AssetManager, java.lang.String, com.jme3.util.SkyFactory.EnvMapType)}
+     */  
     @Deprecated
     public static Spatial createSky(AssetManager assetManager, String textureName, boolean sphereMap) {
         return createSky(assetManager, textureName,  sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap);
     }
     
     /**
-    * Create a sky using the given cubemap or spheremap texture.
-    *
-    * @param assetManager from which to load materials
-    * @param texture to use  
-    * @param envMapType see {@link EnvMapType}
-    * @return a new spatial representing the sky, ready to be attached to the
-    * scene graph    
-    */  
+     * Create a sky using the given cubemap or spheremap texture.
+     *
+     * @param assetManager from which to load materials
+     * @param texture to use  
+     * @param envMapType see {@link EnvMapType}
+     * @return a new spatial representing the sky, ready to be attached to the
+     * scene graph    
+     */  
     public static Spatial createSky(AssetManager assetManager, Texture texture, EnvMapType envMapType) {
         return createSky(assetManager, texture, Vector3f.UNIT_XYZ, envMapType);
     }
     
     /**
-    * Create a sky using the given cubemap or spheremap texture.
-    *
-    * @param assetManager from which to load materials
-    * @param textureName the path to the texture asset to use    
-    * @param envMapType see {@link EnvMapType}
-    * @return a new spatial representing the sky, ready to be attached to the
-    * scene graph    
-    */  
+     * Create a sky using the given cubemap or spheremap texture.
+     *
+     * @param assetManager from which to load materials
+     * @param textureName the path to the texture asset to use    
+     * @param envMapType see {@link EnvMapType}
+     * @return a new spatial representing the sky, ready to be attached to the
+     * scene graph    
+     */  
     public static Spatial createSky(AssetManager assetManager, String textureName, EnvMapType envMapType) {
         TextureKey key = new TextureKey(textureName, true);
         key.setGenerateMips(false);
@@ -423,18 +423,18 @@ public class SkyFactory {
     }
 
     /**
-    * Create a cube-mapped sky using six textures.
-    *
-    * @param assetManager from which to load materials
-    * @param west texture for the western face of the cube
-    * @param east texture for the eastern face of the cube
-    * @param north texture for the northern face of the cube
-    * @param south texture for the southern face of the cube
-    * @param up texture for the top face of the cube
-    * @param down texture for the bottom face of the cube     * 
-    * @return a new spatial representing the sky, ready to be attached to the
-    * scene graph
-    */
+     * Create a cube-mapped sky using six textures.
+     *
+     * @param assetManager from which to load materials
+     * @param west texture for the western face of the cube
+     * @param east texture for the eastern face of the cube
+     * @param north texture for the northern face of the cube
+     * @param south texture for the southern face of the cube
+     * @param up texture for the top face of the cube
+     * @param down texture for the bottom face of the cube     * 
+     * @return a new spatial representing the sky, ready to be attached to the
+     * scene graph
+     */
     public static Spatial createSky(AssetManager assetManager, Texture west, Texture east, Texture north, Texture south, Texture up, Texture down) {
         return createSky(assetManager, west, east, north, south, up, down, Vector3f.UNIT_XYZ);
     }

--- a/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
+++ b/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
@@ -135,6 +135,7 @@ public class SkyFactory {
             Vector3f normalScale, EnvMapType envMapType) {
         return createSky(assetManager, texture, normalScale, envMapType, 10);
     }
+
     /**
      * Create a sky using the given cubemap or spheremap texture.
      *

--- a/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
+++ b/jme3-core/src/main/java/com/jme3/util/SkyFactory.java
@@ -49,19 +49,18 @@ import java.nio.ByteBuffer;
 /**
  * <code>SkyFactory</code> is used to create jME {@link Spatial}s that can
  * be attached to the scene to display a sky image in the background.
- * 
+ *
  * @author Kirill Vainer
  */
 public class SkyFactory {
 
-    
     /**
-     * The type of map fed to the shader 
+     * The type of map fed to the shader
      */
     public enum EnvMapType {
         /**
          * The env map is a cube map see {@link TextureCubeMap} or 6 separate images that form a cube map
-         * The texture is either a {@link TextureCubeMap} or 6 {@link com.jme3.texture.Texture2D}. 
+         * The texture is either a {@link TextureCubeMap} or 6 {@link com.jme3.texture.Texture2D}.
          * In the latter case, a TextureCubeMap is build from the 6 2d maps.
          */
         CubeMap,
@@ -72,14 +71,14 @@ public class SkyFactory {
          */
         SphereMap,
         /**
-         * The env map is an Equirectangular map. A 2D textures with pixels 
-         * arranged for <a href="http://en.wikipedia.org/wiki/Equirectangular_projection">equirectangular 
+         * The env map is an Equirectangular map. A 2D textures with pixels
+         * arranged for <a href="http://en.wikipedia.org/wiki/Equirectangular_projection">equirectangular
          * projection mapping.</a>.
-         * 
+         *
          */
         EquirectMap
     }
-    
+
     /**
      * A private constructor to inhibit instantiation of this class.
      */
@@ -110,7 +109,7 @@ public class SkyFactory {
      * scene graph
      * @deprecated use {@link SkyFactory#createSky(com.jme3.asset.AssetManager, com.jme3.texture.Texture, com.jme3.math.Vector3f, com.jme3.util.SkyFactory.EnvMapType)}
      */
-    @Deprecated 
+    @Deprecated
     public static Spatial createSky(AssetManager assetManager, Texture texture,
             Vector3f normalScale, boolean sphereMap) {
         return createSky(assetManager, texture, normalScale, sphereMap, 10);
@@ -129,7 +128,7 @@ public class SkyFactory {
      * transformation to the normal.
      * @param envMapType see {@link EnvMapType}
      * @return a new spatial representing the sky, ready to be attached to the
-     * scene graph      
+     * scene graph
      */
     public static Spatial createSky(AssetManager assetManager, Texture texture,
             Vector3f normalScale, EnvMapType envMapType) {
@@ -164,7 +163,7 @@ public class SkyFactory {
             Vector3f normalScale, boolean sphereMap, int sphereRadius) {
         return createSky(assetManager, texture, normalScale, sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap, sphereRadius);
     }
-    
+
     /**
      * Create a sky using the given cubemap or spheremap texture.
      *
@@ -178,7 +177,7 @@ public class SkyFactory {
      * its radius must fall between the near and far planes of the camera's
      * frustum
      * @return a new spatial representing the sky, ready to be attached to the
-     * scene graph     
+     * scene graph
      */
     public static Spatial createSky(AssetManager assetManager, Texture texture,
             Vector3f normalScale, EnvMapType envMapType, float sphereRadius) {
@@ -227,7 +226,7 @@ public class SkyFactory {
 
         return sky;
     }
-     
+
     /**
      * Create a sky using the given cubemap or spheremap texture.
      *
@@ -241,11 +240,11 @@ public class SkyFactory {
      * <li>false: The texture is either a TextureCubeMap or Texture2D. If it is
      * a Texture2D then the image is taken from it and is inserted into a
      * TextureCubeMap</li>
-     * </ul> 
+     * </ul>
      * @return a new spatial representing the sky, ready to be attached to the
      * scene graph
      * @deprecated use {@link SkyFactory#createSky(com.jme3.asset.AssetManager, com.jme3.texture.Texture, com.jme3.math.Vector3f, com.jme3.util.SkyFactory.EnvMapType)}
-     */  
+     */
     @Deprecated
     public static Spatial createSky(AssetManager assetManager, Texture texture, boolean sphereMap) {
         return createSky(assetManager, texture, Vector3f.UNIT_XYZ,  sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap);
@@ -255,7 +254,7 @@ public class SkyFactory {
      * Create a sky using the given cubemap or spheremap texture.
      *
      * @param assetManager from which to load materials
-     * @param textureName the path to the texture asset to use    
+     * @param textureName the path to the texture asset to use
      * @param sphereMap determines how the texture is used:<br>
      * <ul>
      * <li>true: The texture is a Texture2D with the pixels arranged for
@@ -264,38 +263,38 @@ public class SkyFactory {
      * <li>false: The texture is either a TextureCubeMap or Texture2D. If it is
      * a Texture2D then the image is taken from it and is inserted into a
      * TextureCubeMap</li>
-     * </ul> 
+     * </ul>
      * @return a new spatial representing the sky, ready to be attached to the
      * scene graph
      * @deprecated use {@link #createSky(com.jme3.asset.AssetManager, java.lang.String, com.jme3.util.SkyFactory.EnvMapType)}
-     */  
+     */
     @Deprecated
     public static Spatial createSky(AssetManager assetManager, String textureName, boolean sphereMap) {
         return createSky(assetManager, textureName,  sphereMap ? EnvMapType.SphereMap : EnvMapType.CubeMap);
     }
-    
+
     /**
      * Create a sky using the given cubemap or spheremap texture.
      *
      * @param assetManager from which to load materials
-     * @param texture to use  
+     * @param texture to use
      * @param envMapType see {@link EnvMapType}
      * @return a new spatial representing the sky, ready to be attached to the
-     * scene graph    
-     */  
+     * scene graph
+     */
     public static Spatial createSky(AssetManager assetManager, Texture texture, EnvMapType envMapType) {
         return createSky(assetManager, texture, Vector3f.UNIT_XYZ, envMapType);
     }
-    
+
     /**
      * Create a sky using the given cubemap or spheremap texture.
      *
      * @param assetManager from which to load materials
-     * @param textureName the path to the texture asset to use    
+     * @param textureName the path to the texture asset to use
      * @param envMapType see {@link EnvMapType}
      * @return a new spatial representing the sky, ready to be attached to the
-     * scene graph    
-     */  
+     * scene graph
+     */
     public static Spatial createSky(AssetManager assetManager, String textureName, EnvMapType envMapType) {
         TextureKey key = new TextureKey(textureName, true);
         key.setGenerateMips(false);
@@ -327,7 +326,7 @@ public class SkyFactory {
         Format fmt = images[0].getFormat();
         int width = images[0].getWidth();
         int height = images[0].getHeight();
-        
+
         ByteBuffer data = images[0].getData(0);
         int size = data != null ? data.capacity() : 0;
 
@@ -339,7 +338,7 @@ public class SkyFactory {
             if (image.getFormat() != fmt) {
                 throw new IllegalArgumentException("Images must have same format");
             }
-            if (image.getWidth() != width || image.getHeight() != height)  {
+            if (image.getWidth() != width || image.getHeight() != height) {
                 throw new IllegalArgumentException("Images must have same resolution");
             }
             ByteBuffer data2 = image.getData(0);
@@ -417,7 +416,7 @@ public class SkyFactory {
         cubeImage.addData(upImg.getData(0));
         cubeImage.addData(southImg.getData(0));
         cubeImage.addData(northImg.getData(0));
-        
+
         TextureCubeMap cubeMap = new TextureCubeMap(cubeImage);
         return createSky(assetManager, cubeMap, normalScale, EnvMapType.CubeMap, sphereRadius);
     }
@@ -431,7 +430,7 @@ public class SkyFactory {
      * @param north texture for the northern face of the cube
      * @param south texture for the southern face of the cube
      * @param up texture for the top face of the cube
-     * @param down texture for the bottom face of the cube     * 
+     * @param down texture for the bottom face of the cube     *
      * @return a new spatial representing the sky, ready to be attached to the
      * scene graph
      */


### PR DESCRIPTION
I was contacted privately about improving the readability of SkyFactory.java .

This PR attempts to apply standard Java formatting as discussed in PR #1098. Specifically:
 + single space before { and surrounding ?:
 + no line longer than 110 characters
 + 4-space indentation
 + blank line between methods

It also cleans up some other readability issues:
 + remove some excess whitespace
 + delete 2 stray asterisks