### PR TITLE
Fix NullPointerException in AnimLayer.update()

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/AnimLayer.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AnimLayer.java
@@ -189,24 +189,25 @@ public class AnimLayer implements JmeCloneable {
      *     current Action, in seconds
      */
     void update(float appDeltaTimeInSeconds) {
-        if (currentAction == null) {
+        Action runningAction = currentAction;
+        if (runningAction == null) {
             return;
         }
 
-        double speedup = currentAction.getSpeed() * composer.getGlobalSpeed();
+        double speedup = runningAction.getSpeed() * composer.getGlobalSpeed();
         double scaledDeltaTime = speedup * appDeltaTimeInSeconds;
         time += scaledDeltaTime;
 
         // wrap negative times to the [0, length] range:
         if (time < 0.0) {
-            double length = currentAction.getLength();
+            double length = runningAction.getLength();
             time = (time % length + length) % length;
         }
 
         // update the current Action, filtered by this layer's mask:
-        currentAction.setMask(mask);
-        boolean running = currentAction.interpolate(time);
-        currentAction.setMask(null);
+        runningAction.setMask(mask);
+        boolean running = runningAction.interpolate(time);
+        runningAction.setMask(null);
 
         if (!running) { // went past the end of the current Action
             time = 0.0;

--- a/jme3-core/src/main/java/com/jme3/anim/AnimLayer.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AnimLayer.java
@@ -189,25 +189,25 @@ public class AnimLayer implements JmeCloneable {
      *     current Action, in seconds
      */
     void update(float appDeltaTimeInSeconds) {
-        Action runningAction = currentAction;
-        if (runningAction == null) {
+        Action action = currentAction;
+        if (action == null) {
             return;
         }
 
-        double speedup = runningAction.getSpeed() * composer.getGlobalSpeed();
+        double speedup = action.getSpeed() * composer.getGlobalSpeed();
         double scaledDeltaTime = speedup * appDeltaTimeInSeconds;
         time += scaledDeltaTime;
 
         // wrap negative times to the [0, length] range:
         if (time < 0.0) {
-            double length = runningAction.getLength();
+            double length = action.getLength();
             time = (time % length + length) % length;
         }
 
         // update the current Action, filtered by this layer's mask:
-        runningAction.setMask(mask);
-        boolean running = runningAction.interpolate(time);
-        runningAction.setMask(null);
+        action.setMask(mask);
+        boolean running = action.interpolate(time);
+        action.setMask(null);
 
         if (!running) { // went past the end of the current Action
             time = 0.0;


### PR DESCRIPTION
```
java.lang.NullPointerException: Cannot invoke
"com.jme3.anim.tween.action.Action.setMask(com.jme3.anim.AnimationMask)"
because "this.currentAction" is null
        at com.jme3.anim.AnimLayer.update(AnimLayer.java:209)
        at com.jme3.anim.AnimComposer.controlUpdate(AnimComposer.java:391)
        at com.jme3.scene.control.AbstractControl.update(AbstractControl.java:118)
        at com.jme3.scene.Spatial.runControlUpdate(Spatial.java:743)
        at com.jme3.scene.Spatial.updateLogicalState(Spatial.java:890)
        at com.jme3.scene.Node.updateLogicalState(Node.java:228)
        at com.jme3.scene.Node.updateLogicalState(Node.java:239)
```


Edit:
Link to the forum post: https://hub.jmonkeyengine.org/t/v3-5-0-beta-testing/45209/17

Edit 2:
To facilitate the understanding of the problem I also add the explanation of the fix discussed on the forum and suggested by Ali-RS: "the `currentAction` should be copied into a local variable inside `AnimLayer.update()` because it might be changed, removed or replaced with new action in `Action.interpolate(time)`"

For clarity here is a sample code that can cause the exception:
```java
class NonLoopingAction extends BaseAction {

    ...
     public boolean interpolate(double t) {
        var result = delegate.interpolate(t);
        if (!result) {
            composer.removeCurrentAction(AnimComposer.DEFAULT_LAYER);
        }
        return result;
    }
}
```