### PR TITLE
set initial window position

### DIFF
--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -289,6 +289,7 @@ public final class AppSettings extends HashMap<String, Object> {
         defaults.put("SwapBuffers", true);
         defaults.put("OpenCL", false);
         defaults.put("OpenCLPlatformChooser", DefaultPlatformChooser.class.getName());
+        defaults.put("CenterWindow", true);
         //  defaults.put("Icons", null);
     }
 
@@ -1330,5 +1331,64 @@ public final class AppSettings extends HashMap<String, Object> {
      */
     public void setGraphicsTrace(boolean trace) {
         putBoolean("GraphicsTrace", trace);
+    }
+
+    /**
+     * Get the Center Window state
+     *
+     * @return true for center the window in the middle of the screen
+     * @see #setCenterWindow(boolean)
+     */
+    public boolean getCenterWindow() {
+        return getBoolean("CenterWindow");
+    }
+    
+    /**
+     * True to enable center the window.
+     *
+     * @param center whether to center the window or not.
+     */
+    public void setCenterWindow(boolean center) {
+        putBoolean("CenterWindow", center);
+    }
+
+    
+    /**
+     * Get the position of the window's X Position
+     *
+     * @return int screen coordinates of the X Position of the window
+     * @see #setWindowXPosition(int)
+     */
+    public int getWindowXPosition() {
+        return getInteger("windowXpos");
+    }
+    
+    /**
+     * The position of the window's X Position.
+     *
+     * @param pos screen coordinates for the X position.
+     */
+    public void setWindowXPosition(int pos) {
+        putInteger("windowXpos", pos);
+    }
+
+
+    /**
+     * Get the position of the window's Y Position
+     *
+     * @return int screen coordinates of the Y Position of the window
+     * @see #setWindowXPosition(int)
+     */
+    public int getWindowYPosition() {
+        return getInteger("windowYpos");
+    }
+    
+    /**
+     * The position of the window's Y Position.
+     *
+     * @param pos screen coordinates for the Y position.
+     */
+    public void setWindowYPosition(int pos) {
+        putInteger("windowYpos", pos);
     }
 }

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -274,11 +274,16 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             }
         });
 
-        // Center the window
         if (!settings.isFullscreen()) {
-            glfwSetWindowPos(window,
+            if (settings.getCenterWindow())
+            {
+                // Center the window
+                glfwSetWindowPos(window,
                     (videoMode.width() - settings.getWidth()) / 2,
                     (videoMode.height() - settings.getHeight()) / 2);
+            } else {
+                glfwSetWindowPos(window,settings.getWindowXPosition(), settings.getWindowYPosition());
+            }
         }
 
         // Make the OpenGL context current


### PR DESCRIPTION
Added the ability under ljwgl3  to be able to position the window instead of forcing it to be center on the screen all the time.   You can set through AppSettings 3 types of values.   CenterWindow, WindowXPosition, WindowYPosition.  By defaul the CenterWindow is set to 'true', so it runs just like it use to do and doesn't affect any previous builds.

  This way the positioning will can be saved and used in the future.