### PR TITLE
Configure circular deps as warning on eclipse

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -6,7 +6,10 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
-
+apply plugin: 'eclipse'
+eclipse.jdt.file.withProperties { props ->
+    props.setProperty "org.eclipse.jdt.core.circularClasspath", "warning"
+}
 group = 'org.jmonkeyengine'
 version = jmeFullVersion
 


### PR DESCRIPTION
This solves an issue with eclipse based IDEs (eg. vscode with redhat's java plugin) that might mark circular dependencies as errors and stop the project from being imported. 
See image below:
![image](https://user-images.githubusercontent.com/4943530/149676782-8c5029d0-e0bb-4a22-b6bf-eba336011f4a.png)
