### PR TITLE
fix issue #1686 (jmeClone() return types)

### DIFF
--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/BetterCharacterControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/BetterCharacterControl.java
@@ -714,7 +714,7 @@ public class BetterCharacterControl extends AbstractPhysicsControl implements Ph
      * @return a new control (not null)
      */
     @Override
-    public Object jmeClone() {
+    public BetterCharacterControl jmeClone() {
         BetterCharacterControl control = new BetterCharacterControl(radius, height, mass);
         control.setJumpForce(jumpForce);
         control.spatial = this.spatial;

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/CharacterControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/CharacterControl.java
@@ -98,7 +98,7 @@ public class CharacterControl extends PhysicsCharacter implements PhysicsControl
     }
 
     @Override
-    public Object jmeClone() {
+    public CharacterControl jmeClone() {
         CharacterControl control = new CharacterControl(collisionShape, stepHeight);
         control.setCcdMotionThreshold(getCcdMotionThreshold());
         control.setCcdSweptSphereRadius(getCcdSweptSphereRadius());

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/GhostControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/GhostControl.java
@@ -162,7 +162,7 @@ public class GhostControl extends PhysicsGhostObject implements PhysicsControl, 
      * @return a new control (not null)
      */
     @Override
-    public Object jmeClone() {
+    public GhostControl jmeClone() {
         GhostControl control = new GhostControl(collisionShape);
         control.setCcdMotionThreshold(getCcdMotionThreshold());
         control.setCcdSweptSphereRadius(getCcdSweptSphereRadius());

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/KinematicRagdollControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/KinematicRagdollControl.java
@@ -1112,7 +1112,7 @@ public class KinematicRagdollControl extends AbstractPhysicsControl implements P
      * @return a new control (not null)
      */
     @Override   
-    public Object jmeClone() {
+    public KinematicRagdollControl jmeClone() {
         KinematicRagdollControl control = new KinematicRagdollControl(preset, weightThreshold);        
         control.setMode(mode);
         control.setRootMass(rootMass);

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/RigidBodyControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/RigidBodyControl.java
@@ -142,7 +142,7 @@ public class RigidBodyControl extends PhysicsRigidBody implements PhysicsControl
      * @return a new control (not null)
      */
     @Override   
-    public Object jmeClone() {
+    public RigidBodyControl jmeClone() {
         RigidBodyControl control = new RigidBodyControl(collisionShape, mass);
         control.setAngularFactor(getAngularFactor());
         control.setAngularSleepingThreshold(getAngularSleepingThreshold());

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/VehicleControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/VehicleControl.java
@@ -160,7 +160,7 @@ public class VehicleControl extends PhysicsVehicle implements PhysicsControl, Jm
      * @return a new control (not null)
      */
     @Override
-    public Object jmeClone() {
+    public VehicleControl jmeClone() {
         VehicleControl control = new VehicleControl(collisionShape, mass);
         control.setAngularFactor(getAngularFactor());
         control.setAngularSleepingThreshold(getAngularSleepingThreshold());

--- a/jme3-core/src/main/java/com/jme3/anim/AnimClip.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AnimClip.java
@@ -112,9 +112,9 @@ public class AnimClip implements JmeCloneable, Savable {
      * @return a new instance
      */
     @Override
-    public Object jmeClone() {
+    public AnimClip jmeClone() {
         try {
-            return super.clone();
+            return (AnimClip) super.clone();
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException("Error cloning", e);
         }

--- a/jme3-core/src/main/java/com/jme3/anim/AnimComposer.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AnimComposer.java
@@ -476,7 +476,7 @@ public class AnimComposer extends AbstractControl {
      * @return a new instance
      */
     @Override
-    public Object jmeClone() {
+    public AnimComposer jmeClone() {
         try {
             AnimComposer clone = (AnimComposer) super.clone();
             return clone;

--- a/jme3-core/src/main/java/com/jme3/anim/AnimLayer.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AnimLayer.java
@@ -231,7 +231,7 @@ public class AnimLayer implements JmeCloneable {
     }
 
     @Override
-    public Object jmeClone() {
+    public AnimLayer jmeClone() {
         try {
             AnimLayer clone = (AnimLayer) super.clone();
             return clone;

--- a/jme3-core/src/main/java/com/jme3/anim/Armature.java
+++ b/jme3-core/src/main/java/com/jme3/anim/Armature.java
@@ -276,7 +276,7 @@ public class Armature implements JmeCloneable, Savable {
     }
 
     @Override
-    public Object jmeClone() {
+    public Armature jmeClone() {
         try {
             Armature clone = (Armature) super.clone();
             return clone;

--- a/jme3-core/src/main/java/com/jme3/anim/Joint.java
+++ b/jme3-core/src/main/java/com/jme3/anim/Joint.java
@@ -444,7 +444,7 @@ public class Joint implements Savable, JmeCloneable, HasLocalTransform {
      * @return a new instance
      */
     @Override
-    public Object jmeClone() {
+    public Joint jmeClone() {
         try {
             Joint clone = (Joint) super.clone();
             return clone;

--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -283,7 +283,7 @@ public class MorphTrack implements AnimTrack<float[]> {
     }
 
     @Override
-    public Object jmeClone() {
+    public MorphTrack jmeClone() {
         try {
             MorphTrack clone = (MorphTrack) super.clone();
             return clone;

--- a/jme3-core/src/main/java/com/jme3/anim/SkinningControl.java
+++ b/jme3-core/src/main/java/com/jme3/anim/SkinningControl.java
@@ -356,8 +356,8 @@ public class SkinningControl extends AbstractControl implements Cloneable, JmeCl
     }
 
     @Override
-    public Object jmeClone() {
-        return super.jmeClone();
+    public SkinningControl jmeClone() {
+        return (SkinningControl) super.jmeClone();
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/animation/AnimControl.java
+++ b/jme3-core/src/main/java/com/jme3/animation/AnimControl.java
@@ -110,7 +110,7 @@ public final class AnimControl extends AbstractControl implements Cloneable, Jme
     }
 
     @Override   
-    public Object jmeClone() {
+    public AnimControl jmeClone() {
         AnimControl clone = (AnimControl) super.jmeClone();
         clone.channels = new ArrayList<AnimChannel>();
         clone.listeners = new ArrayList<AnimEventListener>();

--- a/jme3-core/src/main/java/com/jme3/animation/Animation.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Animation.java
@@ -214,9 +214,9 @@ public class Animation implements Savable, Cloneable, JmeCloneable {
     }
 
     @Override   
-    public Object jmeClone() {
+    public Animation jmeClone() {
         try {
-            return super.clone();
+            return (Animation) super.clone();
         } catch( CloneNotSupportedException e ) {
             throw new RuntimeException("Error cloning", e);
         }

--- a/jme3-core/src/main/java/com/jme3/animation/AudioTrack.java
+++ b/jme3-core/src/main/java/com/jme3/animation/AudioTrack.java
@@ -198,9 +198,9 @@ public class AudioTrack implements ClonableTrack {
     }
 
     @Override   
-    public Object jmeClone() {
+    public AudioTrack jmeClone() {
         try {
-            return super.clone();
+            return (AudioTrack) super.clone();
         } catch( CloneNotSupportedException e ) {
             throw new RuntimeException("Error cloning", e);
         }

--- a/jme3-core/src/main/java/com/jme3/animation/Bone.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Bone.java
@@ -180,7 +180,7 @@ public final class Bone implements Savable, JmeCloneable {
     }
     
     @Override   
-    public Object jmeClone() {
+    public Bone jmeClone() {
         try {
             Bone clone = (Bone)super.clone();
             return clone;

--- a/jme3-core/src/main/java/com/jme3/animation/CompactArray.java
+++ b/jme3-core/src/main/java/com/jme3/animation/CompactArray.java
@@ -278,9 +278,9 @@ public abstract class CompactArray<T> implements JmeCloneable {
      * @return a new array
      */
     @Override
-    public Object jmeClone() {
+    public CompactArray jmeClone() {
         try {
-            return super.clone();
+            return (CompactArray) super.clone();
         } catch (CloneNotSupportedException exception) {
             throw new RuntimeException("Can't clone array", exception);
         }

--- a/jme3-core/src/main/java/com/jme3/animation/EffectTrack.java
+++ b/jme3-core/src/main/java/com/jme3/animation/EffectTrack.java
@@ -115,7 +115,7 @@ public class EffectTrack implements ClonableTrack {
         }
 
         @Override
-        public Object jmeClone() {
+        public KillParticleControl jmeClone() {
             KillParticleControl c = new KillParticleControl();
             //this control should be removed as it shouldn't have been persisted in the first place
             //In the quest to find the less hackish solution to achieve this,
@@ -285,9 +285,9 @@ public class EffectTrack implements ClonableTrack {
     }
 
     @Override
-    public Object jmeClone() {
+    public EffectTrack jmeClone() {
         try {
-            return super.clone();
+            return (EffectTrack) super.clone();
         } catch( CloneNotSupportedException e ) {
             throw new RuntimeException("Error cloning", e);
         }

--- a/jme3-core/src/main/java/com/jme3/animation/Skeleton.java
+++ b/jme3-core/src/main/java/com/jme3/animation/Skeleton.java
@@ -125,7 +125,7 @@ public final class Skeleton implements Savable, JmeCloneable {
     }
 
     @Override   
-    public Object jmeClone() {
+    public Skeleton jmeClone() {
         try {
             Skeleton clone = (Skeleton)super.clone();
             return clone;

--- a/jme3-core/src/main/java/com/jme3/animation/SkeletonControl.java
+++ b/jme3-core/src/main/java/com/jme3/animation/SkeletonControl.java
@@ -352,8 +352,8 @@ public class SkeletonControl extends AbstractControl implements Cloneable, JmeCl
     }
 
     @Override   
-    public Object jmeClone() {
-        return super.jmeClone();
+    public SkeletonControl jmeClone() {
+        return (SkeletonControl) super.jmeClone();
     }     
 
     @Override   

--- a/jme3-core/src/main/java/com/jme3/animation/TrackInfo.java
+++ b/jme3-core/src/main/java/com/jme3/animation/TrackInfo.java
@@ -77,9 +77,9 @@ public class TrackInfo implements Savable, JmeCloneable {
     }
     
     @Override   
-    public Object jmeClone() {
+    public TrackInfo jmeClone() {
         try {
-            return super.clone();
+            return (TrackInfo) super.clone();
         } catch( CloneNotSupportedException e ) {
             throw new RuntimeException("Error cloning", e);
         }

--- a/jme3-core/src/main/java/com/jme3/cinematic/events/MotionEvent.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/events/MotionEvent.java
@@ -291,7 +291,7 @@ public class MotionEvent extends AbstractCinematicEvent implements Control, JmeC
     }
 
     @Override   
-    public Object jmeClone() {
+    public MotionEvent jmeClone() {
         MotionEvent control = new MotionEvent();
         control.path = path;
         control.playState = playState;

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -128,9 +128,9 @@ public class ParticleEmitter extends Geometry {
         }
 
         @Override
-        public Object jmeClone() {
+        public ParticleEmitterControl jmeClone() {
             try {
-                return super.clone();
+                return (ParticleEmitterControl) super.clone();
             } catch( CloneNotSupportedException e ) {
                 throw new RuntimeException("Error cloning", e);
             }

--- a/jme3-core/src/main/java/com/jme3/effect/influencers/DefaultParticleInfluencer.java
+++ b/jme3-core/src/main/java/com/jme3/effect/influencers/DefaultParticleInfluencer.java
@@ -114,9 +114,9 @@ public class DefaultParticleInfluencer implements ParticleInfluencer {
      *  Called internally by com.jme3.util.clone.Cloner.  Do not call directly.
      */
     @Override
-    public Object jmeClone() {
+    public DefaultParticleInfluencer jmeClone() {
         try {
-            return super.clone();
+            return (DefaultParticleInfluencer) super.clone();
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
         }

--- a/jme3-core/src/main/java/com/jme3/effect/influencers/EmptyParticleInfluencer.java
+++ b/jme3-core/src/main/java/com/jme3/effect/influencers/EmptyParticleInfluencer.java
@@ -89,9 +89,9 @@ public class EmptyParticleInfluencer implements ParticleInfluencer {
      *  Called internally by com.jme3.util.clone.Cloner.  Do not call directly.
      */
     @Override
-    public Object jmeClone() {
+    public EmptyParticleInfluencer jmeClone() {
         try {
-            return super.clone();
+            return (EmptyParticleInfluencer) super.clone();
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
         }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterBoxShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterBoxShape.java
@@ -91,9 +91,9 @@ public class EmitterBoxShape implements EmitterShape {
      *  Called internally by com.jme3.util.clone.Cloner.  Do not call directly.
      */
     @Override
-    public Object jmeClone() {
+    public EmitterBoxShape jmeClone() {
         try {
-            return super.clone();
+            return (EmitterBoxShape) super.clone();
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
         }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshVertexShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshVertexShape.java
@@ -173,9 +173,9 @@ public class EmitterMeshVertexShape implements EmitterShape {
      *  Called internally by com.jme3.util.clone.Cloner.  Do not call directly.
      */
     @Override
-    public Object jmeClone() {
+    public EmitterMeshVertexShape jmeClone() {
         try {
-            return super.clone();
+            return (EmitterMeshVertexShape) super.clone();
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
         }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterPointShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterPointShape.java
@@ -64,9 +64,9 @@ public class EmitterPointShape implements EmitterShape {
      *  Called internally by com.jme3.util.clone.Cloner.  Do not call directly.
      */
     @Override
-    public Object jmeClone() {
+    public EmitterPointShape jmeClone() {
         try {
-            return super.clone();
+            return (EmitterPointShape) super.clone();
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
         }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
@@ -76,9 +76,9 @@ public class EmitterSphereShape implements EmitterShape {
      *  Called internally by com.jme3.util.clone.Cloner.  Do not call directly.
      */
     @Override
-    public Object jmeClone() {
+    public EmitterSphereShape jmeClone() {
         try {
-            return super.clone();
+            return (EmitterSphereShape) super.clone();
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
         }

--- a/jme3-core/src/main/java/com/jme3/input/ChaseCamera.java
+++ b/jme3-core/src/main/java/com/jme3/input/ChaseCamera.java
@@ -605,7 +605,7 @@ public class ChaseCamera implements ActionListener, AnalogListener, Control, Jme
     }
 
     @Override
-    public Object jmeClone() {
+    public ChaseCamera jmeClone() {
         ChaseCamera cc = new ChaseCamera(cam, inputManager);
         cc.target = target;
         cc.setMaxDistance(getMaxDistance());

--- a/jme3-core/src/main/java/com/jme3/scene/control/AbstractControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/AbstractControl.java
@@ -97,9 +97,9 @@ public abstract class AbstractControl implements Control, JmeCloneable {
     }
 
     @Override
-    public Object jmeClone() {
+    public AbstractControl jmeClone() {
         try {
-            return super.clone();
+            return (AbstractControl) super.clone();
         } catch( CloneNotSupportedException e ) {
             throw new RuntimeException( "Can't clone control for spatial", e );
         }

--- a/jme3-core/src/main/java/com/jme3/scene/control/LodControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/LodControl.java
@@ -141,7 +141,7 @@ public class LodControl extends AbstractControl implements Cloneable, JmeCloneab
     }
 
     @Override
-    public Object jmeClone() {
+    public LodControl jmeClone() {
         LodControl clone = (LodControl)super.jmeClone();
         clone.lastDistance = 0;
         clone.lastLevel = 0;

--- a/jme3-core/src/main/java/com/jme3/scene/control/UpdateControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/UpdateControl.java
@@ -89,7 +89,7 @@ public class UpdateControl extends AbstractControl {
     }
 
     @Override
-    public Object jmeClone() {
+    public UpdateControl jmeClone() {
         UpdateControl clone = (UpdateControl)super.jmeClone();
         clone.taskQueue = new ConcurrentLinkedQueue<>();
         

--- a/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedNode.java
+++ b/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedNode.java
@@ -105,9 +105,9 @@ public class InstancedNode extends GeometryGroupNode {
         }
 
         @Override
-        public Object jmeClone() {
+        public InstanceTypeKey jmeClone() {
             try {
-                return super.clone();
+                return (InstanceTypeKey) super.clone();
             } catch( CloneNotSupportedException e ) {
                 throw new AssertionError();
             }
@@ -138,9 +138,9 @@ public class InstancedNode extends GeometryGroupNode {
         }
 
         @Override
-        public Object jmeClone() {
+        public InstancedNodeControl jmeClone() {
             try {
-                return super.clone();
+                return (InstancedNodeControl) super.clone();
             } catch( CloneNotSupportedException e ) {
                 throw new RuntimeException("Error cloning control", e);
             }

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowRenderer.java
@@ -820,9 +820,9 @@ public abstract class AbstractShadowRenderer implements SceneProcessor, Savable,
     }
 
     @Override
-    public Object jmeClone() {
+    public AbstractShadowRenderer jmeClone() {
         try {
-            return super.clone();
+            return (AbstractShadowRenderer) super.clone();
         } catch (final CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }

--- a/jme3-core/src/main/java/com/jme3/util/IntMap.java
+++ b/jme3-core/src/main/java/com/jme3/util/IntMap.java
@@ -100,9 +100,10 @@ public final class IntMap<T> implements Iterable<Entry<T>>, Cloneable, JmeClonea
      *  Called internally by com.jme3.util.clone.Cloner.  Do not call directly.
      */
     @Override
-    public Object jmeClone() {
+    @SuppressWarnings("unchecked")
+    public IntMap<T> jmeClone() {
         try {
-            return super.clone();
+            return (IntMap<T>) super.clone();
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
         }
@@ -337,9 +338,10 @@ public final class IntMap<T> implements Iterable<Entry<T>>, Cloneable, JmeClonea
         }
 
         @Override
-        public Object jmeClone() {
+        @SuppressWarnings("unchecked")
+        public Entry<T> jmeClone() {
             try {
-                return super.clone();
+                return (Entry<T>) super.clone();
             } catch (CloneNotSupportedException ex) {
                 throw new AssertionError();
             }

--- a/jme3-core/src/main/java/com/jme3/util/clone/JmeCloneable.java
+++ b/jme3-core/src/main/java/com/jme3/util/clone/JmeCloneable.java
@@ -77,7 +77,7 @@ public interface JmeCloneable extends Cloneable {
      *
      * @return a new instance
      */
-    public Object jmeClone();     
+    public JmeCloneable jmeClone();     
 
     /**
      *  Implemented to perform deep cloning for this object, resolving

--- a/jme3-effects/src/main/java/com/jme3/water/WaterFilter.java
+++ b/jme3-effects/src/main/java/com/jme3/water/WaterFilter.java
@@ -1309,9 +1309,9 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
     }
 
     @Override
-    public Object jmeClone() {
+    public WaterFilter jmeClone() {
         try {
-            return super.clone();
+            return (WaterFilter) super.clone();
         } catch (final CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }

--- a/jme3-examples/src/main/java/jme3test/bullet/PhysicsHoverControl.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/PhysicsHoverControl.java
@@ -103,7 +103,7 @@ public class PhysicsHoverControl extends PhysicsVehicle implements PhysicsContro
     }
 
     @Override   
-    public Object jmeClone() {
+    public PhysicsHoverControl jmeClone() {
         throw new UnsupportedOperationException("Not yet implemented.");
     }     
 

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/NormalRecalcControl.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/NormalRecalcControl.java
@@ -71,7 +71,7 @@ public class NormalRecalcControl extends AbstractControl {
      *  Called internally by com.jme3.util.clone.Cloner.  Do not call directly.
      */
     @Override
-    public Object jmeClone() {
+    public NormalRecalcControl jmeClone() {
         NormalRecalcControl control = (NormalRecalcControl)super.jmeClone();
         control.setEnabled(true);
         return control;

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainLodControl.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainLodControl.java
@@ -386,9 +386,9 @@ public class TerrainLodControl extends AbstractControl {
     }
 
     @Override
-    public Object jmeClone() {
+    public TerrainLodControl jmeClone() {
         try {
-            return super.clone();
+            return (TerrainLodControl) super.clone();
         } catch (final CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This is riskier than #1683. For one thing, it affects many commonly extended classes including `BetterCharacterControl` and `AbstractControl`.  Also, it modifies the `JmeCloneable` interface itself.