### PR TITLE
avoid self-closing HTML tags in javadoc

### DIFF
--- a/jme3-examples/src/main/java/jme3test/renderer/TestBlendEquations.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestBlendEquations.java
@@ -107,7 +107,7 @@ public class TestBlendEquations extends SimpleApplication {
     }
 
     /**
-     * Adds a "transparent" quad to the scene, that limits the color values of the scene behind the object.<br/>
+     * Adds a "transparent" quad to the scene, that limits the color values of the scene behind the object.<br>
      * This effect can be good seen on bright areas of the scene (e.g. areas with specular lighting effects).
      */
     private void createRightQuad() {

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/util/DebugShapeFactory.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/util/DebugShapeFactory.java
@@ -212,7 +212,7 @@ public class DebugShapeFactory {
 
 /**
  *  A callback is used to process the triangles of the shape as there is no direct access to a concave shapes, shape.
- *  <p/>
+ *  <p>
  *  The triangles are simply put into a list (which in extreme condition will cause memory problems) then put into a direct buffer.
  *
  * @author CJ Hare

--- a/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/info/InfoQuery.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/info/InfoQuery.java
@@ -15,7 +15,7 @@ import static org.lwjgl.system.Pointer.*;
 
 /**
  * Base class for OpenCL object information queries.
- * <p/>
+ * <p>
  * All methods require the object being queried (a pointer value) and the
  * integer parameter name.
  *
@@ -43,7 +43,7 @@ abstract class InfoQuery {
 
     /**
      * Returns the integer value for the specified {@code parameterName}.
-     * <p/>
+     * <p>
      * For integer parameters that may be 32 or 64 bits (e.g. {@code size_t}),
      * {@link #getPointer} should be used instead.
      *
@@ -63,7 +63,7 @@ abstract class InfoQuery {
 
     /**
      * Returns the long value for the specified {@code parameterName}.
-     * <p/>
+     * <p>
      * For integer parameters that may be 32 or 64 bits (e.g. {@code size_t}),
      * {@link #getPointer} should be used instead.
      *
@@ -83,7 +83,7 @@ abstract class InfoQuery {
 
     /**
      * Returns the pointer value for the specified {@code parameterName}.
-     * <p/>
+     * <p>
      * This method should also be used for integer parameters that may be 32 or
      * 64 bits (e.g. {@code size_t}).
      *
@@ -104,7 +104,7 @@ abstract class InfoQuery {
     /**
      * Writes the pointer list for the specified {@code parameterName} into
      * {@code target}.
-     * <p/>
+     * <p>
      * This method should also be used for integer parameters that may be 32 or
      * 64 bits (e.g. {@code size_t}).
      *

--- a/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/info/InfoQueryInt.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/info/InfoQueryInt.java
@@ -15,7 +15,7 @@ import static org.lwjgl.system.Pointer.*;
 
 /**
  * Base class for OpenCL object information queries.
- * <p/>
+ * <p>
  * All methods require the object being queried (a pointer value), a second
  * integer argument and the integer parameter name.
  *
@@ -44,7 +44,7 @@ abstract class InfoQueryInt {
 
     /**
      * Returns the integer value for the specified {@code parameterName}.
-     * <p/>
+     * <p>
      * For integer parameters that may be 32 or 64 bits (e.g. {@code size_t}),
      * {@link #getPointer} should be used instead.
      *
@@ -65,7 +65,7 @@ abstract class InfoQueryInt {
 
     /**
      * Returns the long value for the specified {@code parameterName}.
-     * <p/>
+     * <p>
      * For integer parameters that may be 32 or 64 bits (e.g. {@code size_t}),
      * {@link #getPointer} should be used instead.
      *
@@ -86,7 +86,7 @@ abstract class InfoQueryInt {
 
     /**
      * Returns the pointer value for the specified {@code parameterName}.
-     * <p/>
+     * <p>
      * This method should also be used for integer parameters that may be 32 or
      * 64 bits (e.g. {@code size_t}).
      *
@@ -108,7 +108,7 @@ abstract class InfoQueryInt {
     /**
      * Writes the pointer list for the specified {@code parameterName} into
      * {@code target}.
-     * <p/>
+     * <p>
      * This method should also be used for integer parameters that may be 32 or
      * 64 bits (e.g. {@code size_t}).
      *

--- a/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/info/InfoQueryObject.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/info/InfoQueryObject.java
@@ -15,7 +15,7 @@ import static org.lwjgl.system.Pointer.*;
 
 /**
  * Base class for OpenCL object information queries.
- * <p/>
+ * <p>
  * All methods require the object being queried (a pointer value), a second
  * object argument (another pointer value) and the integer parameter name.
  *
@@ -45,7 +45,7 @@ abstract class InfoQueryObject {
 
     /**
      * Returns the integer value for the specified {@code parameterName}.
-     * <p/>
+     * <p>
      * For integer parameters that may be 32 or 64 bits (e.g. {@code size_t}),
      * {@link #getPointer} should be used instead.
      *
@@ -66,7 +66,7 @@ abstract class InfoQueryObject {
 
     /**
      * Returns the long value for the specified {@code parameterName}.
-     * <p/>
+     * <p>
      * For integer parameters that may be 32 or 64 bits (e.g. {@code size_t}),
      * {@link #getPointer} should be used instead.
      *
@@ -87,7 +87,7 @@ abstract class InfoQueryObject {
 
     /**
      * Returns the pointer value for the specified {@code parameterName}.
-     * <p/>
+     * <p>
      * This method should also be used for integer parameters that may be 32 or
      * 64 bits (e.g. {@code size_t}).
      *
@@ -109,7 +109,7 @@ abstract class InfoQueryObject {
     /**
      * Writes the pointer list for the specified {@code parameterName} into
      * {@code target}.
-     * <p/>
+     * <p>
      * This method should also be used for integer parameters that may be 32 or
      * 64 bits (e.g. {@code size_t}).
      *


### PR DESCRIPTION
Starting with JDK 8, javadoc regards self-closing HTML tags as errors. This PR corrects 17 such errors.