### PR TITLE
jme3-core:  solve 10 javadoc diagnostics from JDK 11

### DIFF
--- a/jme3-core/src/main/java/checkers/quals/DefaultLocation.java
+++ b/jme3-core/src/main/java/checkers/quals/DefaultLocation.java
@@ -15,8 +15,8 @@ public enum DefaultLocation {
     ALL_EXCEPT_LOCALS,
 
     /** Apply default annotations to unannotated upper bounds:  both
-     * explicit ones in <tt>extends</tt> clauses, and implicit upper bounds
-     * when no explicit <tt>extends</tt> or <tt>super</tt> clause is
+     * explicit ones in <code>extends</code> clauses, and implicit upper bounds
+     * when no explicit <code>extends</code> or <code>super</code> clause is
      * present. */
     // Especially useful for parameterized classes that provide a lot of
     // static methods with the same generic parameters as the class.

--- a/jme3-core/src/main/java/com/jme3/bounding/BoundingSphere.java
+++ b/jme3-core/src/main/java/com/jme3/bounding/BoundingSphere.java
@@ -382,8 +382,7 @@ public class BoundingSphere extends BoundingVolume {
      *            the transform to apply
      * @param store
      *            sphere to store result in
-     * @return BoundingVolume
-     * @return ref
+     * @return either store or a new BoundingSphere
      */
     @Override
     public BoundingVolume transform(Transform trans, BoundingVolume store) {

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -870,7 +870,6 @@ public class ParticleEmitter extends Geometry {
     }
 
     /**
-     * @return the velocity variation
      * @deprecated
      * This method is deprecated.
      * Use ParticleEmitter.getParticleInfluencer().getVelocityVariation(); instead.

--- a/jme3-core/src/main/java/com/jme3/input/Input.java
+++ b/jme3-core/src/main/java/com/jme3/input/Input.java
@@ -77,8 +77,6 @@ public interface Input {
     /**
      * @return The current absolute time as nanoseconds. This time is expected
      * to be relative to the time given in InputEvents time property.
-     *
-     * @return the current time (in nanoseconds)
      */
     public long getInputTimeNanos();
 }

--- a/jme3-core/src/main/java/com/jme3/math/FastMath.java
+++ b/jme3-core/src/main/java/com/jme3/math/FastMath.java
@@ -846,8 +846,7 @@ final public class FastMath {
     /**
      * Returns a random float between 0 and 1.
      *
-     * @return A random float between <tt>0.0f</tt> (inclusive) to
-     * <tt>1.0f</tt> (exclusive).
+     * @return a random float between 0 (inclusive) and 1 (exclusive)
      */
     public static float nextRandomFloat() {
         return rand.nextFloat();
@@ -858,8 +857,7 @@ final public class FastMath {
      *
      * @param min the desired minimum value
      * @param max the desired maximum value
-     * @return A random int between <tt>min</tt> (inclusive) to
-     * <tt>max</tt> (inclusive).
+     * @return a random int between min (inclusive) and max (inclusive)
      */
     public static int nextRandomInt(int min, int max) {
         return (int) (nextRandomFloat() * (max - min + 1)) + min;


### PR DESCRIPTION
Most of the javadoc in the Engine was written for old JDKs, resulting in warnings and errors when it is built using newer ones. Some sub-projects (such as "jme3-lwjgl3" and "jme3-networking") work around this by disabling doclint for JDK8+. Others, including "jme3-core", don't disable doclint.

This PR solves the 3 warnings and 7 errors that JDK 11 currently reports for jme3-core.