### PR TITLE
Fix error 1280 in MacOS when querying GL_FRAMEBUFFER_SRGB_CAPABLE_EXT

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -48,6 +48,8 @@ import com.jme3.scene.VertexBuffer.Usage;
 import com.jme3.shader.*;
 import com.jme3.shader.Shader.ShaderSource;
 import com.jme3.shader.Shader.ShaderType;
+import com.jme3.system.JmeSystem;
+import com.jme3.system.Platform;
 import com.jme3.texture.FrameBuffer;
 import com.jme3.texture.FrameBuffer.RenderBuffer;
 import com.jme3.texture.Image;
@@ -3268,9 +3270,12 @@ public final class GLRenderer implements Renderer {
         setFrameBuffer(null);
 
         if (enableSrgb) {
-            if (!getBoolean(GLExt.GL_FRAMEBUFFER_SRGB_CAPABLE_EXT)) {
-                logger.warning("Driver claims that default framebuffer "
-                        + "is not sRGB capable. Enabling anyway.");
+            if (
+                // Workaround: getBoolean(GLExt.GL_FRAMEBUFFER_SRGB_CAPABLE_EXT) causes error 1280 (invalid enum) on macos
+                JmeSystem.getPlatform().getOs() != Platform.Os.MacOS
+                && !getBoolean(GLExt.GL_FRAMEBUFFER_SRGB_CAPABLE_EXT)
+            ) {
+                logger.warning("Driver claims that default framebuffer " + "is not sRGB capable. Enabling anyway.");
             }
 
             gl.glEnable(GLExt.GL_FRAMEBUFFER_SRGB_EXT);

--- a/jme3-core/src/main/java/com/jme3/system/Platform.java
+++ b/jme3-core/src/main/java/com/jme3/system/Platform.java
@@ -39,109 +39,122 @@ public enum Platform {
     /**
      * Microsoft Windows 32-bit AMD/Intel
      */
-    Windows32,
-    
+    Windows32(Os.Windows),
+
     /**
      * Microsoft Windows 64-bit AMD/Intel
      */
-    Windows64(true),
-    
+    Windows64(Os.Windows, true),
+
     /**
      * Microsoft Windows 32-bit ARM
      */
-    Windows_ARM32,
+    Windows_ARM32(Os.Windows),
 
     /**
      * Microsoft Windows 64-bit ARM
      */
-    Windows_ARM64(true),
+    Windows_ARM64(Os.Windows, true),
 
     /**
      * Linux 32-bit Intel
      */
-    Linux32,
-    
+    Linux32(Os.Linux),
+
     /**
      * Linux 64-bit Intel
      */
-    Linux64(true),
-    
+    Linux64(Os.Linux, true),
+
     /**
      * Linux 32-bit ARM
      */
-    Linux_ARM32,
-    
+    Linux_ARM32(Os.Linux),
+
     /**
      * Linux 64-bit ARM
      */
-    Linux_ARM64(true),
-    
+    Linux_ARM64(Os.Linux, true),
+
     /**
      * Apple Mac OS X 32-bit Intel
      */
-    MacOSX32,
-    
+    MacOSX32(Os.MacOS),
+
     /**
      * Apple Mac OS X 64-bit Intel
      */
-    MacOSX64(true),
-    
+    MacOSX64(Os.MacOS, true),
+
     /**
      * Apple Mac OS X 64-bit ARM
      */
-    MacOSX_ARM64(true),
+    MacOSX_ARM64(Os.MacOS, true),
 
     /**
      * Apple Mac OS X 32 bit PowerPC
      */
-    MacOSX_PPC32,
-    
+    MacOSX_PPC32(Os.MacOS),
+
     /**
      * Apple Mac OS X 64 bit PowerPC
      */
-    MacOSX_PPC64(true),
-    
+    MacOSX_PPC64(Os.MacOS, true),
+
     /**
      * Android ARM5
      */
-    Android_ARM5,
-    
+    Android_ARM5(Os.Android),
+
     /**
      * Android ARM6
      */
-    Android_ARM6,
+    Android_ARM6(Os.Android),
 
     /**
      * Android ARM7
      */
-    Android_ARM7,
+    Android_ARM7(Os.Android),
 
     /**
      * Android ARM8
      */
-    Android_ARM8,
+    Android_ARM8(Os.Android),
 
     /**
      * Android x86
      */
-    Android_X86,
+    Android_X86(Os.Android),
 
     /**
      * iOS on x86
      */
-    iOS_X86,
+    iOS_X86(Os.iOS),
 
     /**
      * iOS on ARM
      */
-    iOS_ARM,
-    
+    iOS_ARM(Os.iOS),
+
     /**
      * Android running on unknown platform (could be x86 or mips for example).
      */
-    Android_Other;
+    Android_Other(Os.Android);
+
     
+    /**
+     * Enumerate generic names of operating systems
+     */
+    public enum Os {
+        Linux, 
+        Windows, 
+        iOS, 
+        MacOS, 
+        Android
+    }
+
     private final boolean is64bit;
+    private final Os os;
 
     /**
      * Test for a 64-bit address space.
@@ -151,12 +164,22 @@ public enum Platform {
     public boolean is64Bit() {
         return is64bit;
     }
-    
-    private Platform(boolean is64bit) {
+
+    /**
+     * Get the opterating system of this platform
+     * 
+     * @return the generic name of the operating system of this platform
+     */
+    public Os getOs() {
+        return os;
+    }
+
+    private Platform(Os os, boolean is64bit) {
+        this.os = os;
         this.is64bit = is64bit;
     }
-    
-    private Platform() {
-        this(false);
+
+    private Platform(Os os) {
+        this(os, false);
     }
 }


### PR DESCRIPTION
The line `getBoolean(GLExt.GL_FRAMEBUFFER_SRGB_CAPABLE_EXT)` in GLRenderer throw an opengl error 1280 (invalid enum) when the GL debugger is enabled. 
I am not sure why this is the case, however i believe it is safe to assume that every modern macos device is sRGB capable.