### PR TITLE
jme3-core/src/test:  upgrade MockitoJUnitRunner from deprecated version

### DIFF
--- a/jme3-core/src/test/java/com/jme3/material/MaterialTest.java
+++ b/jme3-core/src/test/java/com/jme3/material/MaterialTest.java
@@ -50,7 +50,7 @@ import java.util.EnumSet;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MaterialTest {

--- a/jme3-core/src/test/java/com/jme3/material/plugins/J3MLoaderTest.java
+++ b/jme3-core/src/test/java/com/jme3/material/plugins/J3MLoaderTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;

--- a/jme3-core/src/test/java/com/jme3/material/plugins/LoadJ3mdTest.java
+++ b/jme3-core/src/test/java/com/jme3/material/plugins/LoadJ3mdTest.java
@@ -42,7 +42,7 @@ import java.util.*;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LoadJ3mdTest {


### PR DESCRIPTION
While reviewing some deprecation warnings, I discovered that 3 tests in jme3-core were using a deprecated version of `MockitoJUnitRunner`.

See https://stackoverflow.com/questions/41909538/mockitojunitrunner-is-deprecated

This PR corrects the issue.