### PR TITLE
jme-lwjgl3: config GLFW using AppSettings and org.lwjgl.system.Platform

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -64,6 +64,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.lwjgl.system.Configuration;
+import org.lwjgl.system.Platform;
 
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.opengl.GL11.GL_FALSE;
@@ -575,6 +577,12 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
                     }
                 });
             }
+
+            String libraryName = settings.getString("GlfwLibraryName");
+            if (libraryName == null) { // use the (platform-dependent) default
+                libraryName = (Platform.get() == Platform.MACOSX) ? "glfw_async" : "glfw";
+            }
+            Configuration.GLFW_LIBRARY_NAME.set(libraryName);
 
             timer = new NanoTimer();
 


### PR DESCRIPTION
This a step toward allowing JME applications developed for Linux/Windows to run on macOS without any changes. Since LWJGL v2, doesn't support the newer "Apple Silicon" hardware, the focus is on LWJGL v3. For portability, we want to use the "glfw_async" library (added in LWJGL v3.3.1) when running on macOS. To reduce the risk of regressions, we'll use the old library when running on other operating systems.

For extra flexibility, a new `AppSetting` named "GlfwLibraryName" specifies which library to use: "glfw" or "glfw_async". If this setting is unset or null, `org.lwjgl.system.Platform` is used to determine which library to use.