### PR TITLE
JoyButtonTrigger:  clarify that the constructor arg is not an axis ID

### DIFF
--- a/jme3-core/src/main/java/com/jme3/input/controls/JoyButtonTrigger.java
+++ b/jme3-core/src/main/java/com/jme3/input/controls/JoyButtonTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,11 +41,11 @@ public class JoyButtonTrigger implements Trigger {
      * Use {@link Joystick#assignButton(java.lang.String, int) } instead.
      *
      * @param joyId the ID of a joystick
-     * @param axisId the ID of a joystick axis
+     * @param buttonId the index of a joystick button
      */
-    public JoyButtonTrigger(int joyId, int axisId) {
+    public JoyButtonTrigger(int joyId, int buttonId) {
         this.joyId = joyId;
-        this.buttonId = axisId;
+        this.buttonId = buttonId;
     }
 
     public static int joyButtonHash(int joyId, int joyButton) {


### PR DESCRIPTION
The sourcecode for the `JoyButtonTrigger` class in jme3-core is confusing because it refers to the 2nd argument of the constructor as an axis ID. It is actually a button ID.

This PR corrects the javadoc and renames the method argument.