### PR TITLE
avoid use of deprecated methods (mostly Class.newInstance())

### DIFF
--- a/jme3-android/src/main/java/com/jme3/app/AndroidHarness.java
+++ b/jme3-android/src/main/java/com/jme3/app/AndroidHarness.java
@@ -190,6 +190,7 @@ public class AndroidHarness extends Activity implements TouchListener, DialogInt
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void onCreate(Bundle savedInstanceState) {
         initializeLogHandler();
 
@@ -240,7 +241,7 @@ public class AndroidHarness extends Activity implements TouchListener, DialogInt
             try {
                 if (app == null) {
                     Class clazz = Class.forName(appClass);
-                    app = (LegacyApplication)clazz.newInstance();
+                    app = (LegacyApplication) clazz.getDeclaredConstructor().newInstance();
                 }
 
                 app.setSettings(settings);

--- a/jme3-android/src/main/java/com/jme3/app/AndroidHarnessFragment.java
+++ b/jme3-android/src/main/java/com/jme3/app/AndroidHarnessFragment.java
@@ -232,6 +232,7 @@ public class AndroidHarnessFragment extends Fragment implements
      * @param savedInstanceState the saved instance state
      */
     @Override
+    @SuppressWarnings("unchecked")
     public void onCreate(Bundle savedInstanceState) {
         initializeLogHandler();
         logger.fine("onCreate");
@@ -258,7 +259,7 @@ public class AndroidHarnessFragment extends Fragment implements
         try {
             if (app == null) {
                 Class clazz = Class.forName(appClass);
-                app = (LegacyApplication)clazz.newInstance();
+                app = (LegacyApplication) clazz.getDeclaredConstructor().newInstance();
             }
 
             app.setSettings(settings);

--- a/jme3-core/src/main/java/com/jme3/anim/Armature.java
+++ b/jme3-core/src/main/java/com/jme3/anim/Armature.java
@@ -37,8 +37,8 @@ import com.jme3.export.*;
 import com.jme3.math.Matrix4f;
 import com.jme3.util.clone.Cloner;
 import com.jme3.util.clone.JmeCloneable;
-
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 /**
@@ -130,8 +130,10 @@ public class Armature implements JmeCloneable, Savable {
 
     private void instantiateJointModelTransform(Joint joint) {
         try {
-            joint.setJointModelTransform(modelTransformClass.newInstance());
-        } catch (InstantiationException | IllegalAccessException e) {
+            joint.setJointModelTransform(modelTransformClass.getDeclaredConstructor().newInstance());
+        } catch (InstantiationException | IllegalAccessException
+                | IllegalArgumentException | InvocationTargetException
+                | NoSuchMethodException | SecurityException e) {
             throw new IllegalArgumentException(e);
         }
     }

--- a/jme3-core/src/main/java/com/jme3/animation/CompactArray.java
+++ b/jme3-core/src/main/java/com/jme3/animation/CompactArray.java
@@ -246,7 +246,7 @@ public abstract class CompactArray<T> implements JmeCloneable {
         try {
             T[] compactArr = (T[]) Array.newInstance(getElementClass(), getSerializedSize() / getTupleSize());
             for (int i = 0; i < compactArr.length; i++) {
-                compactArr[i] = getElementClass().newInstance();
+                compactArr[i] = getElementClass().getDeclaredConstructor().newInstance();
                 deserialize(i, compactArr[i]);
             }
 

--- a/jme3-core/src/main/java/com/jme3/asset/ImplHandler.java
+++ b/jme3-core/src/main/java/com/jme3/asset/ImplHandler.java
@@ -32,7 +32,7 @@
 package com.jme3.asset;
 
 import com.jme3.asset.cache.AssetCache;
-
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -115,12 +115,15 @@ final class ImplHandler {
         @Override
         protected T initialValue() {
             try {
-                T obj = type.newInstance();
+                T obj = type.getDeclaredConstructor().newInstance();
+
                 if (path != null) {
                     ((AssetLocator) obj).setRootPath(path);
                 }
                 return obj;
-            } catch (InstantiationException | IllegalAccessException ex) {
+            } catch (InstantiationException | IllegalAccessException
+                    | IllegalArgumentException | InvocationTargetException
+                    | NoSuchMethodException | SecurityException ex) {
                 logger.log(Level.SEVERE, "Cannot create locator of type {0}, does"
                         + " the class have an empty and publicly accessible"
                         + " constructor?", type.getName());
@@ -220,12 +223,12 @@ final class ImplHandler {
                 cache = (T) classToCacheMap.get(cacheClass);
                 if (cache == null) {
                     try {
-                        cache = cacheClass.newInstance();
+                        cache = cacheClass.getDeclaredConstructor().newInstance();
                         classToCacheMap.put(cacheClass, cache);
-                    } catch (InstantiationException ex) {
+                    } catch (InstantiationException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException ex) {
                         throw new IllegalArgumentException("The cache class cannot"
                                 + " be created, ensure it has empty constructor", ex);
-                    } catch (IllegalAccessException ex) {
+                    } catch (IllegalAccessException | SecurityException ex) {
                         throw new IllegalArgumentException("The cache class cannot "
                                 + "be accessed", ex);
                     }
@@ -246,12 +249,12 @@ final class ImplHandler {
                 proc = (T) classToProcMap.get(procClass);
                 if (proc == null) {
                     try {
-                        proc = procClass.newInstance();
+                        proc = procClass.getDeclaredConstructor().newInstance();
                         classToProcMap.put(procClass, proc);
-                    } catch (InstantiationException ex) {
+                    } catch (InstantiationException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException ex) {
                         throw new IllegalArgumentException("The processor class cannot"
                                 + " be created, ensure it has empty constructor", ex);
-                    } catch (IllegalAccessException ex) {
+                    } catch (IllegalAccessException | SecurityException ex) {
                         throw new IllegalArgumentException("The processor class cannot "
                                 + "be accessed", ex);
                     }

--- a/jme3-core/src/main/java/com/jme3/cinematic/events/SoundEvent.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/events/SoundEvent.java
@@ -33,6 +33,7 @@ package com.jme3.cinematic.events;
 
 import com.jme3.animation.LoopMode;
 import com.jme3.app.Application;
+import com.jme3.audio.AudioData;
 import com.jme3.audio.AudioNode;
 import com.jme3.audio.AudioSource;
 import com.jme3.cinematic.Cinematic;
@@ -153,7 +154,7 @@ public class SoundEvent extends AbstractCinematicEvent {
     @Override
     public void initEvent(Application app, Cinematic cinematic) {
         super.initEvent(app, cinematic);
-        audioNode = new AudioNode(app.getAssetManager(), path, stream);
+        audioNode = new AudioNode(app.getAssetManager(), path, stream ? AudioData.DataType.Stream : AudioData.DataType.Buffer);
         audioNode.setPositional(false);
         setLoopMode(loopMode);
     }

--- a/jme3-core/src/main/java/com/jme3/math/Spline.java
+++ b/jme3-core/src/main/java/com/jme3/math/Spline.java
@@ -501,9 +501,9 @@ public class Spline implements Savable {
         /* Empty List as default, prevents null pointers */
         float list[] = in.readFloatArray("segmentsLength", null);
         if (list != null) {
-            segmentsLength = new ArrayList<Float>();
+            segmentsLength = new ArrayList<>(list.length);
             for (int i = 0; i < list.length; i++) {
-                segmentsLength.add(new Float(list[i]));
+                segmentsLength.add(list[i]);
             }
         }
         type = in.readEnum("pathSplineType", SplineType.class, SplineType.CatmullRom);

--- a/jme3-core/src/main/java/com/jme3/shader/Uniform.java
+++ b/jme3-core/src/main/java/com/jme3/shader/Uniform.java
@@ -34,7 +34,7 @@ package com.jme3.shader;
 import com.jme3.math.*;
 import com.jme3.util.BufferUtils;
 import com.jme3.util.TempVars;
-
+import java.lang.reflect.InvocationTargetException;
 import java.nio.*;
 
 public class Uniform extends ShaderVariable {
@@ -355,9 +355,11 @@ public class Uniform extends ShaderVariable {
                 //handle the null case
                 if (this.value == null) {
                     try {
-                        this.value = value.getClass().newInstance();
-                    } catch (InstantiationException | IllegalAccessException e) {
-                        throw new IllegalArgumentException("Cannot instantiate param of class " + value.getClass().getCanonicalName());
+                        this.value = value.getClass().getDeclaredConstructor().newInstance();
+                    } catch (InstantiationException | IllegalAccessException
+                            | IllegalArgumentException | InvocationTargetException
+                            | NoSuchMethodException | SecurityException e) {
+                        throw new IllegalArgumentException("Cannot instantiate param of class " + value.getClass().getCanonicalName(), e);
                     }
                 }
                 //feed the pivot vec 4 with the correct value

--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -1025,7 +1025,7 @@ public final class AppSettings extends HashMap<String, Object> {
      * Get the width of the window
      *
      * @return the width of the window (in pixels)
-     * @see #setWindowWidth(int)
+     * @see #setWindowSize(int, int)
      */
     public int getWindowWidth() {
         int w = getInteger("WindowWidth");
@@ -1036,7 +1036,7 @@ public final class AppSettings extends HashMap<String, Object> {
      * Get the height of the window
      *
      * @return the height of the window (in pixels)
-     * @see #setWindowHeight(int)
+     * @see #setWindowSize(int, int)
      */
     public int getWindowHeight() {
         int h = getInteger("WindowHeight");

--- a/jme3-core/src/main/java/com/jme3/system/JmeSystem.java
+++ b/jme3-core/src/main/java/com/jme3/system/JmeSystem.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.logging.Level;
@@ -202,9 +203,9 @@ public class JmeSystem {
         systemDelegate.initialize(settings);
     }
 
-    private static JmeSystemDelegate tryLoadDelegate(String className) throws InstantiationException, IllegalAccessException {
+    private static JmeSystemDelegate tryLoadDelegate(String className) throws InstantiationException, IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
         try {
-            return (JmeSystemDelegate) Class.forName(className).newInstance();
+            return (JmeSystemDelegate) Class.forName(className).getDeclaredConstructor().newInstance();
         } catch (ClassNotFoundException ex) {
             return null;
         }
@@ -227,7 +228,7 @@ public class JmeSystem {
                         }
                     }
                 }
-            } catch (InstantiationException | IllegalAccessException ex) {
+            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | IllegalArgumentException | InvocationTargetException ex) {
                 Logger.getLogger(JmeSystem.class.getName()).log(Level.SEVERE, "Failed to create JmeSystem delegate:\n{0}", ex);
             }
         }

--- a/jme3-core/src/main/java/com/jme3/util/BufferAllocatorFactory.java
+++ b/jme3-core/src/main/java/com/jme3/util/BufferAllocatorFactory.java
@@ -1,7 +1,6 @@
 package com.jme3.util;
 
 import com.jme3.system.Annotations.Internal;
-
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -28,7 +27,7 @@ public class BufferAllocatorFactory {
 
         final String className = System.getProperty(PROPERTY_BUFFER_ALLOCATOR_IMPLEMENTATION, ReflectionAllocator.class.getName());
         try {
-            return (BufferAllocator) Class.forName(className).newInstance();
+            return (BufferAllocator) Class.forName(className).getDeclaredConstructor().newInstance();
         } catch (final Throwable e) {
             LOGGER.log(Level.WARNING, "Unable to access {0}", className);
             return new PrimitiveAllocator();

--- a/jme3-core/src/tools/java/jme3tools/optimize/TextureAtlas.java
+++ b/jme3-core/src/tools/java/jme3tools/optimize/TextureAtlas.java
@@ -358,7 +358,7 @@ public class TextureAtlas {
                 return null;
             }
             Image newImage = new Image(format, source.getWidth(), source.getHeight(), BufferUtils.createByteBuffer(source.getWidth() * source.getHeight() * 4), null, ColorSpace.Linear);
-            clazz.getMethod("convert", Image.class, Image.class).invoke(clazz.newInstance(), source, newImage);
+            clazz.getMethod("convert", Image.class, Image.class).invoke(clazz.getDeclaredConstructor().newInstance(), source, newImage);
             return newImage;
         } catch (InstantiationException
                 | IllegalAccessException

--- a/jme3-desktop/src/main/java/com/jme3/app/AppletHarness.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/AppletHarness.java
@@ -39,6 +39,7 @@ import java.awt.Canvas;
 import java.awt.Graphics;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
@@ -65,6 +66,7 @@ public class AppletHarness extends Applet {
         return appToApplet.get(app);
     }
 
+    @SuppressWarnings("unchecked")
     private void createCanvas(){
         AppSettings settings = new AppSettings(true);
 
@@ -104,10 +106,13 @@ public class AppletHarness extends Applet {
 
         try{
             Class clazz = Class.forName(appClass);
-            app = (LegacyApplication) clazz.newInstance();
+            app = (LegacyApplication) clazz.getDeclaredConstructor().newInstance();
         } catch (ClassNotFoundException
-                | InstantiationException 
-                | IllegalAccessException ex) {
+                | InstantiationException
+                | IllegalAccessException
+                | NoSuchMethodException
+                | IllegalArgumentException
+                | InvocationTargetException ex) {
             ex.printStackTrace();
         }
 

--- a/jme3-desktop/src/main/java/com/jme3/system/JmeDesktopSystem.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/JmeDesktopSystem.java
@@ -50,6 +50,7 @@ import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -191,6 +192,7 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
         return result.get() == SettingsDialog.APPROVE_SELECTION;
     }
 
+    @SuppressWarnings("unchecked")
     private JmeContext newContextLwjgl(AppSettings settings, JmeContext.Type type) {
         try {
             Class ctxClazz = null;
@@ -208,8 +210,10 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
                     throw new IllegalArgumentException("Unsupported context type " + type);
             }
 
-            return (JmeContext) ctxClazz.newInstance();
-        } catch (InstantiationException | IllegalAccessException ex) {
+            return (JmeContext) ctxClazz.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException
+                | IllegalArgumentException | InvocationTargetException
+                | NoSuchMethodException | SecurityException ex) {
             logger.log(Level.SEVERE, "Failed to create context", ex);
         } catch (ClassNotFoundException ex) {
             logger.log(Level.SEVERE, "CRITICAL ERROR: Context class is missing!\n"
@@ -219,6 +223,7 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
         return null;
     }
 
+    @SuppressWarnings("unchecked")
     private JmeContext newContextJogl(AppSettings settings, JmeContext.Type type) {
         try {
             Class ctxClazz = null;
@@ -236,8 +241,10 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
                     throw new IllegalArgumentException("Unsupported context type " + type);
             }
 
-            return (JmeContext) ctxClazz.newInstance();
-        } catch (InstantiationException | IllegalAccessException ex) {
+            return (JmeContext) ctxClazz.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException
+                | IllegalArgumentException | InvocationTargetException
+                | NoSuchMethodException | SecurityException ex) {
             logger.log(Level.SEVERE, "Failed to create context", ex);
         } catch (ClassNotFoundException ex) {
             logger.log(Level.SEVERE, "CRITICAL ERROR: Context class is missing!\n"
@@ -247,13 +254,16 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
         return null;
     }
 
+    @SuppressWarnings("unchecked")
     private JmeContext newContextCustom(AppSettings settings, JmeContext.Type type) {
         try {
             String className = settings.getRenderer().substring("CUSTOM".length());
 
             Class ctxClazz = Class.forName(className);
-            return (JmeContext) ctxClazz.newInstance();
-        } catch (InstantiationException | IllegalAccessException ex) {
+            return (JmeContext) ctxClazz.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException
+                | IllegalArgumentException | InvocationTargetException
+                | NoSuchMethodException | SecurityException ex) {
             logger.log(Level.SEVERE, "Failed to create context", ex);
         } catch (ClassNotFoundException ex) {
             logger.log(Level.SEVERE, "CRITICAL ERROR: Context class is missing!", ex);
@@ -292,11 +302,13 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
     private <T> T newObject(String className) {
         try {
             Class<T> clazz = (Class<T>) Class.forName(className);
-            return clazz.newInstance();
+            return clazz.getDeclaredConstructor().newInstance();
         } catch (ClassNotFoundException ex) {
             logger.log(Level.SEVERE, "CRITICAL ERROR: Audio implementation class "
                     + className + " is missing!\n", ex);
-        } catch (IllegalAccessException | InstantiationException ex) {
+        } catch (InstantiationException | IllegalAccessException
+                | IllegalArgumentException | InvocationTargetException
+                | NoSuchMethodException | SecurityException ex) {
             logger.log(Level.SEVERE, "Failed to create context", ex);
         }
 

--- a/jme3-examples/src/main/java/jme3test/TestChooser.java
+++ b/jme3-examples/src/main/java/jme3test/TestChooser.java
@@ -268,7 +268,7 @@ public class TestChooser extends JFrame {
                 for (Class<?> clazz : appClass) {
                     try {
                         if (LegacyApplication.class.isAssignableFrom(clazz)) {
-                            Object app = clazz.newInstance();
+                            Object app = clazz.getDeclaredConstructor().newInstance();
                             if (app instanceof SimpleApplication) {
                                 final Method settingMethod = clazz.getMethod("setShowSettings", boolean.class);
                                 settingMethod.invoke(app, showSetting);

--- a/jme3-examples/src/main/java/jme3test/awt/AppHarness.java
+++ b/jme3-examples/src/main/java/jme3test/awt/AppHarness.java
@@ -41,6 +41,7 @@ import java.awt.Canvas;
 import java.awt.Graphics;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import javax.swing.SwingUtilities;
@@ -58,6 +59,7 @@ public class AppHarness extends Applet {
     private String appClass;
     private URL appCfg = null;
 
+    @SuppressWarnings("unchecked")
     private void createCanvas(){
         AppSettings settings = new AppSettings(true);
 
@@ -80,10 +82,15 @@ public class AppHarness extends Applet {
 
         try{
             Class clazz = Class.forName(appClass);
-            app = (LegacyApplication) clazz.newInstance();
+            app = (LegacyApplication) clazz.getDeclaredConstructor().newInstance();
         }catch (ClassNotFoundException
                 | InstantiationException
-                | IllegalAccessException ex){
+                | IllegalAccessException
+                | IllegalArgumentException
+                | InvocationTargetException
+                | NoSuchMethodException
+                | SecurityException ex            
+                ){
             ex.printStackTrace();
         }
 

--- a/jme3-examples/src/main/java/jme3test/awt/AppHarness.java
+++ b/jme3-examples/src/main/java/jme3test/awt/AppHarness.java
@@ -89,8 +89,7 @@ public class AppHarness extends Applet {
                 | IllegalArgumentException
                 | InvocationTargetException
                 | NoSuchMethodException
-                | SecurityException ex            
-                ){
+                | SecurityException ex) {
             ex.printStackTrace();
         }
 

--- a/jme3-examples/src/main/java/jme3test/awt/TestApplet.java
+++ b/jme3-examples/src/main/java/jme3test/awt/TestApplet.java
@@ -40,6 +40,7 @@ import com.jme3.system.JmeSystem;
 import java.applet.Applet;
 import java.awt.Canvas;
 import java.awt.Graphics;
+import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Callable;
 import javax.swing.SwingUtilities;
 
@@ -53,6 +54,7 @@ public class TestApplet extends Applet {
     public TestApplet(){
     }
 
+    @SuppressWarnings("unchecked")
     public static void createCanvas(String appClass){
         AppSettings settings = new AppSettings(true);
         settings.setWidth(640);
@@ -63,10 +65,14 @@ public class TestApplet extends Applet {
 
         try{
             Class clazz = Class.forName(appClass);
-            app = (LegacyApplication) clazz.newInstance();
+            app = (LegacyApplication) clazz.getDeclaredConstructor().newInstance();
         } catch (ClassNotFoundException
                 | InstantiationException
-                | IllegalAccessException ex){
+                | IllegalAccessException
+                | IllegalArgumentException
+                | InvocationTargetException
+                | NoSuchMethodException
+                | SecurityException ex) {
             ex.printStackTrace();
         }
 

--- a/jme3-examples/src/main/java/jme3test/awt/TestCanvas.java
+++ b/jme3-examples/src/main/java/jme3test/awt/TestCanvas.java
@@ -45,6 +45,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Callable;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
@@ -203,6 +204,7 @@ public class TestCanvas {
         createMenu();
     }
 
+    @SuppressWarnings("unchecked")
     public static void createCanvas(String appClass){
         AppSettings settings = new AppSettings(true);
         settings.setWidth(640);
@@ -210,10 +212,14 @@ public class TestCanvas {
 
         try{
             Class clazz = Class.forName(appClass);
-            app = (LegacyApplication)clazz.newInstance();
+            app = (LegacyApplication) clazz.getDeclaredConstructor().newInstance();
         }catch (ClassNotFoundException
                 | InstantiationException
-                | IllegalAccessException ex){
+                | IllegalAccessException
+                | IllegalArgumentException
+                | InvocationTargetException
+                | NoSuchMethodException
+                | SecurityException ex) {
             ex.printStackTrace();
         }
 

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -35,11 +35,11 @@ package com.jme3.system.lwjgl;
 import com.jme3.input.lwjgl.JInputJoyInput;
 import com.jme3.input.lwjgl.LwjglKeyInput;
 import com.jme3.input.lwjgl.LwjglMouseInput;
+import com.jme3.opencl.DefaultPlatformChooser;
 import com.jme3.opencl.Device;
 import com.jme3.opencl.PlatformChooser;
 import com.jme3.opencl.lwjgl.LwjglDevice;
 import com.jme3.opencl.lwjgl.LwjglPlatform;
-import com.jme3.opencl.DefaultPlatformChooser;
 import com.jme3.renderer.Renderer;
 import com.jme3.renderer.RendererException;
 import com.jme3.renderer.lwjgl.LwjglGL;
@@ -60,7 +60,6 @@ import com.jme3.renderer.opengl.GLTracer;
 import com.jme3.system.*;
 import java.util.ArrayList;
 import java.util.List;
-
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -389,7 +388,7 @@ public abstract class LwjglContext implements JmeContext {
         PlatformChooser chooser = null;
         if (settings.getOpenCLPlatformChooser() != null) {
             try {
-                chooser = (PlatformChooser) Class.forName(settings.getOpenCLPlatformChooser()).newInstance();
+                chooser = (PlatformChooser) Class.forName(settings.getOpenCLPlatformChooser()).getDeclaredConstructor().newInstance();
             } catch (Exception ex) {
                 logger.log(Level.WARNING, "unable to instantiate custom PlatformChooser", ex);
             }

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -32,12 +32,6 @@
 
 package com.jme3.system.lwjgl;
 
-import static com.jme3.util.LWJGLBufferAllocator.PROPERTY_CONCURRENT_BUFFER_ALLOCATOR;
-import static java.util.stream.Collectors.toSet;
-import static org.lwjgl.opencl.CL10.CL_CONTEXT_PLATFORM;
-import static org.lwjgl.opengl.GL.createCapabilities;
-import static org.lwjgl.opengl.GL11.glGetInteger;
-
 import com.jme3.input.lwjgl.GlfwJoystickInput;
 import com.jme3.input.lwjgl.GlfwKeyInput;
 import com.jme3.input.lwjgl.GlfwMouseInput;
@@ -63,25 +57,29 @@ import com.jme3.system.Timer;
 import com.jme3.util.BufferAllocatorFactory;
 import com.jme3.util.LWJGLBufferAllocator;
 import com.jme3.util.LWJGLBufferAllocator.ConcurrentLWJGLBufferAllocator;
+import static com.jme3.util.LWJGLBufferAllocator.PROPERTY_CONCURRENT_BUFFER_ALLOCATOR;
+import java.nio.IntBuffer;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static java.util.stream.Collectors.toSet;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.Version;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWJoystickCallback;
 import org.lwjgl.opencl.APPLEGLSharing;
 import org.lwjgl.opencl.CL10;
+import static org.lwjgl.opencl.CL10.CL_CONTEXT_PLATFORM;
 import org.lwjgl.opencl.KHRGLSharing;
 import org.lwjgl.opengl.ARBDebugOutput;
 import org.lwjgl.opengl.ARBFramebufferObject;
 import org.lwjgl.opengl.EXTFramebufferMultisample;
+import static org.lwjgl.opengl.GL.createCapabilities;
+import static org.lwjgl.opengl.GL11.glGetInteger;
 import org.lwjgl.opengl.GLCapabilities;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.Platform;
-
-import java.nio.IntBuffer;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * A LWJGL implementation of a graphics context.
@@ -372,7 +370,7 @@ public abstract class LwjglContext implements JmeContext {
         PlatformChooser chooser = null;
         if (settings.getOpenCLPlatformChooser() != null) {
             try {
-                chooser = (PlatformChooser) Class.forName(settings.getOpenCLPlatformChooser()).newInstance();
+                chooser = (PlatformChooser) Class.forName(settings.getOpenCLPlatformChooser()).getDeclaredConstructor().newInstance();
             } catch (Exception ex) {
                 logger.log(Level.WARNING, "Unable to instantiate custom PlatformChooser", ex);
             }

--- a/jme3-networking/src/main/java/com/jme3/network/message/SerializerRegistrationsMessage.java
+++ b/jme3-networking/src/main/java/com/jme3/network/message/SerializerRegistrationsMessage.java
@@ -37,6 +37,7 @@ import com.jme3.network.serializing.Serializable;
 import com.jme3.network.serializing.Serializer;
 import com.jme3.network.serializing.SerializerRegistration;
 import com.jme3.network.serializing.serializers.FieldSerializer;
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import java.util.jar.Attributes;
 import java.util.logging.Level;
@@ -203,6 +204,7 @@ public class SerializerRegistrationsMessage extends AbstractMessage {
             } 
         }
  
+        @SuppressWarnings("unchecked")
         public void register() {        
             try {
                 Class type = Class.forName(className);
@@ -211,13 +213,13 @@ public class SerializerRegistrationsMessage extends AbstractMessage {
                     serializer = fieldSerializer;
                 } else {
                     Class serializerType = Class.forName(serializerClassName);
-                    serializer = (Serializer)serializerType.newInstance();                    
+                    serializer = (Serializer) serializerType.getDeclaredConstructor().newInstance();
                 }
                 SerializerRegistration result = Serializer.registerClassForId(id, type, serializer);
                 log.log(Level.FINE, "   result:{0}", result);                
             } catch( ClassNotFoundException e ) {
                 throw new RuntimeException( "Class not found attempting to register:" + this, e );
-            } catch( InstantiationException | IllegalAccessException e ) {
+            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | IllegalArgumentException | InvocationTargetException e) {
                 throw new RuntimeException( "Error instantiating serializer registering:" + this, e );
             }            
         }

--- a/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/CollectionSerializer.java
+++ b/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/CollectionSerializer.java
@@ -54,7 +54,7 @@ public class CollectionSerializer extends Serializer {
 
         Collection collection;
         try {
-            collection = (Collection)c.newInstance();
+            collection = (Collection) c.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             log.log(Level.FINE, "[Serializer][???] Could not determine collection type. Using ArrayList.");
             collection = new ArrayList(length);

--- a/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/MapSerializer.java
+++ b/jme3-networking/src/main/java/com/jme3/network/serializing/serializers/MapSerializer.java
@@ -77,7 +77,7 @@ public class MapSerializer extends Serializer {
 
         Map map;
         try {
-            map = (Map)c.newInstance();
+            map = (Map) c.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             log.log(Level.WARNING, "[Serializer][???] Could not determine map type. Using HashMap.");
             map = new HashMap();

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -43,6 +43,7 @@ import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.*;
 import com.jme3.scene.control.CameraControl;
 import com.jme3.scene.mesh.MorphTarget;
+import static com.jme3.scene.plugins.gltf.GltfUtils.*;
 import com.jme3.texture.Texture;
 import com.jme3.texture.Texture2D;
 import com.jme3.util.IntMap;
@@ -54,8 +55,6 @@ import java.nio.FloatBuffer;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static com.jme3.scene.plugins.gltf.GltfUtils.*;
 
 /**
  * GLTF 2.0 loader
@@ -120,15 +119,14 @@ public class GltfLoader implements AssetLoader {
                 defaultMat.setFloat("Roughness", 1f);
             }
 
-            docRoot = new JsonParser().parse(new JsonReader(new InputStreamReader(stream))).getAsJsonObject();
+            docRoot = JsonParser.parseReader(new JsonReader(new InputStreamReader(stream))).getAsJsonObject();
 
             JsonObject asset = docRoot.getAsJsonObject().get("asset").getAsJsonObject();
             getAsString(asset, "generator");
             String version = getAsString(asset, "version");
             String minVersion = getAsString(asset, "minVersion");
             if (!isSupported(version, minVersion)) {
-                logger.log(Level.SEVERE, "Gltf Loader doesn't support this gltf version: " + version
-                        + (minVersion != null ? ("/" + minVersion) : ""));
+                logger.log(Level.SEVERE, "Gltf Loader doesn''t support this gltf version: {0}{1}", new Object[]{version, minVersion != null ? ("/" + minVersion) : ""});
             }
 
             scenes = docRoot.getAsJsonArray("scenes");


### PR DESCRIPTION
Removes deprecated code and some warnings.

Compiled with JDK 11 (-Xlint:deprecation)...

- Class.newInstance() was deprecated in Java 9, I replaced it with Class.getDeclaredConstructor().newInstance(); (get empty constructor and call it)
- new Float() is deprecated, unnecessary boxing
- new JsonParser() is deprecated, use the static methods instead