### PR TITLE
Upgraded to LWJGL 3.3.0

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -25,7 +25,7 @@ tasks.withType(JavaCompile) { // compile-time options:
 }
 
 ext {
-    lwjgl3Version = '3.2.3' // used in both the jme3-lwjgl3 and jme3-vr build scripts
+    lwjgl3Version = '3.3.0' // used in both the jme3-lwjgl3 and jme3-vr build scripts
 }
 
 repositories {

--- a/jme3-vr/src/main/java/com/jme3/input/vr/lwjgl_openvr/LWJGLOpenVR.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/lwjgl_openvr/LWJGLOpenVR.java
@@ -15,12 +15,7 @@ import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.lwjgl.BufferUtils;
-import org.lwjgl.openvr.HmdMatrix34;
-import org.lwjgl.openvr.HmdMatrix44;
-import org.lwjgl.openvr.TrackedDevicePose;
-import org.lwjgl.openvr.VR;
-import org.lwjgl.openvr.VRCompositor;
-import org.lwjgl.openvr.VRSystem;
+import org.lwjgl.openvr.*;
 
 /**
  * A class that wraps an <a href="https://github.com/ValveSoftware/openvr/wiki/API-Documentation">OpenVR</a> system. 
@@ -235,7 +230,7 @@ public class LWJGLOpenVR implements VRAPI {
 
     @Override
     public void reset() {
-        VRSystem.VRSystem_ResetSeatedZeroPose();
+        VRChaperone.VRChaperone_ResetZeroPose(VR.ETrackingUniverseOrigin_TrackingUniverseSeated);
         hmdSeatToStand = null;
     }
 


### PR DESCRIPTION
@stephengold I have resolved the compilation issue with OpenVR inside jme-vr module, and updated the lwjgl version to 3.3.0.

I apologize, IDEA is trying to trim trailing whitespace, and no matter what I hit, I cannot get it to leave it alone. All other changes are whitespace changes, the only change is on line 233 (and the imports, which again IDEA does on its own...)

I guess this is a step in the right direction for the new style guide 🤣 