### PR TITLE
CenterQuad:  new class javadoc

### DIFF
--- a/jme3-vr/src/main/java/com/jme3/scene/CenterQuad.java
+++ b/jme3-vr/src/main/java/com/jme3/scene/CenterQuad.java
@@ -39,13 +39,11 @@ import com.jme3.scene.VertexBuffer.Type;
  * A static, indexed, Triangles-mode mesh for an axis-aligned rectangle in the
  * X-Y plane.
  *
- * <p>
- * The rectangle extends from (-width/2, -height/2, 0) to (width/2, height/2, 0)
- * with normals set to (0,0,1).
+ * <p>The rectangle extends from (-width/2, -height/2, 0) to
+ * (width/2, height/2, 0) with normals set to (0,0,1).
  *
- * <p>
- * This differs from {@link com.jme3.scene.shape.Quad} because it puts (0,0,0)
- * at the rectangle's center instead of in a corner.
+ * <p>This differs from {@link com.jme3.scene.shape.Quad} because it puts
+ * (0,0,0) at the rectangle's center instead of in a corner.
  *
  * @author Kirill Vainer
  */

--- a/jme3-vr/src/main/java/com/jme3/scene/CenterQuad.java
+++ b/jme3-vr/src/main/java/com/jme3/scene/CenterQuad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2010 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,11 +36,17 @@ import com.jme3.scene.Mesh;
 import com.jme3.scene.VertexBuffer.Type;
 
 /**
- * <code>Quad</code> represents a rectangular plane in space
- * defined by 4 vertices. The quad's lower-left side is contained
- * at the local space origin (0, 0, 0), while the upper-right
- * side is located at the width/height coordinates (width, height, 0).
- * 
+ * A static, indexed, Triangles-mode mesh for an axis-aligned rectangle in the
+ * X-Y plane.
+ *
+ * <p>
+ * The rectangle extends from (-width/2, -height/2, 0) to (width/2, height/2, 0)
+ * with normals set to (0,0,1).
+ *
+ * <p>
+ * This differs from {@link com.jme3.scene.shape.Quad} because it puts (0,0,0)
+ * at the rectangle's center instead of in a corner.
+ *
  * @author Kirill Vainer
  */
 public class CenterQuad extends Mesh {


### PR DESCRIPTION
This addresses issue #1677, correcting the glaring inaccuracies and adding some useful details:
 + The resulting Mesh is indexed.
 + The resulting Mesh is in `Triangles` mode.
 + The resulting Mesh is static.
 + The resulting mesh includes normals.
 + The rectangle is axis-aligned.
 + Explain how `CenterQuad` differs from `Quad`.
