### PR TITLE
Use OpenGL 3.2 as default

### DIFF
--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -276,7 +276,7 @@ public final class AppSettings extends HashMap<String, Object> {
         defaults.put("Samples", 0);
         defaults.put("Fullscreen", false);
         defaults.put("Title", JmeVersion.FULL_NAME);
-        defaults.put("Renderer", LWJGL_OPENGL2);
+        defaults.put("Renderer", LWJGL_OPENGL32);
         defaults.put("AudioRenderer", LWJGL_OPENAL);
         defaults.put("DisableJoysticks", true);
         defaults.put("UseInput", true);
@@ -704,7 +704,7 @@ public final class AppSettings extends HashMap<String, Object> {
      * <li>null - Disable graphics rendering</li>
      * </ul>
      * @param renderer The renderer to set
-     * (Default: AppSettings.LWJGL_OPENGL2)
+     * (Default: AppSettings.LWJGL_OPENGL32)
      */
     public void setRenderer(String renderer) {
         putString("Renderer", renderer);


### PR DESCRIPTION
This is the best GL version for compatibility and features, pretty much every system supports it now, so i think it should become the default.
The primary reason for this change is that by doing so we enforce by default a core profile that is supposed to respect the opengl standards and implement all its features, contrary to the compatibility profile (what we have now by default) that is implementation specific and might not respect standards, also it is not always in sync with the core profile in drivers, eg. the compatibility profile might stop at opengl 3.1 while the same driver might be opengl4 capable if the core profile is used.

This solves the issue of PBRLighting not working in MacOS due to missing textureCubeLod in the compat profile.

