### PR TITLE
Fix issue 1705 (serialize 6 mesh subclasses)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/debug/SkeletonWire.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/SkeletonWire.java
@@ -37,6 +37,10 @@ import java.util.Map;
 
 import com.jme3.animation.Bone;
 import com.jme3.animation.Skeleton;
+import com.jme3.export.InputCapsule;
+import com.jme3.export.JmeExporter;
+import com.jme3.export.JmeImporter;
+import com.jme3.export.OutputCapsule;
 import com.jme3.math.Vector3f;
 import com.jme3.scene.Mesh;
 import com.jme3.scene.VertexBuffer;
@@ -44,6 +48,8 @@ import com.jme3.scene.VertexBuffer.Format;
 import com.jme3.scene.VertexBuffer.Type;
 import com.jme3.scene.VertexBuffer.Usage;
 import com.jme3.util.BufferUtils;
+import java.io.IOException;
+import java.util.HashMap;
 
 /**
  * The class that displays either wires between the bones' heads if no length data is supplied and
@@ -112,6 +118,12 @@ public class SkeletonWire extends Mesh {
     }
 
     /**
+     * For serialization only. Do not use.
+     */
+    protected SkeletonWire() {
+    }
+
+    /**
      * This method updates the geometry according to the positions of the bones.
      */
     public void updateGeometry() {
@@ -132,6 +144,65 @@ public class SkeletonWire extends Mesh {
         vb.updateData(posBuf);
 
         this.updateBound();
+    }
+
+    /**
+     * De-serializes from the specified importer, for example when loading from
+     * a J3O file.
+     *
+     * @param importer the importer to use (not null)
+     * @throws IOException from the importer
+     */
+    @Override
+    public void read(JmeImporter importer) throws IOException {
+        super.read(importer);
+        InputCapsule capsule = importer.getCapsule(this);
+
+        numConnections = capsule.readInt("numConnections", 1);
+        skeleton = (Skeleton) capsule.readSavable("skeleton", null);
+
+        int[] blKeys = capsule.readIntArray("blKeys", null);
+        float[] blValues = capsule.readFloatArray("blValues", null);
+        if (blKeys == null) {
+            boneLengths = null;
+        } else {
+            assert blValues.length == blKeys.length;
+            int numLengths = blKeys.length;
+            boneLengths = new HashMap<>(numLengths);
+            for (int i = 0; i < numLengths; ++i) {
+                boneLengths.put(blKeys[i], blValues[i]);
+            }
+        }
+    }
+
+    /**
+     * Serializes to the specified exporter, for example when saving to a J3O
+     * file. The current instance is unaffected.
+     *
+     * @param exporter the exporter to use (not null)
+     * @throws IOException from the exporter
+     */
+    @Override
+    public void write(JmeExporter exporter) throws IOException {
+        super.write(exporter);
+        OutputCapsule capsule = exporter.getCapsule(this);
+
+        capsule.write(numConnections, "numConnections", 1);
+        capsule.write(skeleton, "skeleton", null);
+
+        if (boneLengths != null) {
+            int numLengths = boneLengths.size();
+            int[] blKeys = new int[numLengths];
+            float[] blValues = new float[numLengths];
+            int i = 0;
+            for (Map.Entry<Integer, Float> entry : boneLengths.entrySet()) {
+                blKeys[i] = entry.getKey();
+                blValues[i] = entry.getValue();
+                ++i;
+            }
+            capsule.write(blKeys, "blKeys", null);
+            capsule.write(blValues, "blValues", null);
+        }
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/debug/custom/ArmatureInterJointsWire.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/custom/ArmatureInterJointsWire.java
@@ -54,6 +54,12 @@ public class ArmatureInterJointsWire extends Mesh {
         updateGeometry(start, ends);
     }
 
+    /**
+     * For serialization only. Do not use.
+     */
+    protected ArmatureInterJointsWire() {
+    }
+
     protected void updateGeometry(Vector3f start, Vector3f[] ends) {
         float[] pos = new float[ends.length * 3 + 3];
         pos[0] = start.x;

--- a/jme3-core/src/test/java/com/jme3/scene/debug/TestCloneMesh.java
+++ b/jme3-core/src/test/java/com/jme3/scene/debug/TestCloneMesh.java
@@ -89,6 +89,7 @@ public class TestCloneMesh {
     /**
      * Test cloning/saving/loading a SkeletonDebugger.
      */
+    @Test
     public void testCloneSkeletonDebugger() {
         Bone[] boneArray = new Bone[2];
         boneArray[0] = new Bone("rootBone");
@@ -111,8 +112,9 @@ public class TestCloneMesh {
     }
 
     /**
-     * Test cloning/saving/loading a SkeletonInterBoneWire.
+     * Test cloning/saving/loading a SkeletonInterBoneWire.  See JME issue #1705.
      */
+    @Test
     public void testCloneSkeletonInterBoneWire() {
         Bone[] boneArray = new Bone[2];
         boneArray[0] = new Bone("rootBone");
@@ -138,8 +140,9 @@ public class TestCloneMesh {
     }
 
     /**
-     * Test cloning/saving/loading a SkeletonPoints.
+     * Test cloning/saving/loading a SkeletonPoints.  See JME issue #1705.
      */
+    @Test
     public void testCloneSkeletonPoints() {
         Bone[] boneArray = new Bone[2];
         boneArray[0] = new Bone("rootBone");
@@ -161,8 +164,9 @@ public class TestCloneMesh {
     }
 
     /**
-     * Test cloning/saving/loading a SkeletonWire.
+     * Test cloning/saving/loading a SkeletonWire.  See JME issue #1705.
      */
+    @Test
     public void testCloneSkeletonWire() {
         Bone[] boneArray = new Bone[2];
         boneArray[0] = new Bone("rootBone");

--- a/jme3-vr/src/main/java/com/jme3/scene/CenterQuad.java
+++ b/jme3-vr/src/main/java/com/jme3/scene/CenterQuad.java
@@ -31,7 +31,12 @@
  */
 package com.jme3.scene;
 
+import com.jme3.export.InputCapsule;
+import com.jme3.export.JmeExporter;
+import com.jme3.export.JmeImporter;
+import com.jme3.export.OutputCapsule;
 import com.jme3.scene.VertexBuffer.Type;
+import java.io.IOException;
 
 /**
  * A static, indexed, Triangles-mode mesh for an axis-aligned rectangle in the
@@ -78,6 +83,12 @@ public class CenterQuad extends Mesh {
     public CenterQuad(float width, float height, boolean flipCoords){
         updateGeometry(width, height, flipCoords);
         this.setStatic();
+    }
+
+    /**
+     * For serialization only. Do not use.
+     */
+    protected CenterQuad() {
     }
 
     public float getHeight() {
@@ -128,5 +139,35 @@ public class CenterQuad extends Mesh {
         updateBound();
     }
 
+    /**
+     * De-serializes from the specified importer, for example when loading from
+     * a J3O file.
+     *
+     * @param importer the importer to use (not null)
+     * @throws IOException from the importer
+     */
+    @Override
+    public void read(JmeImporter importer) throws IOException {
+        super.read(importer);
+        InputCapsule capsule = importer.getCapsule(this);
 
+        width = capsule.readFloat("width", 0f);
+        height = capsule.readFloat("height", 0f);
+    }
+
+    /**
+     * Serializes to the specified exporter, for example when saving to a J3O
+     * file. The current instance is unaffected.
+     *
+     * @param exporter the exporter to use (not null)
+     * @throws IOException from the exporter
+     */
+    @Override
+    public void write(JmeExporter exporter) throws IOException {
+        super.write(exporter);
+        OutputCapsule capsule = exporter.getCapsule(this);
+
+        capsule.write(width, "width", 0f);
+        capsule.write(height, "height", 0f);
+    }
 }


### PR DESCRIPTION
This adds no-arg constructors to 6 `Mesh` subclasses and implements `read()` and `write()` methods as needed.

A few `final` fields had to be made non-final in order for reads to work.

In addition, the automated tests for skeleton-debug mesh serialization (in `TestCloneMesh`) were enabled.