### PR TITLE
#1734 actions based vr input

### DIFF
--- a/jme3-vr/src/main/java/com/jme3/app/VRConstants.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VRConstants.java
@@ -123,22 +123,31 @@ public class VRConstants {
 
     /**
      * The identifier of the OpenVR system.
+     *
+     * Deprecated as only the lwjgl OpenVr version has been upgraded to modern action based inputs
+     *
      * @see #SETTING_VRAPI_OSVR_VALUE
      * @see #SETTING_VRAPI_OPENVR_LWJGL_VALUE
      * @see #SETTING_VRAPI_OCULUSVR_VALUE
      */
+    @Deprecated
     public static final int SETTING_VRAPI_OPENVR_VALUE       = 1;
 
     /**
      * The identifier of the OSVR system.
+     *
+     * Deprecated as an OpenVr system should be used instead for a non vender specific api
+     *
      * @see #SETTING_VRAPI_OPENVR_VALUE
      * @see #SETTING_VRAPI_OPENVR_LWJGL_VALUE
      * @see #SETTING_VRAPI_OCULUSVR_VALUE
      */
+    @Deprecated
     public static final int SETTING_VRAPI_OSVR_VALUE         = 2;
 
     /**
      * The identifier of the OpenVR from LWJGL system.
+     *
      * @see #SETTING_VRAPI_OPENVR_VALUE
      * @see #SETTING_VRAPI_OSVR_VALUE
      * @see #SETTING_VRAPI_OCULUSVR_VALUE
@@ -147,10 +156,14 @@ public class VRConstants {
 
     /**
      * The identifier of the Oculus Rift system.
+     *
+     * Deprecated as an OpenVr system should be used instead (and the rift itself is discontinued)
+     *
      * @see #SETTING_VRAPI_OPENVR_VALUE
      * @see #SETTING_VRAPI_OSVR_VALUE
      * @see #SETTING_VRAPI_OPENVR_LWJGL_VALUE
      */
+    @Deprecated
     public static final int SETTING_VRAPI_OCULUSVR_VALUE    = 4;
 
     /**

--- a/jme3-vr/src/main/java/com/jme3/app/VREnvironment.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VREnvironment.java
@@ -513,6 +513,8 @@ public class VREnvironment {
 
             if (settings.get(VRConstants.SETTING_VRAPI) != null){
                 vrBinding = settings.getInteger(VRConstants.SETTING_VRAPI);
+            }else{
+                vrBinding = VRConstants.SETTING_VRAPI_OPENVR_LWJGL_VALUE; //this is the binding that is best supported so makes sense to be the default
             }
 
             if (settings.get(VRConstants.SETTING_SEATED_EXPERIENCE) != null){

--- a/jme3-vr/src/main/java/com/jme3/input/vr/AnalogActionState.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/AnalogActionState.java
@@ -1,0 +1,48 @@
+package com.jme3.input.vr;
+
+public class AnalogActionState{
+
+    /**
+     * The X coordinate of the analog data (typically between -1 and 1 for joystick coordinates or 0 and 1 for
+     * trigger pulls)
+     */
+    public final float x;
+
+    /**
+     * The Y coordinate of the analog data (typically between -1 and 1)
+     *
+     * Will be zero if the analog action doesn't have at least 2 dimensions
+     */
+    public final float y;
+
+    /**
+     * The Z coordinate of the analog data (typically between -1 and 1)
+     *
+     * Will be zero if the analog action doesn't have at least 3 dimensions
+     */
+    public final float z;
+
+    /**
+     * The change in the X coordinate since the last frame
+     */
+    public final float deltaX;
+
+    /**
+     * The change in the Y coordinate since the last frame
+     */
+    public final float deltaY;
+
+    /**
+     * The change in the Z coordinate since the last frame
+     */
+    public final float deltaZ;
+
+    public AnalogActionState(float x, float y, float z, float deltaX, float deltaY, float deltaZ){
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.deltaX = deltaX;
+        this.deltaY = deltaY;
+        this.deltaZ = deltaZ;
+    }
+}

--- a/jme3-vr/src/main/java/com/jme3/input/vr/DigitalActionState.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/DigitalActionState.java
@@ -1,0 +1,19 @@
+package com.jme3.input.vr;
+
+public class DigitalActionState{
+
+    /**
+     * The current value of this action
+     */
+    public final boolean state;
+
+    /**
+     * If since the last loop the value of this action has changed
+     */
+    public final boolean changed;
+
+    public DigitalActionState(boolean state, boolean changed){
+        this.state = state;
+        this.changed = changed;
+    }
+}

