### PR TITLE
new javadoc for Transform

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -177,9 +177,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Stores this translation component into the given vector3f. If trans is null,
+     * Stores this translation component into the argument. If the argument is null,
      * a new vector3f is created to hold the value. The current instance is
-     * unaffected, unless <code>trans</code>
+     * unaffected, unless the argument
      * is its scaling component.
      *
      * @param trans storage for the result (modified if not null)
@@ -195,7 +195,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Stores the rotation component into the given Quaternion. If quat is null, a
+     * Stores the rotation component into the argument. If the argument is null, a
      * new Quaternion is created to hold the value. The current instance is unaffected.
      *
      * @param quat storage for the result (modified if not null)
@@ -219,9 +219,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Stores the scaling component into the given vector3f. If scale is null, a new
+     * Stores the scaling component into the argument. If the argument is null, a new
      * vector3f is created to hold the value. The current instance is
-     * unaffected, unless <code>scale</code>
+     * unaffected, unless the argument
      * is its translation component.
      *
      * @param scale storage for the result (modified if not null)
@@ -254,7 +254,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Changes the values of this Transform according to its parent and returns
+     * Changes the values of this Transform according the argument and returns
      * the (modified) current instance. Very similar to the concept of
      * Node/Spatial transforms.
      *
@@ -437,7 +437,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Tests for exact equality with another object. The current instance is
+     * Tests for exact equality with the argument. The current instance is
      * unaffected.
      *
      * @param obj the object to compare to (may be null, unaffected)
@@ -476,7 +476,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets this Transform to be equal to the given Transform.
+     * Sets this Transform to be equal to the argument.
      *
      * @param matrixQuat The Transform to be equal to. (not null, unaffected)
      * @return the (modified) current instance (for chaining)
@@ -489,7 +489,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Serializes this transform to the specified exporter, for example when
+     * Serializes this transform to the argument, for example when
      * saving to a J3O file. The current instance is unaffected.
      *
      * @param e (not null)
@@ -504,7 +504,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * De-serializes this transform from the specified importer, for example
+     * De-serializes this transform from the argument, for example
      * when loading from a J3O file.
      *
      * @param e (not null)

--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -177,8 +177,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Stores this translation component into the argument. If the argument is null,
-     * a new vector3f is created to hold the value. The current instance is
+     * Copies the translation component to the argument. If the argument is null,
+     * a new Vector3f is created to hold the value. Either way, the current instance is
      * unaffected, unless the argument
      * is its scaling component.
      *
@@ -195,8 +195,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Stores the rotation component into the argument. If the argument is null, a
-     * new Quaternion is created to hold the value. The current instance is unaffected.
+     * Copies the rotation component to the argument. If the argument is null, a
+     * new Quaternion is created to hold the value. Either way, the current
+     * instance is unaffected.
      *
      * @param quat storage for the result (modified if not null)
      * @return the rotation value (either <code>quat</code> or a new Quaternion)
@@ -219,8 +220,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Stores the scaling component into the argument. If the argument is null, a new
-     * vector3f is created to hold the value. The current instance is
+     * Copies the scaling component to the argument. If the argument is null, a new
+     * Vector3f is created to hold the value. Either way, the current instance is
      * unaffected, unless the argument
      * is its translation component.
      *
@@ -305,7 +306,10 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Transforms the specified coordinates. The current instance is unaffected,
+     * Transforms the specified coordinates and returns the result in
+     * <code>store</code>. If the <code>store</code> is null,
+     * a new Vector3f is created to hold the value. Either way,
+     * the current instance is unaffected,
      * unless <code>store</code> is its translation or scaling.
      *
      * @param in the coordinates to transform (not null, unaffected)
@@ -324,7 +328,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Applies the inverse transform to the specified coordinates. The current
+     * Applies the inverse transform to the specified coordinates and returns
+     * the result in <code>store</code>. If the <code>store</code> is null,
+     * a new Vector3f is created to hold the value. Either way, the current
      * instance is unaffected, unless <code>store</code> is its translation or
      * scaling.
      *

