### PR TITLE
more precise return types for 13 clone() methods

### DIFF
--- a/jme3-core/src/main/java/com/jme3/animation/AudioTrack.java
+++ b/jme3-core/src/main/java/com/jme3/animation/AudioTrack.java
@@ -165,7 +165,7 @@ public class AudioTrack implements ClonableTrack {
      * @return a new track
      */
     @Override
-    public Track clone() {
+    public AudioTrack clone() {
         return new AudioTrack(audio, length, startOffset);
     }
 

--- a/jme3-core/src/main/java/com/jme3/animation/CompactArray.java
+++ b/jme3-core/src/main/java/com/jme3/animation/CompactArray.java
@@ -268,7 +268,7 @@ public abstract class CompactArray<T> implements JmeCloneable {
      * @throws CloneNotSupportedException never
      */
     @Override
-    public Object clone() throws CloneNotSupportedException {
+    public CompactArray clone() throws CloneNotSupportedException {
         return Cloner.deepClone(this);
     }
 

--- a/jme3-core/src/main/java/com/jme3/animation/EffectTrack.java
+++ b/jme3-core/src/main/java/com/jme3/animation/EffectTrack.java
@@ -250,7 +250,7 @@ public class EffectTrack implements ClonableTrack {
      * @return a new instance
      */
     @Override
-    public Track clone() {
+    public EffectTrack clone() {
         return new EffectTrack(emitter, length, startOffset);
     }
 

--- a/jme3-core/src/main/java/com/jme3/asset/CloneableSmartAsset.java
+++ b/jme3-core/src/main/java/com/jme3/asset/CloneableSmartAsset.java
@@ -62,7 +62,7 @@ public interface CloneableSmartAsset extends Cloneable {
      * @return A clone of this asset. 
      * The cloned asset cannot reference equal this asset.
      */
-    public Object clone();
+    public CloneableSmartAsset clone();
     
     /**
      * Set by the {@link AssetManager} to track this asset. 

--- a/jme3-core/src/main/java/com/jme3/effect/influencers/DefaultParticleInfluencer.java
+++ b/jme3-core/src/main/java/com/jme3/effect/influencers/DefaultParticleInfluencer.java
@@ -100,7 +100,7 @@ public class DefaultParticleInfluencer implements ParticleInfluencer {
     }
 
     @Override
-    public ParticleInfluencer clone() {
+    public DefaultParticleInfluencer clone() {
         try {
             DefaultParticleInfluencer clone = (DefaultParticleInfluencer) super.clone();
             clone.initialVelocity = initialVelocity.clone();

--- a/jme3-core/src/main/java/com/jme3/effect/influencers/EmptyParticleInfluencer.java
+++ b/jme3-core/src/main/java/com/jme3/effect/influencers/EmptyParticleInfluencer.java
@@ -77,9 +77,9 @@ public class EmptyParticleInfluencer implements ParticleInfluencer {
     }
 
     @Override
-    public ParticleInfluencer clone() {
+    public EmptyParticleInfluencer clone() {
         try {
-            return (ParticleInfluencer) super.clone();
+            return (EmptyParticleInfluencer) super.clone();
         } catch (CloneNotSupportedException e) {
             throw new AssertionError();
         }

--- a/jme3-core/src/main/java/com/jme3/effect/influencers/NewtonianParticleInfluencer.java
+++ b/jme3-core/src/main/java/com/jme3/effect/influencers/NewtonianParticleInfluencer.java
@@ -143,7 +143,7 @@ public class NewtonianParticleInfluencer extends DefaultParticleInfluencer {
     }
 
     @Override
-    public ParticleInfluencer clone() {
+    public NewtonianParticleInfluencer clone() {
         NewtonianParticleInfluencer result = new NewtonianParticleInfluencer();
         result.normalVelocity = normalVelocity;
         result.initialVelocity = initialVelocity;

--- a/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedNode.java
+++ b/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedNode.java
@@ -326,12 +326,12 @@ public class InstancedNode extends GeometryGroupNode {
     }
 
     @Override
-    public Node clone() {
+    public InstancedNode clone() {
         return clone(true);
     }
 
     @Override
-    public Node clone(boolean cloneMaterials) {
+    public InstancedNode clone(boolean cloneMaterials) {
         InstancedNode clone = (InstancedNode)super.clone(cloneMaterials);
 
         if (instancesMap.size() > 0) {

--- a/jme3-examples/src/main/java/jme3test/asset/TestAssetCache.java
+++ b/jme3-examples/src/main/java/jme3test/asset/TestAssetCache.java
@@ -59,7 +59,7 @@ public class TestAssetCache {
         private byte[] data = new byte[10 * 1024];
 
         @Override
-        public Object clone(){
+        public DummyData clone(){
             try {
                 DummyData clone = (DummyData) super.clone();
                 clone.data = data.clone();

--- a/jme3-plugins/src/main/java/com/jme3/scene/plugins/IrBoneWeightIndex.java
+++ b/jme3-plugins/src/main/java/com/jme3/scene/plugins/IrBoneWeightIndex.java
@@ -42,9 +42,9 @@ public class IrBoneWeightIndex implements Cloneable, Comparable<IrBoneWeightInde
     }
 
     @Override
-    public Object clone() {
+    public IrBoneWeightIndex clone() {
         try {
-            return super.clone();
+            return (IrBoneWeightIndex)super.clone();
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError(ex);
         }

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/lodcalc/DistanceLodCalculator.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/lodcalc/DistanceLodCalculator.java
@@ -130,7 +130,7 @@ public class DistanceLodCalculator implements LodCalculator {
     }
 
     @Override
-    public LodCalculator clone() {
+    public DistanceLodCalculator clone() {
         DistanceLodCalculator clone = new DistanceLodCalculator(size, lodMultiplier);
         return clone;
     }

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/lodcalc/PerspectiveLodCalculator.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/lodcalc/PerspectiveLodCalculator.java
@@ -132,9 +132,9 @@ public class PerspectiveLodCalculator implements LodCalculator {
     }
 
     @Override
-    public LodCalculator clone() {
+    public PerspectiveLodCalculator clone() {
         try {
-            return (LodCalculator) super.clone();
+            return (PerspectiveLodCalculator) super.clone();
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
         }


### PR DESCRIPTION
This addresses issue #1676, changing the return types of 13 `clone()` methods to the class in which they're declared.

This is technically an API change. The most likely breakage would be if external code extended one of these classes and overrode `clone()` with a method returning a supertype (such as `Object`). That would lead to a compile-time error due to incompatible return types.