### PR TITLE
throw better exceptions in TransformTrack

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -123,7 +123,7 @@ public class TransformTrack implements AnimTrack<Transform> {
      * @param times the keyframes times
      */
     public void setTimes(float[] times) {
-        if (times.length == 0) {
+        if (times == null || times.length == 0) {
             throw new RuntimeException(
                     "No keyframe times were provided.");
         }
@@ -142,7 +142,7 @@ public class TransformTrack implements AnimTrack<Transform> {
                     "TransformTrack lacks keyframe times.  "
                     + "Please invoke setTimes() first.");
         }
-        if (translations.length == 0) {
+        if (translations == null || translations.length == 0) {
             throw new RuntimeException(
                     "No translations were provided.");
         }
@@ -164,7 +164,7 @@ public class TransformTrack implements AnimTrack<Transform> {
                     "TransformTrack lacks keyframe times.  "
                     + "Please invoke setTimes() first.");
         }
-        if (scales.length == 0) {
+        if (scales == null || scales.length == 0) {
             throw new RuntimeException(
                     "No scale vectors were provided.");
         }
@@ -186,7 +186,7 @@ public class TransformTrack implements AnimTrack<Transform> {
                     "TransformTrack lacks keyframe times.  "
                     + "Please invoke setTimes() first.");
         }
-        if (rotations.length == 0) {
+        if (rotations == null || rotations.length == 0) {
             throw new RuntimeException(
                     "No rotations were provided.");
         }

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -124,7 +124,8 @@ public class TransformTrack implements AnimTrack<Transform> {
      */
     public void setTimes(float[] times) {
         if (times.length == 0) {
-            throw new RuntimeException("TransformTrack with no keyframes!");
+            throw new RuntimeException(
+                    "No keyframe times were provided.");
         }
         this.times = times;
         length = times[times.length - 1] - times[0];
@@ -137,10 +138,13 @@ public class TransformTrack implements AnimTrack<Transform> {
      */
     public void setKeyframesTranslation(Vector3f[] translations) {
         if (times == null) {
-            throw new RuntimeException("TransformTrack doesn't have any time for key frames, please call setTimes first");
+            throw new RuntimeException(
+                    "TransformTrack lacks keyframe times.  "
+                    + "Please invoke setTimes() first.");
         }
         if (translations.length == 0) {
-            throw new RuntimeException("TransformTrack with no translation keyframes!");
+            throw new RuntimeException(
+                    "No translations were provided.");
         }
         this.translations = new CompactVector3Array();
         this.translations.add(translations);
@@ -156,10 +160,13 @@ public class TransformTrack implements AnimTrack<Transform> {
      */
     public void setKeyframesScale(Vector3f[] scales) {
         if (times == null) {
-            throw new RuntimeException("TransformTrack doesn't have any time for key frames, please call setTimes first");
+            throw new RuntimeException(
+                    "TransformTrack lacks keyframe times.  "
+                    + "Please invoke setTimes() first.");
         }
         if (scales.length == 0) {
-            throw new RuntimeException("TransformTrack with no scale keyframes!");
+            throw new RuntimeException(
+                    "No scale vectors were provided.");
         }
         this.scales = new CompactVector3Array();
         this.scales.add(scales);
@@ -175,10 +182,13 @@ public class TransformTrack implements AnimTrack<Transform> {
      */
     public void setKeyframesRotation(Quaternion[] rotations) {
         if (times == null) {
-            throw new RuntimeException("TransformTrack doesn't have any time for key frames, please call setTimes first");
+            throw new RuntimeException(
+                    "TransformTrack lacks keyframe times.  "
+                    + "Please invoke setTimes() first.");
         }
         if (rotations.length == 0) {
-            throw new RuntimeException("TransformTrack with no rotation keyframes!");
+            throw new RuntimeException(
+                    "No rotations were provided.");
         }
         this.rotations = new CompactQuaternionArray();
         this.rotations.add(rotations);

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -124,7 +124,7 @@ public class TransformTrack implements AnimTrack<Transform> {
      */
     public void setTimes(float[] times) {
         if (times == null || times.length == 0) {
-            throw new RuntimeException(
+            throw new IllegalArgumentException(
                     "No keyframe times were provided.");
         }
         this.times = times;
@@ -138,12 +138,12 @@ public class TransformTrack implements AnimTrack<Transform> {
      */
     public void setKeyframesTranslation(Vector3f[] translations) {
         if (times == null) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "TransformTrack lacks keyframe times.  "
                     + "Please invoke setTimes() first.");
         }
         if (translations == null || translations.length == 0) {
-            throw new RuntimeException(
+            throw new IllegalArgumentException(
                     "No translations were provided.");
         }
         this.translations = new CompactVector3Array();
@@ -160,12 +160,12 @@ public class TransformTrack implements AnimTrack<Transform> {
      */
     public void setKeyframesScale(Vector3f[] scales) {
         if (times == null) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "TransformTrack lacks keyframe times.  "
                     + "Please invoke setTimes() first.");
         }
         if (scales == null || scales.length == 0) {
-            throw new RuntimeException(
+            throw new IllegalArgumentException(
                     "No scale vectors were provided.");
         }
         this.scales = new CompactVector3Array();
@@ -182,12 +182,12 @@ public class TransformTrack implements AnimTrack<Transform> {
      */
     public void setKeyframesRotation(Quaternion[] rotations) {
         if (times == null) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "TransformTrack lacks keyframe times.  "
                     + "Please invoke setTimes() first.");
         }
         if (rotations == null || rotations.length == 0) {
-            throw new RuntimeException(
+            throw new IllegalArgumentException(
                     "No rotations were provided.");
         }
         this.rotations = new CompactQuaternionArray();


### PR DESCRIPTION
`jme3.anim.TransformTrack` throws generic runtime exceptions in 7 places. This PR changes those exceptions to more specific types, as recommended by Codacy and other static analysis tools.

This PR also checks for null arguments that would otherwise cause NPEs.

It also tries to make the exception message clearer.