### PR TITLE
jme3-lwjgl3: add a WindowSizeListener

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwMouseInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwMouseInput.java
@@ -241,15 +241,6 @@ public class GlfwMouseInput implements MouseInput {
         context.registerWindowSizeListener(windowSizeListener = ((width, height) -> {
             currentHeight = height;
         }));
-
-        // GLFW accepts only one callback, registering a new one here will
-        // remove the one registered in LwjglWindow.
-        /*glfwSetWindowSizeCallback(window, new GLFWWindowSizeCallback() {
-            @Override
-            public void invoke(final long window, final int width, final int height) {
-                currentHeight = height;
-            }
-        });*/
     }
 
     private void initCurrentMousePosition(long window) {

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwMouseInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwMouseInput.java
@@ -37,6 +37,7 @@ import com.jme3.input.RawInputListener;
 import com.jme3.input.event.MouseButtonEvent;
 import com.jme3.input.event.MouseMotionEvent;
 import com.jme3.system.lwjgl.LwjglWindow;
+import com.jme3.system.lwjgl.WindowSizeListener;
 import com.jme3.util.BufferUtils;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
@@ -114,6 +115,7 @@ public class GlfwMouseInput implements MouseInput {
 
     private final LwjglWindow context;
 
+    private WindowSizeListener windowSizeListener;
     private RawInputListener listener;
 
     private IntBuffer currentCursorDelays;
@@ -236,12 +238,18 @@ public class GlfwMouseInput implements MouseInput {
             }
         });
 
-        glfwSetWindowSizeCallback(window, new GLFWWindowSizeCallback() {
+        context.registerWindowSizeListener(windowSizeListener = ((width, height) -> {
+            currentHeight = height;
+        }));
+
+        // GLFW accepts only one callback, registering a new one here will
+        // remove the one registered in LwjglWindow.
+        /*glfwSetWindowSizeCallback(window, new GLFWWindowSizeCallback() {
             @Override
             public void invoke(final long window, final int width, final int height) {
                 currentHeight = height;
             }
-        });
+        });*/
     }
 
     private void initCurrentMousePosition(long window) {
@@ -335,6 +343,7 @@ public class GlfwMouseInput implements MouseInput {
         cursorPosCallback.close();
         scrollCallback.close();
         mouseButtonCallback.close();
+        context.removeWindowSizeListener(windowSizeListener);
     }
 
     @Override

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -47,13 +47,17 @@ import com.jme3.system.NanoTimer;
 import com.jme3.util.BufferUtils;
 import com.jme3.util.SafeArrayList;
 import org.lwjgl.Version;
-import org.lwjgl.glfw.*;
+import org.lwjgl.glfw.GLFWErrorCallback;
+import org.lwjgl.glfw.GLFWFramebufferSizeCallback;
+import org.lwjgl.glfw.GLFWImage;
+import org.lwjgl.glfw.GLFWVidMode;
+import org.lwjgl.glfw.GLFWWindowFocusCallback;
+import org.lwjgl.glfw.GLFWWindowSizeCallback;
 import org.lwjgl.system.Platform;
 
-import java.awt.*;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.nio.ByteBuffer;
-import java.nio.IntBuffer;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -154,12 +158,19 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
     }
 
     /**
-     * Register a listener to get notified when window size changes.
+     * Registers the specified listener to get notified when window size changes.
+     *
+     * @param listener The WindowSizeListener to register.
      */
     public void registerWindowSizeListener(WindowSizeListener listener) {
         windowSizeListeners.add(listener);
     }
 
+    /**
+     * Removes the specified listener from the listeners list.
+     *
+     * @param listener The WindowSizeListener to remove.
+     */
     public void removeWindowSizeListener(WindowSizeListener listener) {
         windowSizeListeners.remove(listener);
     }

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/WindowSizeListener.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/WindowSizeListener.java
@@ -41,6 +41,14 @@ package com.jme3.system.lwjgl;
  */
 public interface WindowSizeListener {
 
+    /**
+     * When registered by {@link LwjglWindow#registerWindowSizeListener(WindowSizeListener)},
+     * it gets invoked on each glfw window size callback to notify the listener about changes
+     * in the window size.
+     *
+     * @param width the new window width.
+     * @param height the new window height.
+     */
     public void onWindowSizeChanged(final int width, final int height);
 
 }

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/WindowSizeListener.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/WindowSizeListener.java
@@ -1,0 +1,12 @@
+package com.jme3.system.lwjgl;
+
+/**
+ * Listen to window size changes.
+ *
+ * @author Ali-RS
+ */
+public interface WindowSizeListener {
+
+    public void onWindowSizeChanged(final int width, final int height);
+
+}

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/WindowSizeListener.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/WindowSizeListener.java
@@ -1,7 +1,10 @@
 package com.jme3.system.lwjgl;
 
 /**
- * Listen to window size changes.
+ * Listen to window size changes. Note, GLFW does not support registering multiple callbacks
+ * in {@link org.lwjgl.glfw.GLFW#glfwSetWindowSizeCallback(long, org.lwjgl.glfw.GLFWWindowSizeCallbackI)},
+ * registering a new one will remove the previous one. Using this interface one can register
+ * multiple listeners.
  *
  * @author Ali-RS
  */

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/WindowSizeListener.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/WindowSizeListener.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2021 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.system.lwjgl;
 
 /**


### PR DESCRIPTION
 Added a `WindowSizeListener` for lwjgl3 which can be registered in `LwjglWindow` also refactored GlfwMouseInput to use this listener instead of directly registering a callback on GLFW as GLFW does not support multiple callbacks.

Also, we need to test to see if this possibly solves issue #1710.