### PR TITLE
TerrainQuad:  publicize fixNormals()

### DIFF
--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1601,7 +1601,7 @@ public class TerrainQuad extends Node implements Terrain {
     /**
      * fix the normals on the edge of the terrain patches.
      */
-    protected void fixNormalEdges(BoundingBox affectedArea) {
+    public void fixNormalEdges(BoundingBox affectedArea) {
         if (children == null)
             return;
 

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1580,7 +1580,7 @@ public class TerrainQuad extends Node implements Terrain {
      * Find what terrain patches need normal recalculations and update
      * their normals;
      */
-    protected void fixNormals(BoundingBox affectedArea) {
+    public void fixNormals(BoundingBox affectedArea) {
         if (children == null)
             return;
 


### PR DESCRIPTION
Per discussion at the Hub/Forum:  https://hub.jmonkeyengine.org/t/normalrecalccontrol-not-working-outside-of-sdk/44140/6

This makes the `fixNormals()` method public.