### PR TITLE
correct typos in Java comments and javadoc

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/tween/Tween.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/Tween.java
@@ -43,7 +43,7 @@ public interface Tween extends Cloneable {
     /**
      * Returns the length of the tween.  If 't' represents time in
      * seconds then this is the notional time in seconds that the tween
-     * will run.  Note: all of the caveats are because tweens may be
+     * will run.  Note: all the caveats are because tweens may be
      * externally scaled in such a way that 't' no longer represents
      * actual time.
      *

--- a/jme3-core/src/main/java/com/jme3/anim/tween/Tweens.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/Tweens.java
@@ -409,7 +409,7 @@ public class Tweens {
             this.length = length;
 
             // Caller desires delegate to be 'length' instead of
-            // its actual length so we will calculate a time scale
+            // its actual length, so we will calculate a time scale.
             // If the desired length is longer than delegate's then
             // we need to feed time in slower, ie: scale < 1
             if (length != 0) {
@@ -538,7 +538,7 @@ public class Tweens {
             }
             this.method.setAccessible(true);
 
-            // So now setup the real args list
+            // So now set up the real args list.
             this.args = new Object[args.length + 1];
             if (tIndex == 0) {
                 for (int i = 0; i < args.length; i++) {
@@ -572,7 +572,7 @@ public class Tweens {
                     continue;
                 }
 
-                // We accept the 't' parameter as either first or last
+                // We accept the 't' parameter as either first or last,
                 // so we'll see which one matches.
                 if (isFloatType(paramTypes[0]) || isDoubleType(paramTypes[0])) {
                     // Try it as the first parameter 

--- a/jme3-core/src/main/java/com/jme3/app/StatsView.java
+++ b/jme3-core/src/main/java/com/jme3/app/StatsView.java
@@ -113,7 +113,7 @@ public class StatsView extends Node implements Control, JmeCloneable {
 
         // Moved to ResetStatsState to make sure it is
         // done even if there is no StatsView or the StatsView
-        // is disable.
+        // is disabled.
         //statistics.clearFrame();
     }
 

--- a/jme3-core/src/main/java/com/jme3/collision/SweepSphere.java
+++ b/jme3-core/src/main/java/com/jme3/collision/SweepSphere.java
@@ -34,7 +34,7 @@ package com.jme3.collision;
 import com.jme3.math.*;
 
 /**
- * No longer public ..
+ * No longer public.
  *
  * @author Kirill Vainer
  */

--- a/jme3-core/src/main/java/com/jme3/light/SpotLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/SpotLight.java
@@ -46,17 +46,17 @@ import com.jme3.util.TempVars;
 import java.io.IOException;
 
 /**
- * Represents a spot light.
- * A spot light emits a cone of light from a position and in a direction.
+ * Represents a spotlight.
+ * A spotlight emits a cone of light from a position and in a direction.
  * It can be used to fake torch lights or car's lights.
  * <p>
- * In addition to a position and a direction, spot lights also have a range which 
+ * In addition to a position and a direction, spotlights also have a range which
  * can be used to attenuate the influence of the light depending on the 
  * distance between the light and the affected object.
- * Also the angle of the cone can be tweaked by changing the spot inner angle and the spot outer angle.
- * the spot inner angle determines the cone of light where light has full influence.
- * the spot outer angle determines the cone global cone of light of the spot light.
- * the light intensity slowly decreases between the inner cone and the outer cone.
+ * Also, the angle of the cone can be tweaked by changing the spot inner angle and the spot outer angle.
+ * The spot inner angle determines the cone where light has full influence.
+ * The spot outer angle determines the global cone of light.
+ * The light intensity slowly decreases from the inner cone to the outer cone.
  *  @author Nehon
  */
 public class SpotLight extends Light {
@@ -96,7 +96,7 @@ public class SpotLight extends Light {
      * given range.
      * @param position the position in world space.
      * @param direction the direction of the light.
-     * @param range the spot light range
+     * @param range the spotlight range
      */
     public SpotLight(Vector3f position, Vector3f direction, float range) {
         this();
@@ -125,7 +125,7 @@ public class SpotLight extends Light {
      * the given range and the given color.
      * @param position the position in world space.
      * @param direction the direction of the light.
-     * @param range the spot light range
+     * @param range the spotlight range
      * @param color the light's color.
      */
     public SpotLight(Vector3f position, Vector3f direction, float range, ColorRGBA color) {
@@ -143,10 +143,10 @@ public class SpotLight extends Light {
      * 
      * @param position the position in world space.
      * @param direction the direction of the light.
-     * @param range the spot light range
+     * @param range the spotlight range
      * @param color the light's color.
-     * @param innerAngle the inner angle of the spot light.
-     * @param outerAngle the outer angle of the spot light.
+     * @param innerAngle the inner angle of the spotlight.
+     * @param outerAngle the outer angle of the spotlight.
      * 
      * @see SpotLight#setSpotInnerAngle(float) 
      * @see SpotLight#setSpotOuterAngle(float) 

--- a/jme3-core/src/main/java/com/jme3/material/TechniqueDef.java
+++ b/jme3-core/src/main/java/com/jme3/material/TechniqueDef.java
@@ -96,7 +96,7 @@ public class TechniqueDef implements Savable, Cloneable {
          * <p>
          * An array of light positions and light colors is passed to the shader
          * containing the world light list for the geometry being rendered.
-         * Also Light probes are passed to the shader.
+         * Light probes are also passed to the shader.
          */
         SinglePassAndImageBased,
 
@@ -299,7 +299,7 @@ public class TechniqueDef implements Savable, Cloneable {
 
     /**
      * Returns true if this technique should not be used to render.
-     * (eg. to not render a material with default technique)
+     * (e.g. to not render a material with default technique)
      *
      * @return true if this technique should not be rendered, false otherwise.
      *
@@ -413,7 +413,7 @@ public class TechniqueDef implements Savable, Cloneable {
      * the appropriate define on the technique will be modified as well.
      * When set, the material parameter will be mapped to an integer define, 
      * typically <code>1</code> if it is set, unless it is an integer or a float,
-     * in which case it will converted into an integer.
+     * in which case it will be converted into an integer.
      *
      * @param paramName The name of the material parameter to link to.
      * @param paramType The type of the material parameter to link to.

--- a/jme3-core/src/main/java/com/jme3/material/logic/TechniqueDefLogic.java
+++ b/jme3-core/src/main/java/com/jme3/material/logic/TechniqueDefLogic.java
@@ -60,7 +60,7 @@ public interface TechniqueDefLogic {
      * Determine the shader to use for the given geometry / material combination.
      * 
      * @param assetManager The asset manager to use for loading shader source code,
-     * shader nodes, and and lookup textures.
+     * shader nodes, and lookup textures.
      * @param renderManager The render manager for which rendering is to be performed.
      * @param rendererCaps Renderer capabilities. The returned shader must
      * support these capabilities.

--- a/jme3-core/src/main/java/com/jme3/math/Spline.java
+++ b/jme3-core/src/main/java/com/jme3/math/Spline.java
@@ -99,7 +99,7 @@ public class Spline implements Savable {
      *
      * @param splineType the type of the spline @see {SplineType}
      * @param controlPoints a list of vector to use as control points of the spline
-     * If the type of the curve is Bezier curve the control points should be provided
+     * If the curve is a Bezier curve, the control points should be provided
      * in the appropriate way. Each point 'p' describing control position in the scene
      * should be surrounded by two handler points. This applies to every point except
      * for the border points of the curve, who should have only one handle point.
@@ -407,7 +407,7 @@ public class Spline implements Savable {
     //////////// NURBS getters /////////////////////
     /**
      * This method returns the minimum nurb curve knot value. Check the nurb
-     * type before calling this method. It the curve is not of a Nurb type - NPE
+     * type before calling this method. If the curve is not of a Nurb type, an NPE
      * will be thrown.
      *
      * @return the minimum nurb curve knot value
@@ -418,7 +418,7 @@ public class Spline implements Savable {
 
     /**
      * This method returns the maximum nurb curve knot value. Check the nurb
-     * type before calling this method. It the curve is not of a Nurb type - NPE
+     * type before calling this method. If the curve is not of a Nurb type, an NPE
      * will be thrown.
      *
      * @return the maximum nurb curve knot value

--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -326,8 +326,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
             store = new Vector3f();
         }
 
-        // The author of this code should look above and take the inverse of that
-        // But for some reason, they didn't ..
+        // The author of this code should've looked above and taken the inverse of that,
+        // but for some reason, they didn't.
 //        in.subtract(translation, store).divideLocal(scale);
 //        rot.inverse().mult(store, store);
         in.subtract(translation, store);

--- a/jme3-core/src/main/java/com/jme3/math/Vector2f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector2f.java
@@ -708,7 +708,7 @@ public final class Vector2f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * are these two vectors the same? they are is they both have the same x and
+     * Are these two vectors the same? They are if they have the same x and
      * y values.
      *
      * @param o   the object to compare for equality

--- a/jme3-core/src/main/java/com/jme3/math/Vector4f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector4f.java
@@ -886,8 +886,8 @@ public final class Vector4f implements Savable, Cloneable, java.io.Serializable 
     }
 
     /**
-     * are these two vectors the same? they are is they both have the same x,y,
-     * and z values.
+     * Are these two vectors the same? They are if they have the same x, y,
+     * z, and w values.
      *
      * @param o   the object to compare for equality
      * @return true if they are equal

--- a/jme3-core/src/main/java/com/jme3/renderer/ViewPort.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/ViewPort.java
@@ -294,7 +294,7 @@ public class ViewPort {
      * Sets the output framebuffer for the ViewPort.
      *
      * <p>The output framebuffer specifies where the scenes attached
-     * to this ViewPort are rendered to. By default this is <code>null</code>
+     * to this ViewPort are rendered to. By default, this is <code>null</code>,
      * which indicates the scenes are rendered to the display window.
      *
      * @param out The framebuffer to render scenes to, or null if to render
@@ -384,7 +384,7 @@ public class ViewPort {
      * <p>When the ViewPort's color buffer is cleared
      * (if {@link #setClearColor(boolean) color clearing} is enabled),
      * this specifies the color to which the color buffer is set to.
-     * By default the background color is black without alpha.
+     * By default, the background color is black without alpha.
      *
      * @param background the background color.
      */
@@ -407,7 +407,7 @@ public class ViewPort {
      * Enables or disables this ViewPort.
      *
      * <p>Disabled ViewPorts are skipped by the {@link RenderManager} when
-     * rendering. By default all ViewPorts are enabled.
+     * rendering. By default, all viewports are enabled.
      *
      * @param enable If the viewport should be disabled or enabled.
      */

--- a/jme3-core/src/main/java/com/jme3/scene/VertexBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/VertexBuffer.java
@@ -91,7 +91,7 @@ public class VertexBuffer extends NativeObject implements Savable, Cloneable {
         Binormal,
         /**
          * Specifies the source data for various vertex buffers
-         * when interleaving is used. By default the format is
+         * when interleaving is used. By default, the format is
          * byte.
          */
         InterleavedData,
@@ -1033,7 +1033,7 @@ public class VertexBuffer extends NativeObject implements Savable, Cloneable {
     @Override
     public VertexBuffer clone() {
         // NOTE: Superclass GLObject automatically creates shallow clone
-        // e.g re-use ID.
+        // e.g. re-use ID.
         VertexBuffer vb = (VertexBuffer) super.clone();
         vb.handleRef = new Object();
         vb.id = -1;

--- a/jme3-core/src/main/java/com/jme3/scene/shape/Sphere.java
+++ b/jme3-core/src/main/java/com/jme3/scene/shape/Sphere.java
@@ -337,7 +337,7 @@ public class Sphere extends Mesh {
             }
         }
 
-        // south pole triangles
+        // south-pole triangles
         for (int i = 0; i < radialSamples; i++, index += 3) {
             if (!interior) {
                 idxBuf.put((short) i);
@@ -350,7 +350,7 @@ public class Sphere extends Mesh {
             }
         }
 
-        // north pole triangles
+        // north-pole triangles
         int iOffset = (zSamples - 3) * (radialSamples + 1);
         for (int i = 0; i < radialSamples; i++, index += 3) {
             if (!interior) {

--- a/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowFilter.java
@@ -71,7 +71,7 @@ public class SpotLightShadowFilter extends AbstractShadowFilter<SpotLightShadowR
      *
      * @param assetManager the application asset manager
      * @param shadowMapSize the size of the rendered shadowmaps (512,1024,2048,
-     * etc...) the more quality, the less fps).
+     * etc...) The more quality, the fewer fps.
      */
     public SpotLightShadowFilter(AssetManager assetManager, int shadowMapSize) {
         super(assetManager, shadowMapSize, new SpotLightShadowRenderer(assetManager, shadowMapSize));

--- a/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/SpotLightShadowRenderer.java
@@ -82,7 +82,7 @@ public class SpotLightShadowRenderer extends AbstractShadowRenderer {
      *
      * @param assetManager the application asset manager
      * @param shadowMapSize the size of the rendered shadowmaps (512,1024,2048,
-     * etc...) the more quality, the less fps).
+     * etc...) The more quality, the fewer fps.
      */
     public SpotLightShadowRenderer(AssetManager assetManager, int shadowMapSize) {
         super(assetManager, shadowMapSize, 1);

--- a/jme3-core/src/main/java/com/jme3/system/SystemListener.java
+++ b/jme3-core/src/main/java/com/jme3/system/SystemListener.java
@@ -60,7 +60,7 @@ public interface SystemListener {
     /**
      * Called when the user requests to close the application. This
      * could happen when he clicks the X button on the window, presses
-     * the Alt-F4 combination, attempts to shutdown the process from 
+     * the Alt-F4 combination, attempts to shut down the process from
      * the task manager, or presses ESC. 
      * @param esc If true, the user pressed ESC to close the application.
      */

--- a/jme3-core/src/main/java/com/jme3/texture/Texture.java
+++ b/jme3-core/src/main/java/com/jme3/texture/Texture.java
@@ -66,12 +66,12 @@ public abstract class Texture implements CloneableSmartAsset, Savable, Cloneable
         TwoDimensional,
         
         /**
-         * An array of two dimensional textures. 
+         * An array of two-dimensional textures.
          */
         TwoDimensionalArray,
 
         /**
-         * Three dimensional texture. (A cube)
+         * Three-dimensional texture. (A cube)
          */
         ThreeDimensional,
 
@@ -224,7 +224,7 @@ public abstract class Texture implements CloneableSmartAsset, Savable, Cloneable
          * computes:
          * <code>mirrorClampToBorder(f) = min(1+1/(2*N), max(1/(2*N), abs(f)))</code>
          * where N is the size of the one-, two-, or three-dimensional texture
-         * image in the direction of wrapping." (Introduced after OpenGL1.4)
+         * image in the direction of wrapping. (Introduced after OpenGL1.4)
          * Falls back on BorderClamp if not supported.
          * 
          * @deprecated Not supported by OpenGL 3

--- a/jme3-core/src/main/java/com/jme3/util/TangentBinormalGenerator.java
+++ b/jme3-core/src/main/java/com/jme3/util/TangentBinormalGenerator.java
@@ -269,8 +269,8 @@ public class TangentBinormalGenerator {
     }
 
     //Don't remove split mirrored boolean. It's not used right now, but I intend to
-    //make this method also split vertices with rotated tangent space and I'll
-    //add another splitRotated boolean 
+    // make this method also split vertices with rotated tangent space, and I'll
+    // add another splitRotated boolean.
     private static List<VertexData> splitVertices(Mesh mesh, List<VertexData> vertexData, boolean splitMirorred) {
         
         int nbVertices = mesh.getBuffer(Type.Position).getNumElements();

--- a/jme3-core/src/main/java/com/jme3/util/TempVars.java
+++ b/jme3-core/src/main/java/com/jme3/util/TempVars.java
@@ -45,7 +45,7 @@ import java.util.ArrayList;
  * these temp variables with TempVars.get(), all retrieved TempVars
  * instances must be returned via TempVars.release().
  * This returns an available instance of the TempVar class ensuring this 
- * particular instance is never used elsewhere in the mean time.
+ * particular instance is never used elsewhere in the meantime.
  */
 public class TempVars {
 

--- a/jme3-core/src/plugins/java/com/jme3/texture/plugins/TGALoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/texture/plugins/TGALoader.java
@@ -299,7 +299,7 @@ public final class TGALoader implements AssetLoader {
                         // Get the number of pixels the next chunk covers (either packed or unpacked)
                         int count = dis.readByte();
                         if ((count & 0x80) != 0) {
-                            // Its an RLE packed block - use the following 1 pixel for the next <count> pixels
+                            // It's an RLE-packed block: use the following pixel for the next <count> pixels.
                             count &= 0x07f;
                             j += count;
                             blue = dis.readByte();
@@ -338,7 +338,7 @@ public final class TGALoader implements AssetLoader {
                         // Get the number of pixels the next chunk covers (either packed or unpacked)
                         int count = dis.readByte();
                         if ((count & 0x80) != 0) {
-                            // Its an RLE packed block - use the following 1 pixel for the next <count> pixels
+                            // It's an RLE-packed block: use the following pixel for the next <count> pixels.
                             count &= 0x07f;
                             j += count;
                             blue = dis.readByte();
@@ -375,7 +375,7 @@ public final class TGALoader implements AssetLoader {
                         // Get the number of pixels the next chunk covers (either packed or unpacked)
                         int count = dis.readByte();
                         if ((count & 0x80) != 0) {
-                            // Its an RLE packed block - use the following 1 pixel for the next <count> pixels
+                            // It's an RLE-packed block: use the following pixel for the next <count> pixels.
                             count &= 0x07f;
                             j += count;
                             data[1] = dis.readByte();

--- a/jme3-effects/src/main/java/com/jme3/post/ssao/SSAOFilter.java
+++ b/jme3-effects/src/main/java/com/jme3/post/ssao/SSAOFilter.java
@@ -53,7 +53,7 @@ import java.util.ArrayList;
 
 /**
  * SSAO stands for screen space ambient occlusion
- * It's a technique that fakes ambient lighting by computing shadows that near by objects would casts on each others 
+ * It's a technique that fakes ambient lighting by computing shadows that nearby objects would cast on each other.
  * under the effect of an ambient light
  * more info on this in this blog post <a href="http://jmonkeyengine.org/2010/08/16/screen-space-ambient-occlusion-for-jmonkeyengine-3-0/">http://jmonkeyengine.org/2010/08/16/screen-space-ambient-occlusion-for-jmonkeyengine-3-0/</a>
  * 

--- a/jme3-effects/src/main/java/com/jme3/water/WaterFilter.java
+++ b/jme3-effects/src/main/java/com/jme3/water/WaterFilter.java
@@ -58,8 +58,8 @@ import com.jme3.util.clone.JmeCloneable;
 import java.io.IOException;
 
 /**
- * The WaterFilter is a 2D post process that simulate water.
- * It renders water above and under water.
+ * The WaterFilter is a 2-D post process that simulates water.
+ * It renders water from both above and below the surface.
  * See the jMonkeyEngine wiki for more info <a href="https://jmonkeyengine.github.io/wiki/jme3/advanced/post-processor_water.html">https://jmonkeyengine.github.io/wiki/jme3/advanced/post-processor_water.html</a>.
  *
  *
@@ -170,7 +170,7 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
         WaterUtils.updateReflectionCam(reflectionCam, plane, sceneCam);
       
 
-        //if we're under water no need to compute reflection
+        // If we're underwater, we don't need to compute reflection.
         if (sceneCam.getLocation().y >= waterHeight) {
             boolean rtb = true;
             if (!renderManager.isHandleTranslucentBucket()) {
@@ -525,9 +525,9 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
     }
 
     /**
-     * Sets how fast will colours fade out. You can also think about this
-     * values as how clear water is. Therefore use smaller values (eg. 0.05)
-     * to have crystal clear water and bigger to achieve "muddy" water.
+     * Sets how fast colours fade out. You can also think about this
+     * as how clear water is. Therefore, use smaller values (e.g. 0.05)
+     * for crystal-clear water and bigger values for "muddy" water.
      * default is 0.1f
      *
      * @param waterTransparency the desired muddiness (default=0.1)
@@ -573,7 +573,7 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
      * This is a constant related to the index of refraction (IOR) used to compute the fresnel term.
      * F = R0 + (1-R0)( 1 - N.V)^5
      * where F is the fresnel term, R0 the constant, N the normal vector and V the view vector.
-     * It usually depend on the material you are looking through (here water).
+     * It depends on the substance you are looking through (here water).
      * Default value is 0.5
      * In practice, the lowest the value and the less the reflection can be seen on water
      *
@@ -703,7 +703,7 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
     /**
      * This value modifies current fresnel term. If you want to weaken
      * reflections use bigger value. If you want to emphasize them use
-     * value smaller then 0. Default is 0.0f.
+     * a value smaller than 0. Default is 0.
      *
      * @param refractionStrength the desired strength (default=0)
      */
@@ -715,7 +715,7 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
     }
 
     /**
-     * returns the scale factor of the waves height map
+     * Returns the scale factor of the waves' height map.
      * @return the scale factor
      */
     public float getWaveScale() {
@@ -723,9 +723,9 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
     }
 
     /**
-     * Sets the scale factor of the waves height map
-     * the smaller the value the bigger the waves
-     * default is 0.005f
+     * Sets the scale factor of the waves' height map.
+     * The smaller the value, the bigger the waves.
+     * Default is 0.005 .
      *
      * @param waveScale the desired scale factor (default=0.005)
      */
@@ -1203,7 +1203,7 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
     }
 
     /**
-     * returns the distance of the fog when under water
+     * returns the distance of the fog when underwater
      * @return the distance
      */
     public float getUnderWaterFogDistance() {
@@ -1211,8 +1211,8 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
     }
 
     /**
-     * sets the distance of the fog when under water.
-     * default is 120 (120 world units) use a high value to raise the view range under water
+     * Sets the distance of the fog when underwater.
+     * Default is 120 (120 world units). Use a high value to raise the view range underwater.
      *
      * @param underWaterFogDistance the desired distance (in world units,
      * default=120)
@@ -1225,7 +1225,7 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
     }
 
     /**
-     * get the intensity of caustics under water
+     * Gets the intensity of caustics underwater
      * @return the intensity value (&ge;0, &le;1)
      */
     public float getCausticsIntensity() {
@@ -1233,7 +1233,7 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
     }
 
     /**
-     * sets the intensity of caustics under water. goes from 0 to 1, default is 0.5f
+     * Sets the intensity of caustics underwater. Goes from 0 to 1, default is 0.5.
      *
      * @param causticsIntensity the desired intensity (&ge;0, &le;1,
      * default=0.5)
@@ -1255,7 +1255,7 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
 
     /**
      * Set the center of the effect.
-     * By default the water will extent to the entire scene.
+     * By default, the water will extend across the entire scene.
      * By setting a center and a radius you can restrain it to a portion of the scene.
      * @param center the center of the effect
      */
@@ -1277,7 +1277,7 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
 
     /**
      * Set the radius of the effect.
-     * By default the water will extent to the entire scene.
+     * By default, the water will extend across the entire scene.
      * By setting a center and a radius you can restrain it to a portion of the scene.
      * @param radius the radius of the effect
      */

--- a/jme3-examples/src/main/java/jme3test/app/TestCloneSpatial.java
+++ b/jme3-examples/src/main/java/jme3test/app/TestCloneSpatial.java
@@ -54,7 +54,7 @@ public class TestCloneSpatial {
 
     public static void main( String... args ) throws Exception {
 
-        // Setup a test node with some children, controls, etc.
+        // Set up a test node with some children, controls, etc.
         Node root = new Node("rootNode");
 
         // A root light

--- a/jme3-examples/src/main/java/jme3test/app/TestIDList.java
+++ b/jme3-examples/src/main/java/jme3test/app/TestIDList.java
@@ -152,7 +152,7 @@ public class TestIDList {
         for (int i = 0; i < states.length; i++)
             states[i] = new StateCol();
 
-        // shuffle would be useful here..
+        // Shuffle would be useful here.
 
         for (int i = 0; i < states.length; i++){
             setState(states[i]);

--- a/jme3-examples/src/main/java/jme3test/asset/TestAssetCache.java
+++ b/jme3-examples/src/main/java/jme3test/asset/TestAssetCache.java
@@ -157,7 +157,7 @@ public class TestAssetCache {
             // Create some data
             DummyData data = new DummyData();
             
-            // Post process the data before placing it in the cache
+            // Postprocess the data before placing it in the cache.
             if (proc != null){
                 data = (DummyData) proc.postProcess(key, data);
             }
@@ -202,7 +202,7 @@ public class TestAssetCache {
             // collections of the asset in the cache thus causing
             // an out of memory error.
             if (keepRefs){
-                // Prevent the saved references from taking too much memory ..
+                // Prevent the saved references from taking too much memory.
                 if (cloneAssets) {
                     data.data = null;
                 }

--- a/jme3-examples/src/main/java/jme3test/bullet/TestBetterCharacter.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestBetterCharacter.java
@@ -104,8 +104,8 @@ public class TestBetterCharacter extends SimpleApplication implements ActionList
         characterNode = new Node("character node");
         characterNode.setLocalTranslation(new Vector3f(4, 5, 2));
 
-        // Add a character control to the node so we can add other things and
-        // control the model rotation
+        // Add a character control to the node, so we can add other things and
+        // control the model rotation.
         physicsCharacter = new BetterCharacterControl(0.3f, 2.5f, 8f);
         characterNode.addControl(physicsCharacter);
         getPhysicsSpace().add(physicsCharacter);

--- a/jme3-examples/src/main/java/jme3test/bullet/TestFancyCar.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestFancyCar.java
@@ -138,8 +138,8 @@ public class TestFancyCar extends SimpleApplication implements ActionListener {
         player.setSuspensionStiffness(stiffness);
         player.setMaxSuspensionForce(10000);
 
-        //Create four wheels and add them at their locations
-        //note that our fancy car actually goes backwards..
+        // Create four wheels and add them at their locations.
+        // Note that our fancy car actually goes backward.
         Vector3f wheelDirection = new Vector3f(0, -1, 0);
         Vector3f wheelAxle = new Vector3f(-1, 0, 0);
 
@@ -193,7 +193,7 @@ public class TestFancyCar extends SimpleApplication implements ActionListener {
                 steeringValue += .5f;
             }
             player.steer(steeringValue);
-        } //note that our fancy car actually goes backwards..
+        } // Note that our fancy car actually goes backward.
         else if (binding.equals("Ups")) {
             if (value) {
                 accelerationValue -= 800;

--- a/jme3-examples/src/main/java/jme3test/gui/TestBitmapFontLayout.java
+++ b/jme3-examples/src/main/java/jme3test/gui/TestBitmapFontLayout.java
@@ -165,7 +165,7 @@ public class TestBitmapFontLayout extends SimpleApplication {
         // JME BitmapText (currently) renders from what it thinks the top of the letter is
         // down.  The actual bitmap text bounds may extend upwards... so we need to account
         // for that in any labeling we add above it.
-        // Thus we add and setup the main test text first.
+        // Thus we add and set up the main test text first.
 
         BitmapFont bitmapFont = assetManager.loadFont(test.jmeFont);
         BitmapCharacterSet charset = bitmapFont.getCharSet();
@@ -390,7 +390,7 @@ public class TestBitmapFontLayout extends SimpleApplication {
                                  loadTtf("/jme3test/font/DroidSansMono.ttf").deriveFont(Font.BOLD | Font.ITALIC, 32f)));
         */                                         
 
-        // Setup the test root node so that y = 0 is the top of the screen
+        // Set up the test root node so that y = 0 is the top of the screen
         testRoot.setLocalTranslation(0, cam.getHeight(), 0);
         testRoot.attachChild(scrollRoot);
         guiNode.attachChild(testRoot);

--- a/jme3-examples/src/main/java/jme3test/input/TestCameraNode.java
+++ b/jme3-examples/src/main/java/jme3test/input/TestCameraNode.java
@@ -86,7 +86,7 @@ public class TestCameraNode extends SimpleApplication implements AnalogListener,
 
     //creating the camera Node
     CameraNode camNode = new CameraNode("CamNode", cam);
-    //Setting the direction to Spatial to camera, this means the camera will copy the movements of the Node
+    // Set the direction to SpatialToCamera, which means the camera will copy the movements of the Node.
     camNode.setControlDir(ControlDirection.SpatialToCamera);
     //attaching the camNode to the teaNode
     teaNode.attachChild(camNode);

--- a/jme3-examples/src/main/java/jme3test/input/TestChaseCamera.java
+++ b/jme3-examples/src/main/java/jme3test/input/TestChaseCamera.java
@@ -95,11 +95,11 @@ public class TestChaseCamera extends SimpleApplication implements AnalogListener
     //chaseCam.setLookAtOffset(Vector3f.UNIT_Y.mult(3));
 
     //Uncomment this to enable rotation when the middle mouse button is pressed (like Blender)
-    //WARNING : setting this trigger disable the rotation on right and left mouse button click
+    // WARNING: setting this trigger disables the rotation on right and left mouse button click
     //chaseCam.setToggleRotationTrigger(new MouseButtonTrigger(MouseInput.BUTTON_MIDDLE));
 
     //Uncomment this to set multiple triggers to enable rotation of the cam
-    //Here spade bar and middle mouse button
+    // Here spacebar and middle mouse button
     //chaseCam.setToggleRotationTrigger(new MouseButtonTrigger(MouseInput.BUTTON_MIDDLE),new KeyTrigger(KeyInput.KEY_SPACE));
 
     //registering inputs for target's movement

--- a/jme3-examples/src/main/java/jme3test/input/TestChaseCameraAppState.java
+++ b/jme3-examples/src/main/java/jme3test/input/TestChaseCameraAppState.java
@@ -88,7 +88,7 @@ public class TestChaseCameraAppState extends SimpleApplication implements Analog
     //chaseCamAS.setInvertHorizontalAxis(true);
 
     //Uncomment this to enable rotation when the middle mouse button is pressed (like Blender)
-    //WARNING : setting this trigger disable the rotation on right and left mouse button click
+    // WARNING: setting this trigger disables the rotation on right and left mouse button click
     //chaseCamAS.setToggleRotationTrigger(new MouseButtonTrigger(MouseInput.BUTTON_MIDDLE));
 
     //Uncomment this to set multiple triggers to enable rotation of the cam

--- a/jme3-examples/src/main/java/jme3test/input/TestJoystick.java
+++ b/jme3-examples/src/main/java/jme3test/input/TestJoystick.java
@@ -302,7 +302,7 @@ public class TestJoystick extends SimpleApplication {
             } else if( axis == axis.getJoystick().getYAxis() ) {
                 setYAxis(-value);
             } else if( axis == axis.getJoystick().getAxis(JoystickAxis.Z_AXIS) ) {
-                // Note: in the above condition, we could check the axis name but
+                // Note: in the above condition, we could check the axis name, but
                 //       I have at least one joystick that reports 2 "Z Axis" axes.
                 //       In this particular case, the first one is the right one so
                 //       a name based lookup will find the proper one.  It's a problem

--- a/jme3-examples/src/main/java/jme3test/input/combomoves/TestComboMoves.java
+++ b/jme3-examples/src/main/java/jme3test/input/combomoves/TestComboMoves.java
@@ -195,7 +195,7 @@ public class TestComboMoves extends SimpleApplication implements ActionListener 
         }
 
         if (invokedMoves.size() > 0){
-            // choose move with highest priority
+            // Choose the move with the highest priority.
             float priority = 0;
             ComboMove toExec = null;
             for (ComboMove move : invokedMoves){

--- a/jme3-examples/src/main/java/jme3test/light/TestLightControlSpot.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestLightControlSpot.java
@@ -48,7 +48,7 @@ import com.jme3.scene.shape.Sphere;
 import com.jme3.util.TempVars;
 
 /**
- * Creates a spot light controlled by rotating a node. The light will shine on a surrounding sphere.
+ * Creates a spotlight controlled by rotating a node. The light will shine on a surrounding sphere.
  * The light will rotate upon each axis before working on a random axis and then reverting to the x
  * axis.
  *

--- a/jme3-examples/src/main/java/jme3test/light/TestTwoSideLighting.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestTwoSideLighting.java
@@ -47,7 +47,7 @@ import com.jme3.scene.shape.Sphere;
 import com.jme3.util.TangentBinormalGenerator;
 
 /**
- * Checks two sided lighting capability.
+ * Checks two-sided lighting capability.
  * 
  * @author Kirill Vainer
  */

--- a/jme3-examples/src/main/java/jme3test/light/pbr/TestIssue1340.java
+++ b/jme3-examples/src/main/java/jme3test/light/pbr/TestIssue1340.java
@@ -16,8 +16,8 @@ import com.jme3.system.AppSettings;
 
 /**
  * This test case validates a shader compilation fix with a model using a PBR material in combination with a
- * SkinningControl. When you run this application and you don't see a RenderException, the test is successful.
- * For a detailed explanation consult the github issue: https://github.com/jMonkeyEngine/jmonkeyengine/issues/1340
+ * SkinningControl. When you run this application and don't see a RenderException, the test is successful.
+ * For a detailed explanation consult the GitHub issue: https://github.com/jMonkeyEngine/jmonkeyengine/issues/1340
  * -rvandoosselaer
  */
 public class TestIssue1340 extends SimpleApplication {

--- a/jme3-examples/src/main/java/jme3test/network/TestChatServer.java
+++ b/jme3-examples/src/main/java/jme3test/network/TestChatServer.java
@@ -163,8 +163,8 @@ public class TestChatServer {
         public void messageReceived(HostedConnection source, Message m) {
             if (m instanceof ChatMessage) {
                 // Keep track of the name just in case we 
-                // want to know it for some other reason later and it's
-                // a good example of session data
+                // want to know it for some other reason later, and it's
+                // a good example of session data.
                 ChatMessage cm = (ChatMessage)m;
                 source.setAttribute("name", cm.getName());
 

--- a/jme3-examples/src/main/java/jme3test/network/TestThroughput.java
+++ b/jme3-examples/src/main/java/jme3test/network/TestThroughput.java
@@ -61,7 +61,7 @@ public class TestThroughput implements MessageListener<MessageConnection> { //ex
     public void messageReceived(MessageConnection source, Message msg) {
 
         if (!isOnServer) {
-            // It's local to the client so we got it back
+            // It's local to the client, so we got it back.
             counter++;
             total++;
             long time = System.currentTimeMillis();

--- a/jme3-examples/src/main/java/jme3test/renderer/TestBackgroundImage.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestBackgroundImage.java
@@ -51,7 +51,7 @@ import com.jme3.texture.Texture;
 import java.util.List;
 
 /**
- * Demonstrates how to render an non-moving background image using a pre
+ * Demonstrates how to render a non-moving background image using a pre
  * ViewPort.
  *
  * @author Stephen Gold sgold@sonic.net

--- a/jme3-examples/src/main/java/jme3test/terrain/TerrainTest.java
+++ b/jme3-examples/src/main/java/jme3test/terrain/TerrainTest.java
@@ -148,7 +148,7 @@ public class TerrainTest extends SimpleApplication {
          */
         /**
          * Optimal terrain patch size is 65 (64x64).
-         * The total size is up to you. At 1025 it ran fine for me (200+FPS), however at
+         * The total size is up to you. At 1025, it ran fine for me (200+FPS), however at
          * size=2049, it got really slow. But that is a jump from 2 million to 8 million triangles...
          */
         terrain = new TerrainQuad("terrain", 65, 513, heightmap.getHeightMap());
@@ -198,9 +198,9 @@ public class TerrainTest extends SimpleApplication {
                 triPlanar = !triPlanar;
                 if (triPlanar) {
                     matRock.setBoolean("useTriPlanarMapping", true);
-                    // planar textures don't use the mesh's texture coordinates but real world coordinates,
-                    // so we need to convert these texture coordinate scales into real world scales so it looks
-                    // the same when we switch to/from tri-planar mode
+                    // Planar textures don't use the mesh's texture coordinates but real-world coordinates,
+                    // so we need to convert these texture coordinate scales into real-world scales, so it looks
+                    // the same when we switch to/from tri-planar mode.
                     matRock.setFloat("Tex1Scale", 1f / (512f / grassScale));
                     matRock.setFloat("Tex2Scale", 1f / (512f / dirtScale));
                     matRock.setFloat("Tex3Scale", 1f / (512f / rockScale));

--- a/jme3-examples/src/main/java/jme3test/terrain/TerrainTestAdvanced.java
+++ b/jme3-examples/src/main/java/jme3test/terrain/TerrainTestAdvanced.java
@@ -196,7 +196,7 @@ public class TerrainTestAdvanced extends SimpleApplication {
          */
         /**
          * Optimal terrain patch size is 65 (64x64).
-         * The total size is up to you. At 1025 it ran fine for me (200+FPS), however at
+         * The total size is up to you. At 1025, it ran fine for me (200+FPS), however at
          * size=2049 it got really slow. But that is a jump from 2 million to 8 million triangles...
          */
         terrain = new TerrainQuad("terrain", 65, 513, heightmap.getHeightMap());//, new LodPerspectiveCalculatorFactory(getCamera(), 4)); // add this in to see it use entropy for LOD calculations
@@ -258,9 +258,9 @@ public class TerrainTestAdvanced extends SimpleApplication {
                 triPlanar = !triPlanar;
                 if (triPlanar) {
                     matTerrain.setBoolean("useTriPlanarMapping", true);
-                    // planar textures don't use the mesh's texture coordinates but real world coordinates,
-                    // so we need to convert these texture coordinate scales into real world scales so it looks
-                    // the same when we switch to/from tr-planar mode (1024f is the alphamap size)
+                    // Planar textures don't use the mesh's texture coordinates but real-world coordinates,
+                    // so we need to convert these texture coordinate scales into real-world scales, so it looks
+                    // the same when we switch to/from tri-planar mode. (1024 is the alphamap size.)
                     matTerrain.setFloat("DiffuseMap_0_scale", 1f / (1024f / dirtScale));
                     matTerrain.setFloat("DiffuseMap_1_scale", 1f / (1024f / darkRockScale));
                     matTerrain.setFloat("DiffuseMap_2_scale", 1f / (1024f / pinkRockScale));

--- a/jme3-examples/src/main/java/jme3test/terrain/TerrainTestAndroid.java
+++ b/jme3-examples/src/main/java/jme3test/terrain/TerrainTestAndroid.java
@@ -51,8 +51,8 @@ import com.jme3.texture.Texture.WrapMode;
 
 /**
  * Demonstrates how to use terrain on Android.
- * The only difference is it uses a much smaller heightmap so it won't use up
- * all of the android device's memory.
+ * The only difference is it uses a much smaller heightmap, so it won't use
+ * all the device's memory.
  *
  * @author bowens
  */

--- a/jme3-examples/src/main/java/jme3test/texture/TestTexture3DLoading.java
+++ b/jme3-examples/src/main/java/jme3test/texture/TestTexture3DLoading.java
@@ -68,7 +68,7 @@ public class TestTexture3DLoading extends SimpleApplication {
 
         q.scaleTextureCoordinates(new Vector2f(rows, rows));
 
-        //The image only have 8 pictures and we have 16 thumbs, the data will be interpolated by the GPU
+        // The image has only 8 pictures, and we have 16 thumbs, so the data will be interpolated by the GPU.
         material.setFloat("InvDepth", 1f / 16f);
         material.setInt("Rows", rows);
         material.setTexture("Texture", t);

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/objects/VehicleWheel.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/objects/VehicleWheel.java
@@ -200,7 +200,7 @@ public class VehicleWheel implements Savable {
 
     /**
      * the coefficient of friction between the tyre and the ground.
-     * Should be about 0.8 for realistic cars, but can increased for better handling.
+     * Should be about 0.8 for realistic cars, but can be increased for better handling.
      * Set large (10000.0) for kart racers
      *
      * @param frictionSlip the desired coefficient of friction between tyre and

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/Sync.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/Sync.java
@@ -43,7 +43,7 @@ class Sync {
 
 
 
-    /** number of nano seconds in a second */
+    /** number of nanoseconds in a second */
     private static final long NANOS_IN_SECOND = 1000L * 1000L * 1000L;
 
     /** The time to sleep/yield until the next frame */
@@ -93,7 +93,7 @@ class Sync {
      * This method will initialise the sync method by setting initial
      * values for sleepDurations/yieldDurations and nextFrame.
      * 
-     * If running on windows it will start the sleep timer fix.
+     * If running on Windows, it will start the sleep timer fix.
      */
     private static void initialise() {
         initialised = true;
@@ -104,8 +104,8 @@ class Sync {
         nextFrame = getTime();
 
 
-            // On windows the sleep functions can be highly inaccurate by 
-            // over 10ms making in unusable. However it can be forced to 
+            // On Windows, the sleep functions can be highly inaccurate by
+            // over 10ms making in unusable. However, it can be forced to
             // be a bit more accurate by running a separate sleeping daemon
             // thread.
             Thread timerAccuracyThread = new Thread(new Runnable() {
@@ -124,7 +124,7 @@ class Sync {
 
 
     /**
-     * Get the system time in nano seconds
+     * Gets the system time in nanoseconds.
      * 
      * @return will return the current time in nano's
      */

--- a/jme3-networking/src/main/java/com/jme3/network/kernel/udp/UdpEndpoint.java
+++ b/jme3-networking/src/main/java/com/jme3/network/kernel/udp/UdpEndpoint.java
@@ -113,7 +113,7 @@ public class UdpEndpoint implements Endpoint
     @Override
     public boolean isConnected()
     {
-        // The socket is always unconnected anyway so we track our
+        // The socket is always unconnected anyway, so we track our
         // own logical state for the kernel's benefit.
         return connected;
     }

--- a/jme3-networking/src/main/java/com/jme3/network/kernel/udp/UdpKernel.java
+++ b/jme3-networking/src/main/java/com/jme3/network/kernel/udp/UdpKernel.java
@@ -183,7 +183,7 @@ public class UdpKernel extends AbstractKernel
     {
         // So the tricky part here is figuring out the endpoint and
         // whether it's new or not.  In these UDP schemes, firewalls have
-        // to be ported back to a specific machine so we will consider
+        // to be ported back to a specific machine, so we will consider
         // the address + port (ie: SocketAddress) the de facto unique
         // ID.
         Endpoint p = getEndpoint( packet.getSocketAddress(), true );
@@ -275,8 +275,8 @@ public class UdpKernel extends AbstractKernel
             // An atomic is safest and costs almost nothing
             while( go.get() ) {
                 try {
-                    // Could reuse the packet but I don't see the
-                    // point and it may lead to subtle bugs if not properly
+                    // Could reuse the packet, but I don't see the
+                    // point, and it may lead to subtle bugs if not properly
                     // reset.
                     DatagramPacket packet = new DatagramPacket( buffer, buffer.length );
                     socket.receive(packet);

--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
@@ -43,7 +43,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 /**
- * Part of the jME XML IO system as introduced in the google code jmexml project.
+ * Part of the jME XML IO system as introduced in the Google Code jmexml project.
  * 
  * @author Kai Rabien (hevee) - original author of the code.google.com jmexml project
  * @author Doug Daniels (dougnukem) - adjustments for jME 2.0 and Java 1.5

--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLImporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLImporter.java
@@ -46,7 +46,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.xml.sax.SAXException;
 
 /**
- * Part of the jME XML IO system as introduced in the google code jmexml project.
+ * Part of the jME XML IO system as introduced in the Google Code jmexml project.
  * @author Kai Rabien (hevee) - original author of the code.google.com jmexml project
  * @author Doug Daniels (dougnukem) - adjustments for jME 2.0 and Java 1.5
  */

--- a/jme3-terrain/src/main/java/com/jme3/terrain/Terrain.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/Terrain.java
@@ -37,7 +37,7 @@ import com.jme3.math.Vector3f;
 import java.util.List;
 
 /**
- * Terrain can be one or many meshes comprising of a, probably large, piece of land.
+ * Terrain can be one or many meshes comprising a (probably large) piece of land.
  * Terrain is Y-up in the grid axis, meaning gravity acts in the -Y direction.
  * Level of Detail (LOD) is supported and expected as terrains can get very large. LOD can
  * also be disabled if you so desire, however some terrain implementations can choose to ignore
@@ -166,7 +166,7 @@ public interface Terrain {
     /**
      * Used for painting to get the number of vertices along the edge of the
      * terrain.
-     * This is an un-scaled size, and should represent the vertex count (ie. the
+     * This is an un-scaled size, and should represent the vertex count (i.e. the
      * texture coord count) along an edge of a square terrain.
      * 
      * In the standard TerrainQuad default implementation, this will return

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainGridLodControl.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainGridLodControl.java
@@ -58,7 +58,7 @@ public class TerrainGridLodControl extends TerrainLodControl {
         // 1: every camera has an associated grid, then the location is not enough to identify which camera location has changed
         // 2: grids are associated with locations, and no incremental update is done, we load new grids for new locations, and unload those that are not needed anymore
         Vector3f cam = locations.isEmpty() ? Vector3f.ZERO.clone() : locations.get(0);
-        Vector3f camCell = terrainGrid.getCamCell(cam); // get the grid index value of where the camera is (ie. 2,1)
+        Vector3f camCell = terrainGrid.getCamCell(cam); // get the grid index where the camera is (i.e. 2,1)
         if (terrainGrid.cellsLoaded > 1) {                  // Check if cells are updated before updating gridOffset.
             terrainGrid.gridOffset[0] = Math.round(camCell.x * (terrainGrid.size / 2));
             terrainGrid.gridOffset[1] = Math.round(camCell.z * (terrainGrid.size / 2));

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainLodControl.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainLodControl.java
@@ -157,14 +157,14 @@ public class TerrainLodControl extends AbstractControl {
     }
 
     /**
-     * @param useRenderCamera true if need to use a camera from render view port.
+     * @param useRenderCamera true to use camera from the render viewport
      */
     public void setUseRenderCamera(final boolean useRenderCamera) {
         this.useRenderCamera = useRenderCamera;
     }
 
     /**
-     * @return true if need to use a camera from render view port.
+     * @return true to use camera from the render viewport
      */
     public boolean isUseRenderCamera() {
         return useRenderCamera;
@@ -236,7 +236,7 @@ public class TerrainLodControl extends AbstractControl {
         getSpatial().removeControl(this);
     }
 
-    // do all of the LOD calculations
+    // Do all the LOD calculations.
     protected void updateLOD(final LodCalculator lodCalculator) {
 
         if (getSpatial() == null || camera == null) {
@@ -270,7 +270,7 @@ public class TerrainLodControl extends AbstractControl {
         indexer = executorService.submit(createLodUpdateTask(singletonList(currentLocation), lodCalculator));
     }
 
-    // do all of the LOD calculations
+    // Do all the LOD calculations.
     protected void updateLOD(final SafeArrayList<Vector3f> locations, final LodCalculator lodCalculator) {
 
         if (getSpatial() == null || locations.isEmpty()) {

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainPatch.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainPatch.java
@@ -69,7 +69,7 @@ import java.util.List;
  * LOD. If this doesn't happen, you will see gaps.
  *
  * The LOD value is most detailed at zero. It gets less detailed the higher the LOD value until you reach maxLod, which
- * is a mathematical limit on the number of times the 'size' of the patch can be divided by two. However there is a -1 to that
+ * is a mathematical limit on the number of times the 'size' of the patch can be divided by two. However, there is a -1 to that
  * for now until I add in a custom index buffer calculation for that max level, the current algorithm does not go that far.
  *
  * You can supply a LodThresholdCalculator for use in determining when the LOD should change. Its API will no doubt change
@@ -165,7 +165,7 @@ public class TerrainPatch extends Geometry {
      *            the origin offset of the patch.
      * @param totalSize
      *            the total size of the terrain. (Higher if the patch is part of
-     *            a <code>TerrainQuad</code> tree.
+     *            a <code>TerrainQuad</code> tree.)
      * @param offset
      *            the offset for texture coordinates.
      * @param offsetAmount
@@ -319,7 +319,7 @@ public class TerrainPatch extends Geometry {
     }
 
     /**
-     * recalculate all of the normal vectors in this terrain patch
+     * Recalculates all normal vectors in this terrain patch.
      */
     protected void updateNormals() {
         FloatBuffer newNormalBuffer = geomap.writeNormalArray(null, getWorldScale());
@@ -350,7 +350,7 @@ public class TerrainPatch extends Geometry {
      * Computes the normals for the right, bottom, left, and top edges of the
      * patch, and saves those normals in the neighbour's edges too.
      *
-     * Takes 4 points (if has neighbour on that side) for each
+     * Takes 4 points (if it has a neighbour on that side) for each
      * point on the edge of the patch:
      *              *
      *              |
@@ -605,7 +605,7 @@ public class TerrainPatch extends Geometry {
 
     /**
      * Locks the mesh (sets it static) to improve performance.
-     * But it it not editable then. Set unlock to make it editable.
+     * If it is not editable, then unlock to make it editable.
      */
     public void lockMesh() {
         getMesh().setStatic();
@@ -966,14 +966,14 @@ public class TerrainPatch extends Geometry {
         this.rightNeighbour = null;
         this.bottomNeighbour = null;
 
-        // Don't feel like making geomap cloneable tonight
+        // Don't feel like making geomap cloneable tonight,
         // so I'll copy the old logic.
         this.geomap = new LODGeomap(size, geomap.getHeightArray());
         Mesh m = geomap.createMesh(stepScale, Vector2f.UNIT_XY, offset, offsetAmount, totalSize, false);
         this.setMesh(m);
 
-        // In this case, we always clone material even if the cloner is setup
-        // not to clone it.  Terrain uses mutable textures and stuff so it's important
+        // In this case, we always clone material even if the cloner is set up
+        // not to clone it.  Terrain uses mutable textures and stuff, so it's important
         // to clone it.  (At least that's my understanding and is evidenced by the old
         // clone code specifically cloning material.)  -pspeed
         // Also note that Geometry will have potentially already cloned this but the pre-JmeCloner

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -146,9 +146,9 @@ public class TerrainQuad extends Node implements Terrain {
      * @param name the name of the scene element. This is required for
      * identification and comparison purposes.
      * @param patchSize size of the individual patches (geometry). Power of 2 plus 1,
-     * must be smaller than totalSize. (eg. 33, 65...)
+     * must be smaller than totalSize. (e.g. 33, 65...)
      * @param totalSize the size of this entire terrain (on one side). Power of 2 plus 1
-     * (eg. 513, 1025, 2049...)
+     * (e.g. 513, 1025, 2049...)
      * @param heightMap The height map to generate the terrain from (a flat
      * height map will be generated if this is null). The size of one side of the heightmap
      * must match the totalSize. So a 513x513 heightmap is needed for a terrain with totalSize of 513.
@@ -1051,7 +1051,7 @@ public class TerrainQuad extends Node implements Terrain {
     /**
      * Get the interpolated height of the terrain at the specified point.
      * @param xz the location to get the height for
-     * @return Float.NAN if the value does not exist, or the coordinates are outside of the terrain
+     * @return Float.NAN if the value does not exist, or the coordinates lie outside the terrain
      */
     @Override
     public float getHeight(Vector2f xz) {

--- a/jme3-vr/src/main/java/com/jme3/app/VRAppState.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VRAppState.java
@@ -128,7 +128,7 @@ public class VRAppState extends AbstractAppState {
 
     
     /**
-     * Simple update of the app state, this method should contains any spatial updates.
+     * Simple update of the app state, this method should contain any spatial updates.
      * This method is called by the {@link #update(float) update()} method and should not be called manually.
      * @param tpf the application time.
      */

--- a/jme3-vr/src/main/java/com/jme3/app/VRApplication.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VRApplication.java
@@ -68,7 +68,7 @@ import org.lwjgl.system.Platform;
 
 
 /**
- * A JMonkey application dedicated to Virtual Reality. An application that use VR devices (HTC vive, ...) has to extends this one.<br>
+ * A JMonkey application dedicated to Virtual Reality. An application that use VR devices (HTC vive, ...) has to extend this one.<br>
  * <p>
  * <b>This class is no more functional and is deprecated. Please use {@link VRAppState VRAppState} instead.</b>
  * @author reden - phr00t - https://github.com/phr00t
@@ -378,7 +378,7 @@ public abstract class VRApplication implements Application, SystemListener {
     }
     
     /**
-     * Simple update of the application, this method should contains {@link #getRootNode() root node} updates.
+     * Simple update of the application, this method should contain {@link #getRootNode() root node} updates.
      * This method is called by the {@link #update() update()} method and should not be called manually.
      * @param tpf the application time.
      */
@@ -1348,7 +1348,7 @@ public abstract class VRApplication implements Application, SystemListener {
 //        timer.update();
         timer.reset();
 
-        // user code here..
+        // user code here
     }
     
     @Override

--- a/jme3-vr/src/main/java/com/jme3/input/vr/VRAPI.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/VRAPI.java
@@ -51,7 +51,7 @@ public interface VRAPI {
     public VRInputAPI getVRinput();
     
     /**
-     * Flip the left and right eye..
+     * Flip the left and right eye.
      * @param set <code>true</code> if the eyes has to be flipped and <code>false</code> otherwise.
      */
     public void setFlipEyes(boolean set);

--- a/jme3-vr/src/main/java/com/jme3/input/vr/VRBounds.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/VRBounds.java
@@ -3,7 +3,7 @@ package com.jme3.input.vr;
 import com.jme3.math.Vector2f;
 
 /**
- * This interface describe the VR playground bounds.
+ * This interface describes the VR playground bounds.
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  *
  */

--- a/jme3-vr/src/main/java/com/jme3/input/vr/VRInputAPI.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/VRInputAPI.java
@@ -169,7 +169,7 @@ public interface VRInputAPI {
     
     /**
      * Get where is the controller pointing, after all rotations are combined.
-     * This position should include includes observer rotation from the VR application.
+     * This position should include observer rotation from the VR application.
      * @param index the index of the controller.
      * @return the rotation of the input after all positional tracking is complete.
      */
@@ -177,7 +177,7 @@ public interface VRInputAPI {
     
     /**
      * Get the position of the input after all positional tracking is complete.
-     * This position should include includes observer position from the VR application.
+     * This position should include observer position from the VR application.
      * @param index the index of the controller.
      * @return the position of the input after all positional tracking is complete.
      */

--- a/jme3-vr/src/main/java/com/jme3/shadow/VRDirectionalLightShadowRenderer.java
+++ b/jme3-vr/src/main/java/com/jme3/shadow/VRDirectionalLightShadowRenderer.java
@@ -54,8 +54,8 @@ public class VRDirectionalLightShadowRenderer extends DirectionalLightShadowRend
      * @param assetManager the application asset manager
      * @param shadowMapSize the size of the rendered shadowmaps (512,1024,2048,
      * etc...)
-     * @param nbSplits the number of shadow maps rendered (the more shadow maps
-     * the more quality, the less fps).
+     * @param nbSplits the number of shadow maps rendered (More shadow maps
+     * result in higher quality, fewer fps.)
      */
     public VRDirectionalLightShadowRenderer(AssetManager assetManager, int shadowMapSize, int nbSplits) {
         super(assetManager, shadowMapSize, nbSplits);


### PR DESCRIPTION
Very similar to #1663, this PR solves missing words/hyphens, unintentionally repeated words, non-standard punctuation, and similar issues.