### PR TITLE
add a version of CenterQuad to jme3-core

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -1475,7 +1475,7 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
 
     /**
      * @return A new quaternion that describes a rotation that would point you
-     * in the exact opposite direction of this Quaternion.
+     *         in the exact opposite direction of this Quaternion.
      */
     public Quaternion opposite() {
         return opposite(null);

--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -1385,9 +1385,10 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * <code>ObjectInput</code> object. <br>
      * NOTE: Used with serialization. Not to be called manually.
      *
-     * @param in the ObjectInput value to read from.
-     * @throws IOException if the ObjectInput value has problems reading a
-     * float.
+     * @param in
+     *            the ObjectInput value to read from.
+     * @throws IOException
+     *             if the ObjectInput value has problems reading a float.
      * @see java.io.Externalizable
      */
     public void readExternal(ObjectInput in) throws IOException {
@@ -1402,8 +1403,10 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * <code>ObjectOutput</code> object. NOTE: Used with serialization. Not to
      * be called manually.
      *
-     * @param out the object to write to.
-     * @throws IOException if writing to the ObjectOutput fails.
+     * @param out
+     *            the object to write to.
+     * @throws IOException
+     *             if writing to the ObjectOutput fails.
      * @see java.io.Externalizable
      */
     public void writeExternal(ObjectOutput out) throws IOException {
@@ -1415,15 +1418,17 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
 
     /**
      * <code>lookAt</code> is a convenience method for auto-setting the
-     * quaternion based on a direction and an up vector. It computes the
-     * rotation to transform the z-axis to point into 'direction' and the y-axis
-     * to 'up'. Note that the results will be invalid if a zero length direction
-     * vector (0,0,0) is supplied, or if the direction and up vectors are
-     * parallel.
+     * quaternion based on a direction and an up vector. It computes
+     * the rotation to transform the z-axis to point into 'direction'
+     * and the y-axis to 'up'.  Note that the results will be invalid
+     * if a zero length direction vector (0,0,0) is supplied, or if the 
+     * direction and up vectors are parallel.
      *
-     * @param direction where to look at in terms of local coordinates
-     * @param up a vector indicating the local up direction. (typically {0, 1,
-     * 0} in jME.)
+     * @param direction
+     *            where to look at in terms of local coordinates
+     * @param up
+     *            a vector indicating the local up direction.
+     *            (typically {0, 1, 0} in jME.)
      * @return this
      */
     public Quaternion lookAt(Vector3f direction, Vector3f up) {
@@ -1477,14 +1482,14 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
     }
 
     /**
-     * FIXME: This seems to have singularity type issues with angle == 0,
-     * possibly others such as PI.
+     * FIXME: This seems to have singularity type issues with angle == 0, possibly others such as PI.
      *
-     * @param store A Quaternion to store our result in. If null, a new one is
-     * created.
+     * @param store
+     *            A Quaternion to store our result in. If null, a new one is
+     *            created.
      * @return The store quaternion (or a new Quaternion, if store is null) that
-     * describes a rotation that would point you in the exact opposite direction
-     * of this Quaternion.
+     *         describes a rotation that would point you in the exact opposite
+     *         direction of this Quaternion.
      */
     public Quaternion opposite(Quaternion store) {
         if (store == null) {
@@ -1500,7 +1505,8 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
 
     /**
      * @return This Quaternion, altered to describe a rotation that would point
-     * you in the exact opposite direction of where it is pointing currently.
+     *         you in the exact opposite direction of where it is pointing
+     *         currently.
      */
     public Quaternion oppositeLocal() {
         return opposite(this);

--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -1279,10 +1279,10 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * @return the (modified) current instance (for chaining)
      */
     public Quaternion negateLocal() {
-        x *= -1;
-        y *= -1;
-        z *= -1;
-        w *= -1;
+        x = -x;
+        y = -y;
+        z = -z;
+        w = -w;
 
         return this;
     }

--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -1264,12 +1264,27 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
 
     /**
      * Flip the signs of all components of this Quaternion.
+     *
+     * @deprecated The naming of this method doesn't follow convention. Please
+     *     use {@link #normalizeLocal()} instead.
      */
+    @Deprecated
     public void negate() {
+        negateLocal();
+    }
+
+    /**
+     * Flip the signs of all components.
+     *
+     * @return the (modified) current instance (for chaining)
+     */
+    public Quaternion negateLocal() {
         x *= -1;
         y *= -1;
         z *= -1;
         w *= -1;
+
+        return this;
     }
 
     /**
@@ -1370,10 +1385,9 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * <code>ObjectInput</code> object. <br>
      * NOTE: Used with serialization. Not to be called manually.
      *
-     * @param in
-     *            the ObjectInput value to read from.
-     * @throws IOException
-     *             if the ObjectInput value has problems reading a float.
+     * @param in the ObjectInput value to read from.
+     * @throws IOException if the ObjectInput value has problems reading a
+     * float.
      * @see java.io.Externalizable
      */
     public void readExternal(ObjectInput in) throws IOException {
@@ -1388,10 +1402,8 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * <code>ObjectOutput</code> object. NOTE: Used with serialization. Not to
      * be called manually.
      *
-     * @param out
-     *            the object to write to.
-     * @throws IOException
-     *             if writing to the ObjectOutput fails.
+     * @param out the object to write to.
+     * @throws IOException if writing to the ObjectOutput fails.
      * @see java.io.Externalizable
      */
     public void writeExternal(ObjectOutput out) throws IOException {
@@ -1403,17 +1415,15 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
 
     /**
      * <code>lookAt</code> is a convenience method for auto-setting the
-     * quaternion based on a direction and an up vector. It computes
-     * the rotation to transform the z-axis to point into 'direction'
-     * and the y-axis to 'up'.  Note that the results will be invalid
-     * if a zero length direction vector (0,0,0) is supplied, or if the 
-     * direction and up vectors are parallel.
+     * quaternion based on a direction and an up vector. It computes the
+     * rotation to transform the z-axis to point into 'direction' and the y-axis
+     * to 'up'. Note that the results will be invalid if a zero length direction
+     * vector (0,0,0) is supplied, or if the direction and up vectors are
+     * parallel.
      *
-     * @param direction
-     *            where to look at in terms of local coordinates
-     * @param up
-     *            a vector indicating the local up direction.
-     *            (typically {0, 1, 0} in jME.)
+     * @param direction where to look at in terms of local coordinates
+     * @param up a vector indicating the local up direction. (typically {0, 1,
+     * 0} in jME.)
      * @return this
      */
     public Quaternion lookAt(Vector3f direction, Vector3f up) {
@@ -1460,21 +1470,21 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
 
     /**
      * @return A new quaternion that describes a rotation that would point you
-     *         in the exact opposite direction of this Quaternion.
+     * in the exact opposite direction of this Quaternion.
      */
     public Quaternion opposite() {
         return opposite(null);
     }
 
     /**
-     * FIXME: This seems to have singularity type issues with angle == 0, possibly others such as PI.
+     * FIXME: This seems to have singularity type issues with angle == 0,
+     * possibly others such as PI.
      *
-     * @param store
-     *            A Quaternion to store our result in. If null, a new one is
-     *            created.
+     * @param store A Quaternion to store our result in. If null, a new one is
+     * created.
      * @return The store quaternion (or a new Quaternion, if store is null) that
-     *         describes a rotation that would point you in the exact opposite
-     *         direction of this Quaternion.
+     * describes a rotation that would point you in the exact opposite direction
+     * of this Quaternion.
      */
     public Quaternion opposite(Quaternion store) {
         if (store == null) {
@@ -1490,8 +1500,7 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
 
     /**
      * @return This Quaternion, altered to describe a rotation that would point
-     *         you in the exact opposite direction of where it is pointing
-     *         currently.
+     * you in the exact opposite direction of where it is pointing currently.
      */
     public Quaternion oppositeLocal() {
         return opposite(this);

--- a/jme3-core/src/main/java/com/jme3/scene/shape/CenterQuad.java
+++ b/jme3-core/src/main/java/com/jme3/scene/shape/CenterQuad.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2009-2021 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.scene.shape;
+
+import com.jme3.export.InputCapsule;
+import com.jme3.export.JmeExporter;
+import com.jme3.export.JmeImporter;
+import com.jme3.export.OutputCapsule;
+import com.jme3.scene.Mesh;
+import com.jme3.scene.VertexBuffer.Type;
+import java.io.IOException;
+
+/**
+ * A static, indexed, Triangles-mode mesh for an axis-aligned rectangle in the
+ * X-Y plane.
+ *
+ * <p>The rectangle extends from (-width/2, -height/2, 0) to
+ * (width/2, height/2, 0) with normals set to (0,0,1).
+ *
+ * <p>This differs from {@link com.jme3.scene.shape.Quad} because it puts
+ * (0,0,0) at the rectangle's center instead of in a corner.
+ *
+ * @author Kirill Vainer
+ */
+public class CenterQuad extends Mesh {
+
+    private float width;
+    private float height;
+
+    /**
+     * For serialization only. Do not use.
+     */
+    protected CenterQuad() {
+    }
+
+    /**
+     * Instantiate an unflipped quad in the X-Y plane with the specified width
+     * and height.
+     *
+     * @param width the desired X extent or width
+     * @param height the desired Y extent or height
+     */
+    public CenterQuad(float width, float height) {
+        this(width, height, false);
+    }
+
+    /**
+     * Instantiate a quad in the X-Y plane with the specified width and height.
+     *
+     * @param width the desired X extent or width
+     * @param height the desired Y extent or height
+     * @param flipCoords true to flip the texture coordinates (v=0 when
+     *     y=height/2) or false to leave them unflipped (v=1 when y=height/2)
+     */
+    public CenterQuad(float width, float height, boolean flipCoords) {
+        updateGeometry(width, height, flipCoords);
+        super.setStatic();
+    }
+
+    /**
+     * Returns the height (or Y extent).
+     *
+     * @return the height
+     */
+    public float getHeight() {
+        return height;
+    }
+
+    /**
+     * Returns the width (or X extent).
+     *
+     * @return the width
+     */
+    public float getWidth() {
+        return width;
+    }
+
+    /**
+     * De-serializes from the specified importer, for example when loading from
+     * a J3O file.
+     *
+     * @param importer the importer to use (not null)
+     * @throws IOException from the importer
+     */
+    @Override
+    public void read(JmeImporter importer) throws IOException {
+        super.read(importer);
+        InputCapsule capsule = importer.getCapsule(this);
+
+        width = capsule.readFloat("width", 0f);
+        height = capsule.readFloat("height", 0f);
+    }
+
+    /**
+     * Serializes to the specified exporter, for example when saving to a J3O
+     * file. The current instance is unaffected.
+     *
+     * @param exporter the exporter to use (not null)
+     * @throws IOException from the exporter
+     */
+    @Override
+    public void write(JmeExporter exporter) throws IOException {
+        super.write(exporter);
+        OutputCapsule capsule = exporter.getCapsule(this);
+
+        capsule.write(width, "width", 0f);
+        capsule.write(height, "height", 0f);
+    }
+
+    private void updateGeometry(float width, float height, boolean flipCoords) {
+        this.width = width;
+        this.height = height;
+
+        float x = width / 2;
+        float y = height / 2;
+        setBuffer(Type.Position, 3, new float[]{
+            -x, -y, 0f,
+            +x, -y, 0f,
+            +x, +y, 0f,
+            -x, +y, 0f
+        });
+
+        if (flipCoords) {
+            setBuffer(Type.TexCoord, 2, new float[]{
+                0f, 1f,
+                1f, 1f,
+                1f, 0f,
+                0f, 0f
+            });
+        } else {
+            setBuffer(Type.TexCoord, 2, new float[]{
+                0f, 0f,
+                1f, 0f,
+                1f, 1f,
+                0f, 1f
+            });
+        }
+
+        setBuffer(Type.Normal, 3, new float[]{
+            0f, 0f, 1f,
+            0f, 0f, 1f,
+            0f, 0f, 1f,
+            0f, 0f, 1f
+        });
+
+        if (width * height < 0f) {
+            setBuffer(Type.Index, 3, new byte[]{
+                0, 2, 1,
+                0, 3, 2
+            });
+        } else {
+            setBuffer(Type.Index, 3, new byte[]{
+                0, 1, 2,
+                0, 2, 3
+            });
+        }
+
+        updateBound();
+        setStatic();
+    }
+}

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/FbxToJmeTrack.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/FbxToJmeTrack.java
@@ -154,7 +154,7 @@ public final class FbxToJmeTrack {
                 if (i > 0) {
                     if (rotations[i - 1].dot(rotations[i]) < 0) {
                         System.out.println("rotation will go the long way, oh noes");
-                        rotations[i - 1].negate();
+                        rotations[i - 1].negateLocal();
                     }
                 }
             } else {


### PR DESCRIPTION
The `CenterQuad` class in jme3-vr seems to have some general utility, for instance for UI objects that will be rotated and/or scaled. This PR cleans it up and adds it to the jme3-core. Long-term, we may want to deprecate the version in jme3-vr.

Notable changes relative to jme3-vr:
+ no static instances
+ privatized the `updateGeometry()` methods
+ added a no-arg constructor and read/write methods to allow serialization
+ solved a winding-order bug when `width` is negative
+ avoided invocation of overridable methods in constructors
+ improved javadoc