### PR TITLE
Remove print statements from FBX plugin

### DIFF
--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/FbxAnimCurveNode.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/FbxAnimCurveNode.java
@@ -103,9 +103,9 @@ public class FbxAnimCurveNode extends FbxObject {
      */
     public Quaternion getQuaternionValue(long time) {
         Vector3f eulerAngles = getVector3Value(time);
-        logger.fine("\tT: " + time + ". Rotation: " +
-                                eulerAngles.x + ", " + 
-                                eulerAngles.y + ", " + eulerAngles.z);
+//        System.out.println("\tT: " + time + ". Rotation: " +
+//                                eulerAngles.x + ", " +
+//                                eulerAngles.y + ", " + eulerAngles.z);
         Quaternion q = new Quaternion();
         q.fromAngles(eulerAngles.x * FastMath.DEG_TO_RAD, 
                      eulerAngles.y * FastMath.DEG_TO_RAD, 

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/FbxAnimCurveNode.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/FbxAnimCurveNode.java
@@ -103,7 +103,7 @@ public class FbxAnimCurveNode extends FbxObject {
      */
     public Quaternion getQuaternionValue(long time) {
         Vector3f eulerAngles = getVector3Value(time);
-        System.out.println("\tT: " + time + ". Rotation: " + 
+        logger.fine("\tT: " + time + ". Rotation: " +
                                 eulerAngles.x + ", " + 
                                 eulerAngles.y + ", " + eulerAngles.z);
         Quaternion q = new Quaternion();

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/FbxToJmeTrack.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/FbxToJmeTrack.java
@@ -140,7 +140,7 @@ public final class FbxToJmeTrack {
             if (time > duration) {
                 // Expand animation duration to fit the curve.
                 duration = time;
-                System.out.println("actual duration: " + duration);
+//                System.out.println("actual duration: " + duration);
             }
 
             times[i] = time;
@@ -153,7 +153,7 @@ public final class FbxToJmeTrack {
                 rotations[i] = rotationCurve.getQuaternionValue(fbxTime);
                 if (i > 0) {
                     if (rotations[i - 1].dot(rotations[i]) < 0) {
-                        System.out.println("rotation will go the long way, oh noes");
+//                        System.out.println("rotation will go the long way, oh noes");
                         rotations[i - 1].negateLocal();
                     }
                 }

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/node/FbxNode.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/node/FbxNode.java
@@ -171,14 +171,14 @@ public class FbxNode extends FbxObject<Spatial> {
         this.jmeWorldBindPose.setRotation(worldBindPose.toRotationQuat());
         this.jmeWorldBindPose.setScale(worldBindPose.toScaleVector());
         
-        System.out.println("\tBind Pose for " + getName());
-        System.out.println(jmeWorldBindPose);
+//        System.out.println("\tBind Pose for " + getName());
+//        System.out.println(jmeWorldBindPose);
         
         float[] angles = new float[3];
         jmeWorldBindPose.getRotation().toAngles(angles);
-        System.out.println("Angles: " + angles[0] * FastMath.RAD_TO_DEG + ", " + 
-                                        angles[1] * FastMath.RAD_TO_DEG + ", " + 
-                                        angles[2] * FastMath.RAD_TO_DEG);
+//        System.out.println("Angles: " + angles[0] * FastMath.RAD_TO_DEG + ", " +
+//                                        angles[1] * FastMath.RAD_TO_DEG + ", " +
+//                                        angles[2] * FastMath.RAD_TO_DEG);
     }
     
     public void updateWorldTransforms(Transform jmeParentNodeTransform, Transform parentBindPose) {
@@ -208,15 +208,15 @@ public class FbxNode extends FbxObject<Spatial> {
             jmeLocalBindPose.combineWithParent(parentBindPose.invert());
             
             // It's somewhat odd for the transforms to differ ...
-            System.out.println("Bind Pose for: " + getName());
-            if (!jmeLocalBindPose.equals(jmeLocalNodeTransform)) {
-                System.out.println("Local Bind: " + jmeLocalBindPose);
-                System.out.println("Local Trans: " + jmeLocalNodeTransform);
-            }
-            if (!jmeWorldBindPose.equals(jmeWorldNodeTransform)) {
-                System.out.println("World Bind: " + jmeWorldBindPose);
-                System.out.println("World Trans: " + jmeWorldNodeTransform);
-            }
+//            System.out.println("Bind Pose for: " + getName());
+//            if (!jmeLocalBindPose.equals(jmeLocalNodeTransform)) {
+//                System.out.println("Local Bind: " + jmeLocalBindPose);
+//                System.out.println("Local Trans: " + jmeLocalNodeTransform);
+//            }
+//            if (!jmeWorldBindPose.equals(jmeWorldNodeTransform)) {
+//                System.out.println("World Bind: " + jmeWorldBindPose);
+//                System.out.println("World Trans: " + jmeWorldNodeTransform);
+//            }
         } else {
             // World pose derived from local transforms
             // (this is to be expected for FBX nodes)
@@ -480,7 +480,7 @@ public class FbxNode extends FbxObject<Spatial> {
                 throw new UnsupportedOperationException();
             }
             fbxNode.skeleton = FbxLimbNode.createSkeleton(fbxNode);
-            System.out.println("created skeleton: " + fbxNode.skeleton);
+//            System.out.println("created skeleton: " + fbxNode.skeleton);
         }
     }
     
@@ -505,7 +505,7 @@ public class FbxNode extends FbxObject<Spatial> {
                     FbxNode preferredParent = fbxChild.getPreferredParent();
                     Spatial jmeChild = fbxChild.getJmeObject();
                     if (preferredParent != null) {
-                        System.out.println("Preferred parent for " + fbxChild + " is " + preferredParent);
+//                        System.out.println("Preferred parent for " + fbxChild + " is " + preferredParent);
                         
                         Node jmePreferredParent = (Node) preferredParent.getJmeObject();
                         relocateSpatial(jmeChild, fbxChild.jmeWorldNodeTransform, 


### PR DESCRIPTION
This changes a print statement in `FbxAnimCurveNode.java` to a logger call so it doesn't contaminate output.