### PR TITLE
Add simple math methods to Vector3f

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -569,7 +569,20 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
         }
         return mult(vec, null);
     }
-
+    
+    /**
+     * Multiplies component-wise by the specified components and returns the 
+     * product as a new instance. The current instance is unaffected.
+     *
+     * @param x the scale factor for the X component
+     * @param y the scale factor for the Y component
+     * @param z the scale factor for the Z component
+     * @return a new Vector3f
+     */
+    public Vector3f mult(float x, float y, float z) {
+        return new Vector3f(this.x * x, this.y * y, this.z * z);
+    }
+    
     /**
      * Multiplies component-wise with the specified vector and returns the
      * product in a 3rd vector. If the argument is null, null is returned.
@@ -617,6 +630,22 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
         z *= scalar;
         return this;
     }
+    
+    /**
+     * Divides component-wise by the specified components returns the (modified) 
+     * current instance.
+     *
+     * @param x the divisor for the X component
+     * @param y the divisor for the Y component
+     * @param z the divisor for the Z component
+     * @return the (modified) current instance (for chaining)
+     */
+    public Vector3f divideLocal(float x, float y, float z) {
+        this.x /= x;
+        this.y /= y;
+        this.z /= z;
+        return this;
+    }
 
     /**
      * Divides component-wise by the argument and returns the quotient as a new
@@ -629,6 +658,19 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
         return new Vector3f(x / divisor.x, y / divisor.y, z / divisor.z);
     }
 
+    /**
+     * Divides component-wise by the specified components and returns the quotient
+     * as a new instance. The current instance is unaffected.
+     *
+     * @param x the divisor for the X component
+     * @param y the divisor for the Y component
+     * @param z the divisor for the Z component
+     * @return a new Vector3f
+     */
+    public Vector3f divide(float x, float y, float z) {
+        return new Vector3f(this.x / x, this.y / y, this.z / z);
+    }
+    
     /**
      * Divides component-wise by the argument and returns the (modified) current
      * instance.


### PR DESCRIPTION
I've added these convenience multiplication and division methods that were missing from the Vector3f class, and did my best to also follow the same javadoc formatting that the rest of the similar methods have. 

Let me know if this looks alright and then I will do the same for Vector2f and Vector4f. And should I make the changes to Vector2f and Vector4f in this PR or should I make a new PR for each?