### PR TITLE
RenderDeviceJme:  CachedTextKey.equals() lacks a type check

### DIFF
--- a/jme3-niftygui/src/main/java/com/jme3/niftygui/RenderDeviceJme.java
+++ b/jme3-niftygui/src/main/java/com/jme3/niftygui/RenderDeviceJme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -93,11 +93,20 @@ public class RenderDeviceJme implements RenderDevice {
         }
 
         @Override
-        public boolean equals(Object other) {
-            CachedTextKey otherKey = (CachedTextKey) other;
-            return font.equals(otherKey.font) &&
-                   text.equals(otherKey.text)/* &&
-                   color.equals(otherKey.color)*/;
+        public boolean equals(Object otherObject) {
+            boolean result;
+            if (otherObject == this) {
+                result = true;
+            } else if (otherObject != null
+                    && otherObject.getClass() == getClass()) {
+                CachedTextKey otherKey = (CachedTextKey) otherObject;
+                result = font.equals(otherKey.font)
+                        && text.equals(otherKey.text);
+            } else {
+                result = false;
+            }
+
+            return result;
         }
 
         @Override


### PR DESCRIPTION
The `Object.equals()` method requires an exact class match, and so should methods that override it. However, that is not the case for `CachedTextKey.equals()` in the jme3-niftygui library. See issue #1289.

This is similar to PR #1302, which add type checks to `Matrix3f` and `Matrix4f`. 
