### PR TITLE
LwjglCanvas: initialize OpenCL for LWJGL2

### DIFF
--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
@@ -477,7 +477,10 @@ public class LwjglCanvas extends LwjglAbstractDisplay implements JmeCanvasContex
                 }else{
                     Display.create(acquirePixelFormat(false));
                 }
-
+				if (settings.isOpenCLSupport()) {
+					initOpenCL();
+				}
+				
                 renderer.invalidateState();
             }else{
                 // First create the pbuffer, if it is needed.

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
@@ -438,6 +438,9 @@ public class LwjglCanvas extends LwjglAbstractDisplay implements JmeCanvasContex
      * This is called:
      * 1) When the context thread starts
      * 2) Any time the canvas becomes displayable again.
+	 * In the first call of this method, OpenGL context is not ready yet. Therefore, OpenCL context cannot be created.
+	 * The second call of this method is done after "simpleInitApp" is called. Therefore, OpenCL won't be available in "simpleInitApp" if Canvas/Swing is used.
+	 * To use OpenCL with Canvas/Swing, you need to use OpenCL in the rendering loop "simpleUpdate" and check for "context.getOpenCLContext()!=null".
      */
     @Override
     protected void createContext(AppSettings settings) {


### PR DESCRIPTION
Fixing OpenCL context null issue with LwjglCanvas. It is important that for Swing applications and with this fix, OpenCL won't be available in "simpleInitApp" and everything needs to be initialized inside the "simpleUpdate" with a boolean variable.
The discussion is in the following post:
https://hub.jmonkeyengine.org/t/opencl-context-for-lwjglcanvas-is-always-null/45213/3