### PR TITLE
account for world transform in TerrainQuad.setNormalRecalcNeeded()

### DIFF
--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -44,7 +44,6 @@ import com.jme3.math.FastMath;
 import com.jme3.math.Ray;
 import com.jme3.math.Vector2f;
 import com.jme3.math.Vector3f;
-import com.jme3.math.Quaternion;
 import com.jme3.scene.Geometry;
 import com.jme3.scene.Node;
 import com.jme3.scene.Spatial;
@@ -853,12 +852,22 @@ public class TerrainQuad extends Node implements Terrain {
         }
         
         Vector2f worldLocVec2 = changedPoint.clone();
-        worldLocVec2.multLocal(new Vector2f(getWorldScale().getX(), getWorldScale().getZ()));
-        worldLocVec2.addLocal(getWorldTranslation().getX(), getWorldTranslation().getZ());		
+        worldLocVec2.multLocal(new Vector2f(getWorldScale().x, getWorldScale().z));
+        worldLocVec2.addLocal(getWorldTranslation().x, getWorldTranslation().z);		
         changedPoint = worldLocVec2;
 
-        if(!getWorldRotation().equals(Quaternion.IDENTITY)){ 
-            affectedAreaBBox = (BoundingBox)getWorldBound().clone(); 
+        Quaternion wr = getWorldRotation();
+        if (wr.getX() != 0 || wr.getY() != 0 || wr.getZ() != 0) {
+            BoundingVolume bv = getWorldBound();
+            if (bv instanceof BoundingSphere) {
+                BoundingSphere bs = (BoundingSphere) bv;
+                float r = bs.getRadius();
+                float center = bs.getCenter();
+                affectedAreaBBox = new BoundingBox(center, r, r, r);
+            } else {
+                affectedAreaBBox = (BoundingBox) bv.clone();
+            }            
+            return;
         }
         
         if (affectedAreaBBox == null) {

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -44,6 +44,7 @@ import com.jme3.math.FastMath;
 import com.jme3.math.Ray;
 import com.jme3.math.Vector2f;
 import com.jme3.math.Vector3f;
+import com.jme3.math.Quaternion;
 import com.jme3.scene.Geometry;
 import com.jme3.scene.Node;
 import com.jme3.scene.Spatial;
@@ -850,11 +851,16 @@ public class TerrainQuad extends Node implements Terrain {
             affectedAreaBBox = null;
             return;
         }
-        Vector3f worldLoc = getWorldTranslation();
-        worldLoc = worldLoc.mult(getWorldScale());
-        Vector2f worldLocVec2 = new Vector2f(worldLoc.getX(), worldLoc.getZ());
-        changedPoint = changedPoint.add(worldLocVec2);
+        
+        Vector2f worldLocVec2 = changedPoint.clone();
+        worldLocVec2.multLocal(new Vector2f(getWorldScale().getX(), getWorldScale().getZ()));
+        worldLocVec2.addLocal(new Vector2f(getWorldTranslation().getX(), getWorldTranslation().getZ()));		
+        changedPoint = worldLocVec2;
 
+        if(!getWorldRotation().equals(Quaternion.IDENTITY)){ 
+            affectedAreaBBox = (BoundingBox)getWorldBound().clone(); 
+        }
+        
         if (affectedAreaBBox == null) {
             affectedAreaBBox = new BoundingBox(new Vector3f(changedPoint.x, 0, changedPoint.y), 1f, Float.MAX_VALUE, 1f); // unit length
         } else {

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -850,9 +850,9 @@ public class TerrainQuad extends Node implements Terrain {
             affectedAreaBBox = null;
             return;
         }else{
-			Vector3f worldLoc = getWorldTranslation();
-			changedPoint = changedPoint.add(new Vector2f(worldLoc.getX(), worldLoc.getZ()));
-		}	
+		Vector3f worldLoc = getWorldTranslation();
+		changedPoint = changedPoint.add(new Vector2f(worldLoc.getX(), worldLoc.getZ()));
+	}	
 
         if (affectedAreaBBox == null) {
             affectedAreaBBox = new BoundingBox(new Vector3f(changedPoint.x, 0, changedPoint.y), 1f, Float.MAX_VALUE, 1f); // unit length

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -864,7 +864,7 @@ public class TerrainQuad extends Node implements Terrain {
             if (bv instanceof BoundingSphere) {
                 BoundingSphere bs = (BoundingSphere) bv;
                 float r = bs.getRadius();
-                float center = bs.getCenter();
+                Vector3f center = bs.getCenter();
                 affectedAreaBBox = new BoundingBox(center, r, r, r);
             } else {
                 affectedAreaBBox = (BoundingBox) bv.clone();

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -849,10 +849,11 @@ public class TerrainQuad extends Node implements Terrain {
         if (changedPoint == null) { // set needToRecalculateNormals() to false
             affectedAreaBBox = null;
             return;
-        }else{
-	    Vector3f worldLoc = getWorldTranslation();
-	    changedPoint = changedPoint.add(new Vector2f(worldLoc.getX(), worldLoc.getZ()));
-	}	
+        }
+        Vector3f worldLoc = getWorldTranslation();
+        worldLoc = worldLoc.mult(getWorldScale());
+        Vector2f worldLocVec2 = new Vector2f(worldLoc.getX(), worldLoc.getZ());
+        changedPoint = changedPoint.add(worldLocVec2);
 
         if (affectedAreaBBox == null) {
             affectedAreaBBox = new BoundingBox(new Vector3f(changedPoint.x, 0, changedPoint.y), 1f, Float.MAX_VALUE, 1f); // unit length

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -849,7 +849,10 @@ public class TerrainQuad extends Node implements Terrain {
         if (changedPoint == null) { // set needToRecalculateNormals() to false
             affectedAreaBBox = null;
             return;
-        }
+        }else{
+			Vector3f worldLoc = getWorldTranslation();
+			changedPoint = changedPoint.add(new Vector2f(worldLoc.getX(), worldLoc.getZ()));
+		}	
 
         if (affectedAreaBBox == null) {
             affectedAreaBBox = new BoundingBox(new Vector3f(changedPoint.x, 0, changedPoint.y), 1f, Float.MAX_VALUE, 1f); // unit length

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -854,7 +854,7 @@ public class TerrainQuad extends Node implements Terrain {
         
         Vector2f worldLocVec2 = changedPoint.clone();
         worldLocVec2.multLocal(new Vector2f(getWorldScale().getX(), getWorldScale().getZ()));
-        worldLocVec2.addLocal(new Vector2f(getWorldTranslation().getX(), getWorldTranslation().getZ()));		
+        worldLocVec2.addLocal(getWorldTranslation().getX(), getWorldTranslation().getZ());		
         changedPoint = worldLocVec2;
 
         if(!getWorldRotation().equals(Quaternion.IDENTITY)){ 

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -850,8 +850,8 @@ public class TerrainQuad extends Node implements Terrain {
             affectedAreaBBox = null;
             return;
         }else{
-		Vector3f worldLoc = getWorldTranslation();
-		changedPoint = changedPoint.add(new Vector2f(worldLoc.getX(), worldLoc.getZ()));
+	    Vector3f worldLoc = getWorldTranslation();
+	    changedPoint = changedPoint.add(new Vector2f(worldLoc.getX(), worldLoc.getZ()));
 	}	
 
         if (affectedAreaBBox == null) {

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -44,6 +44,7 @@ import com.jme3.math.FastMath;
 import com.jme3.math.Ray;
 import com.jme3.math.Vector2f;
 import com.jme3.math.Vector3f;
+import com.jme3.math.Quaternion;
 import com.jme3.scene.Geometry;
 import com.jme3.scene.Node;
 import com.jme3.scene.Spatial;

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -32,6 +32,7 @@
 package com.jme3.terrain.geomipmap;
 
 import com.jme3.bounding.BoundingBox;
+import com.jme3.bounding.BoundingSphere;
 import com.jme3.bounding.BoundingVolume;
 import com.jme3.collision.Collidable;
 import com.jme3.collision.CollisionResults;


### PR DESCRIPTION
Fixes issue in setNormalRecalcNeeded() method where the bounding box containing recently changed points was always located with the assumption that the terrain's world location is 0,0,0 regardless of the terrain's actual world translation.