### PR TITLE
AlAudioRenderer: update OpenAL state when dry filter is re-applied

### DIFF
--- a/jme3-core/src/main/java/com/jme3/audio/openal/ALAudioRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/audio/openal/ALAudioRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-core/src/main/java/com/jme3/audio/openal/ALAudioRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/audio/openal/ALAudioRenderer.java
@@ -503,18 +503,18 @@ public class ALAudioRenderer implements AudioRenderer, Runnable {
                     if (!supportEfx) {
                         return;
                     }
-
-                    if (src.getDryFilter() != null) {
-                        Filter f = src.getDryFilter();
-                        if (f.isUpdateNeeded()) {
-                            updateFilter(f);
-
-                            // NOTE: must re-attach filter for changes to apply.
-                            al.alSourcei(id, EFX.AL_DIRECT_FILTER, f.getId());
-                        }
+                    Filter dryFilter = src.getDryFilter();
+                    int filterId;
+                    if (dryFilter == null) {
+                        filterId = EFX.AL_FILTER_NULL;
                     } else {
-                        al.alSourcei(id, EFX.AL_DIRECT_FILTER, EFX.AL_FILTER_NULL);
+                        if (dryFilter.isUpdateNeeded()) {
+                            updateFilter(dryFilter);
+                        }
+                        filterId = dryFilter.getId();
                     }
+                    // NOTE: must re-attach filter for changes to apply.
+                    al.alSourcei(id, EFX.AL_DIRECT_FILTER, filterId);
                     break;
                 case Looping:
                     if (src.isLooping() && !(src.getAudioData() instanceof AudioStream)) {


### PR DESCRIPTION
This attempts to solve issue #1699 by updating OpenAL's direct-filter parameter whenever the `DryFilter` changes, even if the filter itself has already been initialized.

I rearranged the `DryFilter` logic to make it slightly more readable. 