### PR TITLE
Separate concept of window size from default framebuffer size

### DIFF
--- a/jme3-android/src/main/java/com/jme3/app/AndroidHarness.java
+++ b/jme3-android/src/main/java/com/jme3/app/AndroidHarness.java
@@ -495,6 +495,11 @@ public class AndroidHarness extends Activity implements TouchListener, DialogInt
     }
 
     @Override
+    public void rescale(float x, float y) {
+        app.rescale(x, y);
+    }
+
+    @Override
     public void update() {
         app.update();
         // call to remove the splash screen, if present.

--- a/jme3-android/src/main/java/com/jme3/app/AndroidHarnessFragment.java
+++ b/jme3-android/src/main/java/com/jme3/app/AndroidHarnessFragment.java
@@ -572,6 +572,11 @@ public class AndroidHarnessFragment extends Fragment implements
     }
 
     @Override
+    public void rescale(float x, float y) {
+        app.rescale(x, y);
+    }
+
+    @Override
     public void update() {
         app.update();
         // call to remove the splash screen, if present.

--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
@@ -395,6 +395,17 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
         jmeSurfaceViewLogger.log(Level.INFO, "Requested reshaping from the system listener");
     }
 
+
+    @Override
+    public void rescale(float x, float y) {
+        if (legacyApplication == null) {
+            return;
+        }
+        legacyApplication.rescale(x, y);
+        jmeSurfaceViewLogger.log(Level.INFO, "Requested rescaling from the system listener");
+    }
+
+
     @Override
     public void update() {
         /*Invoking can be delayed by delaying the draw of GlSurfaceView component on the screen*/

--- a/jme3-core/src/main/java/com/jme3/app/LegacyApplication.java
+++ b/jme3-core/src/main/java/com/jme3/app/LegacyApplication.java
@@ -579,9 +579,6 @@ public class LegacyApplication implements Application, SystemListener {
     }
 
 
-    /**
-     * Internal use only.
-     */
     @Override
     public void rescale(float x, float y){
         if (renderManager != null) {

--- a/jme3-core/src/main/java/com/jme3/app/LegacyApplication.java
+++ b/jme3-core/src/main/java/com/jme3/app/LegacyApplication.java
@@ -578,6 +578,17 @@ public class LegacyApplication implements Application, SystemListener {
         }
     }
 
+
+    /**
+     * Internal use only.
+     */
+    @Override
+    public void rescale(float x, float y){
+        if (renderManager != null) {
+            renderManager.notifyRescale(x, y);
+        }
+    }
+
     /**
      * Restarts the context, applying any changed settings.
      * <p>

--- a/jme3-core/src/main/java/com/jme3/post/SceneProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/SceneProcessor.java
@@ -66,8 +66,8 @@ public interface SceneProcessor {
      * Called when the scale of the viewport has been changed.
      *
      * @param vp the affected ViewPort
-     * @param x the new scale (in pixels)
-     * @param y the new scale (in pixels)
+     * @param x the new horizontal scale 
+     * @param y the new vertical scale 
      */
     public default void rescale(ViewPort vp, float x, float y){
 

--- a/jme3-core/src/main/java/com/jme3/post/SceneProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/SceneProcessor.java
@@ -69,7 +69,7 @@ public interface SceneProcessor {
      * @param x the new horizontal scale 
      * @param y the new vertical scale 
      */
-    public default void rescale(ViewPort vp, float x, float y){
+    public default void rescale(ViewPort vp, float x, float y) {
 
     }
 

--- a/jme3-core/src/main/java/com/jme3/post/SceneProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/SceneProcessor.java
@@ -63,6 +63,17 @@ public interface SceneProcessor {
     public void reshape(ViewPort vp, int w, int h);
 
     /**
+     * Called when the scale of the viewport has been changed.
+     *
+     * @param vp the affected ViewPort
+     * @param x the new scale (in pixels)
+     * @param y the new scale (in pixels)
+     */
+    public default void rescale(ViewPort vp, float x, float y){
+
+    }
+
+    /**
      * @return True if initialize() has been called on this SceneProcessor,
      * false if otherwise.
      */

--- a/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
@@ -385,6 +385,13 @@ public class RenderManager {
         }
     }
 
+    /**
+     * Internal use only.
+     * Updates the scale of all on-screen ViewPorts
+     *
+     * @param x the new horizontal scale
+     * @param y the new vertical scale
+     */
     public void notifyRescale(float x, float y) {
         for (ViewPort vp : preViewPorts) {
             notifyRescale(vp, x, y);

--- a/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
@@ -342,6 +342,17 @@ public class RenderManager {
         }
     }
 
+    private void notifyRescale(ViewPort vp, float x, float y) {
+        List<SceneProcessor> processors = vp.getProcessors();
+        for (SceneProcessor proc : processors) {
+            if (!proc.isInitialized()) {
+                proc.initialize(this, vp);
+            } else {
+                proc.rescale(vp, x, y);
+            }
+        }
+    }
+
     /**
      * Internal use only.
      * Updates the resolution of all on-screen cameras to match
@@ -371,6 +382,18 @@ public class RenderManager {
                 cam.resize(w, h, true);
             }
             notifyReshape(vp, w, h);
+        }
+    }
+
+    public void notifyRescale(float x, float y) {
+        for (ViewPort vp : preViewPorts) {
+            notifyRescale(vp, x, y);
+        }
+        for (ViewPort vp : viewPorts) {        
+            notifyRescale(vp, x, y);
+        }
+        for (ViewPort vp : postViewPorts) {
+            notifyRescale(vp, x, y);
         }
     }
 

--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -767,8 +767,8 @@ public final class AppSettings extends HashMap<String, Object> {
     /**
      * Set the size of the window
      * 
-     * @param width The width in pixels (default = resolution width)
-     * @param height The height in pixels (default = resolution height)
+     * @param width The width in pixels (default = width of the default framebuffer)
+     * @param height The height in pixels (default = height of the default framebuffer)
      */
     public void setWindowSize(int width, int height) {
         putInteger("WindowWidth", width);

--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -269,6 +269,8 @@ public final class AppSettings extends HashMap<String, Object> {
         defaults.put("CenterWindow", true);
         defaults.put("Width", 640);
         defaults.put("Height", 480);
+        defaults.put("WindowWidth", Integer.MIN_VALUE);
+        defaults.put("WindowHeight", Integer.MIN_VALUE);
         defaults.put("BitsPerPixel", 24);
         defaults.put("Frequency", 60);
         defaults.put("DepthBits", 24);
@@ -735,7 +737,7 @@ public final class AppSettings extends HashMap<String, Object> {
     }
 
     /**
-     * @param value the width for the rendering display.
+     * @param value the width for the default framebuffer.
      * (Default: 640)
      */
     public void setWidth(int value) {
@@ -743,7 +745,7 @@ public final class AppSettings extends HashMap<String, Object> {
     }
 
     /**
-     * @param value the height for the rendering display.
+     * @param value the height for the default framebuffer.
      * (Default: 480)
      */
     public void setHeight(int value) {
@@ -751,7 +753,8 @@ public final class AppSettings extends HashMap<String, Object> {
     }
 
     /**
-     * Set the resolution for the rendering display
+     * Set the resolution for the default framebuffer
+     * Use {@link #setWindowSize(int, int)} instead, for HiDPI display support.
      * @param width The width
      * @param height The height
      * (Default: 640x480)
@@ -761,6 +764,18 @@ public final class AppSettings extends HashMap<String, Object> {
         setHeight(height);
     }
 
+    /**
+     * Set the size of the window
+     * 
+     * @param width
+     *            The width
+     * @param height
+     *            The height (Default: 640x480)
+     */
+    public void setWindowSize(int width, int height) {
+        putInteger("WindowWidth", width);
+        putInteger("WindowHeight", height);
+    }
 
     /**
      * @param value the minimum width the settings window will allow for the rendering display.
@@ -991,7 +1006,7 @@ public final class AppSettings extends HashMap<String, Object> {
     /**
      * Get the width
      *
-     * @return the width of the rendering display (in pixels)
+     * @return the width of the default framebuffer (in pixels)
      * @see #setWidth(int)
      */
     public int getWidth() {
@@ -1001,11 +1016,33 @@ public final class AppSettings extends HashMap<String, Object> {
     /**
      * Get the height
      *
-     * @return the height of the rendering display (in pixels)
+     * @return the height of the default framebuffer (in pixels)
      * @see #setHeight(int)
      */
     public int getHeight() {
         return getInteger("Height");
+    }
+
+    /**
+     * Get the width of the window
+     *
+     * @return the width of the window (in pixels)
+     * @see #setWindowWidth(int)
+     */
+    public int getWindowWidth() {
+        int w = getInteger("WindowWidth");
+        return w != Integer.MIN_VALUE ? w : getWidth();
+    }
+
+    /**
+     * Get the height of the window
+     *
+     * @return the height of the window (in pixels)
+     * @see #setWindowHeight(int)
+     */
+    public int getWindowHeight() {
+        int h = getInteger("WindowHeight");
+        return h != Integer.MIN_VALUE ? h : getHeight();
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -767,10 +767,8 @@ public final class AppSettings extends HashMap<String, Object> {
     /**
      * Set the size of the window
      * 
-     * @param width
-     *            The width
-     * @param height
-     *            The height (Default: 640x480)
+     * @param width The width in pixels (default = resolution width)
+     * @param height The height in pixels (default = resolution height)
      */
     public void setWindowSize(int width, int height) {
         putInteger("WindowWidth", width);

--- a/jme3-core/src/main/java/com/jme3/system/SystemListener.java
+++ b/jme3-core/src/main/java/com/jme3/system/SystemListener.java
@@ -53,10 +53,12 @@ public interface SystemListener {
 
     /**
      * Called to notify the application that the scale has changed.
-     * @param x the new scale of the display (in pixels, &ge;0)
-     * @param y the new scale of the display (in pixels, &ge;0)
+     * @param x the new horizontal scale of the display 
+     * @param y the new vertical scale of the display
      */
-    public void rescale(float x, float y);
+    public default void rescale(float x, float y){
+
+    }
 
 
     /**

--- a/jme3-core/src/main/java/com/jme3/system/SystemListener.java
+++ b/jme3-core/src/main/java/com/jme3/system/SystemListener.java
@@ -52,6 +52,14 @@ public interface SystemListener {
     public void reshape(int width, int height);
 
     /**
+     * Called to notify the application that the scale has changed.
+     * @param x the new scale of the display (in pixels, &ge;0)
+     * @param y the new scale of the display (in pixels, &ge;0)
+     */
+    public void rescale(float x, float y);
+
+
+    /**
      * Callback to update the application state, and render the scene
      * to the back buffer.
      */

--- a/jme3-desktop/src/main/java/com/jme3/system/awt/AwtPanelsContext.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/awt/AwtPanelsContext.java
@@ -68,6 +68,11 @@ public class AwtPanelsContext implements JmeContext {
         }
 
         @Override
+        public void rescale(float x, float y) {
+            throw new IllegalStateException();
+        }
+
+        @Override
         public void update() {
             updateInThread();
         }

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -338,6 +338,10 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         setWindowIcon(settings);
         showWindow();
 
+        // HACK: the framebuffer seems to be initialized with the wrong size
+        // on some HiDPI platforms untill glfwPollEvents is called 2 or 3 times
+        for (int i = 0; i < 4; i++) glfwPollEvents();
+        
         // Windows resize callback
         glfwSetWindowSizeCallback(window, windowSizeCallback = new GLFWWindowSizeCallback() {
 
@@ -374,7 +378,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
         updateDefaultFramebufferSize();
 
-        framesAfterContextStarted = 0;
     }
 
     private void updateDefaultFramebufferSize() {
@@ -595,7 +598,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         return true;
     }
 
-    private int framesAfterContextStarted = 0;
 
     /**
      * execute one iteration of the render loop in the OpenGL thread
@@ -610,15 +612,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             throw new IllegalStateException();
         }
 
-        // Update the frame buffer size from 2nd frame since the initial value
-        // of frame buffer size from glfw maybe incorrect when HiDPI display is in use 
-        // and GLFW_COCOA_RETINA_FRAMEBUFFER is false
-        if (framesAfterContextStarted < 2) {
-            framesAfterContextStarted++;
-            if (framesAfterContextStarted == 2) {
-                updateDefaultFramebufferSize();
-            }
-        }
 
         listener.update();
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -151,7 +151,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
     // temp variables used for glfw calls
     private int width[] = new int[1];
     private int height[] = new int[1];
-    private final Vector2f currentScale = new Vector2f(1,1);
+    private final Vector2f currentScale = new Vector2f(1, 1);
 
     public LwjglWindow(final JmeContext.Type type) {
 
@@ -340,7 +340,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         showWindow();
 
         // HACK: the framebuffer seems to be initialized with the wrong size
-        // on some HiDPI platforms untill glfwPollEvents is called 2 or 3 times
+        // on some HiDPI platforms until glfwPollEvents is called 2 or 3 times
         for (int i = 0; i < 4; i++) glfwPollEvents();
         
         // Windows resize callback
@@ -384,12 +384,12 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
     
     private void updateDefaultFramebufferSize(boolean updateListener) {
-        // If default framebuffer size is different than window size (eg. HiDPI)
+        // If default framebuffer size is different than window size (e.g. HiDPI)
         int[] width = new int[1];
         int[] height = new int[1];
         glfwGetFramebufferSize(window, width, height);
 
-        Vector2f scale=getWindowContentScale(null);
+        Vector2f scale = getWindowContentScale(null);
 
         if (updateListener) {
             if (settings.getWidth() != width[0] || settings.getHeight() != height[0]) {

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -382,11 +382,16 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         int[] width = new int[1];
         int[] height = new int[1];
         glfwGetFramebufferSize(window, width, height);
+
+        Vector2f scale=new Vector2f();
+        getWindowContentScale(scale);
+
         if (settings.getWidth() != width[0] || settings.getHeight() != height[0]) {
             settings.setResolution(width[0], height[0]);
             // https://www.glfw.org/docs/latest/window_guide.html#window_fbsize
+            listener.rescale(scale.x,scale.y);
             listener.reshape(width[0], height[0]);
-        }
+        }   
     }
 
     private void onWindowSizeChanged(final int width, final int height) {


### PR DESCRIPTION
This pr makes AppSettings.getWidth/Height return the size of the default framebuffer that is usually what is expected by user code. New methods to set and get window size are added.
The change is backward compatible.

The PR removes also a workaround that caused the engine to be aware of high DPI resolution after the second frame, in my tests waiting two frames has proven to be unnecessary.

EDIT: added rescale listener that propagates the high dpi scaling. Can be used for example to multiply the size of GUI elements.