### PR TITLE
avoid invoking the newly-deprecated BitmapText 2-arg constructor

### DIFF
--- a/jme3-core/src/main/java/com/jme3/app/StatsAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/StatsAppState.java
@@ -85,7 +85,7 @@ public class StatsAppState extends AbstractAppState {
      */
     public void setFont( BitmapFont guiFont ) {
         this.guiFont = guiFont;
-        this.fpsText = new BitmapText(guiFont, false);
+        this.fpsText = new BitmapText(guiFont);
     }
 
     public BitmapText getFpsText() {
@@ -170,7 +170,7 @@ public class StatsAppState extends AbstractAppState {
      */
     public void loadFpsText() {
         if (fpsText == null) {
-            fpsText = new BitmapText(guiFont, false);
+            fpsText = new BitmapText(guiFont);
         }
 
         fpsText.setLocalTranslation(0, fpsText.getLineHeight(), 0);

--- a/jme3-examples/src/main/java/jme3test/animation/TestCameraMotionPath.java
+++ b/jme3-examples/src/main/java/jme3test/animation/TestCameraMotionPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -92,7 +92,7 @@ public class TestCameraMotionPath extends SimpleApplication {
         rootNode.attachChild(camNode);
 
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        final BitmapText wayPointsText = new BitmapText(guiFont, false);
+        final BitmapText wayPointsText = new BitmapText(guiFont);
         wayPointsText.setSize(guiFont.getCharSet().getRenderedSize());
 
         guiNode.attachChild(wayPointsText);

--- a/jme3-examples/src/main/java/jme3test/animation/TestCinematic.java
+++ b/jme3-examples/src/main/java/jme3test/animation/TestCinematic.java
@@ -85,7 +85,7 @@ public class TestCinematic extends SimpleApplication {
         nifty.fromXmlWithoutStartScreen("Interface/Nifty/CinematicTest.xml");
         getGuiViewPort().addProcessor(niftyDisplay);
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        final BitmapText text = new BitmapText(guiFont, false);
+        final BitmapText text = new BitmapText(guiFont);
         text.setSize(guiFont.getCharSet().getRenderedSize());
         text.setText("Press enter to play/pause cinematic");
         text.setLocalTranslation((cam.getWidth() - text.getLineWidth()) / 2, cam.getHeight(), 0);

--- a/jme3-examples/src/main/java/jme3test/animation/TestMotionPath.java
+++ b/jme3-examples/src/main/java/jme3test/animation/TestMotionPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -85,7 +85,7 @@ public class TestMotionPath extends SimpleApplication {
         motionControl.setInitialDuration(10f);
         motionControl.setSpeed(2f);       
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        final BitmapText wayPointsText = new BitmapText(guiFont, false);
+        final BitmapText wayPointsText = new BitmapText(guiFont);
         wayPointsText.setSize(guiFont.getCharSet().getRenderedSize());
 
         guiNode.attachChild(wayPointsText);

--- a/jme3-examples/src/main/java/jme3test/app/TestResizableApp.java
+++ b/jme3-examples/src/main/java/jme3test/app/TestResizableApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -77,7 +77,7 @@ public class TestResizableApp extends SimpleApplication {
         geom.setMaterial(mat);
         rootNode.attachChild(geom);
         
-        txt = new BitmapText(loadGuiFont(), false);
+        txt = new BitmapText(loadGuiFont());
         txt.setText("Drag the corners of the application to resize it.\n" +
                     "Current Size: " + settings.getWidth() + "x" + settings.getHeight());
         txt.setLocalTranslation(0, settings.getHeight(), 0);

--- a/jme3-examples/src/main/java/jme3test/batching/TestBatchNodeTower.java
+++ b/jme3-examples/src/main/java/jme3test/batching/TestBatchNodeTower.java
@@ -239,7 +239,7 @@ public class TestBatchNodeTower extends SimpleApplication {
 
     protected void initCrossHairs() {
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        BitmapText ch = new BitmapText(guiFont, false);
+        BitmapText ch = new BitmapText(guiFont);
         ch.setSize(guiFont.getCharSet().getRenderedSize() * 2);
         ch.setText("+"); // crosshairs
         ch.setLocalTranslation( // center

--- a/jme3-examples/src/main/java/jme3test/bullet/TestBoneRagdoll.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestBoneRagdoll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2019 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -204,7 +204,7 @@ public class TestBoneRagdoll
 
     private void initCrossHairs() {
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        BitmapText ch = new BitmapText(guiFont, false);
+        BitmapText ch = new BitmapText(guiFont);
         ch.setSize(guiFont.getCharSet().getRenderedSize() * 2f);
         ch.setText("+"); // crosshairs
         ch.setLocalTranslation( // center

--- a/jme3-examples/src/main/java/jme3test/bullet/TestBrickTower.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestBrickTower.java
@@ -240,7 +240,7 @@ public class TestBrickTower extends SimpleApplication {
 
     protected void initCrossHairs() {
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        BitmapText ch = new BitmapText(guiFont, false);
+        BitmapText ch = new BitmapText(guiFont);
         ch.setSize(guiFont.getCharSet().getRenderedSize() * 2);
         ch.setText("+"); // crosshairs
         ch.setLocalTranslation( // center

--- a/jme3-examples/src/main/java/jme3test/bullet/TestBrickWall.java
+++ b/jme3-examples/src/main/java/jme3test/bullet/TestBrickWall.java
@@ -193,7 +193,7 @@ public class TestBrickWall extends SimpleApplication {
 
     protected void initCrossHairs() {
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        BitmapText ch = new BitmapText(guiFont, false);
+        BitmapText ch = new BitmapText(guiFont);
         ch.setSize(guiFont.getCharSet().getRenderedSize() * 2);
         ch.setText("+"); // crosshairs
         ch.setLocalTranslation( // center

--- a/jme3-examples/src/main/java/jme3test/games/CubeField.java
+++ b/jme3-examples/src/main/java/jme3test/games/CubeField.java
@@ -93,8 +93,8 @@ public class CubeField extends SimpleApplication implements AnalogListener {
         Keys();
 
         defaultFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        pressStart = new BitmapText(defaultFont, false);
-        fpsScoreText = new BitmapText(defaultFont, false);
+        pressStart = new BitmapText(defaultFont);
+        fpsScoreText = new BitmapText(defaultFont);
 
         loadText(fpsScoreText, "Current Score: 0", defaultFont, 0, 2, 0);
         loadText(pressStart, "PRESS ENTER", defaultFont, 0, 5, 0);

--- a/jme3-examples/src/main/java/jme3test/games/RollingTheMonkey.java
+++ b/jme3-examples/src/main/java/jme3test/games/RollingTheMonkey.java
@@ -272,15 +272,15 @@ public class RollingTheMonkey extends SimpleApplication implements ActionListene
                 , INPUT_MAPPING_LEFT, INPUT_MAPPING_RIGHT, INPUT_MAPPING_RESET);
         
         // init UI
-        BitmapText infoText = new BitmapText(guiFont, false);
+        BitmapText infoText = new BitmapText(guiFont);
         infoText.setText(INFO_MESSAGE);
         guiNode.attachChild(infoText);
         
-        scoreText = new BitmapText(guiFont, false);
+        scoreText = new BitmapText(guiFont);
         scoreText.setText("Score: 0");
         guiNode.attachChild(scoreText);
         
-        messageText = new BitmapText(guiFont, false);
+        messageText = new BitmapText(guiFont);
         messageText.setText(MESSAGE);
         messageText.setLocalScale(0.0f);
         guiNode.attachChild(messageText);

--- a/jme3-examples/src/main/java/jme3test/games/WorldOfInception.java
+++ b/jme3-examples/src/main/java/jme3test/games/WorldOfInception.java
@@ -142,7 +142,7 @@ public class WorldOfInception extends SimpleApplication implements AnalogListene
 
     private void setupDisplay() {
         if (fpsText == null) {
-            fpsText = new BitmapText(guiFont, false);
+            fpsText = new BitmapText(guiFont);
         }
         fpsText.setLocalScale(0.7f, 0.7f, 0.7f);
         fpsText.setLocalTranslation(0, fpsText.getLineHeight(), 0);

--- a/jme3-examples/src/main/java/jme3test/gui/TestBitmapFont.java
+++ b/jme3-examples/src/main/java/jme3test/gui/TestBitmapFont.java
@@ -63,20 +63,20 @@ public class TestBitmapFont extends SimpleApplication {
         inputManager.addRawInputListener(textListener);
 
         BitmapFont fnt = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        txt = new BitmapText(fnt, false);
+        txt = new BitmapText(fnt);
         txt.setBox(new Rectangle(0, 0, settings.getWidth(), settings.getHeight()));
         txt.setSize(fnt.getPreferredSize() * 2f);
         txt.setText(txtB);
         txt.setLocalTranslation(0, txt.getHeight(), 0);
         guiNode.attachChild(txt);
 
-        BitmapText txt2 = new BitmapText(fnt, false);
+        BitmapText txt2 = new BitmapText(fnt);
         txt2.setSize(fnt.getPreferredSize() * 1.2f);
         txt2.setText("Text without restriction. \nText without restriction. Text without restriction. Text without restriction");
         txt2.setLocalTranslation(0, txt2.getHeight(), 0);
         guiNode.attachChild(txt2);
 
-        txt3 = new BitmapText(fnt, false);
+        txt3 = new BitmapText(fnt);
         txt3.setBox(new Rectangle(0, 0, settings.getWidth(), 0));
         txt3.setText("Press Tab to toggle word-wrap. type text and enter to input text");
         txt3.setLocalTranslation(0, settings.getHeight()/2, 0);

--- a/jme3-examples/src/main/java/jme3test/gui/TestBitmapText3D.java
+++ b/jme3-examples/src/main/java/jme3test/gui/TestBitmapText3D.java
@@ -59,7 +59,7 @@ public class TestBitmapText3D extends SimpleApplication {
         rootNode.attachChild(g);
 
         BitmapFont fnt = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        BitmapText txt = new BitmapText(fnt, false);
+        BitmapText txt = new BitmapText(fnt);
         txt.setBox(new Rectangle(0, 0, 6, 3));
         txt.setQueueBucket(Bucket.Transparent);
         txt.setSize( 0.5f );

--- a/jme3-examples/src/main/java/jme3test/helloworld/HelloAssets.java
+++ b/jme3-examples/src/main/java/jme3test/helloworld/HelloAssets.java
@@ -71,7 +71,7 @@ public class HelloAssets extends SimpleApplication {
         /* Display a line of text (default font from jme3-testdata) */
         setDisplayStatView(false);
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        BitmapText helloText = new BitmapText(guiFont, false);
+        BitmapText helloText = new BitmapText(guiFont);
         helloText.setSize(guiFont.getCharSet().getRenderedSize());
         helloText.setText("Hello World");
         helloText.setLocalTranslation(300, helloText.getLineHeight(), 0);

--- a/jme3-examples/src/main/java/jme3test/helloworld/HelloPhysics.java
+++ b/jme3-examples/src/main/java/jme3test/helloworld/HelloPhysics.java
@@ -214,7 +214,7 @@ public class HelloPhysics extends SimpleApplication {
   protected void initCrossHairs() {
     setDisplayStatView(false);
     //guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-    BitmapText ch = new BitmapText(guiFont, false);
+    BitmapText ch = new BitmapText(guiFont);
     ch.setSize(guiFont.getCharSet().getRenderedSize() * 2);
     ch.setText("+");        // fake crosshairs :)
     ch.setLocalTranslation( // center

--- a/jme3-examples/src/main/java/jme3test/helloworld/HelloPicking.java
+++ b/jme3-examples/src/main/java/jme3test/helloworld/HelloPicking.java
@@ -159,7 +159,7 @@ public class HelloPicking extends SimpleApplication {
   private void initCrossHairs() {
     setDisplayStatView(false);
     guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-    BitmapText ch = new BitmapText(guiFont, false);
+    BitmapText ch = new BitmapText(guiFont);
     ch.setSize(guiFont.getCharSet().getRenderedSize() * 2);
     ch.setText("+"); // crosshairs
     ch.setLocalTranslation( // center

--- a/jme3-examples/src/main/java/jme3test/light/ShadowTestUIManager.java
+++ b/jme3-examples/src/main/java/jme3test/light/ShadowTestUIManager.java
@@ -174,7 +174,7 @@ public class ShadowTestUIManager implements ActionListener {
     }
 
     private BitmapText createText(BitmapFont guiFont) {
-        BitmapText t = new BitmapText(guiFont, false);
+        BitmapText t = new BitmapText(guiFont);
         t.setSize(guiFont.getCharSet().getRenderedSize() * 0.75f);
         return t;
     }

--- a/jme3-examples/src/main/java/jme3test/light/TestDirectionalLightShadow.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestDirectionalLightShadow.java
@@ -225,14 +225,14 @@ public class TestDirectionalLightShadow extends SimpleApplication implements Act
         inputManager.addMapping("Size+", new KeyTrigger(KeyInput.KEY_W));
         inputManager.addMapping("Size-", new KeyTrigger(KeyInput.KEY_S));
 
-        shadowStabilizationText = new BitmapText(guiFont, false);
+        shadowStabilizationText = new BitmapText(guiFont);
         shadowStabilizationText.setSize(guiFont.getCharSet().getRenderedSize() * 0.75f);
         shadowStabilizationText.setText("(b:on/off) Shadow stabilization : " + dlsr.isEnabledStabilization());
         shadowStabilizationText.setLocalTranslation(10, viewPort.getCamera().getHeight() - 100, 0);
         guiNode.attachChild(shadowStabilizationText);
 
 
-        shadowZfarText = new BitmapText(guiFont, false);
+        shadowZfarText = new BitmapText(guiFont);
         shadowZfarText.setSize(guiFont.getCharSet().getRenderedSize() * 0.75f);
         shadowZfarText.setText("(n:on/off) Shadow extend to 500 and fade to 50 : " + (dlsr.getShadowZExtend() > 0));
         shadowZfarText.setLocalTranslation(10, viewPort.getCamera().getHeight() - 120, 0);

--- a/jme3-examples/src/main/java/jme3test/light/TestManyLightsSingle.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestManyLightsSingle.java
@@ -209,7 +209,7 @@ public class TestManyLightsSingle extends SimpleApplication {
          */
         guiNode.detachAllChildren();
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        helloText = new BitmapText(guiFont, false);
+        helloText = new BitmapText(guiFont);
         helloText.setSize(guiFont.getCharSet().getRenderedSize());
         helloText.setText("(Single pass) nb lights per batch : " + renderManager.getSinglePassLightBatchSize());
         helloText.setLocalTranslation(300, helloText.getLineHeight(), 0);

--- a/jme3-examples/src/main/java/jme3test/model/TestObjGroupsLoading.java
+++ b/jme3-examples/src/main/java/jme3test/model/TestObjGroupsLoading.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -108,7 +108,7 @@ public class TestObjGroupsLoading extends SimpleApplication {
     
     private void initCrossHairs() {
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        BitmapText ch = new BitmapText(guiFont, false);
+        BitmapText ch = new BitmapText(guiFont);
         ch.setSize(guiFont.getCharSet().getRenderedSize() * 2);
         ch.setText("+"); // crosshairs
         ch.setLocalTranslation( // center

--- a/jme3-examples/src/main/java/jme3test/model/anim/TestHWSkinning.java
+++ b/jme3-examples/src/main/java/jme3test/model/anim/TestHWSkinning.java
@@ -123,7 +123,7 @@ public class TestHWSkinning extends SimpleApplication implements ActionListener{
 
     private void makeHudText() {
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        hwsText = new BitmapText(guiFont, false);
+        hwsText = new BitmapText(guiFont);
         hwsText.setSize(guiFont.getCharSet().getRenderedSize());
         hwsText.setText("HWS : "+ hwSkinningEnable);
         hwsText.setLocalTranslation(0, cam.getHeight(), 0);

--- a/jme3-examples/src/main/java/jme3test/model/anim/TestHWSkinningOld.java
+++ b/jme3-examples/src/main/java/jme3test/model/anim/TestHWSkinningOld.java
@@ -103,7 +103,7 @@ public class TestHWSkinningOld extends SimpleApplication implements ActionListen
 
     private void makeHudText() {
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        hwsText = new BitmapText(guiFont, false);
+        hwsText = new BitmapText(guiFont);
         hwsText.setSize(guiFont.getCharSet().getRenderedSize());
         hwsText.setText("HWS : " + hwSkinningEnable);
         hwsText.setLocalTranslation(0, cam.getHeight(), 0);

--- a/jme3-examples/src/main/java/jme3test/model/anim/TestMorph.java
+++ b/jme3-examples/src/main/java/jme3test/model/anim/TestMorph.java
@@ -32,7 +32,7 @@ public class TestMorph extends SimpleApplication {
     @Override
     public void simpleInitApp() {
         BitmapFont font = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        BitmapText text = new BitmapText(font, false);
+        BitmapText text = new BitmapText(font);
         text.setText("Press U-Y-I-J to vary weights. Drag LMB to orbit camera.");
         text.setLocalTranslation(10f, cam.getHeight() - 10f, 0f);
         guiNode.attachChild(text);

--- a/jme3-examples/src/main/java/jme3test/model/anim/TestSkeletonControlRefresh.java
+++ b/jme3-examples/src/main/java/jme3test/model/anim/TestSkeletonControlRefresh.java
@@ -166,7 +166,7 @@ public class TestSkeletonControlRefresh extends SimpleApplication implements Act
  
     private void makeHudText() {
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        hwsText = new BitmapText(guiFont, false);
+        hwsText = new BitmapText(guiFont);
         hwsText.setSize(guiFont.getCharSet().getRenderedSize());
         hwsText.setText("HWS : "+ hwSkinningEnable);
         hwsText.setLocalTranslation(0, cam.getHeight(), 0);

--- a/jme3-examples/src/main/java/jme3test/opencl/TestMultipleApplications.java
+++ b/jme3-examples/src/main/java/jme3test/opencl/TestMultipleApplications.java
@@ -146,7 +146,7 @@ public class TestMultipleApplications extends SimpleApplication {
         infoText.setText("Device: "+clContext.getDevices());
         infoText.setLocalTranslation(0, settings.getHeight(), 0);
         guiNode.attachChild(infoText);
-        statusText = new BitmapText(fnt, false);
+        statusText = new BitmapText(fnt);
         //statusText.setBox(new Rectangle(0, 0, settings.getWidth(), settings.getHeight()));
         statusText.setText("Running");
         statusText.setLocalTranslation(0, settings.getHeight() - infoText.getHeight() - 2, 0);

--- a/jme3-examples/src/main/java/jme3test/opencl/TestMultipleApplications.java
+++ b/jme3-examples/src/main/java/jme3test/opencl/TestMultipleApplications.java
@@ -141,7 +141,7 @@ public class TestMultipleApplications extends SimpleApplication {
         inputManager.setCursorVisible(true);
         
         BitmapFont fnt = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        BitmapText infoText = new BitmapText(fnt, false);
+        BitmapText infoText = new BitmapText(fnt);
         //infoText.setBox(new Rectangle(0, 0, settings.getWidth(), settings.getHeight()));
         infoText.setText("Device: "+clContext.getDevices());
         infoText.setLocalTranslation(0, settings.getHeight(), 0);

--- a/jme3-examples/src/main/java/jme3test/renderer/TestLineWidth.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestLineWidth.java
@@ -73,7 +73,7 @@ public class TestLineWidth extends SimpleApplication {
          * Display the message, centered near the top of the display.
          */
         BitmapFont font = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        BitmapText text = new BitmapText(font, false);
+        BitmapText text = new BitmapText(font);
         text.setSize(font.getCharSet().getRenderedSize());
         text.setText(message);
         float leftX = (cam.getWidth() - text.getLineWidth()) / 2;

--- a/jme3-examples/src/main/java/jme3test/scene/instancing/TestInstancedNodeAttachDetachWithPicking.java
+++ b/jme3-examples/src/main/java/jme3test/scene/instancing/TestInstancedNodeAttachDetachWithPicking.java
@@ -176,7 +176,7 @@ public class TestInstancedNodeAttachDetachWithPicking extends SimpleApplication 
     }
 
     private void addCrossHairs() {
-        BitmapText ch = new BitmapText(guiFont, false);
+        BitmapText ch = new BitmapText(guiFont);
         ch.setSize(guiFont.getCharSet().getRenderedSize()+4);
         ch.setText("+"); // crosshairs
         ch.setColor(ColorRGBA.White);

--- a/jme3-examples/src/main/java/jme3test/stress/TestLodGeneration.java
+++ b/jme3-examples/src/main/java/jme3test/stress/TestLodGeneration.java
@@ -118,7 +118,7 @@ public class TestLodGeneration extends SimpleApplication {
         flyCam.setEnabled(false);
 
         guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        hudText = new BitmapText(guiFont, false);
+        hudText = new BitmapText(guiFont);
         hudText.setSize(guiFont.getCharSet().getRenderedSize());
         hudText.setText(computeNbTri() + " tris");
         hudText.setLocalTranslation(cam.getWidth() / 2, hudText.getLineHeight(), 0);

--- a/jme3-examples/src/main/java/jme3test/terrain/TerrainTest.java
+++ b/jme3-examples/src/main/java/jme3test/terrain/TerrainTest.java
@@ -169,7 +169,7 @@ public class TerrainTest extends SimpleApplication {
     }
 
     public void loadHintText() {
-        BitmapText hintText = new BitmapText(guiFont, false);
+        BitmapText hintText = new BitmapText(guiFont);
         hintText.setSize(guiFont.getCharSet().getRenderedSize());
         hintText.setLocalTranslation(0, getCamera().getHeight(), 0);
         hintText.setText("Press T to toggle wireframe,  P to toggle tri-planar texturing");

--- a/jme3-examples/src/main/java/jme3test/terrain/TerrainTestAdvanced.java
+++ b/jme3-examples/src/main/java/jme3test/terrain/TerrainTestAdvanced.java
@@ -225,7 +225,7 @@ public class TerrainTestAdvanced extends SimpleApplication {
     }
 
     public void loadHintText() {
-        BitmapText hintText = new BitmapText(guiFont, false);
+        BitmapText hintText = new BitmapText(guiFont);
         hintText.setSize(guiFont.getCharSet().getRenderedSize());
         hintText.setLocalTranslation(0, getCamera().getHeight(), 0);
         hintText.setText("Press T to toggle wireframe,  P to toggle tri-planar texturing");

--- a/jme3-examples/src/main/java/jme3test/terrain/TerrainTestAndroid.java
+++ b/jme3-examples/src/main/java/jme3test/terrain/TerrainTestAndroid.java
@@ -150,7 +150,7 @@ public class TerrainTestAndroid extends SimpleApplication {
     }
 
     public void loadHintText() {
-        BitmapText hintText = new BitmapText(guiFont, false);
+        BitmapText hintText = new BitmapText(guiFont);
         hintText.setSize(guiFont.getCharSet().getRenderedSize());
         hintText.setLocalTranslation(0, getCamera().getHeight(), 0);
         hintText.setText("Press T to toggle wireframe,  P to toggle tri-planar texturing");

--- a/jme3-examples/src/main/java/jme3test/terrain/TerrainTestCollision.java
+++ b/jme3-examples/src/main/java/jme3test/terrain/TerrainTestCollision.java
@@ -179,7 +179,7 @@ public class TerrainTestCollision extends SimpleApplication {
     }
 
     public void loadHintText() {
-        BitmapText hintText = new BitmapText(guiFont, false);
+        BitmapText hintText = new BitmapText(guiFont);
         hintText.setSize(guiFont.getCharSet().getRenderedSize());
         hintText.setLocalTranslation(0, getCamera().getHeight(), 0);
         hintText.setText("Press T to toggle wireframe");
@@ -188,7 +188,7 @@ public class TerrainTestCollision extends SimpleApplication {
 
     protected void initCrossHairs() {
         //guiFont = assetManager.loadFont("Interface/Fonts/Default.fnt");
-        BitmapText ch = new BitmapText(guiFont, false);
+        BitmapText ch = new BitmapText(guiFont);
         ch.setSize(guiFont.getCharSet().getRenderedSize() * 2);
         ch.setText("+"); // crosshairs
         ch.setLocalTranslation( // center

--- a/jme3-examples/src/main/java/jme3test/terrain/TerrainTestModifyHeight.java
+++ b/jme3-examples/src/main/java/jme3test/terrain/TerrainTestModifyHeight.java
@@ -144,7 +144,7 @@ public class TerrainTestModifyHeight extends SimpleApplication {
     }
     
     public void loadHintText() {
-        hintText = new BitmapText(guiFont, false);
+        hintText = new BitmapText(guiFont);
         hintText.setLocalTranslation(0, getCamera().getHeight(), 0);
         hintText.setText("Hit 1 to raise terrain, hit 2 to lower terrain");
         guiNode.attachChild(hintText);
@@ -161,7 +161,7 @@ public class TerrainTestModifyHeight extends SimpleApplication {
     }
 
     protected void initCrossHairs() {
-        BitmapText ch = new BitmapText(guiFont, false);
+        BitmapText ch = new BitmapText(guiFont);
         ch.setSize(guiFont.getCharSet().getRenderedSize() * 2);
         ch.setText("+"); // crosshairs
         ch.setLocalTranslation( // center

--- a/jme3-examples/src/main/java/jme3test/terrain/TerrainTestReadWrite.java
+++ b/jme3-examples/src/main/java/jme3test/terrain/TerrainTestReadWrite.java
@@ -188,7 +188,7 @@ public class TerrainTestReadWrite extends SimpleApplication {
     }
 
     public void loadHintText() {
-        BitmapText hintText = new BitmapText(guiFont, false);
+        BitmapText hintText = new BitmapText(guiFont);
         hintText.setSize(guiFont.getCharSet().getRenderedSize());
         hintText.setLocalTranslation(0, getCamera().getHeight(), 0);
         hintText.setText("Hit T to save, and Y to load");

--- a/jme3-examples/src/main/java/jme3test/terrain/TerrainTestTile.java
+++ b/jme3-examples/src/main/java/jme3test/terrain/TerrainTestTile.java
@@ -129,7 +129,7 @@ public class TerrainTestTile extends SimpleApplication {
     }
     
     public void loadHintText() {
-        BitmapText hintText = new BitmapText(guiFont, false);
+        BitmapText hintText = new BitmapText(guiFont);
         hintText.setLocalTranslation(0, getCamera().getHeight(), 0);
         hintText.setText("Press T to toggle wireframe");
         guiNode.attachChild(hintText);


### PR DESCRIPTION
PR #1685 deprecated the 2-arg constructor for `BitmapText`. That constructor is used extensively in the Engine itself, especially in "jme3-examples".

Since the Engine (and especially "jme3-examples") ought to set a good example, this PR replaces all uses of the 2-arg constructor with the 1-arg constructor.