### PR TITLE
correct typos in diagnostic messages

### DIFF
--- a/jme3-core/src/main/java/com/jme3/asset/AssetKey.java
+++ b/jme3-core/src/main/java/com/jme3/asset/AssetKey.java
@@ -157,7 +157,7 @@ public class AssetKey<T> implements Savable, Cloneable {
                     list.removeLast();
                 } else {
                     list.add("..");
-                    Logger.getLogger(AssetKey.class.getName()).log(Level.SEVERE, "Asset path \"{0}\" is outside assetmanager root", path);
+                    Logger.getLogger(AssetKey.class.getName()).log(Level.SEVERE, "Asset path \"{0}\" is outside the asset manager root", path);
                 }
             } else {
                 list.add(string);

--- a/jme3-core/src/main/java/com/jme3/export/SavableClassUtil.java
+++ b/jme3-core/src/main/java/com/jme3/export/SavableClassUtil.java
@@ -190,12 +190,12 @@ public class SavableClassUtil {
         } catch (InvocationTargetException | InstantiationException e) {
             Logger.getLogger(SavableClassUtil.class.getName()).log(
                     Level.SEVERE, "Could not access constructor of class ''{0}" + "''! \n"
-                    + "Some types need to have the BinaryImporter set up in a special way. Please doublecheck the setup.", className);
+                    + "Some types need to have the BinaryImporter set up in a special way. Please double-check the setup.", className);
             throw e;
         } catch (IllegalAccessException e) {
             Logger.getLogger(SavableClassUtil.class.getName()).log(
                     Level.SEVERE, "{0} \n"
-                    + "Some types need to have the BinaryImporter set up in a special way. Please doublecheck the setup.", e.getMessage());
+                    + "Some types need to have the BinaryImporter set up in a special way. Please double-check the setup.", e.getMessage());
             throw e;
         }
     }

