### PR TITLE
jme3-nifty should account for gamma correction

### DIFF
--- a/jme3-examples/src/main/java/jme3test/animation/TestCinematic.java
+++ b/jme3-examples/src/main/java/jme3test/animation/TestCinematic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,6 +54,7 @@ import com.jme3.renderer.queue.RenderQueue.ShadowMode;
 import com.jme3.scene.*;
 import com.jme3.scene.shape.Box;
 import com.jme3.shadow.DirectionalLightShadowRenderer;
+import com.jme3.texture.image.ColorSpace;
 import de.lessvoid.nifty.Nifty;
 
 public class TestCinematic extends SimpleApplication {
@@ -76,10 +77,15 @@ public class TestCinematic extends SimpleApplication {
     @Override
     public void simpleInitApp() {
         //just some text
+
+        ColorSpace colorSpace = renderer.isMainFrameBufferSrgb()
+                ? ColorSpace.sRGB : ColorSpace.Linear;
         NiftyJmeDisplay niftyDisplay = new NiftyJmeDisplay(getAssetManager(),
                 getInputManager(),
                 getAudioRenderer(),
-                getGuiViewPort());
+                guiViewPort,
+                colorSpace);
+
         Nifty nifty;
         nifty = niftyDisplay.getNifty();
         nifty.fromXmlWithoutStartScreen("Interface/Nifty/CinematicTest.xml");

--- a/jme3-examples/src/main/java/jme3test/app/state/TestAppStates.java
+++ b/jme3-examples/src/main/java/jme3test/app/state/TestAppStates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,6 +37,7 @@ import com.jme3.niftygui.NiftyJmeDisplay;
 import com.jme3.scene.Spatial;
 import com.jme3.system.AppSettings;
 import com.jme3.system.JmeContext;
+import com.jme3.texture.image.ColorSpace;
 import jme3test.niftygui.StartScreenController;
 
 public class TestAppStates extends LegacyApplication {
@@ -70,10 +71,13 @@ public class TestAppStates extends LegacyApplication {
         model.setMaterial(assetManager.loadMaterial("Interface/Logo/Logo.j3m"));
         state.getRootNode().attachChild(model);
 
+        ColorSpace colorSpace = renderer.isMainFrameBufferSrgb()
+                ? ColorSpace.sRGB : ColorSpace.Linear;
         NiftyJmeDisplay niftyDisplay = new NiftyJmeDisplay(assetManager,
                 inputManager,
                 audioRenderer,
-                guiViewPort);
+                guiViewPort,
+                colorSpace);
         StartScreenController startScreen = new StartScreenController(this);
         niftyDisplay.getNifty().fromXml("Interface/Nifty/HelloJme.xml", "start",
                 startScreen);

--- a/jme3-examples/src/main/java/jme3test/niftygui/TestIssue99.java
+++ b/jme3-examples/src/main/java/jme3test/niftygui/TestIssue99.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 jMonkeyEngine
+ * Copyright (c) 2019-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,6 +33,7 @@ package jme3test.niftygui;
 
 import com.jme3.app.SimpleApplication;
 import com.jme3.niftygui.NiftyJmeDisplay;
+import com.jme3.texture.image.ColorSpace;
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.screen.Screen;
 import de.lessvoid.nifty.screen.ScreenController;
@@ -64,8 +65,10 @@ public class TestIssue99
         /*
          * Start NiftyGUI without the batched renderer.
          */
+        ColorSpace colorSpace = renderer.isMainFrameBufferSrgb()
+                ? ColorSpace.sRGB : ColorSpace.Linear;
         NiftyJmeDisplay niftyDisplay = new NiftyJmeDisplay(
-                assetManager, inputManager, audioRenderer, guiViewPort);
+                assetManager, inputManager, audioRenderer, guiViewPort, colorSpace);
         guiViewPort.addProcessor(niftyDisplay);
         /*
          * Load GUI controls, styles, and layout from XML assets.

--- a/jme3-examples/src/main/java/jme3test/niftygui/TestNiftyExamples.java
+++ b/jme3-examples/src/main/java/jme3test/niftygui/TestNiftyExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,6 +34,7 @@ package jme3test.niftygui;
 
 import com.jme3.app.SimpleApplication;
 import com.jme3.niftygui.NiftyJmeDisplay;
+import com.jme3.texture.image.ColorSpace;
 import de.lessvoid.nifty.Nifty;
 
 public class TestNiftyExamples extends SimpleApplication {
@@ -46,10 +47,13 @@ public class TestNiftyExamples extends SimpleApplication {
 
     @Override
     public void simpleInitApp() {
+        ColorSpace colorSpace = renderer.isMainFrameBufferSrgb()
+                ? ColorSpace.sRGB : ColorSpace.Linear;
         NiftyJmeDisplay niftyDisplay = new NiftyJmeDisplay(assetManager,
                                                           inputManager,
                                                           audioRenderer,
-                                                          guiViewPort);
+                                                          guiViewPort,
+                                                          colorSpace);
         Nifty nifty = niftyDisplay.getNifty();
         nifty.fromXml("all/intro.xml", "start");
 

--- a/jme3-examples/src/main/java/jme3test/niftygui/TestNiftyToMesh.java
+++ b/jme3-examples/src/main/java/jme3test/niftygui/TestNiftyToMesh.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,6 +45,7 @@ import com.jme3.texture.Texture.MagFilter;
 import com.jme3.texture.Texture.MinFilter;
 import com.jme3.texture.Texture2D;
 import com.jme3.texture.FrameBuffer.FrameBufferTarget;
+import com.jme3.texture.image.ColorSpace;
 import de.lessvoid.nifty.Nifty;
 
 public class TestNiftyToMesh extends SimpleApplication{
@@ -58,10 +59,14 @@ public class TestNiftyToMesh extends SimpleApplication{
     public void simpleInitApp() {
        ViewPort niftyView = renderManager.createPreView("NiftyView", new Camera(1024, 768));
        niftyView.setClearFlags(true, true, true);
+
+        ColorSpace colorSpace = renderer.isMainFrameBufferSrgb()
+                ? ColorSpace.sRGB : ColorSpace.Linear;
         NiftyJmeDisplay niftyDisplay = new NiftyJmeDisplay(assetManager,
                                                           inputManager,
                                                           audioRenderer,
-                                                          niftyView);
+                                                          niftyView,
+                                                          colorSpace);
         Nifty nifty = niftyDisplay.getNifty();
         nifty.fromXml("all/intro.xml", "start");
         niftyView.addProcessor(niftyDisplay);

--- a/jme3-niftygui/src/main/java/com/jme3/niftygui/NiftyJmeDisplay.java
+++ b/jme3-niftygui/src/main/java/com/jme3/niftygui/NiftyJmeDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,6 +45,7 @@ import com.jme3.renderer.Renderer;
 import com.jme3.renderer.ViewPort;
 import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.texture.FrameBuffer;
+import com.jme3.texture.image.ColorSpace;
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.render.batch.BatchRenderConfiguration;
 import de.lessvoid.nifty.render.batch.BatchRenderDevice;
@@ -245,6 +246,7 @@ public class NiftyJmeDisplay implements SceneProcessor {
     /**
      * Create a standard NiftyJmeDisplay. This uses the old Nifty renderer. It's probably slower than the batched
      * renderer and is mainly here for backwards compatibility.
+     * Nifty colors are assumed to be in Linear colorspace (no gamma correction).
      *
      * @param assetManager jME AssetManager
      * @param inputManager jME InputManager
@@ -255,9 +257,28 @@ public class NiftyJmeDisplay implements SceneProcessor {
                            InputManager inputManager,
                            AudioRenderer audioRenderer,
                            ViewPort vp){
+        this(assetManager, inputManager, audioRenderer, vp, ColorSpace.Linear);
+    }
+
+    /**
+     * Create a standard NiftyJmeDisplay. This uses the old Nifty renderer.
+     * It's probably slower than the batched
+     * renderer and is mainly here for backwards compatibility.
+     *
+     * @param assetManager jME AssetManager
+     * @param inputManager jME InputManager
+     * @param audioRenderer jME AudioRenderer
+     * @param vp Viewport to use
+     * @param colorSpace the ColorSpace to use for Nifty colors (sRGB or Linear)
+     */
+    public NiftyJmeDisplay(AssetManager assetManager,
+            InputManager inputManager,
+            AudioRenderer audioRenderer,
+            ViewPort vp,
+            ColorSpace colorSpace) {
         initialize(assetManager, inputManager, audioRenderer, vp);
 
-        this.renderDev = new RenderDeviceJme(this);
+        this.renderDev = new RenderDeviceJme(this, colorSpace);
         this.batchRendererBackend = null;
 
         nifty = new Nifty(renderDev, soundDev, inputSys, new AccurateTimeProvider());

--- a/jme3-niftygui/src/main/java/com/jme3/niftygui/RenderDeviceJme.java
+++ b/jme3-niftygui/src/main/java/com/jme3/niftygui/RenderDeviceJme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,6 +46,7 @@ import com.jme3.scene.VertexBuffer.Type;
 import com.jme3.scene.VertexBuffer.Usage;
 import com.jme3.scene.shape.Quad;
 import com.jme3.texture.Texture2D;
+import com.jme3.texture.image.ColorSpace;
 import com.jme3.util.BufferUtils;
 import de.lessvoid.nifty.render.BlendMode;
 import de.lessvoid.nifty.spi.render.MouseCursor;
@@ -60,7 +61,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class RenderDeviceJme implements RenderDevice {
-
+    private final ColorSpace colorSpace;
     private final NiftyJmeDisplay display;
     private RenderManager rm;
     private Renderer r;
@@ -110,8 +111,26 @@ public class RenderDeviceJme implements RenderDevice {
         }
     }
 
+    /**
+     * Instantiates a new RenderDevice, assuming Nifty colors are in linear
+     * colorspace (no gamma correction).
+     *
+     * @param display the SceneProcessor to render Nifty (not null, alias created)
+     */
     public RenderDeviceJme(NiftyJmeDisplay display) {
+        this(display, ColorSpace.Linear);
+    }
+
+    /**
+     * Instantiates a new RenderDevice using the specified ColorSpace for Nifty
+     * colors.
+     *
+     * @param display the SceneProcessor to render Nifty (not null, alias created)
+     * @param colorSpace the ColorSpace to use for Nifty colors (sRGB or Linear)
+     */
+    public RenderDeviceJme(NiftyJmeDisplay display, ColorSpace colorSpace) {
         this.display = display;
+        this.colorSpace = colorSpace;
 
         quadColor = new VertexBuffer(Type.Color);
         quadColor.setNormalized(true);
@@ -242,7 +261,18 @@ public class RenderDeviceJme implements RenderDevice {
     }
 
     private ColorRGBA convertColor(Color inColor, ColorRGBA outColor) {
-        return outColor.set(inColor.getRed(), inColor.getGreen(), inColor.getBlue(), inColor.getAlpha());
+        float red = inColor.getRed();
+        float green = inColor.getGreen();
+        float blue = inColor.getBlue();
+        float alpha = inColor.getAlpha();
+
+        if (colorSpace == ColorSpace.sRGB) {
+            outColor.setAsSrgb(red, green, blue, alpha);
+        } else {
+            outColor.set(red, green, blue, alpha);
+        }
+
+        return outColor;
     }
 
     @Override


### PR DESCRIPTION
This solves an issue with jme3-nifty not taking gamma correction into account. Nifty UIs specify colors by their red, green, and blue components. In order for jme3-nifty to display these colors property, it needs to know whether gamma correction is enabled or not.

If gamma correction is enabled, the application should specify `ColorSpace.sRGB`, in which case `ColorRGBA.setAsSrgb()` will be used to convert Nifty colors to JME colors.

If gamma correction is not enabled, the application should use the old constructor or specify `ColorsSpace.Linear`, in which case `ColorRGBA.set()` will be used to convert Nifty color to JME colors.