### PR TITLE
StatefulObjects

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/Camera.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Camera.java
@@ -45,6 +45,9 @@ import com.jme3.math.Quaternion;
 import com.jme3.math.Vector2f;
 import com.jme3.math.Vector3f;
 import com.jme3.math.Vector4f;
+import com.jme3.export.*;
+import com.jme3.math.*;
+import com.jme3.util.StatefulObject;
 import com.jme3.util.TempVars;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -70,7 +73,7 @@ import java.util.logging.Logger;
  * @author Mark Powell
  * @author Joshua Slack
  */
-public class Camera implements Savable, Cloneable {
+public class Camera extends StatefulObject implements Savable, Cloneable {
 
     private static final Logger logger = Logger.getLogger(Camera.class.getName());
 
@@ -1247,6 +1250,7 @@ public class Camera implements Savable, Cloneable {
             //viewProjectionMatrix.set(viewMatrix).multLocal(projectionMatrix);
             viewProjectionMatrix.set(projectionMatrix).multLocal(viewMatrix);
         }
+        updateStates(null);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/scene/Node.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Node.java
@@ -58,6 +58,9 @@ import java.util.logging.Logger;
  * @author Joshua Slack
  */
 public class Node extends Spatial {
+    public enum StateUpdateHints {
+        INVALIDATE_UPDATE_LIST        
+    }
     private static final Logger logger = Logger.getLogger(Node.class.getName());
     /**
      * This node's children.
@@ -201,6 +204,7 @@ public class Node extends Spatial {
      *  that would change state.
      */
     void invalidateUpdateList() {
+        updateStates(StateUpdateHints.INVALIDATE_UPDATE_LIST);
         updateListValid = false;
         if (parent != null) {
             parent.invalidateUpdateList();

--- a/jme3-core/src/main/java/com/jme3/scene/Spatial.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Spatial.java
@@ -50,6 +50,7 @@ import com.jme3.renderer.queue.RenderQueue.Bucket;
 import com.jme3.renderer.queue.RenderQueue.ShadowMode;
 import com.jme3.scene.control.Control;
 import com.jme3.util.SafeArrayList;
+import com.jme3.util.StatefulObject;
 import com.jme3.util.TempVars;
 import com.jme3.util.clone.Cloner;
 import com.jme3.util.clone.IdentityCloneFunction;
@@ -68,8 +69,8 @@ import java.util.logging.Logger;
  * @author Joshua Slack
  * @version $Revision: 4075 $, $Data$
  */
-public abstract class Spatial implements Savable, Cloneable, Collidable,
-        CloneableSmartAsset, JmeCloneable, HasLocalTransform {
+public abstract class Spatial extends StatefulObject implements Savable, Cloneable, Collidable, CloneableSmartAsset, JmeCloneable, HasLocalTransform {
+
     private static final Logger logger = Logger.getLogger(Spatial.class.getName());
 
     /**
@@ -906,6 +907,7 @@ public abstract class Spatial implements Savable, Cloneable, Collidable,
         // assume that this Spatial is a leaf, a proper implementation
         // for this method should be provided by Node.
 
+        int refreshFlagsCp = refreshFlags;
         // NOTE: Update world transforms first because
         // bound transform depends on them.
         if ((refreshFlags & RF_LIGHTLIST) != 0) {
@@ -921,6 +923,8 @@ public abstract class Spatial implements Savable, Cloneable, Collidable,
             updateMatParamOverrides();
         }
         assert refreshFlags == 0;
+
+        updateStates(refreshFlagsCp);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/util/NativeObject.java
+++ b/jme3-core/src/main/java/com/jme3/util/NativeObject.java
@@ -42,7 +42,7 @@ import java.nio.Buffer;
  * collected by the garbage collector, and then invoke the proper destructor
  * on the OpenGL library to delete it from memory.
  */
-public abstract class NativeObject implements Cloneable {
+public abstract class NativeObject extends StatefulObject implements Cloneable {
 
     public static final int INVALID_ID = -1;
     
@@ -130,6 +130,7 @@ public abstract class NativeObject implements Cloneable {
      * and its state needs to be updated.
      */
     public void setUpdateNeeded(){
+        updateStates(null);
         updateNeeded = true;
     }
 

--- a/jme3-core/src/main/java/com/jme3/util/StatefulObject.java
+++ b/jme3-core/src/main/java/com/jme3/util/StatefulObject.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2009-2021 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.util;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.jme3.util.functional.NoArgFunction;
+import com.jme3.util.functional.VoidFunction;
+
+
+/**
+ * StatefulObject is an object that stores one or more states
+ * 
+ * @author Riccardo Balbo
+ */
+public class StatefulObject implements Cloneable{
+    private static AtomicLong globalId = new AtomicLong(Long.MIN_VALUE);
+
+    private static long getNewSnapshotID(){
+        return  globalId.getAndUpdate(n->{
+            long nn=n+1;
+            if(nn==-1||n==0)nn=1;    
+            return nn;
+        });
+    }
+
+    /** 
+     * A state that can be updated.
+     */
+    public static abstract class State {
+        private volatile long snapshotID=0;
+
+        /**
+         * Get unique ID of the snapshot of the current state.
+         * The ID changes after every update.
+         * @return
+         */
+        public long getSnapshotID(){
+            return snapshotID;
+        }
+            
+        /**
+         * Called when the state needs to be updated
+         * @param hint Hint on what need to be updated (may be ignored)
+         */
+        public abstract void updateState(Object hint);
+
+        /**
+         * Called after the update is completed.
+         * Updates the snapshot ID so that objects monitoring it can know that 
+         * the state has new data.
+         */
+        public void commitUpdate() {
+            snapshotID = getNewSnapshotID(); // update the snapshot id
+        }
+
+        public abstract State cloneStateFor(StatefulObject obj);
+
+    }
+
+    
+    private transient Map<Object, State> states;
+    
+    /**
+     * Get registered states
+     * 
+     * @return Map containing all the registered states and their keys
+     */
+    protected Map<Object, State> getStates() {
+        if (states == null) {
+            states = (Map<Object, State>) Collections.synchronizedMap(new WeakHashMap<Object, State>());         
+        }
+        return states;
+    }
+    /**
+     * Get or attach a state
+     * @param <T>
+     * @param key Something that is unique and represent the state (can be any object)
+     * @param constructor constructor used to create a new state if it doesn't exist
+     * @return
+     */
+    public <T extends State> T  getState(Object key, NoArgFunction<T> constructor) {        
+        State state = getStates().get(key);
+        if (state == null && constructor != null) {
+            state = constructor.eval();
+            getStates().put(key, state);
+        }
+        return (T)state;
+    }
+
+    /**
+     * Detach a state
+     * @param key Key representing the state
+     * @return
+     */
+    public Object removeState(Object key) {
+        return getStates().remove(key);
+    }
+
+    /**
+     * Mark states for update
+     * @param hint Suggest what to update (can be ignored)
+     */
+    protected void updateStates(Object hint){
+        Map<Object,State> m= getStates();
+        for(State s:m.values()){
+            s.updateState(hint);
+        }
+    }
+
+    /**
+     * Execute a function for each state
+     * @param f 
+     */
+    protected void forEachState(VoidFunction<State> f){
+        Map<Object, State> m = getStates();
+        for(State s:m.values()){
+            f.eval(s);
+        }
+    }
+
+
+    @Override
+    protected StatefulObject clone() throws CloneNotSupportedException {
+        StatefulObject clone=(StatefulObject)super.clone();
+        clone.states = null;
+        Map<Object, State> states = getStates();
+        Map<Object, State> clonedStates = clone.getStates();
+        assert states!=clonedStates;        
+        for(Object k:states.keySet()){
+            State s=states.get(k);
+            s=s.cloneStateFor(clone);
+            if(s!=null)clonedStates.put(k,s);
+        }
+        return clone;
+    }
+
+   
+}


### PR DESCRIPTION
In the engine we have the concept of state updates for some objects that represent both jme logical objects and opengl native objects.
This pr extends this approach by introducing a way to store custom states for objects that extend the StatefulObjects class.

This can be used to implement self contained renderers as modules that don't need any change in the core to work nor to maintain large maps to point jme objects to their local representation.

This also allows multiple contexts to be updated and invalidated separately without them being aware of each other and without polling for changes.

As an example let's say we have a Mesh that is needed by the rendering engine and the physics engine:
- both engines append a state to the mesh (eg. GLMeshState and BulletBodyState )
- after some time the mesh is changed (eg. the vertices change position)
-  both the states are invalidated
- the GLMeshState will notify the renderer to submit the new vertices to the gpu, at the same time BulletBodyState will notify the physics engine to update the rigidbody associated to this mesh
- the two states can update out of order and asynchronously 
 