### PR TITLE
Add set methods and constructors to ColorRGBA that take in a Vector param

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
+++ b/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
@@ -203,6 +203,50 @@ public final class ColorRGBA implements Savable, Cloneable, java.io.Serializable
         }
         return this;
     }
+    
+    /**
+     * <code>set</code> sets the values of this <code>ColorRGBA</code> to those
+     * set by a parameter Vector4f.
+     *
+     * @param vec4 The 4 component vector to set this <code>ColorRGBA</code> to.
+     * @return this
+     */
+    public ColorRGBA set(Vector4f vec4) {
+        if (vec4 == null) {
+            r = 0;
+            g = 0;
+            b = 0;
+            a = 0;
+        } else {
+            r = vec4.x;
+            g = vec4.y;
+            b = vec4.z;
+            a = vec4.w;
+        }
+        return this;
+    }    
+    
+    /**
+     * <code>set</code> sets the values of this <code>ColorRGBA</code> to those
+     * set by a parameter Vector3f.
+     *
+     * @param vec3 The 3 component vector to set the r, g, and b values of
+     * this <code>ColorRGBA</code> to respectively.
+     *
+     * @return this
+     */
+    public ColorRGBA set(Vector4f vec3) {
+        if (vec3 == null) {
+            r = 0;
+            g = 0;
+            b = 0;
+        } else {
+            r = vec3.x;
+            g = vec3.y;
+            b = vec3.z;
+        }
+        return this;
+    }       
 
     /**
      * Sets the red color to the specified value.

--- a/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
+++ b/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
@@ -166,7 +166,8 @@ public final class ColorRGBA implements Savable, Cloneable, java.io.Serializable
      * Constructor creates a new <code>ColorRGBA</code> object, based on
      * a provided Vector4f.
      *
-     * @param vec4 The <code>Vector4f</code> object to copy.
+     * @param vec4 The <code>Vector4f</code> object that will have its x, y, z, and w
+     * values copied to this color's r, g, b, and a values respectively.
      */
     public ColorRGBA(Vector4f vec4) {
         this.a = vec4.w;
@@ -179,8 +180,8 @@ public final class ColorRGBA implements Savable, Cloneable, java.io.Serializable
      * Constructor creates a new <code>ColorRGBA</code> object, based on
      * a provided Vector3f, at full opacity with a 1.0 alpha value by default
      *
-     * @param vec3 The <code>Vector3f</code> object to copy to the r, g, and b 
-     * values respectively
+     * @param vec3 The <code>Vector3f</code> object that will have its x, y, and z
+     * values copied to this color's r, g, and b values respectively.
      */
     public ColorRGBA(Vector3f vec3) {
         this.a = 1.0f;
@@ -235,7 +236,9 @@ public final class ColorRGBA implements Savable, Cloneable, java.io.Serializable
      * <code>set</code> sets the values of this <code>ColorRGBA</code> to those
      * set by a parameter Vector4f.
      *
-     * @param vec4 The 4 component vector to set this <code>ColorRGBA</code> to.
+     * @param vec4 The 4 component vector that will have its x, y, z, and w values copied to
+     * this <code>ColorRGBA</code>'s r, g, b, and a values respectively.
+     *
      * @return this
      */
     public ColorRGBA set(Vector4f vec4) {
@@ -257,8 +260,8 @@ public final class ColorRGBA implements Savable, Cloneable, java.io.Serializable
      * <code>set</code> sets the values of this <code>ColorRGBA</code> to those
      * set by a parameter Vector3f.
      *
-     * @param vec3 The 3 component vector to set the r, g, and b values of
-     * this <code>ColorRGBA</code> to respectively.
+     * @param vec3 The 3 component vector that will have its x, y, and z values copied to
+     * this <code>ColorRGBA</code>'s r, g, and b values respectively.
      *
      * @return this
      */

--- a/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
+++ b/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
@@ -161,6 +161,33 @@ public final class ColorRGBA implements Savable, Cloneable, java.io.Serializable
         this.g = rgba.g;
         this.b = rgba.b;
     }
+    
+    /**
+     * Constructor creates a new <code>ColorRGBA</code> object, based on
+     * a provided Vector4f.
+     *
+     * @param vec4 The <code>Vector4f</code> object to copy.
+     */
+    public ColorRGBA(Vector4f vec4) {
+        this.a = vec4.w;
+        this.r = vec4.x;
+        this.g = vec4.y;
+        this.b = vec4.z;
+    }    
+    
+    /**
+     * Constructor creates a new <code>ColorRGBA</code> object, based on
+     * a provided Vector3f, at full opacity with a 1.0 alpha value by default
+     *
+     * @param vec3 The <code>Vector3f</code> object to copy to the r, g, and b 
+     * values respectively
+     */
+    public ColorRGBA(Vector3f vec3) {
+        this.a = 1.0f;
+        this.r = vec3.x;
+        this.g = vec3.y;
+        this.b = vec3.z;
+    }    
 
     /**
      * <code>set</code> sets the RGBA values of this <code>ColorRGBA</code>.

--- a/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
+++ b/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
@@ -235,7 +235,7 @@ public final class ColorRGBA implements Savable, Cloneable, java.io.Serializable
      *
      * @return this
      */
-    public ColorRGBA set(Vector4f vec3) {
+    public ColorRGBA set(Vector3f vec3) {
         if (vec3 == null) {
             r = 0;
             g = 0;

--- a/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
+++ b/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
@@ -180,7 +180,7 @@ public final class ColorRGBA implements Savable, Cloneable, java.io.Serializable
      * a provided Vector3f, at full opacity with a 1.0 alpha value by default
      *
      * @param vec3 The <code>Vector3f</code> object to copy to the r, g, and b 
-     * values to respectively
+     * values respectively
      */
     public ColorRGBA(Vector3f vec3) {
         this.a = 1.0f;

--- a/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
+++ b/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
@@ -180,7 +180,7 @@ public final class ColorRGBA implements Savable, Cloneable, java.io.Serializable
      * a provided Vector3f, at full opacity with a 1.0 alpha value by default
      *
      * @param vec3 The <code>Vector3f</code> object to copy to the r, g, and b 
-     * values respectively
+     * values to respectively
      */
     public ColorRGBA(Vector3f vec3) {
         this.a = 1.0f;


### PR DESCRIPTION
I've noticed that ColorRGBA has a very useful .toVector4f() method (and also toVector3() method), which are great for instances where you need to do math with a ColorRGBA value returned from an ImageRaster, but there is no equally convenient method to convert that Vector back into a color afterwards, so I thought these 2 methods could be useful (specifically for Vector4f, but I added one for Vector3f too since there was also a toVector3f() method)

I initially thought of adding a new toColorRGBA() method to the Vector classes, but it seemed more appropriate to put this functionality into the ColorRGBA class here with set methods the way I did.

Any thoughts on this addition?