### PR TITLE
PhysicsCharacter:  add javadoc for the setGravity() method

### DIFF
--- a/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsCharacter.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/objects/PhysicsCharacter.java
@@ -150,10 +150,13 @@ public class PhysicsCharacter extends PhysicsCollisionObject {
         return jumpSpeed;
     }
 
-    //does nothing
-//    public void setMaxJumpHeight(float height) {
-//        character.setMaxJumpHeight(height);
-//    }
+    /**
+     * Alter the character's gravitational acceleration without altering its
+     * "up" vector.
+     *
+     * @param value the desired downward acceleration (in physics-space units
+     * per second squared, default=29.4)
+     */
     public void setGravity(float value) {
         character.setGravity(value);
     }


### PR DESCRIPTION
Discussion at https://github.com/jMonkeyEngine/wiki/pull/144 highlighted a need for javadoc to document the sign convention of `PhysicsCharacter.setGravity()`, which is perhaps non-intuitive.