--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -178,12 +178,13 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
 
     /**
      * Stores this translation component into the given vector3f. If trans is null,
-     * a new vector3f is created to hold the value. The value, once stored, is
-     * returned. The current instance is unaffected, unless <code>trans</code>
+     * a new vector3f is created to hold the value. The current instance is
+     * unaffected, unless <code>trans</code>
      * is its scaling component.
      *
      * @param trans storage for the result (modified if not null)
-     * @return The value of this transform's translation.
+     * @return the translation offsets (either <code>trans</code> or a new
+     *     Vector3f)
      */
     public Vector3f getTranslation(Vector3f trans) {
         if (trans == null) {
@@ -195,11 +196,10 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
 
     /**
      * Stores the rotation component into the given Quaternion. If quat is null, a
-     * new Quaternion is created to hold the value. The value, once stored, is
-     * returned. The current instance is unaffected.
+     * new Quaternion is created to hold the value. The current instance is unaffected.
      *
      * @param quat storage for the result (modified if not null)
-     * @return The value of this transform's rotation.
+     * @return the rotation value (either <code>quat</code> or a new Quaternion)
      */
     public Quaternion getRotation(Quaternion quat) {
         if (quat == null) {
@@ -220,12 +220,12 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
 
     /**
      * Stores the scaling component into the given vector3f. If scale is null, a new
-     * vector3f is created to hold the value. The value, once stored, is
-     * returned. The current instance is unaffected, unless <code>scale</code>
+     * vector3f is created to hold the value. The current instance is
+     * unaffected, unless <code>scale</code>
      * is its translation component.
      *
      * @param scale storage for the result (modified if not null)
-     * @return The value of this transform's scale.
+     * @return the scale factors (either <code>scale</code> or a new Vector3f)
      */
     public Vector3f getScale(Vector3f scale) {
         if (scale == null) {
@@ -310,7 +310,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      *
      * @param in the coordinates to transform (not null, unaffected)
      * @param store storage for the result (modified if not null)
-     * @return the transformed coordinates (either store or a new vector)
+     * @return the transformed coordinates (either <code>store</code> or a new
+     *     Vector3f)
      */
     public Vector3f transformVector(final Vector3f in, Vector3f store) {
         if (store == null) {
@@ -330,7 +331,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      * @param in the coordinates to transform (not null, unaffected unless it's
      *     <code>store</code>)
      * @param store storage for the result (modified if not null)
-     * @return the transformed coordinates (either store or a new vector)
+     * @return the transformed coordinates (either <code>store</code> or a new
+     *     Vector3f)
      */
     public Vector3f transformInverseVector(final Vector3f in, Vector3f store) {
         if (store == null) {
@@ -352,7 +354,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      * Creates an equivalent transform matrix. The current instance is
      * unaffected.
      *
-     * @return a new 4x4 matrix
+     * @return a new Matrix4f
      */
     public Matrix4f toTransformMatrix() {
         return toTransformMatrix(null);
@@ -363,7 +365,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      * unaffected.
      *
      * @param store storage for the result (modified if not null)
-     * @return a 4x4 matrix (either store or a new vector)
+     * @return a transform matrix (either <code>store</code> or a new Matrix4f)
      */
     public Matrix4f toTransformMatrix(Matrix4f store) {
         if (store == null) {
@@ -391,7 +393,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Creates an inverse of this Transform. The current instance is unaffected.
      *
-     * @return a new instance
+     * @return a new Transform
      */
     public Transform invert() {
         Transform t = new Transform();
@@ -463,7 +465,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      * [RX.XXXX, RY.YYYY, RZ.ZZZZ, RW.WWWW]
      * [SX.XXXX, SY.YYYY, SZ.ZZZZ]
      *
-     * @return a descriptive string of text (not null, not empty)
+     * @return the string representation (not null, not empty)
      */
     @Override
     public String toString() {
@@ -520,7 +522,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Creates a copy of this Transform. The current instance is unaffected.
      *
-     * @return a new instance equivalent to this one
+     * @return a new instance, equivalent to the current one
      */
     @Override
     public Transform clone() {

--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -57,11 +57,11 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      */
     private Quaternion rot = new Quaternion();
     /**
-     * Translation component:  an offset for each axis.
+     * Translation component: an offset for each axis.
      */
     private Vector3f translation = new Vector3f();
     /**
-     * Scaling component:  a scale factor for each axis.
+     * Scaling component: a scale factor for each axis.
      */
     private Vector3f scale = new Vector3f(1, 1, 1);
 
@@ -176,10 +176,10 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Copies the translation component to the argument. If the argument is null,
-     * a new Vector3f is created to hold the value. Either way, the current instance is
-     * unaffected, unless the argument
-     * is its scaling component.
+     * Copies the translation component to the argument. If the argument is
+     * null, a new Vector3f is created to hold the value. Either way, the
+     * current instance is unaffected, unless the argument is its scaling
+     * component.
      *
      * @param trans storage for the result (modified if not null)
      * @return the translation offsets (either <code>trans</code> or a new
@@ -219,10 +219,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Copies the scaling component to the argument. If the argument is null, a new
-     * Vector3f is created to hold the value. Either way, the current instance is
-     * unaffected, unless the argument
-     * is its translation component.
+     * Copies the scaling component to the argument. If the argument is null, a
+     * new Vector3f is created to hold the value. Either way, the current
+     * instance is unaffected, unless the argument is its translation component.
      *
      * @param scale storage for the result (modified if not null)
      * @return the scale factors (either <code>scale</code> or a new Vector3f)
@@ -243,7 +242,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      * @param t2 The ending transform (not null, unaffected unless it's
      *     <code>this</code>)
      * @param delta An amount between 0 and 1 representing how far to
-     * interpolate from t1 to t2.
+     *     interpolate from t1 to t2.
      */
     public void interpolateTransforms(Transform t1, Transform t2, float delta) {
         this.rot.set(t1.rot);
@@ -304,10 +303,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
 
     /**
      * Transforms the specified coordinates and returns the result in
-     * <code>store</code>. If the <code>store</code> is null,
-     * a new Vector3f is created to hold the value. Either way,
-     * the current instance is unaffected,
-     * unless <code>store</code> is its translation or scaling.
+     * <code>store</code>. If the <code>store</code> is null, a new Vector3f is
+     * created to hold the value. Either way, the current instance is
+     * unaffected, unless <code>store</code> is its translation or scaling.
      *
      * @param in the coordinates to transform (not null, unaffected)
      * @param store storage for the result (modified if not null)
@@ -326,8 +324,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
 
     /**
      * Applies the inverse transform to the specified coordinates and returns
-     * the result in <code>store</code>. If the <code>store</code> is null,
-     * a new Vector3f is created to hold the value. Either way, the current
+     * the result in <code>store</code>. If the <code>store</code> is null, a
+     * new Vector3f is created to hold the value. Either way, the current
      * instance is unaffected, unless <code>store</code> is its translation or
      * scaling.
      *
@@ -461,8 +459,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Returns a string representation. The current instance is
-     * unaffected. The format is:
+     * Returns a string representation. The current instance is unaffected. The
+     * format is:
      *
      * [TX.XXXX, TY.YYYY, TZ.ZZZZ]
      * [RX.XXXX, RY.YYYY, RZ.ZZZZ, RW.WWWW]
@@ -492,8 +490,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Serializes to the argument, for example when
-     * saving to a J3O file. The current instance is unaffected.
+     * Serializes to the argument, for example when saving to a J3O file. The
+     * current instance is unaffected.
      *
      * @param e (not null)
      * @throws IOException from the exporter
@@ -507,8 +505,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * De-serializes from the argument, for example
-     * when loading from a J3O file.
+     * De-serializes from the argument, for example when loading from a J3O
+     * file.
      *
      * @param e (not null)
      * @throws IOException from the importer

--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -116,8 +116,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets this rotation to the given Quaternion value.
      *
-     * @param rot The new rotation for this Transform.
-     * @return this
+     * @param rot The new rotation for this Transform. (unaffected)
+     * @return the (modified) current instance (for chaining)
      */
     public Transform setRotation(Quaternion rot) {
         this.rot.set(rot);
@@ -127,8 +127,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets this translation to the given value.
      *
-     * @param trans The new translation for this Transform.
-     * @return this
+     * @param trans The new translation for this Transform. (unaffected)
+     * @return the (modified) current instance (for chaining)
      */
     public Transform setTranslation(Vector3f trans) {
         this.translation.set(trans);
@@ -138,7 +138,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Returns the translation vector in this Transform.
      *
-     * @return translation vector.
+     * @return the pre-existing instance
      */
     public Vector3f getTranslation() {
         return translation;
@@ -147,8 +147,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets this scale to the given value.
      *
-     * @param scale The new scale for this Transform.
-     * @return this
+     * @param scale The new scale for this Transform. (unaffected)
+     * @return the (modified) current instance (for chaining)
      */
     public Transform setScale(Vector3f scale) {
         this.scale.set(scale);
@@ -159,7 +159,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      * Sets this scale to the given value.
      *
      * @param scale The new scale for this Transform.
-     * @return this
+     * @return the (modified) current instance (for chaining)
      */
     public Transform setScale(float scale) {
         this.scale.set(scale, scale, scale);
@@ -169,7 +169,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Returns the scale vector in this Transform.
      *
-     * @return scale vector.
+     * @return the pre-existing instance
      */
     public Vector3f getScale() {
         return scale;
@@ -178,9 +178,10 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Stores this translation value into the given vector3f. If trans is null,
      * a new vector3f is created to hold the value. The value, once stored, is
-     * returned.
+     * returned. The current instance is unaffected, unless <code>trans</code>
+     * is its scale component.
      *
-     * @param trans The store location for this transform's translation.
+     * @param trans storage for the result (modified if not null)
      * @return The value of this transform's translation.
      */
     public Vector3f getTranslation(Vector3f trans) {
@@ -194,9 +195,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Stores this rotation value into the given Quaternion. If quat is null, a
      * new Quaternion is created to hold the value. The value, once stored, is
-     * returned.
+     * returned. The current instance is unaffected.
      *
-     * @param quat The store location for this transform's rotation.
+     * @param quat storage for the result (modified if not null)
      * @return The value of this transform's rotation.
      */
     public Quaternion getRotation(Quaternion quat) {
@@ -210,7 +211,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Returns the rotation quaternion in this Transform.
      *
-     * @return rotation quaternion.
+     * @return the pre-existing instance
      */
     public Quaternion getRotation() {
         return rot;
@@ -219,9 +220,10 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Stores this scale value into the given vector3f. If scale is null, a new
      * vector3f is created to hold the value. The value, once stored, is
-     * returned.
+     * returned. The current instance is unaffected, unless <code>scale</code>
+     * is its translation component.
      *
-     * @param scale The store location for this transform's scale.
+     * @param scale storage for the result (modified if not null)
      * @return The value of this transform's scale.
      */
     public Vector3f getScale(Vector3f scale) {
@@ -236,8 +238,10 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      * Sets this transform to the interpolation between the first transform and
      * the second by delta amount.
      *
-     * @param t1 The beginning transform.
-     * @param t2 The ending transform.
+     * @param t1 The beginning transform. (unaffected unless it's
+     *     <code>this</code>)
+     * @param t2 The ending transform. (unaffected unless it's
+     *     <code>this</code>)
      * @param delta An amount between 0 and 1 representing how far to
      * interpolate from t1 to t2.
      */
@@ -249,11 +253,13 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Changes the values of this Transform according to its parent. Very similar
-     * to the concept of Node/Spatial transforms.
+     * Changes the values of this Transform according to its parent and returns
+     * the (modified) current instance. Very similar to the concept of
+     * Node/Spatial transforms.
      *
-     * @param parent The parent Transform.
-     * @return This Transform, after combining.
+     * @param parent The parent Transform. (unaffected unless it's
+     *     <code>this</code>)
+     * @return the (modified) current instance (for chaining)
      */
     public Transform combineWithParent(Transform parent) {
         //applying parent scale to local scale
@@ -277,7 +283,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      * @param x This transform's new x translation.
      * @param y This transform's new y translation.
      * @param z This transform's new z translation.
-     * @return this
+     * @return the (modified) current instance (for chaining)
      */
     public Transform setTranslation(float x, float y, float z) {
         translation.set(x, y, z);
@@ -290,7 +296,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      * @param x This transform's new x scale.
      * @param y This transform's new y scale.
      * @param z This transform's new z scale.
-     * @return this
+     * @return the (modified) current instance (for chaining)
      */
     public Transform setScale(float x, float y, float z) {
         scale.set(x, y, z);
@@ -298,7 +304,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Transforms the specified coordinates.
+     * Transforms the specified coordinates. The current instance is unaffected,
+     * unless <code>store</code> is its translation or scale.
      *
      * @param in the coordinates to transform (not null, unaffected)
      * @param store storage for the result (modified if not null)
@@ -315,9 +322,12 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Applies the inverse transform to the specified coordinates.
+     * Applies the inverse transform to the specified coordinates. The current
+     * instance is unaffected, unless <code>store</code> is the translation or
+     * scale.
      *
-     * @param in the coordinates to transform (not null, unaffected)
+     * @param in the coordinates to transform (not null, unaffected unless it's
+     *     <code>store</code>)
      * @param store storage for the result (modified if not null)
      * @return the transformed coordinates (either store or a new vector)
      */
@@ -338,7 +348,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Creates an equivalent transform matrix.
+     * Creates an equivalent transform matrix. The current instance is
+     * unaffected.
      *
      * @return a new 4x4 matrix
      */
@@ -347,7 +358,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Converts to an equivalent transform matrix.
+     * Converts to an equivalent transform matrix. The current instance is
+     * unaffected.
      *
      * @param store storage for the result (modified if not null)
      * @return a 4x4 matrix (either store or a new vector)
@@ -376,7 +388,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Creates an inverse of this Transform.
+     * Creates an inverse of this Transform. The current instance is unaffected.
      *
      * @return a new instance
      */
@@ -396,7 +408,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Tests for exact identity.
+     * Tests for exact identity. The current instance is unaffected.
      *
      * @return true if exactly equal to {@link #IDENTITY}, otherwise false
      */
@@ -407,7 +419,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Generates the hash code for this instance.
+     * Generates the hash code for this instance. The current instance is
+     * unaffected.
      *
      * @return a 32-bit value for use in hashing
      */
@@ -421,7 +434,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Tests for exact equality with another object.
+     * Tests for exact equality with another object. The current instance is
+     * unaffected.
      *
      * @param obj the object to compare to (may be null, unaffected)
      * @return true if the objects are exactly equal, otherwise false
@@ -441,7 +455,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Represents this Transform as a String. The format is:
+     * Represents this Transform as a String. The current instance is
+     * unaffected. The format is:
      *
      * [TX.XXXX, TY.YYYY, TZ.ZZZZ]
      * [RX.XXXX, RY.YYYY, RZ.ZZZZ, RW.WWWW]
@@ -460,8 +475,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets this Transform to be equal to the given Transform.
      *
-     * @param matrixQuat The Transform to be equal to.
-     * @return this
+     * @param matrixQuat The Transform to be equal to. (unaffected)
+     * @return the (modified) current instance (for chaining)
      */
     public Transform set(Transform matrixQuat) {
         this.translation.set(matrixQuat.translation);
@@ -472,7 +487,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
 
     /**
      * Serializes this transform to the specified exporter, for example when
-     * saving to a J3O file.
+     * saving to a J3O file. The current instance is unaffected.
      *
      * @param e (not null)
      * @throws IOException from the exporter
@@ -502,7 +517,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Creates a copy of this Transform.
+     * Creates a copy of this Transform. The current instance is unaffected.
      *
      * @return a new instance equivalent to this one
      */

--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -116,7 +116,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets this rotation to the given Quaternion value.
      *
-     * @param rot The new rotation for this Transform. (unaffected)
+     * @param rot The new rotation for this Transform. (not null, unaffected)
      * @return the (modified) current instance (for chaining)
      */
     public Transform setRotation(Quaternion rot) {
@@ -127,7 +127,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets this translation to the given value.
      *
-     * @param trans The new translation for this Transform. (unaffected)
+     * @param trans The new translation for this Transform. (not null,
+     *     unaffected)
      * @return the (modified) current instance (for chaining)
      */
     public Transform setTranslation(Vector3f trans) {
@@ -138,7 +139,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Returns the translation vector in this Transform.
      *
-     * @return the pre-existing instance
+     * @return the pre-existing instance (not null)
      */
     public Vector3f getTranslation() {
         return translation;
@@ -147,7 +148,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets this scale to the given value.
      *
-     * @param scale The new scale for this Transform. (unaffected)
+     * @param scale The new scale for this Transform. (not null, unaffected)
      * @return the (modified) current instance (for chaining)
      */
     public Transform setScale(Vector3f scale) {
@@ -169,7 +170,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Returns the scale vector in this Transform.
      *
-     * @return the pre-existing instance
+     * @return the pre-existing instance (not null)
      */
     public Vector3f getScale() {
         return scale;
@@ -211,7 +212,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Returns the rotation quaternion in this Transform.
      *
-     * @return the pre-existing instance
+     * @return the pre-existing instance (not null)
      */
     public Quaternion getRotation() {
         return rot;
@@ -238,15 +239,15 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      * Sets this transform to the interpolation between the first transform and
      * the second by delta amount.
      *
-     * @param t1 The beginning transform. (unaffected unless it's
+     * @param t1 The beginning transform. (not null, unaffected unless it's
      *     <code>this</code>)
-     * @param t2 The ending transform. (unaffected unless it's
+     * @param t2 The ending transform. (not null, unaffected unless it's
      *     <code>this</code>)
      * @param delta An amount between 0 and 1 representing how far to
      * interpolate from t1 to t2.
      */
     public void interpolateTransforms(Transform t1, Transform t2, float delta) {
-        this.rot.set(t1.rot); 
+        this.rot.set(t1.rot);
         this.rot.nlerp(t2.rot, delta);
         this.translation.interpolateLocal(t1.translation, t2.translation, delta);
         this.scale.interpolateLocal(t1.scale, t2.scale, delta);
@@ -257,7 +258,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      * the (modified) current instance. Very similar to the concept of
      * Node/Spatial transforms.
      *
-     * @param parent The parent Transform. (unaffected unless it's
+     * @param parent The parent Transform. (not null, unaffected unless it's
      *     <code>this</code>)
      * @return the (modified) current instance (for chaining)
      */
@@ -475,7 +476,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets this Transform to be equal to the given Transform.
      *
-     * @param matrixQuat The Transform to be equal to. (unaffected)
+     * @param matrixQuat The Transform to be equal to. (not null, unaffected)
      * @return the (modified) current instance (for chaining)
      */
     public Transform set(Transform matrixQuat) {

--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -49,24 +49,24 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
 
     static final long serialVersionUID = 1;
     /**
-     * shared instance of the identity transform - Do not modify!
+     * Shared instance of the identity transform. Do not modify!
      */
     public static final Transform IDENTITY = new Transform();
     /**
-     * rotation component
+     * Rotation component.
      */
     private Quaternion rot = new Quaternion();
     /**
-     * translation offsets for each axis
+     * Translation offsets for each axis.
      */
     private Vector3f translation = new Vector3f();
     /**
-     * scale factors for each axis
+     * Scale factors for each axis.
      */
     private Vector3f scale = new Vector3f(1, 1, 1);
 
     /**
-     * Instantiate a coordinate transform without any scaling.
+     * Instantiates a coordinate transform without any scaling.
      *
      * @param translation the desired translation (not null, unaffected)
      * @param rot the desired rotation (not null, unaffected)
@@ -77,7 +77,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Instantiate a coordinate transform with scaling.
+     * Instantiates a coordinate transform with scaling.
      *
      * @param translation the desired translation (not null, unaffected)
      * @param rot the desired rotation (not null, unaffected)
@@ -89,7 +89,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Instantiate a translation-only transform.
+     * Instantiates a translation-only transform.
      *
      * @param translation the desired translation (not null, unaffected)
      */
@@ -98,7 +98,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Instantiate a rotation-only transform.
+     * Instantiates a rotation-only transform.
      *
      * @param rot the desired rotation (not null, unaffected)
      */
@@ -107,7 +107,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Instantiate an identity transform.
+     * Instantiates an identity transform.
      */
     public Transform() {
         this(Vector3f.ZERO, Quaternion.IDENTITY);
@@ -136,7 +136,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Return the translation vector in this Transform.
+     * Returns the translation vector in this Transform.
      *
      * @return translation vector.
      */
@@ -167,7 +167,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Return the scale vector in this Transform.
+     * Returns the scale vector in this Transform.
      *
      * @return scale vector.
      */
@@ -208,7 +208,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Return the rotation quaternion in this Transform.
+     * Returns the rotation quaternion in this Transform.
      *
      * @return rotation quaternion.
      */
@@ -298,7 +298,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Transform the specified coordinates.
+     * Transforms the specified coordinates.
      *
      * @param in the coordinates to transform (not null, unaffected)
      * @param store storage for the result (modified if not null)
@@ -315,7 +315,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Apply the inverse transform to the specified coordinates.
+     * Applies the inverse transform to the specified coordinates.
      *
      * @param in the coordinates to transform (not null, unaffected)
      * @param store storage for the result (modified if not null)
@@ -338,7 +338,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Create an equivalent transform matrix.
+     * Creates an equivalent transform matrix.
      *
      * @return a new 4x4 matrix
      */
@@ -347,7 +347,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Convert to an equivalent transform matrix.
+     * Converts to an equivalent transform matrix.
      *
      * @param store storage for the result (modified if not null)
      * @return a 4x4 matrix (either store or a new vector)
@@ -363,7 +363,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Configure based on a transform matrix.
+     * Configures based on a transform matrix.
      *
      * @param mat the input matrix (not null, unaffected)
      */
@@ -376,7 +376,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Create an inverse of this Transform.
+     * Creates an inverse of this Transform.
      *
      * @return a new instance
      */
@@ -396,7 +396,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Test for exact identity.
+     * Tests for exact identity.
      *
      * @return true if exactly equal to {@link #IDENTITY}, otherwise false
      */
@@ -407,7 +407,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Generate the hash code for this instance.
+     * Generates the hash code for this instance.
      *
      * @return a 32-bit value for use in hashing
      */
@@ -421,7 +421,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Test for exact equality with another object.
+     * Tests for exact equality with another object.
      *
      * @param obj the object to compare to (may be null, unaffected)
      * @return true if the objects are exactly equal, otherwise false
@@ -441,7 +441,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Represent this Transform as a String. The format is:
+     * Represents this Transform as a String. The format is:
      *
      * [TX.XXXX, TY.YYYY, TZ.ZZZZ]
      * [RX.XXXX, RY.YYYY, RZ.ZZZZ, RW.WWWW]
@@ -471,7 +471,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Serialize this transform to the specified exporter, for example when
+     * Serializes this transform to the specified exporter, for example when
      * saving to a J3O file.
      *
      * @param e (not null)
@@ -486,7 +486,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * De-serialize this transform from the specified importer, for example
+     * De-serializes this transform from the specified importer, for example
      * when loading from a J3O file.
      *
      * @param e (not null)
@@ -502,7 +502,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Create a copy of this Transform.
+     * Creates a copy of this Transform.
      *
      * @return a new instance equivalent to this one
      */

--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -40,7 +40,7 @@ import java.io.IOException;
  * A 3-D coordinate transform composed of translation, rotation, and scaling.
  * The order of application is: scale then rotate then translate.
  *
- * Started Date: Jul 16, 2004<br><br>
+ * <p>Started July 16, 2004
  *
  * @author Jack Lindamood
  * @author Joshua Slack
@@ -57,11 +57,11 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      */
     private Quaternion rot = new Quaternion();
     /**
-     * Translation component: an offset for each axis.
+     * Translation component: an offset for each local axis.
      */
     private Vector3f translation = new Vector3f();
     /**
-     * Scaling component: a scale factor for each axis.
+     * Scaling component: a scale factor for each local axis.
      */
     private Vector3f scale = new Vector3f(1, 1, 1);
 
@@ -107,7 +107,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Instantiates an identity transform.
+     * Instantiates an identity transform: no translation, no rotation, and no
+     * scaling.
      */
     public Transform() {
         this(Vector3f.ZERO, Quaternion.IDENTITY);
@@ -156,9 +157,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets the scaling component to the argument.
+     * Sets the scaling component to the argument. This yields uniform scaling.
      *
-     * @param scale the desired scale factor
+     * @param scale the desired scale factor for all local axes
      * @return the (modified) current instance (for chaining)
      */
     public Transform setScale(float scale) {
@@ -235,14 +236,15 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Interpolates between the specified transforms.
+     * Interpolates quickly between the specified transforms, using
+     * {@link Quaternion#nlerp(com.jme3.math.Quaternion, float)} and
+     * {@link Vector3f#interpolateLocal(com.jme3.math.Vector3f, com.jme3.math.Vector3f, float)}.
      *
-     * @param t1 The beginning transform (not null, unaffected unless it's
-     *     <code>this</code>)
-     * @param t2 The ending transform (not null, unaffected unless it's
-     *     <code>this</code>)
-     * @param delta An amount between 0 and 1 representing how far to
-     *     interpolate from t1 to t2.
+     * @param t1 the desired value when <code>delta</code>=0 (not null,
+     *     unaffected unless it's <code>this</code>)
+     * @param t2 the desired value when <code>delta</code>=1 (not null,
+     *     unaffected unless it's <code>this</code>)
+     * @param delta the fractional change amount
      */
     public void interpolateTransforms(Transform t1, Transform t2, float delta) {
         this.rot.set(t1.rot);
@@ -255,7 +257,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      * Combines with the argument and returns the (modified) current instance.
      * This method is used to combine Node and Spatial transforms.
      *
-     * @param parent The parent Transform (not null, unaffected unless it's
+     * @param parent the parent transform (not null, unaffected unless it's
      *     <code>this</code>)
      * @return the (modified) current instance (for chaining)
      */
@@ -379,7 +381,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Configures based on a transform matrix.
+     * Sets the current instance from a transform matrix. Any shear in the
+     * matrix is lost -- in other words, it may not be possible to recreate the
+     * original matrix from the result.
      *
      * @param mat the input matrix (not null, unaffected)
      */
@@ -415,7 +419,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Tests for exact identity. The current instance is unaffected.
      *
-     * @return true if exactly equal to {@link #IDENTITY}, otherwise false
+     * @return true if equal to {@link #IDENTITY}, otherwise false
      */
     public boolean isIdentity() {
         return translation.x == 0f && translation.y == 0f && translation.z == 0f
@@ -424,7 +428,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Returns a hash code. The current instance is unaffected.
+     * Returns a hash code. If two transforms are logically equivalent, they
+     * will return the same hash code. The current instance is unaffected.
      *
      * @return a 32-bit value for use in hashing
      */
@@ -438,8 +443,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Tests for exact equality with the argument. The current instance is
-     * unaffected.
+     * Tests for exact equality with the argument, distinguishing -0 from 0. The
+     * current instance is unaffected.
      *
      * @param obj the object to compare to (may be null, unaffected)
      * @return true if the objects are exactly equal, otherwise false

--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -114,7 +114,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets the rotation component to the given Quaternion value.
+     * Sets the rotation component to the argument.
      *
      * @param rot The new rotation for this Transform. (not null, unaffected)
      * @return the (modified) current instance (for chaining)
@@ -125,7 +125,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets the translation component to the given value.
+     * Sets the translation component to the argument.
      *
      * @param trans The new translation for this Transform. (not null,
      *     unaffected)
@@ -146,7 +146,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets the scaling component to the given value.
+     * Sets the scaling component to the argument.
      *
      * @param scale The new scale factors for this Transform. (not null, unaffected)
      * @return the (modified) current instance (for chaining)
@@ -157,7 +157,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets the scaling component to the given value.
+     * Sets the scaling component to the argument.
      *
      * @param scale The new scale factor for this Transform.
      * @return the (modified) current instance (for chaining)
@@ -280,7 +280,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets this transform's translation to the given values.
+     * Sets this transform's translation to the specified values.
      *
      * @param x This transform's new X translation.
      * @param y This transform's new Y translation.
@@ -293,7 +293,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets the scaling component to the given values.
+     * Sets the scaling component to the specified values.
      *
      * @param x This transform's new X scale factor.
      * @param y This transform's new Y scale factor.

--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -279,11 +279,11 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets this transform's translation to the given x,y,z values.
+     * Sets this transform's translation to the given values.
      *
-     * @param x This transform's new x translation.
-     * @param y This transform's new y translation.
-     * @param z This transform's new z translation.
+     * @param x This transform's new X translation.
+     * @param y This transform's new Y translation.
+     * @param z This transform's new Z translation.
      * @return the (modified) current instance (for chaining)
      */
     public Transform setTranslation(float x, float y, float z) {
@@ -292,11 +292,11 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets the scaling component to the given x,y,z values.
+     * Sets the scaling component to the given values.
      *
-     * @param x This transform's new x scale factor.
-     * @param y This transform's new y scale factor.
-     * @param z This transform's new z scale factor.
+     * @param x This transform's new X scale factor.
+     * @param y This transform's new Y scale factor.
+     * @param z This transform's new Z scale factor.
      * @return the (modified) current instance (for chaining)
      */
     public Transform setScale(float x, float y, float z) {

--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -57,11 +57,11 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      */
     private Quaternion rot = new Quaternion();
     /**
-     * Translation offsets for each axis.
+     * Translation component:  an offset for each axis.
      */
     private Vector3f translation = new Vector3f();
     /**
-     * Scale factors for each axis.
+     * Scaling component:  a scale factor for each axis.
      */
     private Vector3f scale = new Vector3f(1, 1, 1);
 
@@ -81,7 +81,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
      *
      * @param translation the desired translation (not null, unaffected)
      * @param rot the desired rotation (not null, unaffected)
-     * @param scale the desired scale factor (not null, unaffected)
+     * @param scale the desired scaling (not null, unaffected)
      */
     public Transform(Vector3f translation, Quaternion rot, Vector3f scale) {
         this(translation, rot);
@@ -114,7 +114,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets this rotation to the given Quaternion value.
+     * Sets the rotation component to the given Quaternion value.
      *
      * @param rot The new rotation for this Transform. (not null, unaffected)
      * @return the (modified) current instance (for chaining)
@@ -125,7 +125,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets this translation to the given value.
+     * Sets the translation component to the given value.
      *
      * @param trans The new translation for this Transform. (not null,
      *     unaffected)
@@ -137,7 +137,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Returns the translation vector in this Transform.
+     * Returns the translation component of this Transform.
      *
      * @return the pre-existing instance (not null)
      */
@@ -146,9 +146,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets this scale to the given value.
+     * Sets the scaling component to the given value.
      *
-     * @param scale The new scale for this Transform. (not null, unaffected)
+     * @param scale The new scale factors for this Transform. (not null, unaffected)
      * @return the (modified) current instance (for chaining)
      */
     public Transform setScale(Vector3f scale) {
@@ -157,9 +157,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets this scale to the given value.
+     * Sets the scaling component to the given value.
      *
-     * @param scale The new scale for this Transform.
+     * @param scale The new scale factor for this Transform.
      * @return the (modified) current instance (for chaining)
      */
     public Transform setScale(float scale) {
@@ -168,7 +168,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Returns the scale vector in this Transform.
+     * Returns the scaling component of this Transform.
      *
      * @return the pre-existing instance (not null)
      */
@@ -177,10 +177,10 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Stores this translation value into the given vector3f. If trans is null,
+     * Stores this translation component into the given vector3f. If trans is null,
      * a new vector3f is created to hold the value. The value, once stored, is
      * returned. The current instance is unaffected, unless <code>trans</code>
-     * is its scale component.
+     * is its scaling component.
      *
      * @param trans storage for the result (modified if not null)
      * @return The value of this transform's translation.
@@ -194,7 +194,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Stores this rotation value into the given Quaternion. If quat is null, a
+     * Stores the rotation component into the given Quaternion. If quat is null, a
      * new Quaternion is created to hold the value. The value, once stored, is
      * returned. The current instance is unaffected.
      *
@@ -210,7 +210,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Returns the rotation quaternion in this Transform.
+     * Returns the rotation component of this Transform.
      *
      * @return the pre-existing instance (not null)
      */
@@ -219,7 +219,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Stores this scale value into the given vector3f. If scale is null, a new
+     * Stores the scaling component into the given vector3f. If scale is null, a new
      * vector3f is created to hold the value. The value, once stored, is
      * returned. The current instance is unaffected, unless <code>scale</code>
      * is its translation component.
@@ -292,11 +292,11 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets this transform's scale to the given x,y,z values.
+     * Sets the scaling component to the given x,y,z values.
      *
-     * @param x This transform's new x scale.
-     * @param y This transform's new y scale.
-     * @param z This transform's new z scale.
+     * @param x This transform's new x scale factor.
+     * @param y This transform's new y scale factor.
+     * @param z This transform's new z scale factor.
      * @return the (modified) current instance (for chaining)
      */
     public Transform setScale(float x, float y, float z) {
@@ -306,7 +306,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
 
     /**
      * Transforms the specified coordinates. The current instance is unaffected,
-     * unless <code>store</code> is its translation or scale.
+     * unless <code>store</code> is its translation or scaling.
      *
      * @param in the coordinates to transform (not null, unaffected)
      * @param store storage for the result (modified if not null)
@@ -324,8 +324,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
 
     /**
      * Applies the inverse transform to the specified coordinates. The current
-     * instance is unaffected, unless <code>store</code> is the translation or
-     * scale.
+     * instance is unaffected, unless <code>store</code> is its translation or
+     * scaling.
      *
      * @param in the coordinates to transform (not null, unaffected unless it's
      *     <code>store</code>)

--- a/jme3-core/src/main/java/com/jme3/math/Transform.java
+++ b/jme3-core/src/main/java/com/jme3/math/Transform.java
@@ -66,7 +66,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     private Vector3f scale = new Vector3f(1, 1, 1);
 
     /**
-     * Instantiates a coordinate transform without any scaling.
+     * Instantiates a coordinate transform without scaling.
      *
      * @param translation the desired translation (not null, unaffected)
      * @param rot the desired rotation (not null, unaffected)
@@ -116,7 +116,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets the rotation component to the argument.
      *
-     * @param rot The new rotation for this Transform. (not null, unaffected)
+     * @param rot the desired rotation value (not null, unaffected)
      * @return the (modified) current instance (for chaining)
      */
     public Transform setRotation(Quaternion rot) {
@@ -127,8 +127,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets the translation component to the argument.
      *
-     * @param trans The new translation for this Transform. (not null,
-     *     unaffected)
+     * @param trans the desired offsets (not null, unaffected)
      * @return the (modified) current instance (for chaining)
      */
     public Transform setTranslation(Vector3f trans) {
@@ -137,7 +136,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Returns the translation component of this Transform.
+     * Returns the translation component.
      *
      * @return the pre-existing instance (not null)
      */
@@ -148,7 +147,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets the scaling component to the argument.
      *
-     * @param scale The new scale factors for this Transform. (not null, unaffected)
+     * @param scale the desired scale factors (not null, unaffected)
      * @return the (modified) current instance (for chaining)
      */
     public Transform setScale(Vector3f scale) {
@@ -159,7 +158,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets the scaling component to the argument.
      *
-     * @param scale The new scale factor for this Transform.
+     * @param scale the desired scale factor
      * @return the (modified) current instance (for chaining)
      */
     public Transform setScale(float scale) {
@@ -168,7 +167,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Returns the scaling component of this Transform.
+     * Returns the scaling component.
      *
      * @return the pre-existing instance (not null)
      */
@@ -211,7 +210,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Returns the rotation component of this Transform.
+     * Returns the rotation component.
      *
      * @return the pre-existing instance (not null)
      */
@@ -237,12 +236,11 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets this transform to the interpolation between the first transform and
-     * the second by delta amount.
+     * Interpolates between the specified transforms.
      *
-     * @param t1 The beginning transform. (not null, unaffected unless it's
+     * @param t1 The beginning transform (not null, unaffected unless it's
      *     <code>this</code>)
-     * @param t2 The ending transform. (not null, unaffected unless it's
+     * @param t2 The ending transform (not null, unaffected unless it's
      *     <code>this</code>)
      * @param delta An amount between 0 and 1 representing how far to
      * interpolate from t1 to t2.
@@ -255,11 +253,10 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Changes the values of this Transform according the argument and returns
-     * the (modified) current instance. Very similar to the concept of
-     * Node/Spatial transforms.
+     * Combines with the argument and returns the (modified) current instance.
+     * This method is used to combine Node and Spatial transforms.
      *
-     * @param parent The parent Transform. (not null, unaffected unless it's
+     * @param parent The parent Transform (not null, unaffected unless it's
      *     <code>this</code>)
      * @return the (modified) current instance (for chaining)
      */
@@ -280,11 +277,11 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets this transform's translation to the specified values.
+     * Sets the translation component to the specified values.
      *
-     * @param x This transform's new X translation.
-     * @param y This transform's new Y translation.
-     * @param z This transform's new Z translation.
+     * @param x the desired X offset
+     * @param y the desired Y offset
+     * @param z the desired Z offset
      * @return the (modified) current instance (for chaining)
      */
     public Transform setTranslation(float x, float y, float z) {
@@ -295,9 +292,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     /**
      * Sets the scaling component to the specified values.
      *
-     * @param x This transform's new X scale factor.
-     * @param y This transform's new Y scale factor.
-     * @param z This transform's new Z scale factor.
+     * @param x the desired X scale factor
+     * @param y the desired Y scale factor
+     * @param z the desired Z scale factor
      * @return the (modified) current instance (for chaining)
      */
     public Transform setScale(float x, float y, float z) {
@@ -397,7 +394,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Creates an inverse of this Transform. The current instance is unaffected.
+     * Returns the inverse. The current instance is unaffected.
      *
      * @return a new Transform
      */
@@ -408,7 +405,8 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Loads the identity.  Equal to translation=0,0,0 scale=1,1,1 rot=0,0,0,1.
+     * Sets the current instance to the identity transform: translation=(0,0,0)
+     * scaling=(1,1,1) rotation=(0,0,0,1).
      */
     public void loadIdentity() {
         translation.set(0, 0, 0);
@@ -428,8 +426,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Generates the hash code for this instance. The current instance is
-     * unaffected.
+     * Returns a hash code. The current instance is unaffected.
      *
      * @return a 32-bit value for use in hashing
      */
@@ -464,7 +461,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Represents this Transform as a String. The current instance is
+     * Returns a string representation. The current instance is
      * unaffected. The format is:
      *
      * [TX.XXXX, TY.YYYY, TZ.ZZZZ]
@@ -482,9 +479,9 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Sets this Transform to be equal to the argument.
+     * Copies all 3 components from the argument.
      *
-     * @param matrixQuat The Transform to be equal to. (not null, unaffected)
+     * @param matrixQuat The Transform to copy (not null, unaffected)
      * @return the (modified) current instance (for chaining)
      */
     public Transform set(Transform matrixQuat) {
@@ -495,7 +492,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Serializes this transform to the argument, for example when
+     * Serializes to the argument, for example when
      * saving to a J3O file. The current instance is unaffected.
      *
      * @param e (not null)
@@ -510,7 +507,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * De-serializes this transform from the argument, for example
+     * De-serializes from the argument, for example
      * when loading from a J3O file.
      *
      * @param e (not null)
@@ -526,7 +523,7 @@ public final class Transform implements Savable, Cloneable, java.io.Serializable
     }
 
     /**
-     * Creates a copy of this Transform. The current instance is unaffected.
+     * Creates a copy. The current instance is unaffected.
      *
      * @return a new instance, equivalent to the current one
      */


### PR DESCRIPTION
This PR tries to raise the javadoc of `com.jme3.math.Transform` to a higher standard:
+ explicitly indicate which methods modify the current instance and which arguments are modified
+ explicitly indicate which methods return a new instance
+ document which arguments cannot be null and what effect null arguments have
+ consistently refer to `translate`, `rot`, and `scale` as "components"