### PR TITLE
improve the TransformTrack javadoc

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -54,7 +54,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     private HasLocalTransform target;
 
     /**
-     * transforms and times for keyframes
+     * Transforms and times for keyframes.
      */
     private CompactVector3Array translations;
     private CompactQuaternionArray rotations;
@@ -68,7 +68,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Creates a transform track for the given target
+     * Creates a transform track for the given target.
      *
      * @param target       the target Joint or Spatial of the new track
      * @param times        the time for each keyframe, or null for none
@@ -85,7 +85,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Copies the rotations
+     * Copies the rotations.
      *
      * @return a new array, or null if no rotations
      */
@@ -94,7 +94,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Copies the scales
+     * Copies the scales.
      *
      * @return a new array, or null if no scales
      */
@@ -103,7 +103,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Gives access to the keyframe times
+     * Gives access to the keyframe times.
      *
      * @return the pre-existing array
      */
@@ -112,7 +112,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Copies the translations
+     * Copies the translations.
      *
      * @return a new array, or null if no translations
      */
@@ -122,7 +122,7 @@ public class TransformTrack implements AnimTrack<Transform> {
 
 
     /**
-     * Sets the keyframe times
+     * Sets the keyframe times.
      *
      * @param times the desired keyframe times (alias created, not null, not
      * empty)
@@ -136,7 +136,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Sets the translations
+     * Sets the translations.
      *
      * @param translations the desired translation of the target for each
      * keyframe (not null, same length as "times")
@@ -156,7 +156,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Sets the scales
+     * Sets the scales.
      *
      * @param scales the desired scale of the target for each keyframe (not
      * null, same length as "times")
@@ -176,7 +176,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Sets the rotations
+     * Sets the rotations.
      *
      * @param rotations the desired rotation of the target for each keyframe
      * (not null, same length as "times")
@@ -197,7 +197,7 @@ public class TransformTrack implements AnimTrack<Transform> {
 
 
     /**
-     * Sets the translations, rotations, and/or scales
+     * Sets the translations, rotations, and/or scales.
      *
      * @param times        the desired time for each keyframe,
      *                     or null to leave the times unchanged

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -81,25 +81,25 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * return the array of rotations
+     * Copy the rotations
      *
-     * @return an array, or null if no rotations
+     * @return a new array, or null if no rotations
      */
     public Quaternion[] getRotations() {
         return rotations == null ? null : rotations.toObjectArray();
     }
 
     /**
-     * returns the array of scales
+     * Copy the scales
      *
-     * @return an array or null
+     * @return a new array, or null if no scales
      */
     public Vector3f[] getScales() {
         return scales == null ? null : scales.toObjectArray();
     }
 
     /**
-     * returns the arrays of time
+     * Access the keyframe times
      *
      * @return the pre-existing array
      */
@@ -108,9 +108,9 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * returns the array of translations
+     * Copy the translations
      *
-     * @return an array, or null if no translations
+     * @return a new array, or null if no translations
      */
     public Vector3f[] getTranslations() {
         return translations == null ? null : translations.toObjectArray();

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -120,7 +120,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the keyframe times
      *
-     * @param times the keyframe times
+     * @param times the keyframe times (alias created)
      */
     public void setTimes(float[] times) {
         if (times.length == 0) {

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -71,12 +71,12 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Create a transform track for the given target
      *
      * @param target       the target Joint or Spatial of the new track
-     * @param times        the time for each frame, or null for none
-     * @param translations the translation of the target for each frame,
+     * @param times        the time for each keyframe, or null for none
+     * @param translations the translation of the target for each keyframe,
      *                     or null for no translation
-     * @param rotations    the rotation of the target for each frame,
+     * @param rotations    the rotation of the target for each keyframe,
      *                     or null for no rotation
-     * @param scales       the scale of the target for each frame,
+     * @param scales       the scale of the target for each keyframe,
      *                     or null for no scaling
      */
     public TransformTrack(HasLocalTransform target, float[] times, Vector3f[] translations, Quaternion[] rotations, Vector3f[] scales) {
@@ -138,8 +138,8 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the translations
      *
-     * @param translations the desired translation of the target for each frame
-     * (not null, not empty)
+     * @param translations the desired translation of the target for each
+     * keyframe (not null, not empty)
      */
     public void setKeyframesTranslation(Vector3f[] translations) {
         if (times == null) {
@@ -158,8 +158,8 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the scales
      *
-     * @param scales the desired scale of the target for each frame (not null,
-     * not empty)
+     * @param scales the desired scale of the target for each keyframe (not
+     * null, not empty)
      */
     public void setKeyframesScale(Vector3f[] scales) {
         if (times == null) {
@@ -178,8 +178,8 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the rotations
      *
-     * @param rotations the desired rotation of the target for each frame (not
-     * null, not empty)
+     * @param rotations the desired rotation of the target for each keyframe
+     * (not null, not empty)
      */
     public void setKeyframesRotation(Quaternion[] rotations) {
         if (times == null) {
@@ -199,13 +199,14 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the translations, rotations, and/or scales
      *
-     * @param times        the desired time for each frame,
+     * @param times        the desired time for each keyframe,
      *                     or null to leave the times unchanged
-     * @param translations the desired translation of the target for each frame,
+     * @param translations the desired translation of the target for each
+     *                     keyframe,
      *                     or null to leave the translations unchanged
-     * @param rotations    the desired rotation of the target for each frame,
+     * @param rotations    the desired rotation of the target for each keyframe,
      *                     or null to leave the rotations unchanged
-     * @param scales       the desired scale of the target for each frame,
+     * @param scales       the desired scale of the target for each keyframe,
      *                     or null to leave the scales unchanged
      */
     public void setKeyframes(float[] times, Vector3f[] translations, Quaternion[] rotations, Vector3f[] scales) {
@@ -250,7 +251,7 @@ public class TransformTrack implements AnimTrack<Transform> {
         int endFrame = 1;
         float blend = 0;
         if (time >= times[lastFrame]) {
-            // extrapolate beyond the final frame of the animation
+            // extrapolate beyond the final keyframe of the animation
             startFrame = lastFrame;
 
             float inferredInterval = times[lastFrame] - times[lastFrame - 1];

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -70,7 +70,7 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Create a transform track for the given target
      *
      * @param target       the target Joint or Spatial of the new track
-     * @param times        a float array with the time of each frame
+     * @param times        the time of each frame
      * @param translations the translation of the target for each frame
      * @param rotations    the rotation of the target for each frame
      * @param scales       the scale of the target for each frame
@@ -191,7 +191,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the translations, rotations, and scales
      *
-     * @param times        a float array with the time of each frame
+     * @param times        the time of each frame
      * @param translations the translation of the target for each frame
      * @param rotations    the rotation of the target for each frame
      * @param scales       the scale of the target for each frame

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -67,13 +67,13 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Creates a transform track for the given bone index
+     * Creates a transform track for the given target
      *
      * @param target       the target Joint or Spatial of the new track
      * @param times        a float array with the time of each frame
-     * @param translations the translation of the bone for each frame
-     * @param rotations    the rotation of the bone for each frame
-     * @param scales       the scale of the bone for each frame
+     * @param translations the translation of the target for each frame
+     * @param rotations    the rotation of the target for each frame
+     * @param scales       the scale of the target for each frame
      */
     public TransformTrack(HasLocalTransform target, float[] times, Vector3f[] translations, Quaternion[] rotations, Vector3f[] scales) {
         this.target = target;
@@ -133,7 +133,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the translations for this joint track
      *
-     * @param translations the translation of the bone for each frame
+     * @param translations the translation of the target for each frame
      */
     public void setKeyframesTranslation(Vector3f[] translations) {
         if (times == null) {
@@ -152,7 +152,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the scales for this joint track
      *
-     * @param scales the scales of the bone for each frame
+     * @param scales the scales of the target for each frame
      */
     public void setKeyframesScale(Vector3f[] scales) {
         if (times == null) {
@@ -171,7 +171,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the rotations for this joint track
      *
-     * @param rotations the rotations of the bone for each frame
+     * @param rotations the rotations of the target for each frame
      */
     public void setKeyframesRotation(Quaternion[] rotations) {
         if (times == null) {
@@ -189,12 +189,12 @@ public class TransformTrack implements AnimTrack<Transform> {
 
 
     /**
-     * Set the translations, rotations and scales for this bone track
+     * Set the translations, rotations and scales for this track
      *
      * @param times        a float array with the time of each frame
-     * @param translations the translation of the bone for each frame
-     * @param rotations    the rotation of the bone for each frame
-     * @param scales       the scale of the bone for each frame
+     * @param translations the translation of the target for each frame
+     * @param rotations    the rotation of the target for each frame
+     * @param scales       the scale of the target for each frame
      */
     public void setKeyframes(float[] times, Vector3f[] translations, Quaternion[] rotations, Vector3f[] scales) {
         if (times != null) {

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -70,10 +70,13 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Create a transform track for the given target
      *
      * @param target       the target Joint or Spatial of the new track
-     * @param times        the time of each frame
-     * @param translations the translation of the target for each frame
-     * @param rotations    the rotation of the target for each frame
-     * @param scales       the scale of the target for each frame
+     * @param times        the time for each frame, or null for none
+     * @param translations the translation of the target for each frame,
+     *                     or null for no translation
+     * @param rotations    the rotation of the target for each frame,
+     *                     or null for no rotation
+     * @param scales       the scale of the target for each frame,
+     *                     or null for no scaling
      */
     public TransformTrack(HasLocalTransform target, float[] times, Vector3f[] translations, Quaternion[] rotations, Vector3f[] scales) {
         this.target = target;
@@ -120,7 +123,8 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the keyframe times
      *
-     * @param times the keyframe times (alias created)
+     * @param times the desired keyframe times (alias created, not null, not
+     * empty)
      */
     public void setTimes(float[] times) {
         if (times.length == 0) {
@@ -133,7 +137,8 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the translations
      *
-     * @param translations the translation of the target for each frame
+     * @param translations the desired translation of the target for each frame
+     * (not null, not empty)
      */
     public void setKeyframesTranslation(Vector3f[] translations) {
         if (times == null) {
@@ -152,7 +157,8 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the scales
      *
-     * @param scales the scale of the target for each frame
+     * @param scales the desired scale of the target for each frame (not null,
+     * not empty)
      */
     public void setKeyframesScale(Vector3f[] scales) {
         if (times == null) {
@@ -171,7 +177,8 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the rotations
      *
-     * @param rotations the rotation of the target for each frame
+     * @param rotations the desired rotation of the target for each frame (not
+     * null, not empty)
      */
     public void setKeyframesRotation(Quaternion[] rotations) {
         if (times == null) {
@@ -189,12 +196,16 @@ public class TransformTrack implements AnimTrack<Transform> {
 
 
     /**
-     * Set the translations, rotations, and scales
+     * Set the translations, rotations, and/or scales
      *
-     * @param times        the time of each frame
-     * @param translations the translation of the target for each frame
-     * @param rotations    the rotation of the target for each frame
-     * @param scales       the scale of the target for each frame
+     * @param times        the desired time for each frame,
+     *                     or null to leave the times unchanged
+     * @param translations the desired translation of the target for each frame,
+     *                     or null to leave the translations unchanged
+     * @param rotations    the desired rotation of the target for each frame,
+     *                     or null to leave the rotations unchanged
+     * @param scales       the desired scale of the target for each frame,
+     *                     or null to leave the scales unchanged
      */
     public void setKeyframes(float[] times, Vector3f[] translations, Quaternion[] rotations, Vector3f[] scales) {
         if (times != null) {

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -42,22 +42,23 @@ import com.jme3.util.clone.Cloner;
 import java.io.IOException;
 
 /**
- * Contains a list of transforms and times for each keyframe.
+ * An AnimTrack that transforms a Joint or Spatial
+ * using a list of transforms and times for keyframes.
  *
  * @author Rémy Bouquet
  */
 public class TransformTrack implements AnimTrack<Transform> {
 
     private double length;
+    private FrameInterpolator interpolator = FrameInterpolator.DEFAULT;
     private HasLocalTransform target;
 
     /**
-     * Transforms and times for track.
+     * transforms and times for keyframes
      */
     private CompactVector3Array translations;
     private CompactQuaternionArray rotations;
     private CompactVector3Array scales;
-    private FrameInterpolator interpolator = FrameInterpolator.DEFAULT;
     private float[] times;
 
     /**

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -124,8 +124,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Sets the keyframe times.
      *
-     * @param times the desired keyframe times (alias created, not null, not
-     * empty)
+     * @param times the desired keyframe times (alias created, not null, not empty)
      */
     public void setTimes(float[] times) {
         if (times.length == 0) {
@@ -139,7 +138,7 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Sets the translations.
      *
      * @param translations the desired translation of the target for each
-     * keyframe (not null, same length as "times")
+     *     keyframe (not null, same length as "times")
      */
     public void setKeyframesTranslation(Vector3f[] translations) {
         if (times == null) {
@@ -159,7 +158,7 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Sets the scales.
      *
      * @param scales the desired scale of the target for each keyframe (not
-     * null, same length as "times")
+     *     null, same length as "times")
      */
     public void setKeyframesScale(Vector3f[] scales) {
         if (times == null) {
@@ -179,7 +178,7 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Sets the rotations.
      *
      * @param rotations the desired rotation of the target for each keyframe
-     * (not null, same length as "times")
+     *     (not null, same length as "times")
      */
     public void setKeyframesRotation(Quaternion[] rotations) {
         if (times == null) {

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -67,7 +67,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Creates a transform track for the given target
+     * Create a transform track for the given target
      *
      * @param target       the target Joint or Spatial of the new track
      * @param times        a float array with the time of each frame
@@ -118,9 +118,9 @@ public class TransformTrack implements AnimTrack<Transform> {
 
 
     /**
-     * Sets the keyframes times
+     * Set the keyframe times
      *
-     * @param times the keyframes times
+     * @param times the keyframe times
      */
     public void setTimes(float[] times) {
         if (times.length == 0) {
@@ -152,7 +152,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the scales
      *
-     * @param scales the scales of the target for each frame
+     * @param scales the scale of the target for each frame
      */
     public void setKeyframesScale(Vector3f[] scales) {
         if (times == null) {
@@ -171,7 +171,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     /**
      * Set the rotations
      *
-     * @param rotations the rotations of the target for each frame
+     * @param rotations the rotation of the target for each frame
      */
     public void setKeyframesRotation(Quaternion[] rotations) {
         if (times == null) {
@@ -189,7 +189,7 @@ public class TransformTrack implements AnimTrack<Transform> {
 
 
     /**
-     * Set the translations, rotations and scales
+     * Set the translations, rotations, and scales
      *
      * @param times        a float array with the time of each frame
      * @param translations the translation of the target for each frame

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -68,7 +68,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Create a transform track for the given target
+     * Creates a transform track for the given target
      *
      * @param target       the target Joint or Spatial of the new track
      * @param times        the time for each keyframe, or null for none
@@ -85,7 +85,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Copy the rotations
+     * Copies the rotations
      *
      * @return a new array, or null if no rotations
      */
@@ -94,7 +94,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Copy the scales
+     * Copies the scales
      *
      * @return a new array, or null if no scales
      */
@@ -103,7 +103,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Access the keyframe times
+     * Gives access to the keyframe times
      *
      * @return the pre-existing array
      */
@@ -112,7 +112,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Copy the translations
+     * Copies the translations
      *
      * @return a new array, or null if no translations
      */
@@ -122,7 +122,7 @@ public class TransformTrack implements AnimTrack<Transform> {
 
 
     /**
-     * Set the keyframe times
+     * Sets the keyframe times
      *
      * @param times the desired keyframe times (alias created, not null, not
      * empty)
@@ -136,7 +136,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Set the translations
+     * Sets the translations
      *
      * @param translations the desired translation of the target for each
      * keyframe (not null, same length as "times")
@@ -156,7 +156,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Set the scales
+     * Sets the scales
      *
      * @param scales the desired scale of the target for each keyframe (not
      * null, same length as "times")
@@ -176,7 +176,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Set the rotations
+     * Sets the rotations
      *
      * @param rotations the desired rotation of the target for each keyframe
      * (not null, same length as "times")
@@ -197,7 +197,7 @@ public class TransformTrack implements AnimTrack<Transform> {
 
 
     /**
-     * Set the translations, rotations, and/or scales
+     * Sets the translations, rotations, and/or scales
      *
      * @param times        the desired time for each keyframe,
      *                     or null to leave the times unchanged
@@ -286,7 +286,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Replace the frame interpolator.
+     * Replaces the frame interpolator.
      *
      * @param interpolator the interpolator to use (alias created)
      */
@@ -295,7 +295,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Access the target, which might be a Joint or a Spatial.
+     * Gives access to the target, which might be a Joint or a Spatial.
      *
      * @return the pre-existing instance
      */
@@ -304,7 +304,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Replace the target, which might be a Joint or a Spatial.
+     * Replaces the target, which might be a Joint or a Spatial.
      *
      * @param target the target to use (alias created)
      */
@@ -313,7 +313,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Serialize this track to the specified exporter, for example when
+     * Serializes this track to the specified exporter, for example when
      * saving to a J3O file.
      *
      * @param ex the exporter to write to (not null)
@@ -330,7 +330,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * De-serialize this track from the specified importer, for example when
+     * De-serializes this track from the specified importer, for example when
      * loading from a J3O file.
      *
      * @param im the importer to read from (not null)

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -72,12 +72,12 @@ public class TransformTrack implements AnimTrack<Transform> {
      *
      * @param target       the target Joint or Spatial of the new track
      * @param times        the time for each keyframe, or null for none
-     * @param translations the translation of the target for each keyframe,
-     *                     or null for no translation
-     * @param rotations    the rotation of the target for each keyframe,
-     *                     or null for no rotation
-     * @param scales       the scale of the target for each keyframe,
-     *                     or null for no scaling
+     * @param translations the translation of the target for each keyframe
+     *                     (same length as times) or null for no translation
+     * @param rotations    the rotation of the target for each keyframe
+     *                     (same length as times) or null for no rotation
+     * @param scales       the scale of the target for each keyframe
+     *                     (same length as times) or null for no scaling
      */
     public TransformTrack(HasLocalTransform target, float[] times, Vector3f[] translations, Quaternion[] rotations, Vector3f[] scales) {
         this.target = target;
@@ -139,7 +139,7 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Set the translations
      *
      * @param translations the desired translation of the target for each
-     * keyframe (not null, not empty)
+     * keyframe (not null, same length as "times")
      */
     public void setKeyframesTranslation(Vector3f[] translations) {
         if (times == null) {
@@ -159,7 +159,7 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Set the scales
      *
      * @param scales the desired scale of the target for each keyframe (not
-     * null, not empty)
+     * null, same length as "times")
      */
     public void setKeyframesScale(Vector3f[] scales) {
         if (times == null) {
@@ -179,7 +179,7 @@ public class TransformTrack implements AnimTrack<Transform> {
      * Set the rotations
      *
      * @param rotations the desired rotation of the target for each keyframe
-     * (not null, not empty)
+     * (not null, same length as "times")
      */
     public void setKeyframesRotation(Quaternion[] rotations) {
         if (times == null) {
@@ -202,11 +202,13 @@ public class TransformTrack implements AnimTrack<Transform> {
      * @param times        the desired time for each keyframe,
      *                     or null to leave the times unchanged
      * @param translations the desired translation of the target for each
-     *                     keyframe,
+     *                     keyframe (same length as times)
      *                     or null to leave the translations unchanged
-     * @param rotations    the desired rotation of the target for each keyframe,
+     * @param rotations    the desired rotation of the target for each keyframe
+     *                     (same length as times)
      *                     or null to leave the rotations unchanged
-     * @param scales       the desired scale of the target for each keyframe,
+     * @param scales       the desired scale of the target for each keyframe
+     *                     (same length as times)
      *                     or null to leave the scales unchanged
      */
     public void setKeyframes(float[] times, Vector3f[] translations, Quaternion[] rotations, Vector3f[] scales) {

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -118,7 +118,7 @@ public class TransformTrack implements AnimTrack<Transform> {
 
 
     /**
-     * Sets the keyframes times for this Joint track
+     * Sets the keyframes times for this track
      *
      * @param times the keyframes times
      */
@@ -131,7 +131,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Set the translations for this joint track
+     * Set the translations for this track
      *
      * @param translations the translation of the target for each frame
      */
@@ -150,7 +150,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Set the scales for this joint track
+     * Set the scales for this track
      *
      * @param scales the scales of the target for each frame
      */
@@ -169,7 +169,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Set the rotations for this joint track
+     * Set the rotations for this track
      *
      * @param rotations the rotations of the target for each frame
      */

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -81,7 +81,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * return the array of rotations of this track
+     * return the array of rotations
      *
      * @return an array, or null if no rotations
      */
@@ -90,7 +90,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * returns the array of scales for this track
+     * returns the array of scales
      *
      * @return an array or null
      */
@@ -99,7 +99,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * returns the arrays of time for this track
+     * returns the arrays of time
      *
      * @return the pre-existing array
      */
@@ -108,7 +108,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * returns the array of translations of this track
+     * returns the array of translations
      *
      * @return an array, or null if no translations
      */
@@ -118,7 +118,7 @@ public class TransformTrack implements AnimTrack<Transform> {
 
 
     /**
-     * Sets the keyframes times for this track
+     * Sets the keyframes times
      *
      * @param times the keyframes times
      */
@@ -131,7 +131,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Set the translations for this track
+     * Set the translations
      *
      * @param translations the translation of the target for each frame
      */
@@ -150,7 +150,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Set the scales for this track
+     * Set the scales
      *
      * @param scales the scales of the target for each frame
      */
@@ -169,7 +169,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Set the rotations for this track
+     * Set the rotations
      *
      * @param rotations the rotations of the target for each frame
      */
@@ -189,7 +189,7 @@ public class TransformTrack implements AnimTrack<Transform> {
 
 
     /**
-     * Set the translations, rotations and scales for this track
+     * Set the translations, rotations and scales
      *
      * @param times        a float array with the time of each frame
      * @param translations the translation of the target for each frame
@@ -280,8 +280,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Access the target affected by this track, which might be a Joint or a
-     * Spatial.
+     * Access the target, which might be a Joint or a Spatial.
      *
      * @return the pre-existing instance
      */
@@ -290,7 +289,7 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
-     * Replace the target of this track, which might be a Joint or a Spatial.
+     * Replace the target, which might be a Joint or a Spatial.
      *
      * @param target the target to use (alias created)
      */


### PR DESCRIPTION
The javadoc for the `TransformTrack` class is confusing because it implies that the track is a "joint track" and also that the target is a "bone". But the track's target might actually be a `Spatial`, and (in the new animation system) bones are called "joints".

The javadoc is also padded with low-value information such as "a float array" and "of this track".

The javadoc also fails to document some important details:
+ which arguments can be null,
+ which getter returns an internal array, and
+ which setter creates an alias, 

This PR attempts to remedy these defects. Aside from rearranging fields, only comments are affected.