--- a/jme3-vr/src/main/java/com/jme3/input/vr/VRInputAPI.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/VRInputAPI.java
@@ -21,7 +21,11 @@ public interface VRInputAPI {
      * Note that registering an actions manifest will deactivate legacy inputs (i.e. methods such as {@link #isButtonDown}
      * will no longer work
      *
+     * See https://github.com/ValveSoftware/openvr/wiki/Action-manifest for documentation on how to create an
+     * action manifest
+     *
      * This option is only relevant to OpenVR
+     *
      * @param actionManifestAbsolutePath
      *          the absolute file path to an actions manifest
      * @param startingActiveActionSet
@@ -136,7 +140,7 @@ public interface VRInputAPI {
     /**
      * Check if the given button is down (more generally if the given input type is activated).
      *
-     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}
+     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}. Note; action based will only work with the OpenVR api
      *
      * @param controllerIndex the index of the controller to check.
      * @param checkButton the button / input to check.
@@ -148,7 +152,7 @@ public interface VRInputAPI {
     /**
      * Check if the given button / input from the given controller has been just pressed / activated.
      *
-     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}
+     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}.  Note; action based will only work with the OpenVR api
      *
      * @param controllerIndex the index of the controller.
      * @param checkButton the button / input to check.
@@ -161,7 +165,7 @@ public interface VRInputAPI {
      * Reset the current activation of the inputs. After a call to this method, all input activation is considered as new activation.
      * @see #wasButtonPressedSinceLastCall(int, VRInputType)
      *
-     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}
+     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}.  Note; action based will only work with the OpenVR api
      */
     @Deprecated
     public void resetInputSinceLastCall();
@@ -169,7 +173,7 @@ public interface VRInputAPI {
     /**
      * Get the controller axis delta from the last value.
      *
-     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}
+     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}.  Note; action based will only work with the OpenVR api
      *
      * @param controllerIndex the index of the controller.
      * @param forAxis the axis.
@@ -198,7 +202,7 @@ public interface VRInputAPI {
      * Get the axis value for the given input on the given controller.
      * This value is the {@link #getAxisRaw(int, VRInputType) raw value} multiplied by the  {@link #getAxisMultiplier() axis multiplier}.
      *
-     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}
+     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}. Note; action based will only work with the OpenVR api
      *
      * @param controllerIndex the index of the controller.
      * @param forAxis the axis.
@@ -212,7 +216,7 @@ public interface VRInputAPI {
     /**
      * Get the axis value for the given input on the given controller.
      *
-     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}
+     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}  Note; action based will only work with the OpenVR api
      *
      * @param controllerIndex the index of the controller.
      * @param forAxis the axis.
@@ -367,7 +371,7 @@ public interface VRInputAPI {
      * @param duration how long in seconds the
      * @param frequency in cycles per second
      * @param amplitude between 0 and 1
-     * @param restrictToInput the input to restrict the action to. E.g. /user/hand/right. Or null, which means "any input"
+     * @param restrictToInput the input to restrict the action to. E.g. /user/hand/right, /user/hand/left. Or null, which means "any input"
      */
     default void triggerHapticAction( String actionName, float duration, float frequency, float amplitude, String restrictToInput){
         throw new UnsupportedOperationException("Action manifests are not supported for the currently used VR API");

--- a/jme3-vr/src/main/java/com/jme3/input/vr/VRInputAPI.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/VRInputAPI.java
@@ -4,40 +4,178 @@ import com.jme3.math.Quaternion;
 import com.jme3.math.Vector2f;
 import com.jme3.math.Vector3f;
 
+import java.util.Collection;
+
 /**
  * An interface that represents a VR input (typically a VR device such as a controller).
  * @author reden - phr00t - https://github.com/phr00t
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  */
 public interface VRInputAPI {
+
+    /**
+     * Registers an action manifest. An actions manifest is a file that defines "actions" a player can make.
+     * (An action is an abstract version of a button press). The action manifest may then also include references to
+     * further files that define default mappings between those actions and physical buttons on the VR controllers.
+     *
+     * Note that registering an actions manifest will deactivate legacy inputs (i.e. methods such as {@link #isButtonDown}
+     * will no longer work
+     *
+     * This option is only relevant to OpenVR
+     * @param actionManifestAbsolutePath
+     *          the absolute file path to an actions manifest
+     * @param startingActiveActionSet
+     *          the actions in the manifest are divided into action sets (groups) by their prefix (e.g. "/actions/main").
+     *          These action sets can be turned off and on per frame. This argument sets the action set that will be
+     *          active now. The active action sets can be later be changed by calling {@link #setActiveActionSet}.
+     *          Note that at present only a single set at a time is supported
+     *
+     */
+    default void registerActionManifest( String actionManifestAbsolutePath, String startingActiveActionSet ){
+        throw new UnsupportedOperationException("Action manifests are not supported for the currently used VR API");
+    }
+
+    /**
+     * Updates the active action set (the action group that will have their states available to be polled).
+     *
+     * Note that this update will not take effect until the next loop
+     * Note that at present only a single set at a time is supported
+     *
+     * @param activeActionSet
+     *          the actions in the manifest are divided into action sets (groups) by their prefix (e.g. "/actions/main").
+     *          These action sets can be turned off and on per frame. This argument sets the action set that will be
+     *          active now.
+     */
+    default void setActiveActionSet( String activeActionSet ){
+        throw new UnsupportedOperationException("Action manifests are not supported for the currently used VR API");
+    }
+
+    /**
+     * Gets the current state of the action (abstract version of a button press).
+     *
+     * This is called for digital style actions (a button is pressed, or not)
+     *
+     * This method is commonly called when it's not important which hand the action is bound to (e.g. if a button press
+     * is opening your inventory that could be bound to either left or right hand and that would not matter).
+     *
+     * If the handedness matters use {@link #getDigitalActionState(String, String)}
+     *
+     * {@link #registerActionManifest} must have been called before using this method.
+     *
+     * @param actionName The name of the action. Will be something like /actions/main/in/openInventory
+     * @return the DigitalActionState that has details on if the state has changed, what the state is etc.
+     */
+    default DigitalActionState getDigitalActionState( String actionName ){
+        return getDigitalActionState(actionName, null);
+    }
+
+    /**
+     * Gets the current state of the action (abstract version of a button press).
+     *
+     * This is called for digital style actions (a button is pressed, or not)
+     *
+     * This method is commonly called when it is important which hand the action is found on. For example while
+     * holding a weapon a button may be bound to "eject magazine" to allow you to load a new one, but that would only
+     * want to take effect on the hand that is holding the weapon
+     *
+     * Note that restrictToInput only restricts, it must still be bound to the input you want to receive the input from in
+     * the action manifest default bindings.
+     *
+     * {@link #registerActionManifest} must have been called before using this method.
+     *
+     * @param actionName The name of the action. E.g. /actions/main/in/openInventory
+     * @param restrictToInput the input to restrict the action to. E.g. /user/hand/right. Or null, which means "any input"
+     * @return the DigitalActionState that has details on if the state has changed, what the state is etc.
+     */
+    default DigitalActionState getDigitalActionState( String actionName, String restrictToInput ){
+        throw new UnsupportedOperationException("Action manifests are not supported for the currently used VR API");
+    }
+
+    /**
+     * Gets the current state of the action (abstract version of a button press).
+     *
+     * This is called for analog style actions (most commonly joysticks, but button pressure can also be mapped in analog).
+     *
+     * This method is commonly called when it's not important which hand the action is bound to (e.g. if the thumb stick
+     * is controlling a third-person character in-game that could be bound to either left or right hand and that would
+     * not matter).
+     *
+     * If the handedness matters use {@link #getAnalogActionState(String, String)}
+     *
+     * {@link #registerActionManifest} must have been called before using this method.
+     *
+     * @param actionName The name of the action. E.g. /actions/main/in/openInventory
+     * @return the DigitalActionState that has details on if the state has changed, what the state is etc.
+     */
+    default AnalogActionState getAnalogActionState( String actionName ){
+        return getAnalogActionState(actionName, null);
+    }
+
+    /**
+     * Gets the current state of the action (abstract version of a button press).
+     *
+     * This is called for analog style actions (most commonly joysticks, but button pressure can also be mapped in analog).
+     *
+     * This method is commonly called when it is important which hand the action is found on. For example an "in universe"
+     * joystick that has a hat control might (while you are holding it) bind to the on-controller hat, but only on the hand
+     * holding it
+     *
+     * Note that restrictToInput only restricts, it must still be bound to the input you want to receive the input from in
+     * the action manifest default bindings.
+     *
+     * {@link #registerActionManifest} must have been called before using this method.
+     *
+     * @param actionName The name of the action. E.g. /actions/main/in/openInventory
+     * @param restrictToInput the input to restrict the action to. E.g. /user/hand/right. Or null, which means "any input"
+     * @return the DigitalActionState that has details on if the state has changed, what the state is etc.
+     */
+    default AnalogActionState getAnalogActionState( String actionName, String restrictToInput ){
+        throw new UnsupportedOperationException("Action manifests are not supported for the currently used VR API");
+    }
+
     /**
      * Check if the given button is down (more generally if the given input type is activated).
+     *
+     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}
+     *
      * @param controllerIndex the index of the controller to check.
      * @param checkButton the button / input to check.
      * @return <code>true</code> if the button / input is down / activated and <code>false</code> otherwise.
      */
+    @Deprecated
     public boolean isButtonDown(int controllerIndex, VRInputType checkButton);
 
     /**
      * Check if the given button / input from the given controller has been just pressed / activated.
+     *
+     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}
+     *
      * @param controllerIndex the index of the controller.
      * @param checkButton the button / input to check.
      * @return <code>true</code> if the given button / input from the given controller has been just pressed / activated and <code>false</code> otherwise.
      */
+    @Deprecated
     public boolean wasButtonPressedSinceLastCall(int controllerIndex, VRInputType checkButton);
 
     /**
      * Reset the current activation of the inputs. After a call to this method, all input activation is considered as new activation.
      * @see #wasButtonPressedSinceLastCall(int, VRInputType)
+     *
+     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}
      */
+    @Deprecated
     public void resetInputSinceLastCall();
 
     /**
      * Get the controller axis delta from the last value.
+     *
+     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}
+     *
      * @param controllerIndex the index of the controller.
      * @param forAxis the axis.
      * @return the controller axis delta from the last call.
      */
+    @Deprecated
     public Vector2f getAxisDeltaSinceLastCall(int controllerIndex, VRInputType forAxis);
 
     /**
@@ -59,21 +197,29 @@ public interface VRInputAPI {
     /**
      * Get the axis value for the given input on the given controller.
      * This value is the {@link #getAxisRaw(int, VRInputType) raw value} multiplied by the  {@link #getAxisMultiplier() axis multiplier}.
+     *
+     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}
+     *
      * @param controllerIndex the index of the controller.
      * @param forAxis the axis.
      * @return the axis value for the given input on the given controller.
      * @see #getAxisRaw(int, VRInputType)
      * @see #getAxisMultiplier()
      */
+    @Deprecated
     public Vector2f getAxis(int controllerIndex, VRInputType forAxis);
 
     /**
      * Get the axis value for the given input on the given controller.
+     *
+     * Deprecated as should use an actions manifest approach. See {@link #registerActionManifest}
+     *
      * @param controllerIndex the index of the controller.
      * @param forAxis the axis.
      * @return the axis value for the given input on the given controller.
      * @see #getAxis(int, VRInputType)
      */
+    @Deprecated
     public Vector2f getAxisRaw(int controllerIndex, VRInputType forAxis);
 
     /**
@@ -184,8 +330,46 @@ public interface VRInputAPI {
 
     /**
      * Trigger a haptic pulse on the selected controller for the duration given in parameters (in seconds).
+     *
+     * Deprecated, use triggerHapticAction instead (as it has more options and doesn't use deprecated methods)
+     *
      * @param controllerIndex the index of the controller.
      * @param seconds the duration of the pulse in seconds.
      */
+    @Deprecated
     public void triggerHapticPulse(int controllerIndex, float seconds);
+
+    /**
+     * Triggers a haptic action (aka a vibration).
+     *
+     * Note if you want a haptic action in only one hand that is done either by only binding the action to one hand in
+     * the action manifest's standard bindings or by binding to both and using {@link #triggerHapticAction(String, float, float, float, String)}
+     * to control which input it gets set to at run time
+     *
+     * @param actionName The name of the action. Will be something like /actions/main/out/vibrate
+     * @param duration how long in seconds the
+     * @param frequency in cycles per second
+     * @param amplitude between 0 and 1
+     */
+   default void triggerHapticAction( String actionName, float duration, float frequency, float amplitude){
+       triggerHapticAction( actionName, duration, frequency, amplitude, null );
+   }
+
+    /**
+     * Triggers a haptic action (aka a vibration) restricted to just one input (e.g. left or right hand).
+     *
+     * Note that restrictToInput only restricts, it must still be bound to the input you want to send the haptic to in
+     * the action manifest default bindings.
+     *
+     * This method is typically used to bind the haptic to both hands then decide at run time which hand to sent to     *
+     *
+     * @param actionName The name of the action. Will be something like /actions/main/out/vibrate
+     * @param duration how long in seconds the
+     * @param frequency in cycles per second
+     * @param amplitude between 0 and 1
+     * @param restrictToInput the input to restrict the action to. E.g. /user/hand/right. Or null, which means "any input"
+     */
+    default void triggerHapticAction( String actionName, float duration, float frequency, float amplitude, String restrictToInput){
+        throw new UnsupportedOperationException("Action manifests are not supported for the currently used VR API");
+    }
 }

--- a/jme3-vr/src/main/java/com/jme3/input/vr/VRInputType.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/VRInputType.java
@@ -5,7 +5,10 @@ package com.jme3.input.vr;
  * @author reden - phr00t - https://github.com/phr00t
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  *
+ * Deprecated, use the LWJGL openVR bindings and use actions instead
+ *
  */
+@Deprecated
 public enum VRInputType {
     /**
      * an HTC vive trigger axis (about <a href="https://www.vive.com/us/support/category_howto/720435.html">Vive controller</a>).

--- a/jme3-vr/src/main/java/com/jme3/input/vr/lwjgl_openvr/LWJGLOpenVRAnalogActionData.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/lwjgl_openvr/LWJGLOpenVRAnalogActionData.java
@@ -1,0 +1,34 @@
+package com.jme3.input.vr.lwjgl_openvr;
+
+import org.lwjgl.openvr.InputAnalogActionData;
+
+/**
+ * This is a set of reusable parts that are used when accessing an analogue action
+ * (Analogue meaning something like a trigger pull or joystick coordinate)
+ */
+public class LWJGLOpenVRAnalogActionData{
+
+    /**
+     * This is the address string for the action. It will be something like /actions/main/in/openInventory
+     */
+    String actionName;
+
+    /**
+     * The handle used to request the action's state from LWJGL.
+     *
+     * It is how the action is addressed efficiently
+     */
+    long actionHandle;
+
+    /**
+     * This is a LWJGL object that will have the actions state passed into it. It is mapped to native memory so we
+     * don't want to keep creating new ones.
+     */
+    InputAnalogActionData actionData;
+
+    public LWJGLOpenVRAnalogActionData(String actionName, long actionHandle, InputAnalogActionData actionData){
+        this.actionName = actionName;
+        this.actionHandle = actionHandle;
+        this.actionData = actionData;
+    }
+}

--- a/jme3-vr/src/main/java/com/jme3/input/vr/lwjgl_openvr/LWJGLOpenVRDigitalActionData.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/lwjgl_openvr/LWJGLOpenVRDigitalActionData.java
@@ -1,0 +1,34 @@
+package com.jme3.input.vr.lwjgl_openvr;
+
+import org.lwjgl.openvr.InputDigitalActionData;
+
+/**
+ * This is a set of reusable parts that are used when accessing a digital action
+ * (Digital meaning something like a button press, that is either on or off)
+ */
+public class LWJGLOpenVRDigitalActionData{
+
+    /**
+     * This is the address string for the action. It will be something like /actions/main/in/openInventory
+     */
+    String actionName;
+
+    /**
+     * The handle used to request the action's state from LWJGL.
+     *
+     * It is how the action is addressed efficiently
+     */
+    long actionHandle;
+
+    /**
+     * This is a LWJGL object that will have the actions state passed into it. It is mapped to native memory so we
+     * don't want to keep creating new ones.
+     */
+    InputDigitalActionData actionData;
+
+    public LWJGLOpenVRDigitalActionData(String actionName, long actionHandle, InputDigitalActionData actionData){
+        this.actionName = actionName;
+        this.actionHandle = actionHandle;
+        this.actionData = actionData;
+    }
+}


### PR DESCRIPTION
This leaves all the old stuff there (the oculus, osvr & other openvr) but focusses on the LWJGL openvr for the short term future (I guess OpenXR later on as the more long term future). I have ended up with a bit of a leaky abstraction where VRInputAPI wants to talk about openVr specific stuff like action manifests but I couldn't avoid that without requiring users to cast to LWJGLOpenVRInput which feels equally as bad (especially as LWJGLOpenVRInput is probably the only one that's going to be usable till OpenXR comes along)

This allows Jmonkey VR to use the actions manifest style VR (which is the non deprecated openVr api for mapping button presses to "stuff" in game).

An example action manifest might look like

```
{
  "default_bindings": [
    {
      "controller_type": "oculus_touch",
      "binding_url": "oculusTouchDefaults.json"
    }
  ],
  "actions": [
    {
      "name": "/actions/main/in/OpenInventory",
      "requirement": "mandatory",
      "type": "boolean"
    },
    {
      "name": "/actions/main/in/scroll",
      "type": "vector2",
      "requirement": "mandatory"
    },
    {
      "name": "/actions/main/out/hapticTest",
      "type": "vibration",
      "requirement": "optional"
    },
    {
      "name": "/actions/main/in/leftTrigger",
      "type": "vector1",
      "requirement": "mandatory"
    }
  ],
  "action_sets": [
    {
      "name": "/actions/main",
      "usage": "leftright"
    }
  ],
  "localization" : [
    {
      "language_tag": "en_us",
      "/actions/main" : "My Game Actions",
      "/actions/main/in/OpenInventory" : "Open Inventory"
    }
  ]
}
```

With a default bindings looking like

```
{
  "action_manifest_version" : 0,
  "bindings": {
    "/actions/main": {
      "haptics" : [
        {
          "output" : "/actions/main/out/hapticTest",
          "path" : "/user/hand/left/output/haptic"
        }
      ],
      "sources" : [
        {
          "inputs" : {
            "click" : {
              "output" : "/actions/main/in/OpenInventory"
            }
          },
          "mode" : "button",
          "path" : "/user/hand/left/input/x"
        },
        {
          "inputs" : {
            "position" : {
              "output" : "/actions/main/in/scroll"
            }
          },
          "mode" : "joystick",
          "path" : "/user/hand/left/input/joystick"
        },
        {
          "inputs" : {
            "pull" : {
              "output" : "/actions/main/in/leftTrigger"
            }
          },
          "mode" : "trigger",
          "path" : "/user/hand/left/input/trigger"
        }
      ]
    }
  },
  "category" : "steamvr_input",
  "controller_type" : "oculus_touch",
  "description" : "Bindings for a oculusTouch controller",
  "name" : "Bindings for a oculusTouch controller",
  "options" : {},
  "simulated_actions" : []
}
```

Then it would be used like:

```
    public static void main(String[] args) {
        AppSettings settings = new AppSettings(true);
        VREnvironment env = new VREnvironment(settings);
        env.initialize();

        if (env.isInitialized()){
            VRAppState vrAppState = new VRAppState(settings, env);
            vrAppState.getVRinput().registerActionManifest("C:/Users/richa/Documents/Development/android/jmonkeyVrTest/src/main/resources/actionManifest.json", "/actions/main");

            Main app = new Main(vrAppState);
            app.setLostFocusBehavior(LostFocusBehavior.Disabled);
            app.setSettings(settings);
            app.setShowSettings(false);
            app.start();
        }
    }
```

And within the update loop like

```
    List<Geometry> handGeometries = new ArrayList<>();

    @Override
    public void simpleUpdate(float tpf) {

        VRAppState vrAppState = getStateManager().getState(VRAppState.class);
        int numberOfControllers = vrAppState.getVRinput().getTrackedControllerCount(); //almost certainly 2, one for each hand

        //build as many geometries as hands, as markers for the demo (Will only tigger on first loop or if number of controllers changes)
        while(handGeometries.size()<numberOfControllers){
            Box b = new Box(0.1f, 0.1f, 0.1f);
            Geometry handMarker = new Geometry("hand", b);
            Material mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
            mat.setColor("Color", ColorRGBA.Red);
            handMarker.setMaterial(mat);
            rootNode.attachChild(handMarker);
            handGeometries.add(handMarker);
        }

        VRInputAPI vrInput = vrAppState.getVRinput();

        for(int i=0;i<numberOfControllers;i++){
            if (vrInput.isInputDeviceTracking(i)){ //might not be active currently, avoid NPE if that's the case

                Vector3f position = vrInput.getFinalObserverPosition(i);
                Quaternion rotation = vrInput.getFinalObserverRotation(i);

                Geometry geometry = handGeometries.get(i);
                geometry.setLocalTranslation(position);
                geometry.setLocalRotation(rotation);
            }
        }

        if (vrInput.getDigitalActionState("/actions/main/in/OpenInventory").state){
            System.out.println("openInventory");
            vrInput.triggerHapticAction("/actions/main/out/hapticTest", 1, 5, 1 );
        }

        System.out.println("left trigger" + vrInput.getAnalogActionState("/actions/main/in/leftTrigger").x);
    }
```

Assuming people are happy with this I intend to expand the wiki to document how to write action manifests etc