### PR TITLE
solve issue 1640 (CartoonEdgeFilter failing to override read() and write())

### DIFF
--- a/jme3-effects/src/main/java/com/jme3/post/filters/CartoonEdgeFilter.java
+++ b/jme3-effects/src/main/java/com/jme3/post/filters/CartoonEdgeFilter.java
@@ -31,11 +31,16 @@
  */
 package com.jme3.post.filters;
 
+import java.io.IOException;
+
 import com.jme3.asset.AssetManager;
+import com.jme3.export.InputCapsule;
+import com.jme3.export.JmeExporter;
+import com.jme3.export.JmeImporter;
+import com.jme3.export.OutputCapsule;
 import com.jme3.material.Material;
 import com.jme3.math.ColorRGBA;
 import com.jme3.post.Filter;
-import com.jme3.post.Filter.Pass;
 import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.Renderer;
 import com.jme3.renderer.ViewPort;
@@ -109,8 +114,6 @@ public class CartoonEdgeFilter extends Filter {
     protected void cleanUpFilter(Renderer r) {
         normalPass.cleanup(r);
     }
-
-    
     
     /**
      * Return the depth sensitivity<br>
@@ -196,7 +199,6 @@ public class CartoonEdgeFilter extends Filter {
         if (material != null) {
             material.setFloat("EdgeWidth", edgeWidth);
         }
-
     }
 
     /**
@@ -260,5 +262,31 @@ public class CartoonEdgeFilter extends Filter {
         if (material != null) {
             material.setColor("EdgeColor", edgeColor);
         }
+    }
+    
+    @Override
+    public void write(JmeExporter ex) throws IOException {
+        super.write(ex);
+        OutputCapsule oc = ex.getCapsule(this);
+        oc.write(edgeWidth, "edgeWidth", 1.0f);
+        oc.write(edgeIntensity, "edgeIntensity", 1.0f);
+        oc.write(normalThreshold, "normalThreshold", 0.5f);
+        oc.write(depthThreshold, "depthThreshold", 0.1f);
+        oc.write(normalSensitivity, "normalSensitivity", 1.0f);
+        oc.write(depthSensitivity, "depthSensitivity", 10.0f);
+        oc.write(edgeColor, "edgeColor", ColorRGBA.Black);
+    }
+
+    @Override
+    public void read(JmeImporter im) throws IOException {
+        super.read(im);
+        InputCapsule ic = im.getCapsule(this);
+        edgeWidth = ic.readFloat("edgeWidth", 1.0f);
+        edgeIntensity = ic.readFloat("edgeIntensity", 1.0f);
+        normalThreshold = ic.readFloat("normalThreshold", 0.5f);
+        depthThreshold = ic.readFloat("depthThreshold", 0.1f);
+        normalSensitivity = ic.readFloat("normalSensitivity", 1.0f);
+        depthSensitivity = ic.readFloat("depthSensitivity", 10.0f);
+        edgeColor = (ColorRGBA) ic.readSavable("edgeColor", ColorRGBA.Black.clone());
     }
 }

--- a/jme3-effects/src/test/java/com/jme3/post/filters/CartoonEdgeFilterTest.java
+++ b/jme3-effects/src/test/java/com/jme3/post/filters/CartoonEdgeFilterTest.java
@@ -1,0 +1,41 @@
+package com.jme3.post.filters;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.jme3.asset.AssetManager;
+import com.jme3.asset.DesktopAssetManager;
+import com.jme3.export.binary.BinaryExporter;
+import com.jme3.math.ColorRGBA;
+
+/**
+ *
+ * @author capdevon
+ */
+public class CartoonEdgeFilterTest {
+
+    @Test
+    public void testSaveAndLoad() {
+        AssetManager assetManager = new DesktopAssetManager(true);
+
+        CartoonEdgeFilter cartoon = new CartoonEdgeFilter();
+        cartoon.setEdgeColor(ColorRGBA.Red);
+        cartoon.setEdgeIntensity(.5f);
+        cartoon.setEdgeWidth(1);
+        cartoon.setNormalSensitivity(2);
+        cartoon.setNormalThreshold(1);
+        cartoon.setDepthSensitivity(20);
+        cartoon.setDepthThreshold(2);
+
+        CartoonEdgeFilter filter = BinaryExporter.saveAndLoad(assetManager, cartoon);
+
+        Assert.assertEquals(ColorRGBA.Red, filter.getEdgeColor());
+        Assert.assertEquals(.5f, filter.getEdgeIntensity(), 0.0001);
+        Assert.assertEquals(1, filter.getEdgeWidth(), 0.0001);
+        Assert.assertEquals(2, filter.getNormalSensitivity(), 0.0001);
+        Assert.assertEquals(1, filter.getNormalThreshold(), 0.0001);
+        Assert.assertEquals(20, filter.getDepthSensitivity(), 0.0001);
+        Assert.assertEquals(2, filter.getDepthThreshold(), 0.0001);
+    }
+
+}

--- a/jme3-effects/src/test/java/com/jme3/post/filters/CartoonEdgeFilterTest.java
+++ b/jme3-effects/src/test/java/com/jme3/post/filters/CartoonEdgeFilterTest.java
@@ -14,6 +14,9 @@ import com.jme3.math.ColorRGBA;
  */
 public class CartoonEdgeFilterTest {
 
+    /**
+     * Test saving/loading a CartoonEdgeFilter
+     */
     @Test
     public void testSaveAndLoad() {
         AssetManager assetManager = new DesktopAssetManager();

--- a/jme3-effects/src/test/java/com/jme3/post/filters/CartoonEdgeFilterTest.java
+++ b/jme3-effects/src/test/java/com/jme3/post/filters/CartoonEdgeFilterTest.java
@@ -16,7 +16,7 @@ public class CartoonEdgeFilterTest {
 
     @Test
     public void testSaveAndLoad() {
-        AssetManager assetManager = new DesktopAssetManager(true);
+        AssetManager assetManager = new DesktopAssetManager();
 
         CartoonEdgeFilter cartoon = new CartoonEdgeFilter();
         cartoon.setEdgeColor(ColorRGBA.Red);


### PR DESCRIPTION
this PR solve issue [#1640](https://github.com/jMonkeyEngine/jmonkeyengine/issues/1640)
- remove unused import and extra empty lines from CartoonEdgeFilter
- add test case for CartoonEdgeFilter save and load