### PR TITLE
solve issue #1612 (NPE while importing from erroneous glTF)

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -1147,8 +1147,16 @@ public class GltfLoader implements AssetLoader {
             if (bw == null || bw.attachedSpatial == null) {
                 continue;
             }
+            String jointName = bw.joint.getName();
             SkinData skinData = fetchFromCache("skins", bw.skinIndex, SkinData.class);
-            skinData.skinningControl.getAttachmentsNode(bw.joint.getName()).attachChild(bw.attachedSpatial);
+            SkinningControl skinControl = skinData.skinningControl;
+            if (skinControl.getSpatial() == null) {
+                logger.log(Level.WARNING,
+                        "No skinned Spatial for joint \"{0}\" -- will skin the model's root node!",
+                        jointName);
+                rootNode.addControl(skinControl);
+            }
+            skinControl.getAttachmentsNode(jointName).attachChild(bw.attachedSpatial);
         }
     }
 


### PR DESCRIPTION
This addresses issue #1612, a `NullPointerException` that occurs while importing a model from an invalid glTF file.

The proposed fix detects that the model's `SkinningControl` isn't added to any `Spatial`. In that case, it logs a warning and adds the control to the model's root node. This allows the import to proceed. However, the resulting model may be incorrect.