--- a/jme3-core/src/plugins/java/com/jme3/material/plugins/ShaderNodeDefinitionLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/material/plugins/ShaderNodeDefinitionLoader.java
@@ -73,7 +73,7 @@ public class ShaderNodeDefinitionLoader implements AssetLoader {
             if (line.startsWith("Exception")) {
                 throw new AssetLoadException(line.substring("Exception ".length()));
             } else {
-                throw new MatParseException("In multiroot shader node definition, expected first statement to be 'Exception'", exception);
+                throw new MatParseException("In multi-root shader node definition, expected first statement to be 'Exception'", exception);
             }
         } else if (roots.size() != 1) {
             throw new MatParseException("Too many roots in J3SN file", roots.get(0));

--- a/jme3-core/src/tools/java/jme3tools/optimize/LodGenerator.java
+++ b/jme3-core/src/tools/java/jme3tools/optimize/LodGenerator.java
@@ -354,7 +354,7 @@ public class LodGenerator {
             if (tri.isMalformed()) {
                 if (!tri.isRemoved) {
                     if (logger.isLoggable(Level.FINE)) {
-                        logger.log(Level.FINE, "malformed triangle found with ID:{0}\n{1} It will be excluded from Lod level calculations.", new Object[]{triangleList.indexOf(tri), tri.toString()});
+                        logger.log(Level.FINE, "malformed triangle found with ID:{0}\n{1} It will be excluded from LOD calculations.", new Object[]{triangleList.indexOf(tri), tri.toString()});
                     }
                     tri.isRemoved = true;
                     indexCount -= 3;
@@ -376,7 +376,7 @@ public class LodGenerator {
             if (!vertex.edges.isEmpty()) {
                 computeVertexCollapseCost(vertex);
             } else {
-                logger.log(Level.FINE, "Found isolated vertex {0} It will be excluded from Lod level calculations.", vertex);
+                logger.log(Level.FINE, "Found isolated vertex {0} It will be excluded from LOD calculations.", vertex);
             }
         }
 //        assert (vertexList.size() == collapseCostSet.size());
@@ -753,7 +753,7 @@ public class LodGenerator {
                     tri.isRemoved = true;
                     indexCount -= 3;
                     if (logger.isLoggable(Level.FINE)) {
-                        logger.log(Level.FINE, "duplicate triangle found{0}{1} It will be excluded from Lod level calculations.", new Object[]{tri, duplicate});
+                        logger.log(Level.FINE, "duplicate triangle found{0}{1} It will be excluded from LOD level calculations.", new Object[]{tri, duplicate});
                     }
                 }
             }

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/PhysicsSpace.java
@@ -408,7 +408,7 @@ public class PhysicsSpace {
 
     public static <V> Future<V> enqueueOnThisThread(Callable<V> callable) {
         AppTask<V> task = new AppTask<>(callable);
-        System.out.println("created apptask");
+        System.out.println("created AppTask");
         pQueueTL.get().add(task);
         return task;
     }

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
@@ -97,7 +97,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     protected void rebuildRigidBody() {
         boolean removed = false;
         if(collisionShape instanceof MeshCollisionShape && mass != 0){
-            throw new IllegalStateException("Dynamic rigidbody can not have mesh collision shape!");
+            throw new IllegalStateException("Dynamic rigid body can not have mesh collision shape!");
         }
         if (rBody != null) {
             if (rBody.isInWorld()) {
@@ -361,7 +361,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     public void setMass(float mass) {
         this.mass = mass;
         if(collisionShape instanceof MeshCollisionShape && mass != 0){
-            throw new IllegalStateException("Dynamic rigidbody can not have mesh collision shape!");
+            throw new IllegalStateException("Dynamic rigid body can not have mesh collision shape!");
         }
         if (collisionShape != null) {
             collisionShape.calculateLocalInertia(mass, localInertia);
@@ -568,7 +568,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     public void setCollisionShape(CollisionShape collisionShape) {
         super.setCollisionShape(collisionShape);
         if(collisionShape instanceof MeshCollisionShape && mass!=0){
-            throw new IllegalStateException("Dynamic rigidbody can not have mesh collision shape!");
+            throw new IllegalStateException("Dynamic rigid body can not have mesh collision shape!");
         }
         if (rBody == null) {
             rebuildRigidBody();

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsRigidBody.java
@@ -97,7 +97,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     protected void rebuildRigidBody() {
         boolean removed = false;
         if(collisionShape instanceof MeshCollisionShape && mass != 0){
-            throw new IllegalStateException("Dynamic rigid body can not have mesh collision shape!");
+            throw new IllegalStateException("Dynamic rigid body cannot have mesh collision shape!");
         }
         if (rBody != null) {
             if (rBody.isInWorld()) {
@@ -361,7 +361,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     public void setMass(float mass) {
         this.mass = mass;
         if(collisionShape instanceof MeshCollisionShape && mass != 0){
-            throw new IllegalStateException("Dynamic rigid body can not have mesh collision shape!");
+            throw new IllegalStateException("Dynamic rigid body cannot have mesh collision shape!");
         }
         if (collisionShape != null) {
             collisionShape.calculateLocalInertia(mass, localInertia);
@@ -568,7 +568,7 @@ public class PhysicsRigidBody extends PhysicsCollisionObject {
     public void setCollisionShape(CollisionShape collisionShape) {
         super.setCollisionShape(collisionShape);
         if(collisionShape instanceof MeshCollisionShape && mass!=0){
-            throw new IllegalStateException("Dynamic rigid body can not have mesh collision shape!");
+            throw new IllegalStateException("Dynamic rigid body cannot have mesh collision shape!");
         }
         if (rBody == null) {
             rebuildRigidBody();

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglOffscreenBuffer.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglOffscreenBuffer.java
@@ -119,7 +119,7 @@ public class LwjglOffscreenBuffer extends LwjglContext implements Runnable {
                 // Context MUST be reset here to avoid invalid objects!
                 renderer.invalidateState();
             } catch (LWJGLException ex) {
-                listener.handleError("Failed to restore pbuffer content", ex);
+                listener.handleError("Failed to restore PBuffer content", ex);
             }
         }
 

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -694,7 +694,7 @@ public class GltfLoader implements AssetLoader {
                 Float ymag = getAsFloat(camData, "ymag");
                 assertNotNull(ymag, "No ymag for orthographic camera");
                 Float zNear = getAsFloat(camData, "znear");
-                assertNotNull(zNear, "No znear for orthographic camere");
+                assertNotNull(zNear, "No znear for orthographic camera");
                 Float zFar = getAsFloat(camData, "zfar", zNear * 1000f);
                 assertNotNull(zFar, "No zfar for orthographic camera");
 

--- a/jme3-terrain/src/main/java/com/jme3/terrain/heightmap/FluidSimHeightMap.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/heightmap/FluidSimHeightMap.java
@@ -123,8 +123,8 @@ public class FluidSimHeightMap extends AbstractHeightMap {
     public FluidSimHeightMap(int size, int iterations) throws Exception {
         if (size <= 0 || iterations <= 0) {
             throw new Exception(
-                    "Either size of the terrain is not greater that zero, "
-                    + "or number of iterations is not greater that zero");
+                    "Either size of the terrain is not greater than zero, "
+                    + "or number of iterations is not greater than zero");
         }
 
         this.size = size;

--- a/jme3-terrain/src/main/java/com/jme3/terrain/heightmap/HillHeightMap.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/heightmap/HillHeightMap.java
@@ -74,8 +74,8 @@ public class HillHeightMap extends AbstractHeightMap {
         if (size <= 0 || iterations <= 0 || minRadius <= 0 || maxRadius <= 0
                 || minRadius >= maxRadius) {
             throw new Exception(
-                    "Either size of the terrain is not greater that zero, "
-                    + "or number of iterations is not greater that zero, "
+                    "Either size of the terrain is not greater than zero, "
+                    + "or number of iterations is not greater than zero, "
                     + "or minimum or maximum radius are not greater than zero, "
                     + "or minimum radius is greater than maximum radius, "
                     + "or power of flattening is below one");


### PR DESCRIPTION
This PR improves the readability of some logger and exception messages, mainly by separating words that were runtogether.