### PR TITLE
new javadoc for Vector3f

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -92,21 +92,21 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
             Float.NEGATIVE_INFINITY,
             Float.NEGATIVE_INFINITY);
     /**
-     * The x value of the vector.
+     * The x component of the vector.
      */
     public float x;
     /**
-     * The y value of the vector.
+     * The y component of the vector.
      */
     public float y;
     /**
-     * The z value of the vector.
+     * The z component of the vector.
      */
     public float z;
 
     /**
-     * Instantiates a new <code>Vector3f</code> with default
-     * values of (0,0,0).
+     * Instantiates a new <code>Vector3f</code> with the default
+     * value of (0,0,0).
      *
      */
     public Vector3f() {
@@ -115,11 +115,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Instantiates a new <code>Vector3f</code> with the provided
-     * values.
+     * components.
      *
-     * @param x   the x value of the vector.
-     * @param y   the y value of the vector.
-     * @param z   the z value of the vector.
+     * @param x   the x component of the vector.
+     * @param y   the y component of the vector.
+     * @param z   the z component of the vector.
      */
     public Vector3f(float x, float y, float z) {
         this.x = x;
@@ -138,12 +138,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Sets the x,y,z values of the vector based on passed
+     * Sets the x,y,z components of the vector based on passed
      * parameters.
      *
-     * @param x   the x value of the vector.
-     * @param y   the y value of the vector.
-     * @param z   the z value of the vector.
+     * @param x   the x component of the vector.
+     * @param y   the y component of the vector.
+     * @param z   the z component of the vector.
      * @return this vector (modified)
      */
     public Vector3f set(float x, float y, float z) {
@@ -154,7 +154,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Sets the x,y,z values of the vector by copying the
+     * Sets the x,y,z components of the vector by copying the
      * supplied vector.
      *
      * @param vect the Vector3f to copy (unaffected)
@@ -185,8 +185,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the values of a provided vector, storing the
-     * values in the supplied vector. The current instance is unaffected unless it is
+     * Adds the components of a provided vector, storing the
+     * sum in the supplied vector. The current instance is unaffected unless it is
      * <code>result</code>.
      *
      * @param vec the vector to add to this (unaffected unless it is
@@ -222,15 +222,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the provided values to this vector, creating a
+     * Adds the provided offsets to this vector, creating a
      * new vector that is then returned. The current instance is unaffected.
      *
-     * @param addX
-     *            the x value to add.
-     * @param addY
-     *            the y value to add.
-     * @param addZ
-     *            the z value to add.
+     * @param addX the amount to add to the X component
+     * @param addY the amount to add to the Y component
+     * @param addZ the amount to add to the Z component
      * @return the result vector.
      */
     public Vector3f add(float addX, float addY, float addZ) {
@@ -238,16 +235,13 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the provided values to this vector
+     * Adds the provided offsets to this vector
      * internally and returns a handle to this (modified) vector for easy chaining of
      * calls.
      *
-     * @param addX
-     *            value to add to x
-     * @param addY
-     *            value to add to y
-     * @param addZ
-     *            value to add to z
+     * @param addX the amount to add to the X component
+     * @param addY the amount to add to the Y component
+     * @param addZ the amount to add to the Z component
      * @return this (modified)
      */
     public Vector3f addLocal(float addX, float addY, float addZ) {
@@ -279,9 +273,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * the given vector, storing the result in the current instance.
      *
      * @param scalar the scaling factor
-     * @param mult the value to multiply the scalar by (unaffected unless it is
+     * @param mult the vector to multiply the scalar by (unaffected unless it is
      *     <code>this</code>)
-     * @param add the value to add (unaffected unless it is <code>this</code>)
+     * @param add the vector to add (unaffected unless it is <code>this</code>)
      * @return this
      */
     public Vector3f scaleAdd(float scalar, Vector3f mult, Vector3f add) {
@@ -616,8 +610,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides the values of this vector by a scalar and
-     * returns the result. The values of this vector remain untouched.
+     * Divides the vector by a scalar and
+     * returns the result. The current instance remains untouched.
      *
      * @param scalar
      *            the value to divide this vectors attributes by.
@@ -645,8 +639,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides the values of this vector component-wise by the argument and
-     * returns the result. The values of this vector remain untouched.
+     * Divides this vector component-wise by the argument and
+     * returns the result. The current instance remains untouched.
      *
      * @param scalar the divisor (unaffected) TODO rename argument!
      * @return the result <code>Vector</code>.
@@ -670,7 +664,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the negative of this vector. All values are
+     * Returns the negative of this vector. All components are
      * negated. The current instance is unaffected.
      *
      * @return a new Vector3f
@@ -680,7 +674,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Negates the internal values of this vector.
+     * Negates the components of this vector.
      *
      * @return this (modified)
      */
@@ -692,8 +686,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the values of a given vector from those
-     * of this vector creating a new vector object.
+     * Subtracts the given vector from this vector creating a new vector object.
      * The current instance is unaffected.
      *
      * @param vec
@@ -749,12 +742,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Subtracts the provided values from this vector,
      * creating a new vector that is then returned. The current instance is unaffected.
      *
-     * @param subtractX
-     *            the x value to subtract.
-     * @param subtractY
-     *            the y value to subtract.
-     * @param subtractZ
-     *            the z value to subtract.
+     * @param subtractX the amount to subtract from the X component
+     * @param subtractY the amount to subtract from the Y component
+     * @param subtractZ the amount to subtract from the Z component
      * @return the result vector.
      */
     public Vector3f subtract(float subtractX, float subtractY, float subtractZ) {
@@ -766,12 +756,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * internally and returns a handle to this (modified) vector for easy chaining of
      * calls.
      *
-     * @param subtractX
-     *            the x value to subtract.
-     * @param subtractY
-     *            the y value to subtract.
-     * @param subtractZ
-     *            the z value to subtract.
+     * @param subtractX the amount to subtract from the X component
+     * @param subtractY the amount to subtract from the Y component
+     * @param subtractZ the amount to subtract from the Z component
      * @return this (modified)
      */
     public Vector3f subtractLocal(float subtractX, float subtractY, float subtractZ) {
@@ -854,7 +841,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Resets this vector's data to zero.
+     * Resets this vector's components to zero.
      *
      * @return this (modified)
      */
@@ -915,7 +902,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Checks a vector. If it is null or its floats are NaN or infinite,
+     * Checks a vector. If it is null or if any component is NaN or infinite,
      * return false.  Else return true.
      *
      * @param vector the vector to check (unaffected)
@@ -988,7 +975,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * @param floats storage for the components (must have length&ge;3. If null, a new float[3] is
      *            created.
-     * @return an array, with X, Y, Z float values in that order (either <code>floats</code> or a new float[3])
+     * @return an array, with X, Y, Z float components in that order (either <code>floats</code> or a new float[3])
      */
     public float[] toArray(float[] floats) {
         if (floats == null) {
@@ -1056,11 +1043,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Returns a hash code for this vector object based
-     * on its values. If two vectors are logically equivalent, they will return
-     * the same hash code value. The current instance is
+     * on its components. If two vectors are logically equivalent, they will return
+     * the same hash code. The current instance is
      * unaffected.
      *
-     * @return the hash code value of this vector.
+     * @return the hash code value
      */
     @Override
     public int hashCode() {
@@ -1178,7 +1165,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Returns the indexed component. The vector is unaffected.
      *
      * @param index 0, 1, or 2
-     * @return x value if index == 0, y value if index == 1 or z value if index == 2
+     * @return x component if index == 0, y component if index == 1 or z component if index == 2
      * @throws IllegalArgumentException
      *             if index is not one of 0, 1, 2.
      */

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -36,10 +36,8 @@ import java.io.IOException;
 import java.util.logging.Logger;
 
 /**
- * A Vector for a three float value tuple.
- * <code>Vector3f</code> can represent any three dimensional value, such as a
- * vertex, a normal, etc. Utility methods are also included to aid in
- * mathematical calculations.
+ * A vector composed of 3 single-precision components, used to represent
+ * locations, offsets, and directions in 3-dimensional space.
  *
  * <p>Methods with names ending in "Local" modify the current instance. They are
  * used to cut down on the creation of new instances.
@@ -92,34 +90,31 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
             Float.NEGATIVE_INFINITY,
             Float.NEGATIVE_INFINITY);
     /**
-     * The X component of the vector.
+     * The X component.
      */
     public float x;
     /**
-     * The Y component of the vector.
+     * The Y component.
      */
     public float y;
     /**
-     * The Z component of the vector.
+     * The Z component.
      */
     public float z;
 
     /**
-     * Instantiates a new <code>Vector3f</code> with the default
-     * value of (0,0,0).
-     *
+     * Instantiates an all-zero vector (0,0,0).
      */
     public Vector3f() {
         x = y = z = 0;
     }
 
     /**
-     * Instantiates a new <code>Vector3f</code> with the specified
-     * components.
+     * Instantiates a vector with specified components.
      *
-     * @param x   the X component of the vector.
-     * @param y   the Y component of the vector.
-     * @param z   the Z component of the vector.
+     * @param x the X component
+     * @param y the Y component
+     * @param z the Z component
      */
     public Vector3f(float x, float y, float z) {
         this.x = x;
@@ -128,22 +123,20 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Instantiates a new <code>Vector3f</code> that is a copy
-     * of the argument.
+     * Instantiates a copy of the argument.
      *
-     * @param copy the Vector3f to copy (not null, unaffected)
+     * @param copy the vector to copy (not null, unaffected)
      */
     public Vector3f(Vector3f copy) {
         this.set(copy);
     }
 
     /**
-     * Sets the X, Y, and Z components of the vector based on passed
-     * parameters.
+     * Sets all 3 components to specified values.
      *
-     * @param x   the X component of the vector.
-     * @param y   the Y component of the vector.
-     * @param z   the Z component of the vector.
+     * @param x the X component
+     * @param y the Y component
+     * @param z the Z component
      * @return the (modified) current instance (for chaining)
      */
     public Vector3f set(float x, float y, float z) {
@@ -154,7 +147,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Sets the X, Y, and Z components of the vector by copying the argument.
+     * Copies all 3 components from the argument.
      *
      * @param vect the Vector3f to copy (not null, unaffected)
      * @return the (modified) current instance (for chaining)
@@ -167,12 +160,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the argument to this vector, creating a
-     * resultant vector which is returned. If the argument is null, null
+     * Adds the argument and returns the sum as a new instance.
+     * If the argument is null, null
      * is returned. Either way, the current instance is unaffected.
      *
-     * @param vec
-     *            the vector to add to this (unaffected) or null for none
+     * @param vec the vector to add (unaffected) or null for none
      * @return a new Vector3f or null
      */
     public Vector3f add(Vector3f vec) {
@@ -184,11 +176,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the specified vector and returns the
+     * Adds a specified vector and returns the
      * sum in a 3rd vector. The current instance is unaffected unless it is
      * <code>result</code>.
      *
-     * @param vec the vector to add to this (not null, unaffected unless it is
+     * @param vec the vector to add (not null, unaffected unless it is
      *     <code>result</code>)
      * @param result storage for the sum (not null)
      * @return <code>result</code> (for chaining)
@@ -201,10 +193,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the argument to this vector and returns the (modified) current
+     * Adds the argument and returns the (modified) current
      * instance. If the argument is null, null is returned.
      *
-     * @param vec the vector to add to this vector (unaffected unless it is <code>this</code>)
+     * @param vec the vector to add (unaffected unless it is <code>this</code>)
      *     or null for none
      * @return the (modified) current instance or null
      */
@@ -220,7 +212,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the specified offsets to this vector and returns the sum as a
+     * Adds specified amounts to the vector and returns the sum as a
      * new instance. The current instance is unaffected.
      *
      * @param addX the amount to add to the X component
@@ -233,7 +225,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the specified offsets to this vector
+     * Adds specified amounts to the vector
      * and returns the (modified) current
      * instance.
      *
@@ -250,11 +242,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector by a scalar, adds the
-     * specified Vector3f, and returns the (modified) current instance.
+     * Multiplies by a scalar, adds a
+     * specified vector, and returns the (modified) current instance.
      *
-     * @param scalar
-     *            the value to multiply this vector by.
+     * @param scalar the scaling factor
      * @param add the value to add (not null)
      * @return the (modified) current instance (for chaining)
      */
@@ -266,11 +257,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies the specified vector by a scalar, then adds
+     * Multiplies a specified vector by a scalar, then adds
      * another vector to it, storing the result in the current instance.
      *
      * @param scalar the scaling factor
-     * @param mult the vector to multiply the scalar by (not null, unaffected unless it is
+     * @param mult the vector to scale (not null, unaffected unless it is
      *     <code>this</code>)
      * @param add the vector to add (not null, unaffected unless it is
      *     <code>this</code>)
@@ -284,11 +275,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the dot product of this vector with the argument. If the argument is null, 0 is returned.
+     * Returns the dot product with the argument. If the argument is null, 0 is returned.
      * Either way, the current instance is unaffected.
      *
-     * @param vec the vector to dot with this vector (unaffected) or null for none
-     * @return the resultant dot product of this vector and the specified vector.
+     * @param vec the vector to multiply (unaffected) or null for none
+     * @return the product
      */
     public float dot(Vector3f vec) {
         if (null == vec) {
@@ -299,19 +290,19 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the cross product of this vector with the argument. The current
+     * Calculates a cross product with the argument. The current
      * instance is unaffected.
      *
      * @param v the right factor (not null, unaffected)
-     * @return the cross product (a new Vector3f)
+     * @return the product (a new Vector3f)
      */
     public Vector3f cross(Vector3f v) {
         return cross(v, null);
     }
 
     /**
-     * Calculates the cross product of this vector with a
-     * parameter vector v and returns the product in a 3rd vector.
+     * Calculates a cross product with a
+     * specified vector and returns the product in a 3rd vector.
      * The current instance is unaffected unless it is <code>result</code>.
      *
      * @param v the right factor (not null, unaffected unless it is
@@ -324,7 +315,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the cross product of this vector with specified components and
+     * Calculates a cross product with specified components and
      * returns the product in the specified vector.
      * The current instance is unaffected unless it is <code>result</code>.
      *
@@ -346,7 +337,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the cross product of this vector with the argument and returns
+     * Right multiplies by the argument (cross product) and returns
      * the (modified) current instance.
      *
      * @param v the right factor (not null, unaffected unless it is
@@ -358,8 +349,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the cross product of this vector
-     * with a parameter vector v and returns the (modified) current instance.
+     * Right multiplies by the specified components (cross product)
+     * and returns the (modified) current instance.
      *
      * @param otherX the X component of the right factor
      * @param otherY the Y component of the right factor
@@ -376,10 +367,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Projects this vector onto the argument and returns the result. The current instance is
+     * Projects onto the argument and returns the result. The current instance is
      * unaffected.
      *
-     * @param other The vector to project this vector onto (not null, unaffected)
+     * @param other The vector to project onto (not null, unaffected)
      * @return a new Vector3f
      */
     public Vector3f project(Vector3f other) {
@@ -389,10 +380,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Projects this vector onto the argument and stores the result in this
+     * Projects onto the argument and stores the result in this
      * vector.
      *
-     * @param other The vector to project this vector onto (not null, unaffected unless it
+     * @param other The vector to project onto (not null, unaffected unless it
      * is <code>this</code>)
      * @return the (modified) current instance (for chaining)
      */
@@ -403,11 +394,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns true if this vector is a unit vector, with 1% tolerance.
-     * Returns false otherwise. The current instance is unaffected.
+     * Tests for a unit vector, with 1% tolerance. The current instance is
+     * unaffected.
      *
      * @return true if the current vector's length is between 0.99 and 1.01
-     *     inclusive, or false otherwise.
+     *     inclusive, otherwise false
      */
     public boolean isUnitVector() {
         float len = length();
@@ -415,10 +406,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the magnitude of this vector. The current instance is
+     * Returns the magnitude. The current instance is
      * unaffected.
      *
-     * @return the length or magnitude of the vector.
+     * @return the length
      */
     public float length() {
         /*
@@ -436,8 +427,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the squared value of the
-     * magnitude of the vector. The current instance is unaffected.
+     * Returns the square of the length. The current instance is
+     * unaffected.
      *
      * @return the magnitude squared of the vector.
      */
@@ -446,11 +437,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the distance squared between
+     * Returns the distance squared between
      * this vector and the argument. The current instance is unaffected.
      *
-     * @param v the second vector to determine the distance squared.
-     * @return the square of the Euclidean distance between the two vectors.
+     * @param v the vector to compare
+     * @return the square of the Euclidean distance
      */
     public float distanceSquared(Vector3f v) {
         double dx = x - v.x;
@@ -463,8 +454,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Returns the distance between this vector and
      * the argument. The current instance is unaffected.
      *
-     * @param v the second vector to determine the distance (not null, unaffected)
-     * @return the Euclidean distance between the two vectors.
+     * @param v the vector to compare (not null, unaffected)
+     * @return the Euclidean distance
      */
     public float distance(Vector3f v) {
         /*
@@ -482,11 +473,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector by the argument and returns the product as a new
+     * Multiplies with the argument and returns the product as a new
      * instance. The current instance is unaffected.
      *
-     * @param scalar
-     *            the value to multiply this vector by.
+     * @param scalar the scaling factor
      * @return a new Vector3f
      */
     public Vector3f mult(float scalar) {
@@ -494,11 +484,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector by the specified scalar and returns the product in
+     * Multiplies by the specified scalar and returns the product in
      * the specified vector.
      * The current instance is unaffected, unless it is <code>product</code>.
      *
-     * @param scalar the scalar to multiply this vector by.
+     * @param scalar the scaling factor
      * @param product storage for the product, or null for a new Vector3f
      * @return either <code>product</code> or a new Vector3f
      */
@@ -514,11 +504,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector by the argument and returns the (modified) current
+     * Multiplies by the argument and returns the (modified) current
      * instance.
      *
-     * @param scalar
-     *            the value to multiply this vector by.
+     * @param scalar the scaling factor
      * @return the (modified) current instance (for chaining)
      */
     public Vector3f multLocal(float scalar) {
@@ -529,11 +518,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies the argument component-wise by this vector and returns
+     * Multiplies component-wise by the argument and returns
      * the (modified) current instance.
      * If the argument is null, null is returned.
      *
-     * @param vec the vector to mult to this vector (unaffected unless it is <code>this</code>)
+     * @param vec the scale vector (unaffected unless it is <code>this</code>)
      *     or null for none
      * @return this (modified) or null
      */
@@ -549,7 +538,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector component-wise by the specified components and returns the
+     * Multiplies component-wise by the specified components and returns the
      * (modified) current instance.
      *
      * @param x the scale factor for the X component
@@ -565,13 +554,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies the argument component-wise with this vector and returns the
+     * Multiplies component-wise with this vector and returns the
      * product as a new instance.
      * If the argument is null, null is returned.
      * Either way, the current instance is unaffected.
      *
-     * @param vec
-     *            the vector to multiply with this vector, or null for none
+     * @param vec the scale vector or null for none
      * @return a new Vector3f or null
      */
     public Vector3f mult(Vector3f vec) {
@@ -583,12 +571,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies the specified vector component-wise with
-     * this vector and returns the product in a 3rd vector. If the argument
+     * Multiplies component-wise with
+     * the specified vector and returns the product in a 3rd vector. If the argument
      * is null, null is returned. Either way, the current instance is unaffected, unless it is
      * <code>store</code>.
      *
-     * @param vec the vector to mult to this vector (unaffected unless it is <code>store</code>)
+     * @param vec the scale vector (unaffected unless it is <code>store</code>)
      *     or null for none
      * @param store storage for the product, or null for a new Vector3f
      * @return either <code>store</code> or a new Vector3f or null
@@ -605,11 +593,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides the vector by the argument and returns the quotient as a new
+     * Divides by the argument and returns the quotient as a new
      * instance. The current instance remains untouched.
      *
-     * @param scalar
-     *            the value to divide this vectors attributes by.
+     * @param scalar the divisor
      * @return a new Vector3f
      */
     public Vector3f divide(float scalar) {
@@ -618,11 +605,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides this vector by the argument and returns the (modified) current
+     * Divides by the argument and returns the (modified) current
      * instance.
      *
-     * @param scalar
-     *            the value to divide this vector by.
+     * @param scalar the divisor
      * @return the (modified) current instance (for chaining)
      */
     public Vector3f divideLocal(float scalar) {
@@ -634,7 +620,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides this vector component-wise by the argument and
+     * Divides component-wise by the argument and
      * returns the quotient as a new instance. The current instance remains untouched.
      *
      * @param scalar the divisor (not null, unaffected) TODO rename argument!
@@ -645,7 +631,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides this vector component-wise by the argument and returns the
+     * Divides component-wise by the argument and returns the
      * (modified) current instance.
      *
      * @param scalar the divisor (not null) TODO rename argument!
@@ -659,7 +645,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the negative of this vector. The current instance is unaffected.
+     * Returns the negative. The current instance is unaffected.
      *
      * @return a new Vector3f
      */
@@ -668,7 +654,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Negates the components of this vector and returns the (modified) current instance.
+     * Negates the components and returns the (modified) current instance.
      *
      * @return the (modified) current instance (for chaining)
      */
@@ -680,10 +666,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the argument from this vector and returns the difference as a
+     * Subtracts the argument and returns the difference as a
      * new instance. The current instance is unaffected.
      *
-     * @param vec the vector to subtract from this vector (not null, unaffected)
+     * @param vec the vector to subtract (not null, unaffected)
      * @return a new Vector3f
      */
     public Vector3f subtract(Vector3f vec) {
@@ -691,7 +677,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the argument from this vector and returns the (modified)
+     * Subtracts the argument and returns the (modified)
      * current instance. If the argument is null, null is returned.
      *
      * @param vec the vector to subtract (unaffected unless it is
@@ -710,11 +696,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the specified vector from this vector and returns the difference
+     * Subtracts the specified vector and returns the difference
      * in a 3rd vector. The current instance is unaffected unless it is
      * <code>result</code>.
      *
-     * @param vec the vector to subtract from this (not null, unaffected unless it is
+     * @param vec the vector to subtract (not null, unaffected unless it is
      *     <code>result</code>)
      * @param result storage for the difference, or null for a new Vector3f
      * @return either <code>result</code> or a new Vector3f
@@ -730,7 +716,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the specified values from this vector and returns the
+     * Subtracts the specified values from the vector and returns the
      * difference as a new instance. The current instance is unaffected.
      *
      * @param subtractX the amount to subtract from the X component
@@ -743,7 +729,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the specified values from this vector and returns the
+     * Subtracts the specified values from the vector and returns the
      * (modified) current instance.
      *
      * @param subtractX the amount to subtract from the X component
@@ -805,7 +791,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * positive value for each component) and returns the (modified) current
      * instance.
      *
-     * @param other the vector to compare with (not null, unaffected)
+     * @param other the vector to compare (not null, unaffected)
      * @return the (modified) current instance (for chaining)
      */
     public Vector3f maxLocal(Vector3f other) {
@@ -820,7 +806,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * negative value for each component) and returns the (modified) current
      * instance.
      *
-     * @param other the vector to compare with (not null, unaffected)
+     * @param other the vector to compare (not null, unaffected)
      * @return the (modified) current instance (for chaining)
      */
     public Vector3f minLocal(Vector3f other) {
@@ -831,7 +817,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Resets this vector's components to zero.
+     * Sets all components to zero.
      *
      * @return the (modified) current instance (for chaining)
      */
@@ -841,11 +827,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns (in radians) the angle between this vector and the argument.
-     * It is assumed that both this vector and the argument are unit vectors (iow, normalized).
+     * Returns (in radians) the angle between this vector and the argument,
+     * provided both vectors have length=1.
      * The current instance is unaffected.
      *
-     * @param otherVector a unit vector to find the angle against (not null, unaffected)
+     * @param otherVector a unit vector to compare (not null, unaffected)
      * @return the angle (in radians, not negative)
      */
     public float angleBetween(Vector3f otherVector) {
@@ -856,7 +842,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Interpolates linearly between this vector and the specified vector,
-     * storing the result in the current instance and returning it.
+     * returning the (modified) current instance.
      *
      * <p>this = (1 - changeAmnt) * this + changeAmnt * finalVec
      *
@@ -873,7 +859,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Interpolates linearly between the specified beginning and final vectors,
-     * storing the result in the current instance and returning it.
+     * returning the (modified) current instance.
      *
      * <p>this = (1 - changeAmnt) * beginVec + changeAmnt * finalVec
      *
@@ -892,10 +878,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Checks the argument. If it is null or if any component is NaN or infinite,
-     * return false.  Else return true.
+     * Tests whether the argument is a valid vector, returning false if it's
+     * null or if any component is NaN or infinite.
      *
-     * @param vector the vector to check (unaffected)
+     * @param vector the vector to test (unaffected)
      * @return if non-null and finite, otherwise false
      */
     public static boolean isValidVector(Vector3f vector) {
@@ -946,7 +932,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Creates a copy of this vector. The current instance is unaffected.
+     * Creates a copy. The current instance is unaffected.
      *
      * @return a new instance, equivalent to the current one
      */
@@ -960,7 +946,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Saves this Vector3f into the argument. The current instance is
+     * Copies the vector into the argument. The current instance is
      * unaffected.
      *
      * @param floats storage for the components (must have length&ge;3) or null
@@ -979,10 +965,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Tests whether the vector is equal to the argument, distinguishing -0
+     * Tests for equality with the argument, distinguishing -0
      * from 0. The current instance is unaffected.
      *
-     * @param o the object to compare for equality (may be null, unaffected)
+     * @param o the object to compare (may be null, unaffected)
      * @return true if equal, otherwise false
      */
     @Override
@@ -1009,11 +995,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns true if this vector is approximately equal to the specified vector within
-     * the specified tolerance. The current instance is unaffected.
+     * Tests for approximate equality with the specified vector, using the
+     * specified tolerance. The current instance is unaffected.
      *
-     * @param other the vector to compare with (not null, unaffected)
-     * @param epsilon the desired error tolerance for each component
+     * @param other the vector to compare (not null, unaffected)
+     * @param epsilon the tolerance for each component
      * @return true if all 3 components are within tolerance, otherwise false
      */
     public boolean isSimilar(Vector3f other, float epsilon) {
@@ -1033,8 +1019,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns a hash code for this vector object based
-     * on its components. If two vectors are logically equivalent, they will return
+     * Returns a hash code. If two vectors are logically equivalent, they will return
      * the same hash code. The current instance is
      * unaffected.
      *
@@ -1050,12 +1035,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns a string representation of this vector. The current instance is
+     * Returns a string representation. The current instance is
      * unaffected. The format is:
      *
      * (XX.XXXX, YY.YYYY, ZZ.ZZZZ)
      *
-     * @return the string representation of this vector.
+     * @return the string representation
      */
     @Override
     public String toString() {
@@ -1063,7 +1048,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Serializes this vector to the argument, for example when
+     * Serializes to the argument, for example when
      * saving to a J3O file. The current instance is unaffected.
      *
      * @param e the exporter to use (not null)
@@ -1078,7 +1063,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * De-serializes this vector from the argument, for example
+     * De-serializes from the argument, for example
      * when loading from a J3O file.
      *
      * @param e the importer to use (not null)
@@ -1093,7 +1078,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the X component of this vector. The vector is unaffected.
+     * Returns the X component. The vector is unaffected.
      *
      * @return the value of the {@link #x} component
      */
@@ -1102,7 +1087,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Alters the X component of this vector.
+     * Sets the X component.
      *
      * @param x the desired value
      * @return the (modified) current instance (for chaining)
@@ -1113,7 +1098,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the Y component of this vector. The vector is unaffected.
+     * Returns the Y component. The vector is unaffected.
      *
      * @return the value of the {@link #y} component
      */
@@ -1122,7 +1107,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Alters the Y component of this vector.
+     * Sets the Y component.
      *
      * @param y the desired value
      * @return the (modified) current instance (for chaining)
@@ -1133,7 +1118,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the Z component of this vector. The vector is unaffected.
+     * Returns the Z component. The vector is unaffected.
      *
      * @return z the value of the {@link #z} component
      */
@@ -1142,7 +1127,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Alters the Z component of this vector.
+     * Sets the Z component.
      *
      * @param z the desired value
      * @return the (modified) current instance (for chaining)
@@ -1158,8 +1143,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * @param index 0, 1, or 2
      * @return the X component if index=0, the Y component if index=1, or the Z
      *     component if index=2
-     * @throws IllegalArgumentException
-     *             if index is not one of 0, 1, 2.
+     * @throws IllegalArgumentException if index is not 0, 1, 2
      */
     public float get(int index) {
         switch (index) {
@@ -1179,8 +1163,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * @param index which component to set: 0 &rarr; the X component, 1 &rarr;
      *     the Ycomponent, 2 &rarr; the Z component
      * @param value the desired component value
-     * @throws IllegalArgumentException
-     *             if index is not one of 0, 1, 2.
+     * @throws IllegalArgumentException if index is not 0, 1, 2
      */
     public void set(int index, float value) {
         switch (index) {

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -523,8 +523,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Multiplies component-wise by the argument and returns the (modified)
      * current instance. If the argument is null, null is returned.
      *
-     * @param vec the scale vector (unaffected unless it's <code>this</code>)
-     *     or null for none
+     * @param vec the scale vector (unaffected unless it's <code>this</code>) or
+     *     null for none
      * @return the (modified) current instance (for chaining) or null
      */
     public Vector3f multLocal(Vector3f vec) {
@@ -555,7 +555,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies component-wise with this vector and returns the product as a
+     * Multiplies component-wise with the argument and returns the product as a
      * new instance. If the argument is null, null is returned. Either way, the
      * current instance is unaffected.
      *
@@ -594,7 +594,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Divides by the argument and returns the quotient as a new instance. The
-     *     current instance is unaffected.
+     * current instance is unaffected.
      *
      * @param scalar the divisor
      * @return a new Vector3f
@@ -845,7 +845,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * <p>this = (1 - changeAmnt) * this + changeAmnt * finalVec
      *
      * @param finalVec the desired value when changeAmnt=1 (not null, unaffected
-     *     unless it's this)
+     *     unless it's <code>this</code>)
      * @param changeAmnt the fractional change amount
      * @return the (modified) current instance (for chaining)
      */
@@ -863,9 +863,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * <p>this = (1 - changeAmnt) * beginVec + changeAmnt * finalVec
      *
      * @param beginVec the desired value when changeAmnt=0 (not null, unaffected
-     *     unless it's this)
+     *     unless it's <code>this</code>)
      * @param finalVec the desired value when changeAmnt=1 (not null, unaffected
-     *     unless it's this)
+     *     unless it's <code>this</code>)
      * @param changeAmnt the fractional change amount
      * @return the (modified) current instance (for chaining)
      */
@@ -1158,7 +1158,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Sets the indexed component.
      *
      * @param index which component to set: 0 &rarr; the X component, 1 &rarr;
-     *     the Ycomponent, 2 &rarr; the Z component
+     *     the Y component, 2 &rarr; the Z component
      * @param value the desired component value
      * @throws IllegalArgumentException if index is not 0, 1, or 2
      */

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -160,9 +160,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the argument and returns the sum as a new instance.
-     * If the argument is null, null
-     * is returned. Either way, the current instance is unaffected.
+     * Adds the argument and returns the sum as a new instance. If the argument
+     * is null, null is returned. Either way, the current instance is
+     * unaffected.
      *
      * @param vec the vector to add (unaffected) or null for none
      * @return a new Vector3f or null
@@ -176,9 +176,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds a specified vector and returns the
-     * sum in a 3rd vector. The current instance is unaffected unless it is
-     * <code>result</code>.
+     * Adds a specified vector and returns the sum in a 3rd vector. The current
+     * instance is unaffected unless it is <code>result</code>.
      *
      * @param vec the vector to add (not null, unaffected unless it is
      *     <code>result</code>)
@@ -193,8 +192,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the argument and returns the (modified) current
-     * instance. If the argument is null, null is returned.
+     * Adds the argument and returns the (modified) current instance. If the
+     * argument is null, null is returned.
      *
      * @param vec the vector to add (unaffected unless it is <code>this</code>)
      *     or null for none
@@ -212,8 +211,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds specified amounts to the vector's components and returns the sum as a
-     * new instance. The current instance is unaffected.
+     * Adds specified amounts to the vector's components and returns the sum as
+     * a new instance. The current instance is unaffected.
      *
      * @param addX the amount to add to the X component
      * @param addY the amount to add to the Y component
@@ -225,9 +224,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds specified amounts to the vector's components
-     * and returns the (modified) current
-     * instance.
+     * Adds specified amounts to the vector's components and returns the
+     * (modified) current instance.
      *
      * @param addX the amount to add to the X component
      * @param addY the amount to add to the Y component
@@ -242,8 +240,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies by the specified scalar, adds the specified
-     * vector, and returns the (modified) current instance.
+     * Multiplies by the specified scalar, adds the specified vector, and
+     * returns the (modified) current instance.
      *
      * <p>this = scalar * this + add
      *
@@ -261,7 +259,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies a specified vector by a specified scalar, then adds another
-     * specified vector to it, before storing the result in the current instance.
+     * specified vector to it, before storing the result in the current
+     * instance.
      *
      * <p>this = scalar * mult + add
      *
@@ -280,8 +279,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the dot (or inner) product with the argument. If the argument is null, 0 is returned.
-     * Either way, the current instance is unaffected.
+     * Returns the dot (or inner) product with the argument. If the argument is
+     * null, 0 is returned. Either way, the current instance is unaffected.
      *
      * @param vec the vector to multiply (unaffected) or null for none
      * @return the product
@@ -296,8 +295,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Calculates a cross product with the argument and returns the product as a
-     * new instance. The current
-     * instance is unaffected.
+     * new instance. The current instance is unaffected.
      *
      * @param v the right factor (not null, unaffected)
      * @return <code>this</code> cross <code>v</code> (a new Vector3f)
@@ -307,9 +305,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates a cross product with a
-     * specified vector and returns the product in a 3rd vector.
-     * The current instance is unaffected unless it is <code>result</code>.
+     * Calculates a cross product with a specified vector and returns the
+     * product in a 3rd vector. The current instance is unaffected unless it is
+     * <code>result</code>.
      *
      * @param v the right factor (not null, unaffected unless it is
      *     <code>result</code>)
@@ -322,9 +320,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates a cross product with specified components and
-     * returns the product in the specified vector.
-     * The current instance is unaffected unless it is <code>result</code>.
+     * Calculates a cross product with specified components and returns the
+     * product in the specified vector. The current instance is unaffected
+     * unless it is <code>result</code>.
      *
      * @param otherX the X component of the right factor
      * @param otherY the Y component of the right factor
@@ -345,8 +343,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Right multiplies by the argument (cross product) and returns
-     * the (modified) current instance.
+     * Right multiplies by the argument (cross product) and returns the
+     * (modified) current instance.
      *
      * @param v the right factor (not null, unaffected unless it is
      *     <code>this</code>)
@@ -357,8 +355,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Right multiplies by the specified components (cross product)
-     * and returns the (modified) current instance.
+     * Right multiplies by the specified components (cross product) and returns
+     * the (modified) current instance.
      *
      * @param otherX the X component of the right factor
      * @param otherY the Y component of the right factor
@@ -375,8 +373,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Projects onto the argument and returns the result as a new vector. The current instance is
-     * unaffected.
+     * Projects onto the argument and returns the result as a new vector. The
+     * current instance is unaffected.
      *
      * @param other the vector to project onto (not null, unaffected)
      * @return a new Vector3f
@@ -388,11 +386,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Projects onto the argument and returns the (modified)
-     * current instance.
+     * Projects onto the argument and returns the (modified) current instance.
      *
      * @param other the vector to project onto (not null, unaffected unless it
-     * is <code>this</code>)
+     *     is <code>this</code>)
      * @return the (modified) current instance (for chaining)
      */
     public Vector3f projectLocal(Vector3f other) {
@@ -414,8 +411,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the length (or magnitude). The current instance is
-     * unaffected.
+     * Returns the length (or magnitude). The current instance is unaffected.
      *
      * @return the root-sum of the squared components (not negative)
      */
@@ -435,8 +431,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the square of the length. The current instance is
-     * unaffected.
+     * Returns the square of the length. The current instance is unaffected.
      *
      * @return the sum of the squared components (not negative)
      */
@@ -445,8 +440,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the square of the distance between
-     * this vector and the argument. The current instance is unaffected.
+     * Returns the square of the distance between this vector and the argument.
+     * The current instance is unaffected.
      *
      * @param v the vector to compare (not null, unaffected)
      * @return the square of the Euclidean distance (not negative)
@@ -459,8 +454,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the distance between this vector and
-     * the argument. The current instance is unaffected.
+     * Returns the distance between this vector and the argument. The current
+     * instance is unaffected.
      *
      * @param v the vector to compare (not null, unaffected)
      * @return the Euclidean distance (not negative)
@@ -481,8 +476,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies with the argument and returns the product as a new
-     * instance. The current instance is unaffected.
+     * Multiplies with the argument and returns the product as a new instance.
+     * The current instance is unaffected.
      *
      * @param scalar the scaling factor
      * @return a new Vector3f
@@ -492,9 +487,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies with the specified scalar and returns the product in
-     * the specified vector.
-     * The current instance is unaffected, unless it is <code>product</code>.
+     * Multiplies with the specified scalar and returns the product in the
+     * specified vector. The current instance is unaffected, unless it is
+     * <code>product</code>.
      *
      * @param scalar the scaling factor
      * @param product storage for the product, or null for a new Vector3f
@@ -512,8 +507,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies by the argument and returns the (modified) current
-     * instance.
+     * Multiplies by the argument and returns the (modified) current instance.
      *
      * @param scalar the scaling factor
      * @return the (modified) current instance (for chaining)
@@ -526,9 +520,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies component-wise by the argument and returns
-     * the (modified) current instance.
-     * If the argument is null, null is returned.
+     * Multiplies component-wise by the argument and returns the (modified)
+     * current instance. If the argument is null, null is returned.
      *
      * @param vec the scale vector (unaffected unless it is <code>this</code>)
      *     or null for none
@@ -562,10 +555,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies component-wise with this vector and returns the
-     * product as a new instance.
-     * If the argument is null, null is returned.
-     * Either way, the current instance is unaffected.
+     * Multiplies component-wise with this vector and returns the product as a
+     * new instance. If the argument is null, null is returned. Either way, the
+     * current instance is unaffected.
      *
      * @param vec the scale vector (unaffected) or null for none
      * @return a new Vector3f or null
@@ -579,9 +571,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies component-wise with
-     * the specified vector and returns the product in a 3rd vector. If the argument
-     * is null, null is returned. Either way, the current instance is unaffected, unless it is
+     * Multiplies component-wise with the specified vector and returns the
+     * product in a 3rd vector. If the argument is null, null is returned.
+     * Either way, the current instance is unaffected, unless it is
      * <code>store</code>.
      *
      * @param vec the scale vector (unaffected unless it is <code>store</code>)
@@ -601,8 +593,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides by the argument and returns the quotient as a new
-     * instance. The current instance is unaffected.
+     * Divides by the argument and returns the quotient as a new instance. The
+     *     current instance is unaffected.
      *
      * @param scalar the divisor
      * @return a new Vector3f
@@ -613,8 +605,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides by the argument and returns the (modified) current
-     * instance.
+     * Divides by the argument and returns the (modified) current instance.
      *
      * @param scalar the divisor
      * @return the (modified) current instance (for chaining)
@@ -628,8 +619,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides component-wise by the argument and
-     * returns the quotient as a new instance. The current instance is unaffected.
+     * Divides component-wise by the argument and returns the quotient as a new
+     * instance. The current instance is unaffected.
      *
      * @param scalar the divisor (not null, unaffected) TODO rename argument!
      * @return a new Vector3f
@@ -639,8 +630,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides component-wise by the argument and returns the
-     * (modified) current instance.
+     * Divides component-wise by the argument and returns the (modified) current
+     * instance.
      *
      * @param scalar the divisor (not null, unaffected) TODO rename argument!
      * @return the (modified) current instance (for chaining)
@@ -674,8 +665,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the argument and returns the difference as a
-     * new instance. The current instance is unaffected.
+     * Subtracts the argument and returns the difference as a new instance. The
+     * current instance is unaffected.
      *
      * @param vec the vector to subtract (not null, unaffected)
      * @return a new Vector3f
@@ -685,8 +676,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the argument and returns the (modified)
-     * current instance. If the argument is null, null is returned.
+     * Subtracts the argument and returns the (modified) current instance. If
+     * the argument is null, null is returned.
      *
      * @param vec the vector to subtract (unaffected unless it is
      *     <code>this</code>) or null for none
@@ -704,8 +695,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the specified vector and returns the difference
-     * in a 3rd vector. The current instance is unaffected unless it is
+     * Subtracts the specified vector and returns the difference in a 3rd
+     * vector. The current instance is unaffected unless it is
      * <code>result</code>.
      *
      * @param vec the vector to subtract (not null, unaffected unless it is
@@ -724,8 +715,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the specified amounts from the vector's components and returns the
-     * difference as a new instance. The current instance is unaffected.
+     * Subtracts the specified amounts from the vector's components and returns
+     * the difference as a new instance. The current instance is unaffected.
      *
      * @param subtractX the amount to subtract from the X component
      * @param subtractY the amount to subtract from the Y component
@@ -737,8 +728,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the specified amounts from the vector's components and returns the
-     * (modified) current instance.
+     * Subtracts the specified amounts from the vector's components and returns
+     * the (modified) current instance.
      *
      * @param subtractX the amount to subtract from the X component
      * @param subtractY the amount to subtract from the Y component
@@ -836,8 +827,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Returns the angle (in radians) between this vector and the argument,
-     * provided both vectors have length=1.
-     * The current instance is unaffected.
+     * provided both vectors have length=1. The current instance is unaffected.
      *
      * @param otherVector a unit vector to compare (not null, unaffected)
      * @return the angle (in radians, not negative)
@@ -854,7 +844,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * <p>this = (1 - changeAmnt) * this + changeAmnt * finalVec
      *
-     * @param finalVec the desired value when changeAmnt=1 (not null, unaffected unless it's this)
+     * @param finalVec the desired value when changeAmnt=1 (not null, unaffected
+     *     unless it's this)
      * @param changeAmnt the fractional change amount
      * @return the (modified) current instance (for chaining)
      */
@@ -954,8 +945,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Copies the vector into the argument. The current instance is
-     * unaffected.
+     * Copies the vector into the argument. The current instance is unaffected.
      *
      * @param floats storage for the components (must have length&ge;3) or null
      *     for a new float[3]
@@ -973,8 +963,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Tests for exact equality with the argument, distinguishing -0
-     * from 0. The current instance is unaffected.
+     * Tests for exact equality with the argument, distinguishing -0 from 0. The
+     * current instance is unaffected.
      *
      * @param o the object to compare (may be null, unaffected)
      * @return true if equal, otherwise false
@@ -1027,9 +1017,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns a hash code. If two vectors are logically equivalent, they will return
-     * the same hash code. The current instance is
-     * unaffected.
+     * Returns a hash code. If two vectors are logically equivalent, they will
+     * return the same hash code. The current instance is unaffected.
      *
      * @return the hash code value
      */
@@ -1043,8 +1032,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns a string representation. The current instance is
-     * unaffected. The format is:
+     * Returns a string representation. The current instance is unaffected. The
+     * format is:
      *
      * <p>(XX.XXXX, YY.YYYY, ZZ.ZZZZ)
      *
@@ -1056,8 +1045,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Serializes to the argument, for example when
-     * saving to a J3O file. The current instance is unaffected.
+     * Serializes to the argument, for example when saving to a J3O file. The
+     * current instance is unaffected.
      *
      * @param e the exporter to use (not null)
      * @throws IOException from the exporter
@@ -1071,8 +1060,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * De-serializes from the argument, for example
-     * when loading from a J3O file.
+     * De-serializes from the argument, for example when loading from a J3O
+     * file.
      *
      * @param e the importer to use (not null)
      * @throws IOException from the importer

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -184,14 +184,13 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the provided vector, storing the
+     * Adds the provided vector and returns the
      * sum in a 3rd vector. The current instance is unaffected unless it is
      * <code>result</code>.
      *
      * @param vec the vector to add to this (not null, unaffected unless it is
      *     <code>result</code>)
-     * @param result
-     *            the vector to store the result in (not null)
+     * @param result storage for the sum (not null)
      * @return <code>result</code> (for chaining)
      */
     public Vector3f add(Vector3f vec, Vector3f result) {
@@ -312,13 +311,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Calculates the cross product of this vector with a
-     * parameter vector v.  The result is stored in <code>result</code>.
+     * parameter vector v and returns the product in a 3rd vector.
      * The current instance is unaffected unless it is <code>result</code>.
      *
      * @param v the right factor (not null, unaffected unless it is
      *     <code>result</code>)
-     * @param result
-     *            the vector to store the cross product result, or null for a new Vector3f
+     * @param result storage for the product, or null for a new Vector3f
      * @return the product (either <code>result</code> or a new Vector3f)
      */
     public Vector3f cross(Vector3f v, Vector3f result) {
@@ -326,15 +324,14 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the cross product of this vector with
-     * specified components.  The result is stored in <code>result</code>.
+     * Calculates the cross product of this vector with specified components and
+     * returns the product in the specified vector.
      * The current instance is unaffected unless it is <code>result</code>.
      *
      * @param otherX the X component of the right factor
      * @param otherY the Y component of the right factor
      * @param otherZ the Z component of the right factor
-     * @param result
-     *            the vector to store the product, or null for a new Vector3f
+     * @param result storage for the product, or null for a new Vector3f
      * @return the product (either <code>result</code> or a new Vector3f)
      */
     public Vector3f cross(float otherX, float otherY, float otherZ, Vector3f result) {
@@ -497,8 +494,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector by the specified scalar. The resultant
-     * vector is stored in the second parameter and returned.
+     * Multiplies this vector by the specified scalar and returns the product in
+     * the specified vector.
      * The current instance is unaffected, unless it is <code>product</code>.
      *
      * @param scalar the scalar to multiply this vector by.
@@ -587,13 +584,13 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies the specified vector component-wise with
-     * this vector and stores the result in a 3rd vector. If the argument
+     * this vector and returns the product in a 3rd vector. If the argument
      * is null, null is returned. Either way, the current instance is unaffected, unless it is
      * <code>store</code>.
      *
      * @param vec the vector to mult to this vector (unaffected unless it is <code>store</code>)
      *     or null for none
-     * @param store result vector (null to create a new vector)
+     * @param store storage for the product, or null for a new Vector3f
      * @return either <code>store</code> or a new Vector3f or null
      */
     public Vector3f mult(Vector3f vec, Vector3f store) {
@@ -713,14 +710,13 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the specified vector from this vector, storing the difference
+     * Subtracts the specified vector from this vector and returns the difference
      * in a 3rd vector. The current instance is unaffected unless it is
      * <code>result</code>.
      *
      * @param vec the vector to subtract from this (not null, unaffected unless it is
      *     <code>result</code>)
-     * @param result
-     *            the vector to store the result in, or null for a new Vector3f
+     * @param result storage for the difference, or null for a new Vector3f
      * @return either <code>result</code> or a new Vector3f
      */
     public Vector3f subtract(Vector3f vec, Vector3f result) {
@@ -967,8 +963,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Saves this Vector3f into the argument. The current instance is
      * unaffected.
      *
-     * @param floats storage for the components (must have length&ge;3). If null, a new float[3] is
-     *            created.
+     * @param floats storage for the components (must have length&ge;3) or null
+     *     for a new float[3]
      * @return an array containing the X, Y, and Z in that order
      *     (either <code>floats</code> or a new float[3])
      */

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -90,15 +90,15 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
             Float.NEGATIVE_INFINITY,
             Float.NEGATIVE_INFINITY);
     /**
-     * The X component.
+     * The first (X) component.
      */
     public float x;
     /**
-     * The Y component.
+     * The 2nd (Y) component.
      */
     public float y;
     /**
-     * The Z component.
+     * The 3rd (Z) component.
      */
     public float z;
 
@@ -112,9 +112,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Instantiates a vector with specified components.
      *
-     * @param x the X component
-     * @param y the Y component
-     * @param z the Z component
+     * @param x the desired X component
+     * @param y the desired Y component
+     * @param z the desired Z component
      */
     public Vector3f(float x, float y, float z) {
         this.x = x;
@@ -134,9 +134,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Sets all 3 components to specified values.
      *
-     * @param x the X component
-     * @param y the Y component
-     * @param z the Z component
+     * @param x the desired X component
+     * @param y the desired Y component
+     * @param z the desired Z component
      * @return the (modified) current instance (for chaining)
      */
     public Vector3f set(float x, float y, float z) {
@@ -212,7 +212,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds specified amounts to the vector and returns the sum as a
+     * Adds specified amounts to the vector's components and returns the sum as a
      * new instance. The current instance is unaffected.
      *
      * @param addX the amount to add to the X component
@@ -225,7 +225,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds specified amounts to the vector
+     * Adds specified amounts to the vector's components
      * and returns the (modified) current
      * instance.
      *
@@ -242,11 +242,14 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies by a scalar, adds a
-     * specified vector, and returns the (modified) current instance.
+     * Multiplies by the specified scalar, adds the specified
+     * vector, and returns the (modified) current instance.
+     *
+     * <p>this = scalar * this + add
      *
      * @param scalar the scaling factor
-     * @param add the value to add (not null)
+     * @param add the vector to add (not null, unaffected unless it is
+     *     <code>this</code>)
      * @return the (modified) current instance (for chaining)
      */
     public Vector3f scaleAdd(float scalar, Vector3f add) {
@@ -257,8 +260,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies a specified vector by a scalar, then adds
-     * another vector to it, storing the result in the current instance.
+     * Multiplies a specified vector by a specified scalar, then adds another
+     * specified vector to it, before storing the result in the current instance.
+     *
+     * <p>this = scalar * mult + add
      *
      * @param scalar the scaling factor
      * @param mult the vector to scale (not null, unaffected unless it is
@@ -275,7 +280,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the dot product with the argument. If the argument is null, 0 is returned.
+     * Returns the dot (or inner) product with the argument. If the argument is null, 0 is returned.
      * Either way, the current instance is unaffected.
      *
      * @param vec the vector to multiply (unaffected) or null for none
@@ -290,11 +295,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates a cross product with the argument. The current
+     * Calculates a cross product with the argument and returns the product as a
+     * new instance. The current
      * instance is unaffected.
      *
      * @param v the right factor (not null, unaffected)
-     * @return the product (a new Vector3f)
+     * @return <code>this</code> cross <code>v</code> (a new Vector3f)
      */
     public Vector3f cross(Vector3f v) {
         return cross(v, null);
@@ -308,7 +314,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * @param v the right factor (not null, unaffected unless it is
      *     <code>result</code>)
      * @param result storage for the product, or null for a new Vector3f
-     * @return the product (either <code>result</code> or a new Vector3f)
+     * @return <code>this</code> cross <code>v</code> (either
+     *     <code>result</code> or a new Vector3f)
      */
     public Vector3f cross(Vector3f v, Vector3f result) {
         return cross(v.x, v.y, v.z, result);
@@ -323,7 +330,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * @param otherY the Y component of the right factor
      * @param otherZ the Z component of the right factor
      * @param result storage for the product, or null for a new Vector3f
-     * @return the product (either <code>result</code> or a new Vector3f)
+     * @return <code>this</code> cross <code>v</code> (either
+     *     <code>result</code> or a new Vector3f)
      */
     public Vector3f cross(float otherX, float otherY, float otherZ, Vector3f result) {
         if (result == null) {
@@ -367,10 +375,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Projects onto the argument and returns the result. The current instance is
+     * Projects onto the argument and returns the result as a new vector. The current instance is
      * unaffected.
      *
-     * @param other The vector to project onto (not null, unaffected)
+     * @param other the vector to project onto (not null, unaffected)
      * @return a new Vector3f
      */
     public Vector3f project(Vector3f other) {
@@ -380,10 +388,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Projects onto the argument and stores the result in this
-     * vector.
+     * Projects onto the argument and returns the (modified)
+     * current instance.
      *
-     * @param other The vector to project onto (not null, unaffected unless it
+     * @param other the vector to project onto (not null, unaffected unless it
      * is <code>this</code>)
      * @return the (modified) current instance (for chaining)
      */
@@ -406,10 +414,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the magnitude. The current instance is
+     * Returns the length (or magnitude). The current instance is
      * unaffected.
      *
-     * @return the length
+     * @return the root-sum of the squared components (not negative)
      */
     public float length() {
         /*
@@ -430,18 +438,18 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Returns the square of the length. The current instance is
      * unaffected.
      *
-     * @return the magnitude squared of the vector.
+     * @return the sum of the squared components (not negative)
      */
     public float lengthSquared() {
         return x * x + y * y + z * z;
     }
 
     /**
-     * Returns the distance squared between
+     * Returns the square of the distance between
      * this vector and the argument. The current instance is unaffected.
      *
-     * @param v the vector to compare
-     * @return the square of the Euclidean distance
+     * @param v the vector to compare (not null, unaffected)
+     * @return the square of the Euclidean distance (not negative)
      */
     public float distanceSquared(Vector3f v) {
         double dx = x - v.x;
@@ -455,7 +463,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * the argument. The current instance is unaffected.
      *
      * @param v the vector to compare (not null, unaffected)
-     * @return the Euclidean distance
+     * @return the Euclidean distance (not negative)
      */
     public float distance(Vector3f v) {
         /*
@@ -484,7 +492,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies by the specified scalar and returns the product in
+     * Multiplies with the specified scalar and returns the product in
      * the specified vector.
      * The current instance is unaffected, unless it is <code>product</code>.
      *
@@ -524,7 +532,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * @param vec the scale vector (unaffected unless it is <code>this</code>)
      *     or null for none
-     * @return this (modified) or null
+     * @return the (modified) current instance (for chaining) or null
      */
     public Vector3f multLocal(Vector3f vec) {
         if (null == vec) {
@@ -559,7 +567,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * If the argument is null, null is returned.
      * Either way, the current instance is unaffected.
      *
-     * @param vec the scale vector or null for none
+     * @param vec the scale vector (unaffected) or null for none
      * @return a new Vector3f or null
      */
     public Vector3f mult(Vector3f vec) {
@@ -594,7 +602,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Divides by the argument and returns the quotient as a new
-     * instance. The current instance remains untouched.
+     * instance. The current instance is unaffected.
      *
      * @param scalar the divisor
      * @return a new Vector3f
@@ -621,7 +629,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Divides component-wise by the argument and
-     * returns the quotient as a new instance. The current instance remains untouched.
+     * returns the quotient as a new instance. The current instance is unaffected.
      *
      * @param scalar the divisor (not null, unaffected) TODO rename argument!
      * @return a new Vector3f
@@ -634,7 +642,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Divides component-wise by the argument and returns the
      * (modified) current instance.
      *
-     * @param scalar the divisor (not null) TODO rename argument!
+     * @param scalar the divisor (not null, unaffected) TODO rename argument!
      * @return the (modified) current instance (for chaining)
      */
     public Vector3f divideLocal(Vector3f scalar) {
@@ -654,7 +662,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Negates the components and returns the (modified) current instance.
+     * Negates all 3 components and returns the (modified) current instance.
      *
      * @return the (modified) current instance (for chaining)
      */
@@ -716,7 +724,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the specified values from the vector and returns the
+     * Subtracts the specified amounts from the vector's components and returns the
      * difference as a new instance. The current instance is unaffected.
      *
      * @param subtractX the amount to subtract from the X component
@@ -729,7 +737,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the specified values from the vector and returns the
+     * Subtracts the specified amounts from the vector's components and returns the
      * (modified) current instance.
      *
      * @param subtractX the amount to subtract from the X component
@@ -817,7 +825,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Sets all components to zero.
+     * Sets all 3 components to zero.
      *
      * @return the (modified) current instance (for chaining)
      */
@@ -827,7 +835,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns (in radians) the angle between this vector and the argument,
+     * Returns the angle (in radians) between this vector and the argument,
      * provided both vectors have length=1.
      * The current instance is unaffected.
      *
@@ -882,7 +890,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * null or if any component is NaN or infinite.
      *
      * @param vector the vector to test (unaffected)
-     * @return if non-null and finite, otherwise false
+     * @return true if non-null and finite, otherwise false
      */
     public static boolean isValidVector(Vector3f vector) {
         if (vector == null) {
@@ -951,7 +959,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * @param floats storage for the components (must have length&ge;3) or null
      *     for a new float[3]
-     * @return an array containing the X, Y, and Z in that order
+     * @return an array containing the X, Y, and Z components in that order
      *     (either <code>floats</code> or a new float[3])
      */
     public float[] toArray(float[] floats) {
@@ -965,7 +973,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Tests for equality with the argument, distinguishing -0
+     * Tests for exact equality with the argument, distinguishing -0
      * from 0. The current instance is unaffected.
      *
      * @param o the object to compare (may be null, unaffected)
@@ -1038,7 +1046,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Returns a string representation. The current instance is
      * unaffected. The format is:
      *
-     * (XX.XXXX, YY.YYYY, ZZ.ZZZZ)
+     * <p>(XX.XXXX, YY.YYYY, ZZ.ZZZZ)
      *
      * @return the string representation
      */
@@ -1143,7 +1151,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * @param index 0, 1, or 2
      * @return the X component if index=0, the Y component if index=1, or the Z
      *     component if index=2
-     * @throws IllegalArgumentException if index is not 0, 1, 2
+     * @throws IllegalArgumentException if index is not 0, 1, or 2
      */
     public float get(int index) {
         switch (index) {
@@ -1163,7 +1171,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * @param index which component to set: 0 &rarr; the X component, 1 &rarr;
      *     the Ycomponent, 2 &rarr; the Z component
      * @param value the desired component value
-     * @throws IllegalArgumentException if index is not 0, 1, 2
+     * @throws IllegalArgumentException if index is not 0, 1, or 2
      */
     public void set(int index, float value) {
         switch (index) {

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -92,15 +92,15 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
             Float.NEGATIVE_INFINITY,
             Float.NEGATIVE_INFINITY);
     /**
-     * The x component of the vector.
+     * The X component of the vector.
      */
     public float x;
     /**
-     * The y component of the vector.
+     * The Y component of the vector.
      */
     public float y;
     /**
-     * The z component of the vector.
+     * The Z component of the vector.
      */
     public float z;
 
@@ -117,9 +117,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Instantiates a new <code>Vector3f</code> with the provided
      * components.
      *
-     * @param x   the x component of the vector.
-     * @param y   the y component of the vector.
-     * @param z   the z component of the vector.
+     * @param x   the X component of the vector.
+     * @param y   the Y component of the vector.
+     * @param z   the Z component of the vector.
      */
     public Vector3f(float x, float y, float z) {
         this.x = x;
@@ -138,12 +138,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Sets the x,y,z components of the vector based on passed
+     * Sets the X, Y, and Z components of the vector based on passed
      * parameters.
      *
-     * @param x   the x component of the vector.
-     * @param y   the y component of the vector.
-     * @param z   the z component of the vector.
+     * @param x   the X component of the vector.
+     * @param y   the Y component of the vector.
+     * @param z   the Z component of the vector.
      * @return this vector (modified)
      */
     public Vector3f set(float x, float y, float z) {
@@ -154,7 +154,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Sets the x,y,z components of the vector by copying the
+     * Sets the X, Y, and Z components of the vector by copying the
      * supplied vector.
      *
      * @param vect the Vector3f to copy (not null, unaffected)
@@ -332,12 +332,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * specified components.  The result is stored in <code>result</code>.
      * The current instance is unaffected unless it is <code>result</code>.
      *
-     * @param otherX
-     *            x component of the right factor
-     * @param otherY
-     *            y component of the right factor
-     * @param otherZ
-     *            z component of the right factor
+     * @param otherX the X component of the right factor
+     * @param otherY the Y component of the right factor
+     * @param otherZ the Z component of the right factor
      * @param result
      *            the vector to store the product, or null for a new Vector3f
      * @return result, after receiving the cross product (either <code>result</code> or a new Vector3f)
@@ -1104,7 +1101,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Determines the X component of this vector. The vector is unaffected.
      *
-     * @return x
+     * @return the X component
      */
     public float getX() {
         return x;
@@ -1124,7 +1121,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Determines the Y component of this vector. The vector is unaffected.
      *
-     * @return y
+     * @return the Y component
      */
     public float getY() {
         return y;
@@ -1144,7 +1141,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Determines the Z component of this vector. The vector is unaffected.
      *
-     * @return z
+     * @return the Z component
      */
     public float getZ() {
         return z;
@@ -1165,7 +1162,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Returns the indexed component. The vector is unaffected.
      *
      * @param index 0, 1, or 2
-     * @return x component if index == 0, y component if index == 1 or z component if index == 2
+     * @return the X component if index == 0, the Y component if index == 1 or the Z component if index == 2
      * @throws IllegalArgumentException
      *             if index is not one of 0, 1, 2.
      */

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -129,7 +129,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Instantiates a new <code>Vector3f</code> that is a copy
-     * of the provided vector.
+     * of the argument.
      *
      * @param copy the Vector3f to copy (not null, unaffected)
      */
@@ -154,8 +154,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Sets the X, Y, and Z components of the vector by copying the
-     * supplied vector.
+     * Sets the X, Y, and Z components of the vector by copying the argument.
      *
      * @param vect the Vector3f to copy (not null, unaffected)
      * @return the (modified) current instance (for chaining)
@@ -168,8 +167,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds a provided vector to this vector, creating a
-     * resultant vector which is returned. If the provided vector is null, null
+     * Adds the argument to this vector, creating a
+     * resultant vector which is returned. If the argument is null, null
      * is returned. Either way, the current instance is unaffected.
      *
      * @param vec
@@ -203,9 +202,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds a provided vector to this vector
-     * and returns the (modified) current instance. If the
-     * provided vector is null, null is returned.
+     * Adds the argument to this vector and returns the (modified) current
+     * instance. If the argument is null, null is returned.
      *
      * @param vec the vector to add to this vector (unaffected unless it is <code>this</code>)
      *     or null for none
@@ -287,8 +285,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the dot product of this vector with a
-     * provided vector. If the provided vector is null, 0 is returned.
+     * Calculates the dot product of this vector with the argument. If the argument is null, 0 is returned.
      * Either way, the current instance is unaffected.
      *
      * @param vec the vector to dot with this vector (unaffected) or null for none
@@ -303,8 +300,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the cross product of this vector with a
-     * parameter vector v. The current instance is unaffected.
+     * Calculates the cross product of this vector with the argument. The current
+     * instance is unaffected.
      *
      * @param v the right factor (not null, unaffected)
      * @return the cross product (a new Vector3f)
@@ -352,7 +349,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the cross product of this vector with a parameter vector v and returns
+     * Calculates the cross product of this vector with the argument and returns
      * the (modified) current instance.
      *
      * @param v the right factor (not null, unaffected unless it is
@@ -382,7 +379,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Projects this vector onto another vector and returns the result. The current instance is
+     * Projects this vector onto the argument and returns the result. The current instance is
      * unaffected.
      *
      * @param other The vector to project this vector onto (not null, unaffected)
@@ -395,7 +392,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Projects this vector onto another vector and stores the result in this
+     * Projects this vector onto the argument and stores the result in this
      * vector.
      *
      * @param other The vector to project this vector onto (not null)
@@ -452,7 +449,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Calculates the distance squared between
-     * this vector and vector v. The current instance is unaffected.
+     * this vector and the argument. The current instance is unaffected.
      *
      * @param v the second vector to determine the distance squared.
      * @return the square of the Euclidean distance between the two vectors.
@@ -466,7 +463,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Returns the distance between this vector and
-     * vector v. The current instance is unaffected.
+     * the argument. The current instance is unaffected.
      *
      * @param v the second vector to determine the distance (not null, unaffected)
      * @return the Euclidean distance between the two vectors.
@@ -487,7 +484,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector by a scalar and returns the product as a new
+     * Multiplies this vector by the argument and returns the product as a new
      * instance. The current instance is unaffected.
      *
      * @param scalar
@@ -519,7 +516,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector by a scalar and returns the (modified) current
+     * Multiplies this vector by the argument and returns the (modified) current
      * instance.
      *
      * @param scalar
@@ -534,9 +531,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies a provided vector component-wise by this vector and returns
+     * Multiplies the argument component-wise by this vector and returns
      * the (modified) current instance.
-     * If the provided vector is null, null is returned.
+     * If the argument is null, null is returned.
      *
      * @param vec the vector to mult to this vector (unaffected unless it is <code>this</code>)
      *     or null for none
@@ -570,9 +567,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies a provided vector component-wise with this vector and returns the
+     * Multiplies the argument component-wise with this vector and returns the
      * product as a new instance.
-     * If the provided vector is null, null is returned.
+     * If the argument is null, null is returned.
      * Either way, the current instance is unaffected.
      *
      * @param vec
@@ -588,9 +585,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies a provided vector component-wise with
-     * this vector and stores the result in a 3rd vector. If the provided
-     * vector is null, null is returned. Either way, the current instance is unaffected, unless it is
+     * Multiplies the specified vector component-wise with
+     * this vector and stores the result in a 3rd vector. If the argument
+     * is null, null is returned. Either way, the current instance is unaffected, unless it is
      * <code>store</code>.
      *
      * @param vec the vector to mult to this vector (unaffected unless it is <code>store</code>)
@@ -610,7 +607,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides the vector by a scalar and returns the quotient as a new
+     * Divides the vector by the argument and returns the quotient as a new
      * instance. The current instance remains untouched.
      *
      * @param scalar
@@ -623,7 +620,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides this vector by a scalar and returns the (modified) current
+     * Divides this vector by the argument and returns the (modified) current
      * instance.
      *
      * @param scalar
@@ -650,7 +647,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides this vector component-wise by a vector and returns the
+     * Divides this vector component-wise by the argument and returns the
      * (modified) current instance.
      *
      * @param scalar the divisor (not null) TODO rename argument!
@@ -686,7 +683,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the given vector from this vector and returns the difference as a
+     * Subtracts the argument from this vector and returns the difference as a
      * new instance. The current instance is unaffected.
      *
      * @param vec the vector to subtract from this vector (not null, unaffected)
@@ -697,8 +694,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts a provided vector to this vector and returns the (modified)
-     * current instance. If the provided vector is null, null is returned.
+     * Subtracts the argument to this vector and returns the (modified)
+     * current instance. If the argument is null, null is returned.
      *
      * @param vec the vector to subtract (unaffected unless it is
      *     <code>this</code>) or null for none
@@ -809,7 +806,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Computes the maximum value for each
-     * component in this and <code>other</code> vector and returns the (modified) current
+     * component in this and the argument and returns the (modified) current
      * instance.
      *
      * @param other the vector to compare with (not null, unaffected)
@@ -824,7 +821,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Computes the minimum value for each
-     * component in this and <code>other</code> vector and returns the (modified) current
+     * component in this and the argument and returns the (modified) current
      * instance.
      *
      * @param other the vector to compare with (not null, unaffected)
@@ -848,8 +845,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns (in radians) the angle between two vectors.
-     * It is assumed that both this vector and the given vector are unit vectors (iow, normalized).
+     * Returns (in radians) the angle between this vector and the argument.
+     * It is assumed that both this vector and the argument are unit vectors (iow, normalized).
      * The current instance is unaffected.
      *
      * @param otherVector a unit vector to find the angle against (not null, unaffected)
@@ -899,7 +896,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Checks a vector. If it is null or if any component is NaN or infinite,
+     * Checks the argument. If it is null or if any component is NaN or infinite,
      * return false.  Else return true.
      *
      * @param vector the vector to check (unaffected)
@@ -967,7 +964,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Saves this Vector3f into the given float[] object. The current instance is
+     * Saves this Vector3f into the argument. The current instance is
      * unaffected.
      *
      * @param floats storage for the components (must have length&ge;3. If null, a new float[3] is
@@ -1070,7 +1067,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Serializes this vector to the specified exporter, for example when
+     * Serializes this vector to the argument, for example when
      * saving to a J3O file. The current instance is unaffected.
      *
      * @param e the exporter to use (not null)
@@ -1085,7 +1082,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * De-serializes this vector from the specified importer, for example
+     * De-serializes this vector from the argument, for example
      * when loading from a J3O file.
      *
      * @param e the importer to use (not null)

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -35,15 +35,14 @@ import com.jme3.export.*;
 import java.io.IOException;
 import java.util.logging.Logger;
 
-/*
- * -- Added *Local methods to cut down on object creation - JS
- */
-
 /**
  * A Vector for a three float value tuple.
  * <code>Vector3f</code> can represent any three dimensional value, such as a
  * vertex, a normal, etc. Utility methods are also included to aid in
  * mathematical calculations.
+ *
+ * <p>Methods with names ending in "Local" modify the current instance. They are
+ * used to cut down on the creation of new instances.
  *
  * @author Mark Powell
  * @author Joshua Slack
@@ -132,7 +131,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Instantiates a new <code>Vector3f</code> that is a copy
      * of the provided vector.
      *
-     * @param copy The Vector3f to copy
+     * @param copy the Vector3f to copy (unaffected)
      */
     public Vector3f(Vector3f copy) {
         this.set(copy);
@@ -145,7 +144,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * @param x   the x value of the vector.
      * @param y   the y value of the vector.
      * @param z   the z value of the vector.
-     * @return this vector
+     * @return this vector (modified)
      */
     public Vector3f set(float x, float y, float z) {
         this.x = x;
@@ -158,9 +157,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Sets the x,y,z values of the vector by copying the
      * supplied vector.
      *
-     * @param vect
-     *            the vector to copy.
-     * @return this vector
+     * @param vect the Vector3f to copy (unaffected)
+     * @return this vector (modified)
      */
     public Vector3f set(Vector3f vect) {
         this.x = vect.x;
@@ -172,10 +170,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Adds a provided vector to this vector, creating a
      * resultant vector which is returned. If the provided vector is null, null
-     * is returned.
+     * is returned. Either way, the current instance is unaffected.
      *
      * @param vec
-     *            the vector to add to this.
+     *            the vector to add to this (unaffected) or null for none
      * @return the resultant vector.
      */
     public Vector3f add(Vector3f vec) {
@@ -188,10 +186,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Adds the values of a provided vector, storing the
-     * values in the supplied vector.
+     * values in the supplied vector. The current instance is unaffected unless it is
+     * <code>result</code>.
      *
-     * @param vec
-     *            the vector to add to this
+     * @param vec the vector to add to this (unaffected unless it is
+     *     <code>result</code>)
      * @param result
      *            the vector to store the result in
      * @return result returns the supplied result vector.
@@ -205,12 +204,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Adds a provided vector to this vector internally
-     * and returns a handle to this vector for easy chaining of calls. If the
+     * and returns a handle to this (modified) vector for easy chaining of calls. If the
      * provided vector is null, null is returned.
      *
-     * @param vec
-     *            the vector to add to this vector.
-     * @return this
+     * @param vec the vector to add to this vector (unaffected unless it is <code>this</code>)
+     * @return this (modified)
      */
     public Vector3f addLocal(Vector3f vec) {
         if (null == vec) {
@@ -225,7 +223,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Adds the provided values to this vector, creating a
-     * new vector that is then returned.
+     * new vector that is then returned. The current instance is unaffected.
      *
      * @param addX
      *            the x value to add.
@@ -241,7 +239,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Adds the provided values to this vector
-     * internally and returns a handle to this vector for easy chaining of
+     * internally and returns a handle to this (modified) vector for easy chaining of
      * calls.
      *
      * @param addX
@@ -250,7 +248,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *            value to add to y
      * @param addZ
      *            value to add to z
-     * @return this
+     * @return this (modified)
      */
     public Vector3f addLocal(float addX, float addY, float addZ) {
         x += addX;
@@ -267,7 +265,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *            the value to multiply this vector by.
      * @param add
      *            the value to add
-     * @return this
+     * @return this (modified)
      */
     public Vector3f scaleAdd(float scalar, Vector3f add) {
         x = x * scalar + add.x;
@@ -281,10 +279,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * the given vector, storing the result in the current instance.
      *
      * @param scalar the scaling factor
-     * @param mult
-     *            the value to multiply the scalar by
-     * @param add
-     *            the value to add
+     * @param mult the value to multiply the scalar by (unaffected unless it is
+     *     <code>this</code>)
+     * @param add the value to add (unaffected unless it is <code>this</code>)
      * @return this
      */
     public Vector3f scaleAdd(float scalar, Vector3f mult, Vector3f add) {
@@ -297,9 +294,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Calculates the dot product of this vector with a
      * provided vector. If the provided vector is null, 0 is returned.
+     * Either way, the current instance is unaffected.
      *
      * @param vec
-     *            the vector to dot with this vector.
+     *            the vector to dot with this vector (unaffected)
      * @return the resultant dot product of this vector and a given vector.
      */
     public float dot(Vector3f vec) {
@@ -312,9 +310,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Calculates the cross product of this vector with a
-     * parameter vector v.
+     * parameter vector v. The current instance is unaffected.
      *
-     * @param v the right factor
+     * @param v the right factor (unaffected)
      * @return the cross product (a new Vector3f)
      */
     public Vector3f cross(Vector3f v) {
@@ -323,9 +321,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Calculates the cross product of this vector with a
-     * parameter vector v.  The result is stored in <code>result</code>
+     * parameter vector v.  The result is stored in <code>result</code>.
+     * The current instance is unaffected unless it is <code>result</code>.
      *
-     * @param v the right factor
+     * @param v the right factor (unaffected unless it is <code>result</code>)
      * @param result
      *            the vector to store the cross product result, or null for a new Vector3f
      * @return result, after receiving the cross product vector.
@@ -336,7 +335,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Calculates the cross product of this vector with
-     * specified components.  The result is stored in <code>result</code>
+     * specified components.  The result is stored in <code>result</code>.
+     * The current instance is unaffected unless it is <code>result</code>.
      *
      * @param otherX
      *            x component of the right factor
@@ -363,8 +363,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Calculates the cross product of this vector
      * with a parameter vector v.
      *
-     * @param v the right factor
-     * @return this.
+     * @param v the right factor (unaffected unless it is <code>this</code>)
+     * @return this (modified)
      */
     public Vector3f crossLocal(Vector3f v) {
         return crossLocal(v.x, v.y, v.z);
@@ -377,7 +377,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * @param otherX the X component of the right factor
      * @param otherY the Y component of the right factor
      * @param otherZ the Z component of the right factor
-     * @return this.
+     * @return this (modified)
      */
     public Vector3f crossLocal(float otherX, float otherY, float otherZ) {
         float tempx = (y * otherZ) - (z * otherY);
@@ -389,9 +389,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Projects this vector onto another vector.
+     * Projects this vector onto another vector. The current instance is
+     * unaffected.
      *
-     * @param other The vector to project this vector onto
+     * @param other The vector to project this vector onto (unaffected)
      * @return A new vector with the projection result
      */
     public Vector3f project(Vector3f other) {
@@ -405,7 +406,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * vector.
      *
      * @param other The vector to project this vector onto
-     * @return This Vector3f, set to the projection result
+     * @return This Vector3f (modified)
      */
     public Vector3f projectLocal(Vector3f other) {
         float n = this.dot(other); // A . B
@@ -415,7 +416,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Returns true if this vector is a unit vector, with 1% tolerance.
-     * Returns false otherwise.
+     * Returns false otherwise. The current instance is unaffected.
      *
      * @return true if the current vector's length is between 0.99 and 1.01
      *     inclusive, or false otherwise.
@@ -426,7 +427,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the magnitude of this vector.
+     * Calculates the magnitude of this vector. The current instance is
+     * unaffected.
      *
      * @return the length or magnitude of the vector.
      */
@@ -447,7 +449,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Calculates the squared value of the
-     * magnitude of the vector.
+     * magnitude of the vector. The current instance is unaffected.
      *
      * @return the magnitude squared of the vector.
      */
@@ -457,7 +459,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Calculates the distance squared between
-     * this vector and vector v.
+     * this vector and vector v. The current instance is unaffected.
      *
      * @param v the second vector to determine the distance squared.
      * @return the square of the Euclidean distance between the two vectors.
@@ -471,9 +473,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Calculates the distance between this vector and
-     * vector v.
+     * vector v. The current instance is unaffected.
      *
-     * @param v the second vector to determine the distance.
+     * @param v the second vector to determine the distance (unaffected)
      * @return the Euclidean distance between the two vectors.
      */
     public float distance(Vector3f v) {
@@ -493,7 +495,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies this vector by a scalar. The resultant
-     * vector is returned.
+     * vector is returned. The current instance is unaffected.
      *
      * @param scalar
      *            the value to multiply this vector by.
@@ -506,6 +508,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Multiplies this vector by a scalar. The resultant
      * vector is stored in the second parameter and returned.
+     * The current instance is unaffected, unless it is <code>product</code>.
      *
      * @param scalar the scalar to multiply this vector by.
      * @param product storage for the product, or null for a new Vector3f
@@ -524,11 +527,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies this vector by a scalar internally,
-     * and returns a handle to this vector for easy chaining of calls.
+     * and returns a handle to this (modified) vector for easy chaining of calls.
      *
      * @param scalar
      *            the value to multiply this vector by.
-     * @return this
+     * @return this (modified)
      */
     public Vector3f multLocal(float scalar) {
         x *= scalar;
@@ -539,12 +542,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies a provided vector component-wise by this vector
-     * internally, and returns a handle to this vector for easy chaining of
+     * internally, and returns a handle to this (modified) vector for easy chaining of
      * calls. If the provided vector is null, null is returned.
      *
-     * @param vec
-     *            the vector to mult to this vector.
-     * @return this
+     * @param vec the vector to mult to this vector (unaffected unless it is <code>this</code>)
+     * @return this (modified)
      */
     public Vector3f multLocal(Vector3f vec) {
         if (null == vec) {
@@ -559,13 +561,13 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies this vector component-wise by 3 scalars
-     * internally, and returns a handle to this vector for easy chaining of
+     * internally, and returns a handle to this (modified) vector for easy chaining of
      * calls.
      *
      * @param x the scale factor for the X component
      * @param y the scale factor for the Y component
      * @param z the scale factor for the Z component
-     * @return this
+     * @return this (modified)
      */
     public Vector3f multLocal(float x, float y, float z) {
         this.x *= x;
@@ -578,6 +580,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Multiplies a provided vector component-wise with
      * this vector and returns a handle to this vector for easy chaining of
      * calls. If the provided vector is null, null is returned.
+     * Either way, the current instance is unaffected.
      *
      * @param vec
      *            the vector to multiply with this vector, or null for none
@@ -594,10 +597,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Multiplies a provided vector component-wise with
      * this vector and stores the result in a 3rd vector. If the provided
-     * vector is null, null is returned.
+     * vector is null, null is returned. Either way, the current instance is unaffected, unless it is
+     * <code>store</code>.
      *
-     * @param vec
-     *            the vector to mult to this vector.
+     * @param vec the vector to mult to this vector (unaffected unless it is <code>store</code>)
      * @param store result vector (null to create a new vector)
      * @return either <code>store</code> or a new Vector3f or null
      */
@@ -627,11 +630,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Divides this vector by a scalar internally
-     * and returns a handle to this vector for easy chaining of calls.
+     * and returns a handle to this (modified) vector for easy chaining of calls.
      *
      * @param scalar
      *            the value to divide this vector by.
-     * @return this
+     * @return this (modified)
      */
     public Vector3f divideLocal(float scalar) {
         scalar = 1f / scalar;
@@ -645,7 +648,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Divides the values of this vector component-wise by the argument and
      * returns the result. The values of this vector remain untouched.
      *
-     * @param scalar the divisor TODO rename argument!
+     * @param scalar the divisor (unaffected) TODO rename argument!
      * @return the result <code>Vector</code>.
      */
     public Vector3f divide(Vector3f scalar) {
@@ -654,10 +657,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Divides this vector component-wise by a vector internally,
-     * and returns a handle to this vector for easy chaining of calls.
+     * and returns a handle to this (modified) vector for easy chaining of calls.
      *
      * @param scalar the divisor TODO rename argument!
-     * @return this
+     * @return this (modified)
      */
     public Vector3f divideLocal(Vector3f scalar) {
         x /= scalar.x;
@@ -668,7 +671,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Returns the negative of this vector. All values are
-     * negated.
+     * negated. The current instance is unaffected.
      *
      * @return a new Vector3f
      */
@@ -679,7 +682,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Negates the internal values of this vector.
      *
-     * @return this.
+     * @return this (modified)
      */
     public Vector3f negateLocal() {
         x = -x;
@@ -691,9 +694,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Subtracts the values of a given vector from those
      * of this vector creating a new vector object.
+     * The current instance is unaffected.
      *
      * @param vec
-     *            the vector to subtract from this vector.
+     *            the vector to subtract from this vector (unaffected)
      * @return the result vector.
      */
     public Vector3f subtract(Vector3f vec) {
@@ -702,12 +706,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Subtracts a provided vector to this vector
-     * internally and returns a handle to this vector for easy chaining of
+     * internally and returns a handle to this (modified) vector for easy chaining of
      * calls. If the provided vector is null, null is returned.
      *
-     * @param vec
-     *            the vector to subtract or null for none
-     * @return this or null
+     * @param vec the vector to subtract (unaffected unless it is
+     *     <code>this</code>) or null for none
+     * @return this (modified) or null
      */
     public Vector3f subtractLocal(Vector3f vec) {
         if (null == vec) {
@@ -722,10 +726,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Subtracts the specified vector from this vector, storing the difference
-     * in a 3rd vector.
+     * in a 3rd vector. The current instnace is unaffected unless it is
+     * <code>result</code>.
      *
-     * @param vec
-     *            the vector to subtract from this
+     * @param vec the vector to subtract from this (unaffected unless it is
+     *     <code>result</code>)
      * @param result
      *            the vector to store the result in, or null for a new Vector3f
      * @return result or a new Vector3f
@@ -742,7 +747,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Subtracts the provided values from this vector,
-     * creating a new vector that is then returned.
+     * creating a new vector that is then returned. The current instance is unaffected.
      *
      * @param subtractX
      *            the x value to subtract.
@@ -758,7 +763,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Subtracts the provided values from this vector
-     * internally and returns a handle to this vector for easy chaining of
+     * internally and returns a handle to this (modified) vector for easy chaining of
      * calls.
      *
      * @param subtractX
@@ -767,7 +772,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *            the y value to subtract.
      * @param subtractZ
      *            the z value to subtract.
-     * @return this
+     * @return this (modified)
      */
     public Vector3f subtractLocal(float subtractX, float subtractY, float subtractZ) {
         x -= subtractX;
@@ -778,7 +783,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Normalizes the vector to length=1 and returns the result as a new
-     * instance. If the vector has length=0, a clone is returned.
+     * instance. If the vector has length=0, a clone is returned. Either way,
+     * the current instance is unaffected.
      *
      * @return unit vector of this vector.
      */
@@ -801,7 +807,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Normalizes the vector to length=1 and returns the (modified) current
      * instance. If the vector has length=0, it is unchanged.
      *
-     * @return this.
+     * @return this (modified)
      */
     public Vector3f normalizeLocal() {
         // NOTE: this implementation is more optimized
@@ -823,7 +829,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * in this vector.
      *
      * @param other the vector to compare with (not null, unaffected)
-     * @return this
+     * @return this (modified)
      */
     public Vector3f maxLocal(Vector3f other) {
         x = other.x > x ? other.x : x;
@@ -838,7 +844,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * in this vector.
      *
      * @param other the vector to compare with (not null, unaffected)
-     * @return this
+     * @return this (modified)
      */
     public Vector3f minLocal(Vector3f other) {
         x = other.x < x ? other.x : x;
@@ -850,7 +856,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Resets this vector's data to zero.
      *
-     * @return this
+     * @return this (modified)
      */
     public Vector3f zero() {
         x = y = z = 0;
@@ -860,8 +866,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Returns (in radians) the angle between two vectors.
      * It is assumed that both this vector and the given vector are unit vectors (iow, normalized).
+     * The current instance is unaffected.
      *
-     * @param otherVector a unit vector to find the angle against
+     * @param otherVector a unit vector to find the angle against (unaffected)
      * @return the angle (in radians, not negative)
      */
     public float angleBetween(Vector3f otherVector) {
@@ -876,9 +883,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * <p>this = (1 - changeAmnt) * this + changeAmnt * finalVec
      *
-     * @param finalVec the desired value when changeAmnt=1
+     * @param finalVec the desired value when changeAmnt=1 (unaffected)
      * @param changeAmnt the fractional change amount
-     * @return this
+     * @return this (modified)
      */
     public Vector3f interpolateLocal(Vector3f finalVec, float changeAmnt) {
         this.x = (1 - changeAmnt) * this.x + changeAmnt * finalVec.x;
@@ -893,10 +900,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * <p>this = (1 - changeAmnt) * beginVec + changeAmnt * finalVec
      *
-     * @param beginVec the desired value when changeAmnt=0
-     * @param finalVec the desired value when changeAmnt=1
+     * @param beginVec the desired value when changeAmnt=0 (unaffected
+     *     unless it's this)
+     * @param finalVec the desired value when changeAmnt=1 (unaffected
+     *     unless it's this)
      * @param changeAmnt the fractional change amount
-     * @return this
+     * @return this (modified)
      */
     public Vector3f interpolateLocal(Vector3f beginVec, Vector3f finalVec, float changeAmnt) {
         this.x = (1 - changeAmnt) * beginVec.x + changeAmnt * finalVec.x;
@@ -909,7 +918,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Checks a vector. If it is null or its floats are NaN or infinite,
      * return false.  Else return true.
      *
-     * @param vector the vector to check
+     * @param vector the vector to check (unaffected)
      * @return true or false as stated above.
      */
     public static boolean isValidVector(Vector3f vector) {
@@ -960,7 +969,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Creates a copy of this vector.
+     * Creates a copy of this vector. The current instance is unaffected.
      *
      * @return a new instance, equivalent to this one
      */
@@ -974,7 +983,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Saves this Vector3f into the given float[] object.
+     * Saves this Vector3f into the given float[] object. The current instance is
+     * unaffected.
      *
      * @param floats storage for the components (must have length&ge;3. If null, a new float[3] is
      *            created.
@@ -992,9 +1002,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Tests whether the vector is equal to the argument, distinguishing -0
-     * from 0.
+     * from 0. The current instance is unaffected.
      *
-     * @param o   the object to compare for equality
+     * @param o   the object to compare for equality (unaffected)
      * @return true if they are equal
      */
     @Override
@@ -1022,7 +1032,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Returns true if this vector is approximately equal to the specified vector within
-     * the specified tolerance.
+     * the specified tolerance. The current instance is unaffected.
      *
      * @param other the vector to compare with (not null, unaffected)
      * @param epsilon the desired error tolerance for each component
@@ -1047,7 +1057,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Returns a hash code for this vector object based
      * on its values. If two vectors are logically equivalent, they will return
-     * the same hash code value.
+     * the same hash code value. The current instance is
+     * unaffected.
      *
      * @return the hash code value of this vector.
      */
@@ -1061,8 +1072,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns a string representation of this vector.
-     * The format is:
+     * Returns a string representation of this vector. The current instance is
+     * unaffected. The format is:
      *
      * (XX.XXXX, YY.YYYY, ZZ.ZZZZ)
      *
@@ -1075,7 +1086,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Serializes this vector to the specified exporter, for example when
-     * saving to a J3O file.
+     * saving to a J3O file. The current instance is unaffected.
      *
      * @param e the exporter to use (not null)
      * @throws IOException from the exporter
@@ -1104,7 +1115,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Determines the X component of this vector.
+     * Determines the X component of this vector. The vector is unaffected.
      *
      * @return x
      */
@@ -1124,7 +1135,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Determines the Y component of this vector.
+     * Determines the Y component of this vector. The vector is unaffected.
      *
      * @return y
      */
@@ -1144,7 +1155,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Determines the Z component of this vector.
+     * Determines the Z component of this vector. The vector is unaffected.
      *
      * @return z
      */
@@ -1164,7 +1175,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the indexed component.
+     * Returns the indexed component. The vector is unaffected.
      *
      * @param index 0, 1, or 2
      * @return x value if index == 0, y value if index == 1 or z value if index == 2

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -114,7 +114,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Instantiates a new <code>Vector3f</code> with the provided
+     * Instantiates a new <code>Vector3f</code> with the specified
      * components.
      *
      * @param x   the X component of the vector.
@@ -184,7 +184,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the provided vector and returns the
+     * Adds the specified vector and returns the
      * sum in a 3rd vector. The current instance is unaffected unless it is
      * <code>result</code>.
      *
@@ -220,7 +220,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the provided offsets to this vector and returns the sum as a
+     * Adds the specified offsets to this vector and returns the sum as a
      * new instance. The current instance is unaffected.
      *
      * @param addX the amount to add to the X component
@@ -233,7 +233,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the provided offsets to this vector
+     * Adds the specified offsets to this vector
      * and returns the (modified) current
      * instance.
      *
@@ -251,7 +251,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies this vector by a scalar, adds the
-     * given Vector3f, and returns the (modified) current instance.
+     * specified Vector3f, and returns the (modified) current instance.
      *
      * @param scalar
      *            the value to multiply this vector by.
@@ -266,7 +266,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies the given vector by a scalar, then adds
+     * Multiplies the specified vector by a scalar, then adds
      * another vector to it, storing the result in the current instance.
      *
      * @param scalar the scaling factor
@@ -288,7 +288,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Either way, the current instance is unaffected.
      *
      * @param vec the vector to dot with this vector (unaffected) or null for none
-     * @return the resultant dot product of this vector and a given vector.
+     * @return the resultant dot product of this vector and the specified vector.
      */
     public float dot(Vector3f vec) {
         if (null == vec) {
@@ -730,7 +730,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the provided values from this vector and returns the
+     * Subtracts the specified values from this vector and returns the
      * difference as a new instance. The current instance is unaffected.
      *
      * @param subtractX the amount to subtract from the X component
@@ -743,7 +743,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the provided values from this vector and returns the
+     * Subtracts the specified values from this vector and returns the
      * (modified) current instance.
      *
      * @param subtractX the amount to subtract from the X component

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -203,7 +203,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds a provided vector to this vector internally
+     * Adds a provided vector to this vector
      * and returns the (modified) current instance. If the
      * provided vector is null, null is returned.
      *
@@ -237,7 +237,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Adds the provided offsets to this vector
-     * internally and returns the (modified) current
+     * and returns the (modified) current
      * instance.
      *
      * @param addX the amount to add to the X component
@@ -519,7 +519,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector by a scalar internally and returns the (modified) current
+     * Multiplies this vector by a scalar and returns the (modified) current
      * instance.
      *
      * @param scalar
@@ -534,7 +534,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies a provided vector component-wise by this vector internally and returns
+     * Multiplies a provided vector component-wise by this vector and returns
      * the (modified) current instance.
      * If the provided vector is null, null is returned.
      *
@@ -554,8 +554,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector component-wise by 3 scalars
-     * internally, and returns the (modified) current instance.
+     * Multiplies this vector component-wise by 3 scalars, and returns the
+     * (modified) current instance.
      *
      * @param x the scale factor for the X component
      * @param y the scale factor for the Y component
@@ -623,7 +623,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides this vector by a scalar internally and returns the (modified) current
+     * Divides this vector by a scalar and returns the (modified) current
      * instance.
      *
      * @param scalar
@@ -650,7 +650,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides this vector component-wise by a vector internally, and returns the
+     * Divides this vector component-wise by a vector and returns the
      * (modified) current instance.
      *
      * @param scalar the divisor (not null) TODO rename argument!
@@ -697,7 +697,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts a provided vector to this vector internally and returns the (modified)
+     * Subtracts a provided vector to this vector and returns the (modified)
      * current instance. If the provided vector is null, null is returned.
      *
      * @param vec the vector to subtract (unaffected unless it is
@@ -750,7 +750,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the provided values from this vector internally and returns the
+     * Subtracts the provided values from this vector and returns the
      * (modified) current instance.
      *
      * @param subtractX the amount to subtract from the X component

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -40,7 +40,7 @@ import java.util.logging.Logger;
  */
 
 /**
- * <code>Vector3f</code> defines a Vector for a three float value tuple.
+ * A Vector for a three float value tuple.
  * <code>Vector3f</code> can represent any three dimensional value, such as a
  * vertex, a normal, etc. Utility methods are also included to aid in
  * mathematical calculations.
@@ -53,60 +53,60 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     static final long serialVersionUID = 1;
     private static final Logger logger = Logger.getLogger(Vector3f.class.getName());
     /**
-     * shared instance of the all-zero vector (0,0,0) - Do not modify!
+     * Shared instance of the all-zero vector (0,0,0). Do not modify!
      */
     public final static Vector3f ZERO = new Vector3f(0, 0, 0);
     /**
-     * shared instance of the all-NaN vector (NaN,NaN,NaN) - Do not modify!
+     * Shared instance of the all-NaN vector (NaN,NaN,NaN). Do not modify!
      */
     public final static Vector3f NAN = new Vector3f(Float.NaN, Float.NaN, Float.NaN);
     /**
-     * shared instance of the +X direction (1,0,0) - Do not modify!
+     * Shared instance of the +X direction (1,0,0). Do not modify!
      */
     public final static Vector3f UNIT_X = new Vector3f(1, 0, 0);
     /**
-     * shared instance of the +Y direction (0,1,0) - Do not modify!
+     * Shared instance of the +Y direction (0,1,0). Do not modify!
      */
     public final static Vector3f UNIT_Y = new Vector3f(0, 1, 0);
     /**
-     * shared instance of the +Z direction (0,0,1) - Do not modify!
+     * Shared instance of the +Z direction (0,0,1). Do not modify!
      */
     public final static Vector3f UNIT_Z = new Vector3f(0, 0, 1);
     /**
-     * shared instance of the all-ones vector (1,1,1) - Do not modify!
+     * Shared instance of the all-ones vector (1,1,1). Do not modify!
      */
     public final static Vector3f UNIT_XYZ = new Vector3f(1, 1, 1);
     /**
-     * shared instance of the all-plus-infinity vector (+Inf,+Inf,+Inf)
-     * - Do not modify!
+     * Shared instance of the all-plus-infinity vector (+Inf,+Inf,+Inf). Do not
+     * modify!
      */
     public final static Vector3f POSITIVE_INFINITY = new Vector3f(
             Float.POSITIVE_INFINITY,
             Float.POSITIVE_INFINITY,
             Float.POSITIVE_INFINITY);
     /**
-     * shared instance of the all-negative-infinity vector (-Inf,-Inf,-Inf)
-     * - Do not modify!
+     * Shared instance of the all-negative-infinity vector (-Inf,-Inf,-Inf). Do
+     * not modify!
      */
     public final static Vector3f NEGATIVE_INFINITY = new Vector3f(
             Float.NEGATIVE_INFINITY,
             Float.NEGATIVE_INFINITY,
             Float.NEGATIVE_INFINITY);
     /**
-     * the x value of the vector.
+     * The x value of the vector.
      */
     public float x;
     /**
-     * the y value of the vector.
+     * The y value of the vector.
      */
     public float y;
     /**
-     * the z value of the vector.
+     * The z value of the vector.
      */
     public float z;
 
     /**
-     * Constructor instantiates a new <code>Vector3f</code> with default
+     * Instantiates a new <code>Vector3f</code> with default
      * values of (0,0,0).
      *
      */
@@ -115,7 +115,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Constructor instantiates a new <code>Vector3f</code> with the provided
+     * Instantiates a new <code>Vector3f</code> with the provided
      * values.
      *
      * @param x   the x value of the vector.
@@ -129,8 +129,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Constructor instantiates a new <code>Vector3f</code> that is a copy
-     * of the provided vector
+     * Instantiates a new <code>Vector3f</code> that is a copy
+     * of the provided vector.
      *
      * @param copy The Vector3f to copy
      */
@@ -139,7 +139,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>set</code> sets the x,y,z values of the vector based on passed
+     * Sets the x,y,z values of the vector based on passed
      * parameters.
      *
      * @param x   the x value of the vector.
@@ -155,7 +155,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>set</code> sets the x,y,z values of the vector by copying the
+     * Sets the x,y,z values of the vector by copying the
      * supplied vector.
      *
      * @param vect
@@ -170,7 +170,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>add</code> adds a provided vector to this vector creating a
+     * Adds a provided vector to this vector, creating a
      * resultant vector which is returned. If the provided vector is null, null
      * is returned.
      *
@@ -187,7 +187,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>add</code> adds the values of a provided vector storing the
+     * Adds the values of a provided vector, storing the
      * values in the supplied vector.
      *
      * @param vec
@@ -204,7 +204,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>addLocal</code> adds a provided vector to this vector internally,
+     * Adds a provided vector to this vector internally
      * and returns a handle to this vector for easy chaining of calls. If the
      * provided vector is null, null is returned.
      *
@@ -224,7 +224,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>add</code> adds the provided values to this vector, creating a
+     * Adds the provided values to this vector, creating a
      * new vector that is then returned.
      *
      * @param addX
@@ -240,8 +240,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>addLocal</code> adds the provided values to this vector
-     * internally, and returns a handle to this vector for easy chaining of
+     * Adds the provided values to this vector
+     * internally and returns a handle to this vector for easy chaining of
      * calls.
      *
      * @param addX
@@ -260,7 +260,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>scaleAdd</code> multiplies this vector by a scalar then adds the
+     * Multiplies this vector by a scalar, then adds the
      * given Vector3f.
      *
      * @param scalar
@@ -277,7 +277,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>scaleAdd</code> multiplies the given vector by a scalar then adds
+     * Multiplies the given vector by a scalar, then adds
      * the given vector, storing the result in the current instance.
      *
      * @param scalar the scaling factor
@@ -295,7 +295,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>dot</code> calculates the dot product of this vector with a
+     * Calculates the dot product of this vector with a
      * provided vector. If the provided vector is null, 0 is returned.
      *
      * @param vec
@@ -311,7 +311,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>cross</code> calculates the cross product of this vector with a
+     * Calculates the cross product of this vector with a
      * parameter vector v.
      *
      * @param v the right factor
@@ -322,7 +322,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>cross</code> calculates the cross product of this vector with a
+     * Calculates the cross product of this vector with a
      * parameter vector v.  The result is stored in <code>result</code>
      *
      * @param v the right factor
@@ -335,7 +335,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>cross</code> calculates the cross product of this vector with
+     * Calculates the cross product of this vector with
      * specified components.  The result is stored in <code>result</code>
      *
      * @param otherX
@@ -360,7 +360,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>crossLocal</code> calculates the cross product of this vector
+     * Calculates the cross product of this vector
      * with a parameter vector v.
      *
      * @param v the right factor
@@ -371,7 +371,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>crossLocal</code> calculates the cross product of this vector
+     * Calculates the cross product of this vector
      * with a parameter vector v.
      *
      * @param otherX the X component of the right factor
@@ -389,7 +389,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Projects this vector onto another vector
+     * Projects this vector onto another vector.
      *
      * @param other The vector to project this vector onto
      * @return A new vector with the projection result
@@ -401,8 +401,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Projects this vector onto another vector, stores the result in this
-     * vector
+     * Projects this vector onto another vector and stores the result in this
+     * vector.
      *
      * @param other The vector to project this vector onto
      * @return This Vector3f, set to the projection result
@@ -426,7 +426,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>length</code> calculates the magnitude of this vector.
+     * Calculates the magnitude of this vector.
      *
      * @return the length or magnitude of the vector.
      */
@@ -446,7 +446,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>lengthSquared</code> calculates the squared value of the
+     * Calculates the squared value of the
      * magnitude of the vector.
      *
      * @return the magnitude squared of the vector.
@@ -456,7 +456,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>distanceSquared</code> calculates the distance squared between
+     * Calculates the distance squared between
      * this vector and vector v.
      *
      * @param v the second vector to determine the distance squared.
@@ -470,7 +470,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>distance</code> calculates the distance between this vector and
+     * Calculates the distance between this vector and
      * vector v.
      *
      * @param v the second vector to determine the distance.
@@ -492,7 +492,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>mult</code> multiplies this vector by a scalar. The resultant
+     * Multiplies this vector by a scalar. The resultant
      * vector is returned.
      *
      * @param scalar
@@ -504,7 +504,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>mult</code> multiplies this vector by a scalar. The resultant
+     * Multiplies this vector by a scalar. The resultant
      * vector is stored in the second parameter and returned.
      *
      * @param scalar the scalar to multiply this vector by.
@@ -523,7 +523,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>multLocal</code> multiplies this vector by a scalar internally,
+     * Multiplies this vector by a scalar internally,
      * and returns a handle to this vector for easy chaining of calls.
      *
      * @param scalar
@@ -538,7 +538,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>multLocal</code> multiplies a provided vector component-wise by this vector
+     * Multiplies a provided vector component-wise by this vector
      * internally, and returns a handle to this vector for easy chaining of
      * calls. If the provided vector is null, null is returned.
      *
@@ -558,7 +558,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>multLocal</code> multiplies this vector component-wise by 3 scalars
+     * Multiplies this vector component-wise by 3 scalars
      * internally, and returns a handle to this vector for easy chaining of
      * calls.
      *
@@ -575,8 +575,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>multLocal</code> multiplies a provided vector component-wise with
-     * this vector, and returns a handle to this vector for easy chaining of
+     * Multiplies a provided vector component-wise with
+     * this vector and returns a handle to this vector for easy chaining of
      * calls. If the provided vector is null, null is returned.
      *
      * @param vec
@@ -592,8 +592,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>multLocal</code> multiplies a provided vector component-wise with
-     * this vector, and stores the result in a 3rd vector. If the provided
+     * Multiplies a provided vector component-wise with
+     * this vector and stores the result in a 3rd vector. If the provided
      * vector is null, null is returned.
      *
      * @param vec
@@ -613,7 +613,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>divide</code> divides the values of this vector by a scalar and
+     * Divides the values of this vector by a scalar and
      * returns the result. The values of this vector remain untouched.
      *
      * @param scalar
@@ -626,7 +626,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>divideLocal</code> divides this vector by a scalar internally,
+     * Divides this vector by a scalar internally
      * and returns a handle to this vector for easy chaining of calls.
      *
      * @param scalar
@@ -642,7 +642,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>divide</code> divides the values of this vector component-wise by the argument and
+     * Divides the values of this vector component-wise by the argument and
      * returns the result. The values of this vector remain untouched.
      *
      * @param scalar the divisor TODO rename argument!
@@ -653,7 +653,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>divideLocal</code> divides this vector component-wise by a vector internally,
+     * Divides this vector component-wise by a vector internally,
      * and returns a handle to this vector for easy chaining of calls.
      *
      * @param scalar the divisor TODO rename argument!
@@ -667,7 +667,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>negate</code> returns the negative of this vector. All values are
+     * Returns the negative of this vector. All values are
      * negated.
      *
      * @return a new Vector3f
@@ -677,7 +677,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>negateLocal</code> negates the internal values of this vector.
+     * Negates the internal values of this vector.
      *
      * @return this.
      */
@@ -689,7 +689,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>subtract</code> subtracts the values of a given vector from those
+     * Subtracts the values of a given vector from those
      * of this vector creating a new vector object.
      *
      * @param vec
@@ -701,8 +701,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>subtractLocal</code> subtracts a provided vector to this vector
-     * internally, and returns a handle to this vector for easy chaining of
+     * Subtracts a provided vector to this vector
+     * internally and returns a handle to this vector for easy chaining of
      * calls. If the provided vector is null, null is returned.
      *
      * @param vec
@@ -741,7 +741,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>subtract</code> subtracts the provided values from this vector,
+     * Subtracts the provided values from this vector,
      * creating a new vector that is then returned.
      *
      * @param subtractX
@@ -757,8 +757,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>subtractLocal</code> subtracts the provided values from this vector
-     * internally, and returns a handle to this vector for easy chaining of
+     * Subtracts the provided values from this vector
+     * internally and returns a handle to this vector for easy chaining of
      * calls.
      *
      * @param subtractX
@@ -818,7 +818,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>maxLocal</code> computes the maximum value for each
+     * Computes the maximum value for each
      * component in this and <code>other</code> vector. The result is stored
      * in this vector.
      *
@@ -833,7 +833,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>minLocal</code> computes the minimum value for each
+     * Computes the minimum value for each
      * component in this and <code>other</code> vector. The result is stored
      * in this vector.
      *
@@ -848,7 +848,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>zero</code> resets this vector's data to zero.
+     * Resets this vector's data to zero.
      *
      * @return this
      */
@@ -858,7 +858,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>angleBetween</code> returns (in radians) the angle between two vectors.
+     * Returns (in radians) the angle between two vectors.
      * It is assumed that both this vector and the given vector are unit vectors (iow, normalized).
      *
      * @param otherVector a unit vector to find the angle against
@@ -906,7 +906,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Check a vector... if it is null or its floats are NaN or infinite,
+     * Checks a vector. If it is null or its floats are NaN or infinite,
      * return false.  Else return true.
      *
      * @param vector the vector to check
@@ -960,7 +960,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Create a copy of this vector.
+     * Creates a copy of this vector.
      *
      * @return a new instance, equivalent to this one
      */
@@ -1045,7 +1045,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>hashCode</code> returns a hash code for this vector object based
+     * Returns a hash code for this vector object based
      * on its values. If two vectors are logically equivalent, they will return
      * the same hash code value.
      *
@@ -1061,7 +1061,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>toString</code> returns a string representation of this vector.
+     * Returns a string representation of this vector.
      * The format is:
      *
      * (XX.XXXX, YY.YYYY, ZZ.ZZZZ)
@@ -1074,7 +1074,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Serialize this vector to the specified exporter, for example when
+     * Serializes this vector to the specified exporter, for example when
      * saving to a J3O file.
      *
      * @param e the exporter to use (not null)
@@ -1089,7 +1089,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * De-serialize this vector from the specified importer, for example
+     * De-serializes this vector from the specified importer, for example
      * when loading from a J3O file.
      *
      * @param e the importer to use (not null)
@@ -1104,7 +1104,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Determine the X component of this vector.
+     * Determines the X component of this vector.
      *
      * @return x
      */
@@ -1113,7 +1113,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Alter the X component of this vector.
+     * Alters the X component of this vector.
      *
      * @param x the desired value
      * @return this vector, modified
@@ -1124,7 +1124,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Determine the Y component of this vector.
+     * Determines the Y component of this vector.
      *
      * @return y
      */
@@ -1133,7 +1133,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Alter the Y component of this vector.
+     * Alters the Y component of this vector.
      *
      * @param y the desired value
      * @return this vector, modified
@@ -1144,7 +1144,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Determine the Z component of this vector.
+     * Determines the Z component of this vector.
      *
      * @return z
      */
@@ -1153,7 +1153,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Alter the Z component of this vector.
+     * Alters the Z component of this vector.
      *
      * @param z the desired value
      * @return this vector, modified

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -131,7 +131,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Instantiates a new <code>Vector3f</code> that is a copy
      * of the provided vector.
      *
-     * @param copy the Vector3f to copy (unaffected)
+     * @param copy the Vector3f to copy (not null, unaffected)
      */
     public Vector3f(Vector3f copy) {
         this.set(copy);
@@ -157,7 +157,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Sets the x,y,z components of the vector by copying the
      * supplied vector.
      *
-     * @param vect the Vector3f to copy (unaffected)
+     * @param vect the Vector3f to copy (not null, unaffected)
      * @return this vector (modified)
      */
     public Vector3f set(Vector3f vect) {
@@ -174,7 +174,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * @param vec
      *            the vector to add to this (unaffected) or null for none
-     * @return the resultant vector.
+     * @return a new Vector3f or null
      */
     public Vector3f add(Vector3f vec) {
         if (null == vec) {
@@ -189,10 +189,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * sum in the supplied vector. The current instance is unaffected unless it is
      * <code>result</code>.
      *
-     * @param vec the vector to add to this (unaffected unless it is
+     * @param vec the vector to add to this (not null, unaffected unless it is
      *     <code>result</code>)
      * @param result
-     *            the vector to store the result in
+     *            the vector to store the result in (not null)
      * @return result returns the supplied result vector.
      */
     public Vector3f add(Vector3f vec, Vector3f result) {
@@ -208,7 +208,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * provided vector is null, null is returned.
      *
      * @param vec the vector to add to this vector (unaffected unless it is <code>this</code>)
-     * @return this (modified)
+     *     or null for none
+     * @return this (modified) or null
      */
     public Vector3f addLocal(Vector3f vec) {
         if (null == vec) {
@@ -257,8 +258,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * @param scalar
      *            the value to multiply this vector by.
-     * @param add
-     *            the value to add
+     * @param add the value to add (not null)
      * @return this (modified)
      */
     public Vector3f scaleAdd(float scalar, Vector3f add) {
@@ -273,9 +273,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * the given vector, storing the result in the current instance.
      *
      * @param scalar the scaling factor
-     * @param mult the vector to multiply the scalar by (unaffected unless it is
+     * @param mult the vector to multiply the scalar by (not null, unaffected unless it is
      *     <code>this</code>)
-     * @param add the vector to add (unaffected unless it is <code>this</code>)
+     * @param add the vector to add (not null, unaffected unless it is
+     *     <code>this</code>)
      * @return this
      */
     public Vector3f scaleAdd(float scalar, Vector3f mult, Vector3f add) {
@@ -290,8 +291,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * provided vector. If the provided vector is null, 0 is returned.
      * Either way, the current instance is unaffected.
      *
-     * @param vec
-     *            the vector to dot with this vector (unaffected)
+     * @param vec the vector to dot with this vector (unaffected) or null for none
      * @return the resultant dot product of this vector and a given vector.
      */
     public float dot(Vector3f vec) {
@@ -306,7 +306,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Calculates the cross product of this vector with a
      * parameter vector v. The current instance is unaffected.
      *
-     * @param v the right factor (unaffected)
+     * @param v the right factor (not null, unaffected)
      * @return the cross product (a new Vector3f)
      */
     public Vector3f cross(Vector3f v) {
@@ -318,7 +318,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * parameter vector v.  The result is stored in <code>result</code>.
      * The current instance is unaffected unless it is <code>result</code>.
      *
-     * @param v the right factor (unaffected unless it is <code>result</code>)
+     * @param v the right factor (not null, unaffected unless it is
+     *     <code>result</code>)
      * @param result
      *            the vector to store the cross product result, or null for a new Vector3f
      * @return result, after receiving the cross product vector.
@@ -357,7 +358,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Calculates the cross product of this vector
      * with a parameter vector v.
      *
-     * @param v the right factor (unaffected unless it is <code>this</code>)
+     * @param v the right factor (not null, unaffected unless it is
+     *     <code>this</code>)
      * @return this (modified)
      */
     public Vector3f crossLocal(Vector3f v) {
@@ -386,7 +388,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Projects this vector onto another vector. The current instance is
      * unaffected.
      *
-     * @param other The vector to project this vector onto (unaffected)
+     * @param other The vector to project this vector onto (not null, unaffected)
      * @return A new vector with the projection result
      */
     public Vector3f project(Vector3f other) {
@@ -399,7 +401,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Projects this vector onto another vector and stores the result in this
      * vector.
      *
-     * @param other The vector to project this vector onto
+     * @param other The vector to project this vector onto (not null)
      * @return This Vector3f (modified)
      */
     public Vector3f projectLocal(Vector3f other) {
@@ -469,13 +471,13 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Calculates the distance between this vector and
      * vector v. The current instance is unaffected.
      *
-     * @param v the second vector to determine the distance (unaffected)
+     * @param v the second vector to determine the distance (not null, unaffected)
      * @return the Euclidean distance between the two vectors.
      */
     public float distance(Vector3f v) {
         /*
-         * Use double-precision arithmetic to reduce the chance of overflow 
-         * (when distanceSquared > Float.MAX_VALUE) or underflow (when 
+         * Use double-precision arithmetic to reduce the chance of overflow
+         * (when distanceSquared > Float.MAX_VALUE) or underflow (when
          * distanceSquared is < Float.MIN_VALUE).
          */
         double dx = x - v.x;
@@ -540,7 +542,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * calls. If the provided vector is null, null is returned.
      *
      * @param vec the vector to mult to this vector (unaffected unless it is <code>this</code>)
-     * @return this (modified)
+     *     or null for none
+     * @return this (modified) or null
      */
     public Vector3f multLocal(Vector3f vec) {
         if (null == vec) {
@@ -595,6 +598,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * <code>store</code>.
      *
      * @param vec the vector to mult to this vector (unaffected unless it is <code>store</code>)
+     *     or null for none
      * @param store result vector (null to create a new vector)
      * @return either <code>store</code> or a new Vector3f or null
      */
@@ -642,7 +646,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Divides this vector component-wise by the argument and
      * returns the result. The current instance remains untouched.
      *
-     * @param scalar the divisor (unaffected) TODO rename argument!
+     * @param scalar the divisor (not null, unaffected) TODO rename argument!
      * @return the result <code>Vector</code>.
      */
     public Vector3f divide(Vector3f scalar) {
@@ -653,7 +657,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Divides this vector component-wise by a vector internally,
      * and returns a handle to this (modified) vector for easy chaining of calls.
      *
-     * @param scalar the divisor TODO rename argument!
+     * @param scalar the divisor (not null) TODO rename argument!
      * @return this (modified)
      */
     public Vector3f divideLocal(Vector3f scalar) {
@@ -689,8 +693,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Subtracts the given vector from this vector creating a new vector object.
      * The current instance is unaffected.
      *
-     * @param vec
-     *            the vector to subtract from this vector (unaffected)
+     * @param vec the vector to subtract from this vector (not null, unaffected)
      * @return the result vector.
      */
     public Vector3f subtract(Vector3f vec) {
@@ -722,7 +725,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * in a 3rd vector. The current instnace is unaffected unless it is
      * <code>result</code>.
      *
-     * @param vec the vector to subtract from this (unaffected unless it is
+     * @param vec the vector to subtract from this (not null, unaffected unless it is
      *     <code>result</code>)
      * @param result
      *            the vector to store the result in, or null for a new Vector3f
@@ -855,7 +858,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * It is assumed that both this vector and the given vector are unit vectors (iow, normalized).
      * The current instance is unaffected.
      *
-     * @param otherVector a unit vector to find the angle against (unaffected)
+     * @param otherVector a unit vector to find the angle against (not null, unaffected)
      * @return the angle (in radians, not negative)
      */
     public float angleBetween(Vector3f otherVector) {
@@ -870,7 +873,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * <p>this = (1 - changeAmnt) * this + changeAmnt * finalVec
      *
-     * @param finalVec the desired value when changeAmnt=1 (unaffected)
+     * @param finalVec the desired value when changeAmnt=1 (not null, unaffected)
      * @param changeAmnt the fractional change amount
      * @return this (modified)
      */
@@ -887,9 +890,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * <p>this = (1 - changeAmnt) * beginVec + changeAmnt * finalVec
      *
-     * @param beginVec the desired value when changeAmnt=0 (unaffected
+     * @param beginVec the desired value when changeAmnt=0 (not null, unaffected
      *     unless it's this)
-     * @param finalVec the desired value when changeAmnt=1 (unaffected
+     * @param finalVec the desired value when changeAmnt=1 (not null, unaffected
      *     unless it's this)
      * @param changeAmnt the fractional change amount
      * @return this (modified)
@@ -991,7 +994,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Tests whether the vector is equal to the argument, distinguishing -0
      * from 0. The current instance is unaffected.
      *
-     * @param o   the object to compare for equality (unaffected)
+     * @param o the object to compare for equality (may be null, unaffected)
      * @return true if they are equal
      */
     @Override

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -204,7 +204,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Adds a provided vector to this vector internally
-     * and returns a handle to this (modified) vector for easy chaining of calls. If the
+     * and returns a handle to this (modified) vector for chaining. If the
      * provided vector is null, null is returned.
      *
      * @param vec the vector to add to this vector (unaffected unless it is <code>this</code>)
@@ -237,8 +237,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Adds the provided offsets to this vector
-     * internally and returns a handle to this (modified) vector for easy chaining of
-     * calls.
+     * internally and returns a handle to this (modified) vector for chaining.
      *
      * @param addX the amount to add to the X component
      * @param addY the amount to add to the Y component
@@ -523,7 +522,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies this vector by a scalar internally,
-     * and returns a handle to this (modified) vector for easy chaining of calls.
+     * and returns a handle to this (modified) vector for chaining.
      *
      * @param scalar
      *            the value to multiply this vector by.
@@ -538,8 +537,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies a provided vector component-wise by this vector
-     * internally, and returns a handle to this (modified) vector for easy chaining of
-     * calls. If the provided vector is null, null is returned.
+     * internally, and returns a handle to this (modified) vector for chaining.
+     * If the provided vector is null, null is returned.
      *
      * @param vec the vector to mult to this vector (unaffected unless it is <code>this</code>)
      *     or null for none
@@ -558,8 +557,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies this vector component-wise by 3 scalars
-     * internally, and returns a handle to this (modified) vector for easy chaining of
-     * calls.
+     * internally, and returns a handle to this (modified) vector for chaining.
      *
      * @param x the scale factor for the X component
      * @param y the scale factor for the Y component
@@ -575,8 +573,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies a provided vector component-wise with
-     * this vector and returns a handle to this vector for easy chaining of
-     * calls. If the provided vector is null, null is returned.
+     * this vector and returns a handle to this vector for chaining.
+     * If the provided vector is null, null is returned.
      * Either way, the current instance is unaffected.
      *
      * @param vec
@@ -628,7 +626,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Divides this vector by a scalar internally
-     * and returns a handle to this (modified) vector for easy chaining of calls.
+     * and returns a handle to this (modified) vector for chaining.
      *
      * @param scalar
      *            the value to divide this vector by.
@@ -655,7 +653,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Divides this vector component-wise by a vector internally,
-     * and returns a handle to this (modified) vector for easy chaining of calls.
+     * and returns a handle to this (modified) vector for chaining.
      *
      * @param scalar the divisor (not null) TODO rename argument!
      * @return this (modified)
@@ -702,8 +700,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Subtracts a provided vector to this vector
-     * internally and returns a handle to this (modified) vector for easy chaining of
-     * calls. If the provided vector is null, null is returned.
+     * internally and returns a handle to this (modified) vector for chaining.
+     * If the provided vector is null, null is returned.
      *
      * @param vec the vector to subtract (unaffected unless it is
      *     <code>this</code>) or null for none
@@ -756,8 +754,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Subtracts the provided values from this vector
-     * internally and returns a handle to this (modified) vector for easy chaining of
-     * calls.
+     * internally and returns a handle to this (modified) vector for chaining.
      *
      * @param subtractX the amount to subtract from the X component
      * @param subtractY the amount to subtract from the Y component

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -184,8 +184,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the components of a provided vector, storing the
-     * sum in the supplied vector. The current instance is unaffected unless it is
+     * Adds the provided vector, storing the
+     * sum in a 3rd vector. The current instance is unaffected unless it is
      * <code>result</code>.
      *
      * @param vec the vector to add to this (not null, unaffected unless it is
@@ -268,7 +268,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies the given vector by a scalar, then adds
-     * the given vector, storing the result in the current instance.
+     * another vector to it, storing the result in the current instance.
      *
      * @param scalar the scaling factor
      * @param mult the vector to multiply the scalar by (not null, unaffected unless it is
@@ -395,7 +395,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Projects this vector onto the argument and stores the result in this
      * vector.
      *
-     * @param other The vector to project this vector onto (not null)
+     * @param other The vector to project this vector onto (not null, unaffected unless it
+     * is <code>this</code>)
      * @return the (modified) current instance (for chaining)
      */
     public Vector3f projectLocal(Vector3f other) {
@@ -496,7 +497,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector by a scalar. The resultant
+     * Multiplies this vector by the specified scalar. The resultant
      * vector is stored in the second parameter and returned.
      * The current instance is unaffected, unless it is <code>product</code>.
      *
@@ -551,7 +552,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector component-wise by 3 scalars, and returns the
+     * Multiplies this vector component-wise by the specified components and returns the
      * (modified) current instance.
      *
      * @param x the scale factor for the X component
@@ -661,8 +662,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns the negative of this vector. All components are
-     * negated. The current instance is unaffected.
+     * Returns the negative of this vector. The current instance is unaffected.
      *
      * @return a new Vector3f
      */
@@ -694,7 +694,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the argument to this vector and returns the (modified)
+     * Subtracts the argument from this vector and returns the (modified)
      * current instance. If the argument is null, null is returned.
      *
      * @param vec the vector to subtract (unaffected unless it is
@@ -714,7 +714,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Subtracts the specified vector from this vector, storing the difference
-     * in a 3rd vector. The current instnace is unaffected unless it is
+     * in a 3rd vector. The current instance is unaffected unless it is
      * <code>result</code>.
      *
      * @param vec the vector to subtract from this (not null, unaffected unless it is
@@ -805,8 +805,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Computes the maximum value for each
-     * component in this and the argument and returns the (modified) current
+     * Compares this vector component-wise with the argument (keeping the most
+     * positive value for each component) and returns the (modified) current
      * instance.
      *
      * @param other the vector to compare with (not null, unaffected)
@@ -820,8 +820,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Computes the minimum value for each
-     * component in this and the argument and returns the (modified) current
+     * Compares this vector component-wise with the argument (keeping the most
+     * negative value for each component) and returns the (modified) current
      * instance.
      *
      * @param other the vector to compare with (not null, unaffected)
@@ -864,7 +864,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * <p>this = (1 - changeAmnt) * this + changeAmnt * finalVec
      *
-     * @param finalVec the desired value when changeAmnt=1 (not null, unaffected)
+     * @param finalVec the desired value when changeAmnt=1 (not null, unaffected unless it's this)
      * @param changeAmnt the fractional change amount
      * @return the (modified) current instance (for chaining)
      */
@@ -967,7 +967,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Saves this Vector3f into the argument. The current instance is
      * unaffected.
      *
-     * @param floats storage for the components (must have length&ge;3. If null, a new float[3] is
+     * @param floats storage for the components (must have length&ge;3). If null, a new float[3] is
      *            created.
      * @return an array containing the X, Y, and Z in that order
      *     (either <code>floats</code> or a new float[3])

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -115,7 +115,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Constructor instantiates a new <code>Vector3f</code> with provides
+     * Constructor instantiates a new <code>Vector3f</code> with the provided
      * values.
      *
      * @param x   the x value of the vector.
@@ -278,10 +278,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * <code>scaleAdd</code> multiplies the given vector by a scalar then adds
-     * the given vector.
+     * the given vector, storing the result in the current instance.
      *
-     * @param scalar
-     *            the value to multiply this vector by.
+     * @param scalar the scaling factor
      * @param mult
      *            the value to multiply the scalar by
      * @param add
@@ -315,8 +314,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * <code>cross</code> calculates the cross product of this vector with a
      * parameter vector v.
      *
-     * @param v   the vector to take the cross product of with this.
-     * @return the cross product vector.
+     * @param v the right factor
+     * @return the cross product (a new Vector3f)
      */
     public Vector3f cross(Vector3f v) {
         return cross(v, null);
@@ -326,9 +325,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * <code>cross</code> calculates the cross product of this vector with a
      * parameter vector v.  The result is stored in <code>result</code>
      *
-     * @param v   the vector to take the cross product of with this.
+     * @param v the right factor
      * @param result
-     *            the vector to store the cross product result.
+     *            the vector to store the cross product result, or null for a new Vector3f
      * @return result, after receiving the cross product vector.
      */
     public Vector3f cross(Vector3f v, Vector3f result) {
@@ -336,18 +335,18 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>cross</code> calculates the cross product of this vector with a
-     * parameter vector v.  The result is stored in <code>result</code>
+     * <code>cross</code> calculates the cross product of this vector with
+     * specified components.  The result is stored in <code>result</code>
      *
      * @param otherX
-     *            x component of the vector to take the cross product of with this.
+     *            x component of the right factor
      * @param otherY
-     *            y component of the vector to take the cross product of with this.
+     *            y component of the right factor
      * @param otherZ
-     *            z component of the vector to take the cross product of with this.
+     *            z component of the right factor
      * @param result
-     *            the vector to store the cross product result.
-     * @return result, after receiving the cross product vector.
+     *            the vector to store the product, or null for a new Vector3f
+     * @return result, after receiving the cross product (either <code>result</code> or a new Vector3f)
      */
     public Vector3f cross(float otherX, float otherY, float otherZ, Vector3f result) {
         if (result == null) {
@@ -364,7 +363,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * <code>crossLocal</code> calculates the cross product of this vector
      * with a parameter vector v.
      *
-     * @param v   the vector to take the cross product of with this.
+     * @param v the right factor
      * @return this.
      */
     public Vector3f crossLocal(Vector3f v) {
@@ -375,12 +374,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * <code>crossLocal</code> calculates the cross product of this vector
      * with a parameter vector v.
      *
-     * @param otherX
-     *            x component of the vector to take the cross product of with this.
-     * @param otherY
-     *            y component of the vector to take the cross product of with this.
-     * @param otherZ
-     *            z component of the vector to take the cross product of with this.
+     * @param otherX the X component of the right factor
+     * @param otherY the Y component of the right factor
+     * @param otherZ the Z component of the right factor
      * @return this.
      */
     public Vector3f crossLocal(float otherX, float otherY, float otherZ) {
@@ -418,11 +414,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns true if this vector is a unit vector (length() ~= 1),
-     * returns false otherwise.
+     * Returns true if this vector is a unit vector, with 1% tolerance.
+     * Returns false otherwise.
      *
-     * @return true if this vector is a unit vector (length() ~= 1),
-     * or false otherwise.
+     * @return true if the current vector's length is between 0.99 and 1.01
+     *     inclusive, or false otherwise.
      */
     public boolean isUnitVector() {
         float len = length();
@@ -464,7 +460,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * this vector and vector v.
      *
      * @param v the second vector to determine the distance squared.
-     * @return the distance squared between the two vectors.
+     * @return the square of the Euclidean distance between the two vectors.
      */
     public float distanceSquared(Vector3f v) {
         double dx = x - v.x;
@@ -478,7 +474,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * vector v.
      *
      * @param v the second vector to determine the distance.
-     * @return the distance between the two vectors.
+     * @return the Euclidean distance between the two vectors.
      */
     public float distance(Vector3f v) {
         /*
@@ -501,7 +497,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * @param scalar
      *            the value to multiply this vector by.
-     * @return the new vector.
+     * @return a new Vector3f
      */
     public Vector3f mult(float scalar) {
         return new Vector3f(x * scalar, y * scalar, z * scalar);
@@ -509,11 +505,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * <code>mult</code> multiplies this vector by a scalar. The resultant
-     * vector is supplied as the second parameter and returned.
+     * vector is stored in the second parameter and returned.
      *
      * @param scalar the scalar to multiply this vector by.
-     * @param product the product to store the result in.
-     * @return product
+     * @param product storage for the product, or null for a new Vector3f
+     * @return either <code>product</code> or a new Vector3f
      */
     public Vector3f mult(float scalar, Vector3f product) {
         if (null == product) {
@@ -542,7 +538,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>multLocal</code> multiplies a provided vector to this vector
+     * <code>multLocal</code> multiplies a provided vector component-wise by this vector
      * internally, and returns a handle to this vector for easy chaining of
      * calls. If the provided vector is null, null is returned.
      *
@@ -562,7 +558,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>multLocal</code> multiplies this vector by 3 scalars
+     * <code>multLocal</code> multiplies this vector component-wise by 3 scalars
      * internally, and returns a handle to this vector for easy chaining of
      * calls.
      *
@@ -579,13 +575,13 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>multLocal</code> multiplies a provided vector to this vector
-     * internally, and returns a handle to this vector for easy chaining of
+     * <code>multLocal</code> multiplies a provided vector component-wise with
+     * this vector, and returns a handle to this vector for easy chaining of
      * calls. If the provided vector is null, null is returned.
      *
      * @param vec
-     *            the vector to mult to this vector.
-     * @return this
+     *            the vector to multiply with this vector, or null for none
+     * @return a new Vector3f or null
      */
     public Vector3f mult(Vector3f vec) {
         if (null == vec) {
@@ -596,14 +592,14 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>multLocal</code> multiplies a provided vector to this vector
-     * internally, and returns a handle to this vector for easy chaining of
-     * calls. If the provided vector is null, null is returned.
+     * <code>multLocal</code> multiplies a provided vector component-wise with
+     * this vector, and stores the result in a 3rd vector. If the provided
+     * vector is null, null is returned.
      *
      * @param vec
      *            the vector to mult to this vector.
      * @param store result vector (null to create a new vector)
-     * @return this
+     * @return either <code>store</code> or a new Vector3f or null
      */
     public Vector3f mult(Vector3f vec, Vector3f store) {
         if (null == vec) {
@@ -622,7 +618,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * @param scalar
      *            the value to divide this vectors attributes by.
-     * @return the result <code>Vector</code>.
+     * @return a new Vector3f
      */
     public Vector3f divide(float scalar) {
         scalar = 1f / scalar;
@@ -631,11 +627,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * <code>divideLocal</code> divides this vector by a scalar internally,
-     * and returns a handle to this vector for easy chaining of calls. Dividing
-     * by zero will result in an exception.
+     * and returns a handle to this vector for easy chaining of calls.
      *
      * @param scalar
-     *            the value to divides this vector by.
+     *            the value to divide this vector by.
      * @return this
      */
     public Vector3f divideLocal(float scalar) {
@@ -647,11 +642,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>divide</code> divides the values of this vector by a scalar and
+     * <code>divide</code> divides the values of this vector component-wise by the argument and
      * returns the result. The values of this vector remain untouched.
      *
-     * @param scalar
-     *            the value to divide this vectors attributes by.
+     * @param scalar the divisor TODO rename argument!
      * @return the result <code>Vector</code>.
      */
     public Vector3f divide(Vector3f scalar) {
@@ -659,12 +653,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>divideLocal</code> divides this vector by a scalar internally,
-     * and returns a handle to this vector for easy chaining of calls. Dividing
-     * by zero will result in an exception.
+     * <code>divideLocal</code> divides this vector component-wise by a vector internally,
+     * and returns a handle to this vector for easy chaining of calls.
      *
-     * @param scalar
-     *            the value to divides this vector by.
+     * @param scalar the divisor TODO rename argument!
      * @return this
      */
     public Vector3f divideLocal(Vector3f scalar) {
@@ -676,9 +668,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * <code>negate</code> returns the negative of this vector. All values are
-     * negated and set to a new vector.
+     * negated.
      *
-     * @return the negated vector.
+     * @return a new Vector3f
      */
     public Vector3f negate() {
         return new Vector3f(-x, -y, -z);
@@ -698,8 +690,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * <code>subtract</code> subtracts the values of a given vector from those
-     * of this vector creating a new vector object. If the provided vector is
-     * null, null is returned.
+     * of this vector creating a new vector object.
      *
      * @param vec
      *            the vector to subtract from this vector.
@@ -715,8 +706,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * calls. If the provided vector is null, null is returned.
      *
      * @param vec
-     *            the vector to subtract
-     * @return this
+     *            the vector to subtract or null for none
+     * @return this or null
      */
     public Vector3f subtractLocal(Vector3f vec) {
         if (null == vec) {
@@ -730,13 +721,14 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>subtract</code>
+     * Subtracts the specified vector from this vector, storing the difference
+     * in a 3rd vector.
      *
      * @param vec
      *            the vector to subtract from this
      * @param result
-     *            the vector to store the result in
-     * @return result
+     *            the vector to store the result in, or null for a new Vector3f
+     * @return result or a new Vector3f
      */
     public Vector3f subtract(Vector3f vec, Vector3f result) {
         if (result == null) {
@@ -785,7 +777,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>normalize</code> returns the unit vector of this vector.
+     * Normalizes the vector to length=1 and returns the result as a new
+     * instance. If the vector has length=0, a clone is returned.
      *
      * @return unit vector of this vector.
      */
@@ -805,8 +798,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>normalizeLocal</code> makes this vector into a unit vector of
-     * itself.
+     * Normalizes the vector to length=1 and returns the (modified) current
+     * instance. If the vector has length=0, it is unchanged.
      *
      * @return this.
      */
@@ -855,7 +848,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>zero</code> resets this vector's data to zero internally.
+     * <code>zero</code> resets this vector's data to zero.
      *
      * @return this
      */
@@ -869,7 +862,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * It is assumed that both this vector and the given vector are unit vectors (iow, normalized).
      *
      * @param otherVector a unit vector to find the angle against
-     * @return the angle in radians.
+     * @return the angle (in radians, not negative)
      */
     public float angleBetween(Vector3f otherVector) {
         float dotProduct = dot(otherVector);
@@ -878,12 +871,13 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Sets this vector to the interpolation by changeAmnt from this to the finalVec
-     * this=(1-changeAmnt)*this + changeAmnt * finalVec
+     * Interpolates linearly between this vector and the specified vector,
+     * storing the result in the current instance and returning it.
      *
-     * @param finalVec The final vector to interpolate towards
-     * @param changeAmnt An amount between 0.0 - 1.0 representing a percentage
-     *  change from this towards finalVec
+     * <p>this = (1 - changeAmnt) * this + changeAmnt * finalVec
+     *
+     * @param finalVec the desired value when changeAmnt=1
+     * @param changeAmnt the fractional change amount
      * @return this
      */
     public Vector3f interpolateLocal(Vector3f finalVec, float changeAmnt) {
@@ -894,13 +888,14 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Sets this vector to the interpolation by changeAmnt from beginVec to finalVec
-     * this=(1-changeAmnt)*beginVec + changeAmnt * finalVec
+     * Interpolates linearly between the specified beginning and final vectors,
+     * storing the result in the current instance and returning it.
      *
-     * @param beginVec the beginning vector (changeAmnt=0)
-     * @param finalVec The final vector to interpolate towards
-     * @param changeAmnt An amount between 0.0 - 1.0 representing a percentage
-     *  change from beginVec towards finalVec
+     * <p>this = (1 - changeAmnt) * beginVec + changeAmnt * finalVec
+     *
+     * @param beginVec the desired value when changeAmnt=0
+     * @param finalVec the desired value when changeAmnt=1
+     * @param changeAmnt the fractional change amount
      * @return this
      */
     public Vector3f interpolateLocal(Vector3f beginVec, Vector3f finalVec, float changeAmnt) {
@@ -981,10 +976,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Saves this Vector3f into the given float[] object.
      *
-     * @param floats
-     *            The float[] to take this Vector3f. If null, a new float[3] is
+     * @param floats storage for the components (must have length&ge;3. If null, a new float[3] is
      *            created.
-     * @return The array, with X, Y, Z float values in that order
+     * @return an array, with X, Y, Z float values in that order (either <code>floats</code> or a new float[3])
      */
     public float[] toArray(float[] floats) {
         if (floats == null) {
@@ -997,8 +991,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * are these two vectors the same? they are is they both have the same x,y,
-     * and z values.
+     * Tests whether the vector is equal to the argument, distinguishing -0
+     * from 0.
      *
      * @param o   the object to compare for equality
      * @return true if they are equal
@@ -1027,8 +1021,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Returns true if this vector is similar to the specified vector within
-     * some value of epsilon.
+     * Returns true if this vector is approximately equal to the specified vector within
+     * the specified tolerance.
      *
      * @param other the vector to compare with (not null, unaffected)
      * @param epsilon the desired error tolerance for each component
@@ -1051,7 +1045,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * <code>hashCode</code> returns a unique code for this vector object based
+     * <code>hashCode</code> returns a hash code for this vector object based
      * on its values. If two vectors are logically equivalent, they will return
      * the same hash code value.
      *
@@ -1083,7 +1077,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Serialize this vector to the specified exporter, for example when
      * saving to a J3O file.
      *
-     * @param e (not null)
+     * @param e the exporter to use (not null)
      * @throws IOException from the exporter
      */
     @Override
@@ -1098,7 +1092,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * De-serialize this vector from the specified importer, for example
      * when loading from a J3O file.
      *
-     * @param e (not null)
+     * @param e the importer to use (not null)
      * @throws IOException from the importer
      */
     @Override
@@ -1170,6 +1164,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
+     * Returns the indexed component.
+     *
      * @param index 0, 1, or 2
      * @return x value if index == 0, y value if index == 1 or z value if index == 2
      * @throws IllegalArgumentException
@@ -1188,10 +1184,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * @param index
-     *            which field index in this vector to set.
-     * @param value
-     *            to set to one of x, y or z.
+     * Sets the indexed component.
+     *
+     * @param index which component to set: 0 &rarr; the X component, 1 &rarr;
+     *     the Ycomponent, 2 &rarr; the Z component
+     * @param value the desired component value
      * @throws IllegalArgumentException
      *             if index is not one of 0, 1, 2.
      */

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -177,9 +177,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Adds a specified vector and returns the sum in a 3rd vector. The current
-     * instance is unaffected unless it is <code>result</code>.
+     * instance is unaffected unless it's <code>result</code>.
      *
-     * @param vec the vector to add (not null, unaffected unless it is
+     * @param vec the vector to add (not null, unaffected unless it's
      *     <code>result</code>)
      * @param result storage for the sum (not null)
      * @return <code>result</code> (for chaining)
@@ -195,7 +195,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Adds the argument and returns the (modified) current instance. If the
      * argument is null, null is returned.
      *
-     * @param vec the vector to add (unaffected unless it is <code>this</code>)
+     * @param vec the vector to add (unaffected unless it's <code>this</code>)
      *     or null for none
      * @return the (modified) current instance or null
      */
@@ -246,7 +246,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * <p>this = scalar * this + add
      *
      * @param scalar the scaling factor
-     * @param add the vector to add (not null, unaffected unless it is
+     * @param add the vector to add (not null, unaffected unless it's
      *     <code>this</code>)
      * @return the (modified) current instance (for chaining)
      */
@@ -265,9 +265,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * <p>this = scalar * mult + add
      *
      * @param scalar the scaling factor
-     * @param mult the vector to scale (not null, unaffected unless it is
+     * @param mult the vector to scale (not null, unaffected unless it's
      *     <code>this</code>)
-     * @param add the vector to add (not null, unaffected unless it is
+     * @param add the vector to add (not null, unaffected unless it's
      *     <code>this</code>)
      * @return the (modified) current instance (for chaining)
      */
@@ -306,10 +306,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Calculates a cross product with a specified vector and returns the
-     * product in a 3rd vector. The current instance is unaffected unless it is
+     * product in a 3rd vector. The current instance is unaffected unless it's
      * <code>result</code>.
      *
-     * @param v the right factor (not null, unaffected unless it is
+     * @param v the right factor (not null, unaffected unless it's
      *     <code>result</code>)
      * @param result storage for the product, or null for a new Vector3f
      * @return <code>this</code> cross <code>v</code> (either
@@ -322,7 +322,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Calculates a cross product with specified components and returns the
      * product in the specified vector. The current instance is unaffected
-     * unless it is <code>result</code>.
+     * unless it's <code>result</code>.
      *
      * @param otherX the X component of the right factor
      * @param otherY the Y component of the right factor
@@ -346,7 +346,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Right multiplies by the argument (cross product) and returns the
      * (modified) current instance.
      *
-     * @param v the right factor (not null, unaffected unless it is
+     * @param v the right factor (not null, unaffected unless it's
      *     <code>this</code>)
      * @return the (modified) current instance (for chaining)
      */
@@ -388,8 +388,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Projects onto the argument and returns the (modified) current instance.
      *
-     * @param other the vector to project onto (not null, unaffected unless it
-     *     is <code>this</code>)
+     * @param other the vector to project onto (not null, unaffected unless it's
+     *     <code>this</code>)
      * @return the (modified) current instance (for chaining)
      */
     public Vector3f projectLocal(Vector3f other) {
@@ -488,7 +488,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies with the specified scalar and returns the product in the
-     * specified vector. The current instance is unaffected, unless it is
+     * specified vector. The current instance is unaffected, unless it's
      * <code>product</code>.
      *
      * @param scalar the scaling factor
@@ -523,7 +523,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Multiplies component-wise by the argument and returns the (modified)
      * current instance. If the argument is null, null is returned.
      *
-     * @param vec the scale vector (unaffected unless it is <code>this</code>)
+     * @param vec the scale vector (unaffected unless it's <code>this</code>)
      *     or null for none
      * @return the (modified) current instance (for chaining) or null
      */
@@ -573,10 +573,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Multiplies component-wise with the specified vector and returns the
      * product in a 3rd vector. If the argument is null, null is returned.
-     * Either way, the current instance is unaffected, unless it is
+     * Either way, the current instance is unaffected, unless it's
      * <code>store</code>.
      *
-     * @param vec the scale vector (unaffected unless it is <code>store</code>)
+     * @param vec the scale vector (unaffected unless it's <code>store</code>)
      *     or null for none
      * @param store storage for the product, or null for a new Vector3f
      * @return either <code>store</code> or a new Vector3f or null
@@ -679,7 +679,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Subtracts the argument and returns the (modified) current instance. If
      * the argument is null, null is returned.
      *
-     * @param vec the vector to subtract (unaffected unless it is
+     * @param vec the vector to subtract (unaffected unless it's
      *     <code>this</code>) or null for none
      * @return the (modified) current instance or null
      */
@@ -696,10 +696,10 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Subtracts the specified vector and returns the difference in a 3rd
-     * vector. The current instance is unaffected unless it is
+     * vector. The current instance is unaffected unless it's
      * <code>result</code>.
      *
-     * @param vec the vector to subtract (not null, unaffected unless it is
+     * @param vec the vector to subtract (not null, unaffected unless it's
      *     <code>result</code>)
      * @param result storage for the difference, or null for a new Vector3f
      * @return either <code>result</code> or a new Vector3f
@@ -767,7 +767,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Normalizes the vector to length=1 and returns the (modified) current
-     * instance. If the vector has length=0, it is unchanged.
+     * instance. If the vector has length=0, it's unchanged.
      *
      * @return the (modified) current instance (for chaining)
      */

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -144,7 +144,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * @param x   the X component of the vector.
      * @param y   the Y component of the vector.
      * @param z   the Z component of the vector.
-     * @return this vector (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f set(float x, float y, float z) {
         this.x = x;
@@ -158,7 +158,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * supplied vector.
      *
      * @param vect the Vector3f to copy (not null, unaffected)
-     * @return this vector (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f set(Vector3f vect) {
         this.x = vect.x;
@@ -193,7 +193,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *     <code>result</code>)
      * @param result
      *            the vector to store the result in (not null)
-     * @return result returns the supplied result vector.
+     * @return <code>result</code> (for chaining)
      */
     public Vector3f add(Vector3f vec, Vector3f result) {
         result.x = x + vec.x;
@@ -204,12 +204,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Adds a provided vector to this vector internally
-     * and returns a handle to this (modified) vector for chaining. If the
+     * and returns the (modified) current instance. If the
      * provided vector is null, null is returned.
      *
      * @param vec the vector to add to this vector (unaffected unless it is <code>this</code>)
      *     or null for none
-     * @return this (modified) or null
+     * @return the (modified) current instance or null
      */
     public Vector3f addLocal(Vector3f vec) {
         if (null == vec) {
@@ -223,13 +223,13 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Adds the provided offsets to this vector, creating a
-     * new vector that is then returned. The current instance is unaffected.
+     * Adds the provided offsets to this vector and returns the sum as a
+     * new instance. The current instance is unaffected.
      *
      * @param addX the amount to add to the X component
      * @param addY the amount to add to the Y component
      * @param addZ the amount to add to the Z component
-     * @return the result vector.
+     * @return a new Vector3f
      */
     public Vector3f add(float addX, float addY, float addZ) {
         return new Vector3f(x + addX, y + addY, z + addZ);
@@ -237,12 +237,13 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Adds the provided offsets to this vector
-     * internally and returns a handle to this (modified) vector for chaining.
+     * internally and returns the (modified) current
+     * instance.
      *
      * @param addX the amount to add to the X component
      * @param addY the amount to add to the Y component
      * @param addZ the amount to add to the Z component
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f addLocal(float addX, float addY, float addZ) {
         x += addX;
@@ -252,13 +253,13 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector by a scalar, then adds the
-     * given Vector3f.
+     * Multiplies this vector by a scalar, adds the
+     * given Vector3f, and returns the (modified) current instance.
      *
      * @param scalar
      *            the value to multiply this vector by.
      * @param add the value to add (not null)
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f scaleAdd(float scalar, Vector3f add) {
         x = x * scalar + add.x;
@@ -276,7 +277,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *     <code>this</code>)
      * @param add the vector to add (not null, unaffected unless it is
      *     <code>this</code>)
-     * @return this
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f scaleAdd(float scalar, Vector3f mult, Vector3f add) {
         this.x = mult.x * scalar + add.x;
@@ -321,7 +322,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *     <code>result</code>)
      * @param result
      *            the vector to store the cross product result, or null for a new Vector3f
-     * @return result, after receiving the cross product vector.
+     * @return the product (either <code>result</code> or a new Vector3f)
      */
     public Vector3f cross(Vector3f v, Vector3f result) {
         return cross(v.x, v.y, v.z, result);
@@ -337,7 +338,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * @param otherZ the Z component of the right factor
      * @param result
      *            the vector to store the product, or null for a new Vector3f
-     * @return result, after receiving the cross product (either <code>result</code> or a new Vector3f)
+     * @return the product (either <code>result</code> or a new Vector3f)
      */
     public Vector3f cross(float otherX, float otherY, float otherZ, Vector3f result) {
         if (result == null) {
@@ -351,12 +352,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the cross product of this vector
-     * with a parameter vector v.
+     * Calculates the cross product of this vector with a parameter vector v and returns
+     * the (modified) current instance.
      *
      * @param v the right factor (not null, unaffected unless it is
      *     <code>this</code>)
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f crossLocal(Vector3f v) {
         return crossLocal(v.x, v.y, v.z);
@@ -364,12 +365,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Calculates the cross product of this vector
-     * with a parameter vector v.
+     * with a parameter vector v and returns the (modified) current instance.
      *
      * @param otherX the X component of the right factor
      * @param otherY the Y component of the right factor
      * @param otherZ the Z component of the right factor
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f crossLocal(float otherX, float otherY, float otherZ) {
         float tempx = (y * otherZ) - (z * otherY);
@@ -381,11 +382,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Projects this vector onto another vector. The current instance is
+     * Projects this vector onto another vector and returns the result. The current instance is
      * unaffected.
      *
      * @param other The vector to project this vector onto (not null, unaffected)
-     * @return A new vector with the projection result
+     * @return a new Vector3f
      */
     public Vector3f project(Vector3f other) {
         float n = this.dot(other); // A . B
@@ -398,7 +399,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * vector.
      *
      * @param other The vector to project this vector onto (not null)
-     * @return This Vector3f (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f projectLocal(Vector3f other) {
         float n = this.dot(other); // A . B
@@ -464,7 +465,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Calculates the distance between this vector and
+     * Returns the distance between this vector and
      * vector v. The current instance is unaffected.
      *
      * @param v the second vector to determine the distance (not null, unaffected)
@@ -486,8 +487,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector by a scalar. The resultant
-     * vector is returned. The current instance is unaffected.
+     * Multiplies this vector by a scalar and returns the product as a new
+     * instance. The current instance is unaffected.
      *
      * @param scalar
      *            the value to multiply this vector by.
@@ -518,12 +519,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies this vector by a scalar internally,
-     * and returns a handle to this (modified) vector for chaining.
+     * Multiplies this vector by a scalar internally and returns the (modified) current
+     * instance.
      *
      * @param scalar
      *            the value to multiply this vector by.
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f multLocal(float scalar) {
         x *= scalar;
@@ -533,8 +534,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies a provided vector component-wise by this vector
-     * internally, and returns a handle to this (modified) vector for chaining.
+     * Multiplies a provided vector component-wise by this vector internally and returns
+     * the (modified) current instance.
      * If the provided vector is null, null is returned.
      *
      * @param vec the vector to mult to this vector (unaffected unless it is <code>this</code>)
@@ -554,12 +555,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Multiplies this vector component-wise by 3 scalars
-     * internally, and returns a handle to this (modified) vector for chaining.
+     * internally, and returns the (modified) current instance.
      *
      * @param x the scale factor for the X component
      * @param y the scale factor for the Y component
      * @param z the scale factor for the Z component
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f multLocal(float x, float y, float z) {
         this.x *= x;
@@ -569,8 +570,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Multiplies a provided vector component-wise with
-     * this vector and returns a handle to this vector for chaining.
+     * Multiplies a provided vector component-wise with this vector and returns the
+     * product as a new instance.
      * If the provided vector is null, null is returned.
      * Either way, the current instance is unaffected.
      *
@@ -609,8 +610,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides the vector by a scalar and
-     * returns the result. The current instance remains untouched.
+     * Divides the vector by a scalar and returns the quotient as a new
+     * instance. The current instance remains untouched.
      *
      * @param scalar
      *            the value to divide this vectors attributes by.
@@ -622,12 +623,12 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Divides this vector by a scalar internally
-     * and returns a handle to this (modified) vector for chaining.
+     * Divides this vector by a scalar internally and returns the (modified) current
+     * instance.
      *
      * @param scalar
      *            the value to divide this vector by.
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f divideLocal(float scalar) {
         scalar = 1f / scalar;
@@ -639,21 +640,21 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Divides this vector component-wise by the argument and
-     * returns the result. The current instance remains untouched.
+     * returns the quotient as a new instance. The current instance remains untouched.
      *
      * @param scalar the divisor (not null, unaffected) TODO rename argument!
-     * @return the result <code>Vector</code>.
+     * @return a new Vector3f
      */
     public Vector3f divide(Vector3f scalar) {
         return new Vector3f(x / scalar.x, y / scalar.y, z / scalar.z);
     }
 
     /**
-     * Divides this vector component-wise by a vector internally,
-     * and returns a handle to this (modified) vector for chaining.
+     * Divides this vector component-wise by a vector internally, and returns the
+     * (modified) current instance.
      *
      * @param scalar the divisor (not null) TODO rename argument!
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f divideLocal(Vector3f scalar) {
         x /= scalar.x;
@@ -673,9 +674,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Negates the components of this vector.
+     * Negates the components of this vector and returns the (modified) current instance.
      *
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f negateLocal() {
         x = -x;
@@ -685,24 +686,23 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the given vector from this vector creating a new vector object.
-     * The current instance is unaffected.
+     * Subtracts the given vector from this vector and returns the difference as a
+     * new instance. The current instance is unaffected.
      *
      * @param vec the vector to subtract from this vector (not null, unaffected)
-     * @return the result vector.
+     * @return a new Vector3f
      */
     public Vector3f subtract(Vector3f vec) {
         return new Vector3f(x - vec.x, y - vec.y, z - vec.z);
     }
 
     /**
-     * Subtracts a provided vector to this vector
-     * internally and returns a handle to this (modified) vector for chaining.
-     * If the provided vector is null, null is returned.
+     * Subtracts a provided vector to this vector internally and returns the (modified)
+     * current instance. If the provided vector is null, null is returned.
      *
      * @param vec the vector to subtract (unaffected unless it is
      *     <code>this</code>) or null for none
-     * @return this (modified) or null
+     * @return the (modified) current instance or null
      */
     public Vector3f subtractLocal(Vector3f vec) {
         if (null == vec) {
@@ -724,7 +724,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *     <code>result</code>)
      * @param result
      *            the vector to store the result in, or null for a new Vector3f
-     * @return result or a new Vector3f
+     * @return either <code>result</code> or a new Vector3f
      */
     public Vector3f subtract(Vector3f vec, Vector3f result) {
         if (result == null) {
@@ -737,26 +737,26 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Subtracts the provided values from this vector,
-     * creating a new vector that is then returned. The current instance is unaffected.
+     * Subtracts the provided values from this vector and returns the
+     * difference as a new instance. The current instance is unaffected.
      *
      * @param subtractX the amount to subtract from the X component
      * @param subtractY the amount to subtract from the Y component
      * @param subtractZ the amount to subtract from the Z component
-     * @return the result vector.
+     * @return a new Vector3f
      */
     public Vector3f subtract(float subtractX, float subtractY, float subtractZ) {
         return new Vector3f(x - subtractX, y - subtractY, z - subtractZ);
     }
 
     /**
-     * Subtracts the provided values from this vector
-     * internally and returns a handle to this (modified) vector for chaining.
+     * Subtracts the provided values from this vector internally and returns the
+     * (modified) current instance.
      *
      * @param subtractX the amount to subtract from the X component
      * @param subtractY the amount to subtract from the Y component
      * @param subtractZ the amount to subtract from the Z component
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f subtractLocal(float subtractX, float subtractY, float subtractZ) {
         x -= subtractX;
@@ -770,7 +770,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * instance. If the vector has length=0, a clone is returned. Either way,
      * the current instance is unaffected.
      *
-     * @return unit vector of this vector.
+     * @return a new Vector3f
      */
     public Vector3f normalize() {
 //        float length = length();
@@ -791,7 +791,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Normalizes the vector to length=1 and returns the (modified) current
      * instance. If the vector has length=0, it is unchanged.
      *
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f normalizeLocal() {
         // NOTE: this implementation is more optimized
@@ -809,11 +809,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Computes the maximum value for each
-     * component in this and <code>other</code> vector. The result is stored
-     * in this vector.
+     * component in this and <code>other</code> vector and returns the (modified) current
+     * instance.
      *
      * @param other the vector to compare with (not null, unaffected)
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f maxLocal(Vector3f other) {
         x = other.x > x ? other.x : x;
@@ -824,11 +824,11 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
 
     /**
      * Computes the minimum value for each
-     * component in this and <code>other</code> vector. The result is stored
-     * in this vector.
+     * component in this and <code>other</code> vector and returns the (modified) current
+     * instance.
      *
      * @param other the vector to compare with (not null, unaffected)
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f minLocal(Vector3f other) {
         x = other.x < x ? other.x : x;
@@ -840,7 +840,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Resets this vector's components to zero.
      *
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f zero() {
         x = y = z = 0;
@@ -869,7 +869,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * @param finalVec the desired value when changeAmnt=1 (not null, unaffected)
      * @param changeAmnt the fractional change amount
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f interpolateLocal(Vector3f finalVec, float changeAmnt) {
         this.x = (1 - changeAmnt) * this.x + changeAmnt * finalVec.x;
@@ -889,7 +889,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * @param finalVec the desired value when changeAmnt=1 (not null, unaffected
      *     unless it's this)
      * @param changeAmnt the fractional change amount
-     * @return this (modified)
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f interpolateLocal(Vector3f beginVec, Vector3f finalVec, float changeAmnt) {
         this.x = (1 - changeAmnt) * beginVec.x + changeAmnt * finalVec.x;
@@ -903,7 +903,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * return false.  Else return true.
      *
      * @param vector the vector to check (unaffected)
-     * @return true or false as stated above.
+     * @return if non-null and finite, otherwise false
      */
     public static boolean isValidVector(Vector3f vector) {
         if (vector == null) {
@@ -955,7 +955,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Creates a copy of this vector. The current instance is unaffected.
      *
-     * @return a new instance, equivalent to this one
+     * @return a new instance, equivalent to the current one
      */
     @Override
     public Vector3f clone() {
@@ -972,7 +972,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      *
      * @param floats storage for the components (must have length&ge;3. If null, a new float[3] is
      *            created.
-     * @return an array, with X, Y, Z float components in that order (either <code>floats</code> or a new float[3])
+     * @return an array containing the X, Y, and Z in that order
+     *     (either <code>floats</code> or a new float[3])
      */
     public float[] toArray(float[] floats) {
         if (floats == null) {
@@ -989,7 +990,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * from 0. The current instance is unaffected.
      *
      * @param o the object to compare for equality (may be null, unaffected)
-     * @return true if they are equal
+     * @return true if equal, otherwise false
      */
     @Override
     public boolean equals(Object o) {
@@ -1099,9 +1100,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Determines the X component of this vector. The vector is unaffected.
+     * Returns the X component of this vector. The vector is unaffected.
      *
-     * @return the X component
+     * @return the value of the {@link #x} component
      */
     public float getX() {
         return x;
@@ -1111,7 +1112,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Alters the X component of this vector.
      *
      * @param x the desired value
-     * @return this vector, modified
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f setX(float x) {
         this.x = x;
@@ -1119,9 +1120,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Determines the Y component of this vector. The vector is unaffected.
+     * Returns the Y component of this vector. The vector is unaffected.
      *
-     * @return the Y component
+     * @return the value of the {@link #y} component
      */
     public float getY() {
         return y;
@@ -1131,7 +1132,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Alters the Y component of this vector.
      *
      * @param y the desired value
-     * @return this vector, modified
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f setY(float y) {
         this.y = y;
@@ -1139,9 +1140,9 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * Determines the Z component of this vector. The vector is unaffected.
+     * Returns the Z component of this vector. The vector is unaffected.
      *
-     * @return the Z component
+     * @return z the value of the {@link #z} component
      */
     public float getZ() {
         return z;
@@ -1151,7 +1152,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Alters the Z component of this vector.
      *
      * @param z the desired value
-     * @return this vector, modified
+     * @return the (modified) current instance (for chaining)
      */
     public Vector3f setZ(float z) {
         this.z = z;
@@ -1162,7 +1163,8 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Returns the indexed component. The vector is unaffected.
      *
      * @param index 0, 1, or 2
-     * @return the X component if index == 0, the Y component if index == 1 or the Z component if index == 2
+     * @return the X component if index=0, the Y component if index=1, or the Z
+     *     component if index=2
      * @throws IllegalArgumentException
      *             if index is not one of 0, 1, 2.
      */


### PR DESCRIPTION
`Vector3f` may be the most crucial class for newcomers to learn, but unfortunately its javadoc is often vague, inconsistent, or even misleading.

This PR tries to raise the javadoc to a higher standard:
+ explicitly indicate which methods modify the current instance and which arguments are modified
+ explicitly indicate which methods return a new instance and which can return null
+ document which arguments cannot be null and what effect null arguments have
+ consistently refer to X, Y, and Z as "components" instead of "values" or "fields"
+ in cross-product methods, distinguish the right factor from the left factor
+ don't refer to calculations that modify the current instance as "internal"
+ don't refer to a fraction as a "percentage"
+ don't constantly tout the benefits of chaining