### PR TITLE
SurfaceView Maintenance

### DIFF
--- a/jme3-android/build.gradle
+++ b/jme3-android/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'java'
 dependencies {
     //added annotations used by JmeSurfaceView.
     compileOnly 'androidx.annotation:annotation:1.2.0'
+    compileOnly 'androidx.lifecycle:lifecycle-common:2.1.0'
     api project(':jme3-core')
     api project(':jme3-plugins')
     compileOnly 'android:android'

--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
@@ -243,12 +243,14 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
 
     /**
      * Instantiates a surface view holder with XML attributes and a default style attribute.
+     * On instantiating this surface view, the holder is bound directly to the
+     * parent context life cycle.
      *
      * @param context      the parent context.
      * @param attrs        a collection of attributes describes the tags in an XML document.
      * @param defStyleAttr an attribute in the current theme that contains a
      *                     reference to a style resource that supplies
-     *                     defaults values.
+     *                     defaults values. Can be 0 to not look for defaults.
      * @see android.content.res.Resources.Theme#obtainStyledAttributes(AttributeSet, int[], int, int)
      */
     public JmeSurfaceView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
@@ -259,12 +261,15 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
 
     /**
      * Instantiates a surface view holder with XML attributes, default style attribute and a default style resource.
+     * On instantiating this surface view, the holder is bound directly to the
+     * parent context life cycle.
      *
      * @param context      the parent context.
      * @param attrs        a collection of attributes describes the tags in an XML document.
-     * @param defStyleAttr an attribute in the current theme that contains defaults.
+     * @param defStyleAttr an attribute in the current theme that contains defaults. Can be 0 to not look for defaults.
      * @param defStyleRes  a resource identifier of a style resource that
      *                     supplies default values, used only if defStyleAttr is 0 or can not be found in the theme.
+     *                     Can be 0 to not look for defaults.
      * @see android.content.res.Resources.Theme#obtainStyledAttributes(AttributeSet, int[], int, int)
      */
     public JmeSurfaceView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {

--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
@@ -131,9 +131,9 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
         private static boolean firstUpdatePassed = false;
 
         /**
-         * Protected constructor to inhibit instantiation of this class.
+         * Private constructor to inhibit instantiation of this class.
          */
-        protected GameState() {
+        private GameState() {
         }
 
         /**

--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
@@ -121,13 +121,20 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
     /**
      * Used as a static memory to protect the game context from destruction by Activity#onDestroy().
      * For usages :
+     *
      * @see DestructionPolicy
      * @see JmeSurfaceView#setDestructionPolicy(DestructionPolicy)
      */
-    protected enum GameState {
-        ;
+    protected static final class GameState {
+
         private static LegacyApplication legacyApplication;
         private static boolean firstUpdatePassed = false;
+
+        /**
+         * Protected constructor to inhibit instantiation of this class.
+         */
+        protected GameState() {
+        }
 
         /**
          * Replaces the current application state.

--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
@@ -311,7 +311,7 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
         if(onLayoutDrawn != null){
             onLayoutDrawn.onLayoutDrawn(legacyApplication, this);
         }
-        /*set the static memory to hold the game state, only if the game life cycle is not bounded to the activity life cycle*/
+        /*set the static memory to hold the game state, only if the destruction policy uses KEEP_WHEN_FINISHED policy*/
         if (destructionPolicy == DestructionPolicy.KEEP_WHEN_FINISH){
             GameState.setLegacyApplication(legacyApplication);
         }else{

--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
@@ -211,18 +211,46 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
 
     //******************End of Helper Classes************************
 
+    //******************Constructors************************
+
+    /**
+     * Instantiates a default surface view holder without XML attributes.
+     * On instantiating this surface view, the holder is bound directly to the
+     * parent context life cycle.
+     *
+     * @param context the parent context.
+     */
     public JmeSurfaceView(@NonNull Context context) {
         super(context);
         //binds the view component to the holder activity life cycle
         bindAppStateToActivityLifeCycle(bindAppState);
     }
 
+    /**
+     * Instantiates a surface view holder with XML attributes from an XML document.
+     * On instantiating this surface view, the holder is bound directly to the
+     * parent context life cycle.
+     *
+     * @param context the parent context.
+     * @param attrs   a collection of attributes describes the tags in an XML document.
+     * @see android.content.res.Resources.Theme#obtainAttributes(AttributeSet, int[])
+     */
     public JmeSurfaceView(@NonNull Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
         //binds the view component to the holder activity life cycle
         bindAppStateToActivityLifeCycle(bindAppState);
     }
 
+    /**
+     * Instantiates a surface view holder with XML attributes and a default style attribute.
+     *
+     * @param context      the parent context.
+     * @param attrs        a collection of attributes describes the tags in an XML document.
+     * @param defStyleAttr an attribute in the current theme that contains a
+     *                     reference to a style resource that supplies
+     *                     defaults values.
+     * @see android.content.res.Resources.Theme#obtainStyledAttributes(AttributeSet, int[], int, int)
+     */
     public JmeSurfaceView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         //binds the view component to the holder activity life cycle
@@ -230,7 +258,26 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
     }
 
     /**
+     * Instantiates a surface view holder with XML attributes, default style attribute and a default style resource.
+     *
+     * @param context      the parent context.
+     * @param attrs        a collection of attributes describes the tags in an XML document.
+     * @param defStyleAttr an attribute in the current theme that contains defaults.
+     * @param defStyleRes  a resource identifier of a style resource that
+     *                     supplies default values, used only if defStyleAttr is 0 or can not be found in the theme.
+     * @see android.content.res.Resources.Theme#obtainStyledAttributes(AttributeSet, int[], int, int)
+     */
+    public JmeSurfaceView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        //binds the view component to the holder activity life cycle
+        bindAppStateToActivityLifeCycle(bindAppState);
+    }
+
+    //******************End of constructors************************
+
+    /**
      * Starts the jmeRenderer on a GlSurfaceView attached to a RelativeLayout.
+     *
      * @param delayMillis delays the attachment of the surface view to the UI (RelativeLayout).
      */
     public void startRenderer(int delayMillis) {

--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
@@ -183,7 +183,7 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
     }
 
     /**
-     * Custom thread that delays the attachment surface view on the UI for the sake of initial frame pacing and splash screens,
+     * Delays the attachment surface view on the UI for the sake of initial frame pacing and splash screens,
      * delaying the display of the game (GlSurfaceView) would lead to a substantial delay in the {@link GLSurfaceView.Renderer#onDrawFrame(GL10)} which would
      * delay invoking both {@link LegacyApplication#initialize()} and {@link LegacyApplication#update()}.
      * @see JmeSurfaceView#startRenderer(int)

--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/OnExceptionThrown.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/OnExceptionThrown.java
@@ -32,8 +32,10 @@
 package com.jme3.app.jmeSurfaceView;
 
 /**
- * Embedded interface designed to listen to exceptions and fire when an exception is thrown.
+ * An interface designed to listen for exceptions and fire an event when an exception is thrown.
  * @see JmeSurfaceView#setOnExceptionThrown(OnExceptionThrown)
+ *
+ * @author pavl_g.
  */
 public interface OnExceptionThrown {
     /**

--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/OnLayoutDrawn.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/OnLayoutDrawn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,22 +31,20 @@
  */
 package com.jme3.app.jmeSurfaceView;
 
+import android.view.View;
 import com.jme3.app.LegacyApplication;
-import com.jme3.system.AppSettings;
 
 /**
- * An interface used for invoking an event when the user delay finishes, on the first update of the game.
- * @see JmeSurfaceView#setOnRendererCompleted(OnRendererCompleted)
+ * An interface used for dispatching an event when the layout holding the {@link android.opengl.GLSurfaceView} is drawn,
+ * the event is dispatched on the user activity context thread.
  *
  * @author pavl_g.
  */
-public interface OnRendererCompleted {
+public interface OnLayoutDrawn {
     /**
-     * Invoked when the user delay finishes, on the first update of the game, the event is dispatched on the
-     * enclosing Activity context thread.
-     * @see JmeSurfaceView#update()
-     * @param application the current jme game instance.
-     * @param appSettings the current window settings of the running jme game.
+     * Dispatched when the layout is drawn on the screen.
+     * @param legacyApplication the application instance.
+     * @param layout the current layout.
      */
-    void onRenderCompletion(LegacyApplication application, AppSettings appSettings);
+    void onLayoutDrawn(LegacyApplication legacyApplication, View layout);
 }

--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/OnRendererStarted.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/OnRendererStarted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,22 +31,25 @@
  */
 package com.jme3.app.jmeSurfaceView;
 
+import android.view.View;
 import com.jme3.app.LegacyApplication;
 import com.jme3.system.AppSettings;
 
 /**
- * An interface used for invoking an event when the user delay finishes, on the first update of the game.
- * @see JmeSurfaceView#setOnRendererCompleted(OnRendererCompleted)
+ * An interface used for invoking an event when the application is started explicitly from {@link JmeSurfaceView#startRenderer(int)}.
+ * NB : This listener must be utilized before using {@link JmeSurfaceView#startRenderer(int)}, ie : it would be ignored if you try to use {@link JmeSurfaceView#setOnRendererStarted(OnRendererStarted)} after
+ * {@link JmeSurfaceView#startRenderer(int)}.
+ * @see JmeSurfaceView#setOnRendererStarted(OnRendererStarted)
  *
  * @author pavl_g.
  */
-public interface OnRendererCompleted {
+public interface OnRendererStarted {
     /**
-     * Invoked when the user delay finishes, on the first update of the game, the event is dispatched on the
-     * enclosing Activity context thread.
-     * @see JmeSurfaceView#update()
-     * @param application the current jme game instance.
-     * @param appSettings the current window settings of the running jme game.
+     * Invoked when the game application is started by the {@link LegacyApplication#start()}, the event is dispatched on the
+     * holder Activity context thread.
+     * @see JmeSurfaceView#startRenderer(int)
+     * @param application the game instance.
+     * @param layout the enclosing layout.
      */
-    void onRenderCompletion(LegacyApplication application, AppSettings appSettings);
+    void onRenderStart(LegacyApplication application, View layout);
 }


### PR DESCRIPTION
A maintenance PR for the `JmeSurfaceView`.

## New features introduced : 

1) Optionally  binding the jmeSurfaceView to the android activity life cycle, it helps in `pausing`, `resuming` game and openGL context, and also helps in releasing memory when the game is destroyed.

2) Added new Listeners events : `OnLayoutDrawn()`, `OnRendererStarted()`.

4) Added a `DestructionPolicy` flag, which uses a static game state `GameState` to determine whether to destroy the game with the activity on exiting the activity or to keep it for a second use.
https://youtu.be/NBWyBzr_YXU

5) Optimizations to the `ErrorDialog` includes : showing a full error stack and `Copy crash log` button.

6) Added other flags such as : `showErrorDialog`, `exitOnEscPressed`, `showEscExitPrompt`.

7) Added a getter field for gl_es version.

8) Documentations and code optimizations following best practices.

`NB : changes here are tested more than once on pre-existing jme3 android apps since jme3.4.0, and they won't likely affect user code.`

### Screenshots : 

![Copy crash log feature](https://user-images.githubusercontent.com/60224159/141504356-a42c4c70-f224-4e33-9127-8791bf899901.png)

I will try to make a video to preview these changes on a live android test.