### PR TITLE
jme3-examples:  simplify 6 unnecessary uses of unary minus

### DIFF
--- a/jme3-examples/src/main/java/jme3test/bullet/TestAttachDriver.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestAttachDriver.java
@@ -250,12 +250,12 @@ public class TestAttachDriver extends SimpleApplication implements ActionListene
             if (value) {
                 steeringValue += .5f;
             } else {
-                steeringValue += -.5f;
+                steeringValue -= .5f;
             }
             vehicle.steer(steeringValue);
         } else if (binding.equals("Rights")) {
             if (value) {
-                steeringValue += -.5f;
+                steeringValue -= .5f;
             } else {
                 steeringValue += .5f;
             }

--- a/jme3-examples/src/main/java/jme3test/bullet/TestFancyCar.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestFancyCar.java
@@ -183,12 +183,12 @@ public class TestFancyCar extends SimpleApplication implements ActionListener {
             if (value) {
                 steeringValue += .5f;
             } else {
-                steeringValue += -.5f;
+                steeringValue -= .5f;
             }
             player.steer(steeringValue);
         } else if (binding.equals("Rights")) {
             if (value) {
-                steeringValue += -.5f;
+                steeringValue -= .5f;
             } else {
                 steeringValue += .5f;
             }

--- a/jme3-examples/src/main/java/jme3test/bullet/TestPhysicsCar.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestPhysicsCar.java
@@ -183,12 +183,12 @@ public class TestPhysicsCar extends SimpleApplication implements ActionListener 
             if (value) {
                 steeringValue += .5f;
             } else {
-                steeringValue += -.5f;
+                steeringValue -= .5f;
             }
             vehicle.steer(steeringValue);
         } else if (binding.equals("Rights")) {
             if (value) {
-                steeringValue += -.5f;
+                steeringValue -= .5f;
             } else {
                 steeringValue += .5f;
             }


### PR DESCRIPTION
Static analysis by IntelliJ IDEA flagged this weird code. This PR makes the examples a tiny bit more readable.