### PR TITLE
Fix draw/read buffer selection for framebuffers (FrameBuffer.setTargetIndex(int))

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/RenderContext.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderContext.java
@@ -216,28 +216,7 @@ public class RenderContext {
      */
     public int boundRB;
 
-    /**
-     * Currently bound draw buffer.
-     * -2 = GL_NONE
-     * -1 = GL_BACK
-     *  0 = GL_COLOR_ATTACHMENT0
-     *  n = GL_COLOR_ATTACHMENTn
-     *  where n is an integer greater than 1
-     *
-     * @see Renderer#setFrameBuffer(com.jme3.texture.FrameBuffer)
-     * @see FrameBuffer#setTargetIndex(int)
-     */
-    public int boundDrawBuf;
-
-    /**
-     * Currently bound read buffer.
-     *
-     * @see RenderContext#boundDrawBuf
-     * @see Renderer#setFrameBuffer(com.jme3.texture.FrameBuffer)
-     * @see FrameBuffer#setTargetIndex(int)
-     */
-    public int boundReadBuf;
-
+  
     /**
      * Currently bound element array vertex buffer.
      *
@@ -396,8 +375,7 @@ public class RenderContext {
         boundFBO = 0;
         boundFB = null;
         boundRB = 0;
-        boundDrawBuf = -1;
-        boundReadBuf = -1;
+
         boundElementArrayVBO = 0;
         boundVertexArray = 0;
         boundArrayVBO = 0;

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -1996,28 +1996,13 @@ public final class GLRenderer implements Renderer {
         final int INITIAL = -1;
         final int MRT_OFF = 100;
 
-        if (fb == null) {
-            // Set Read/Draw buffers to initial value.
-            if (context.boundDrawBuf != INITIAL) {
-                gl2.glDrawBuffer(context.initialDrawBuf);
-                context.boundDrawBuf = INITIAL;
-            }
-            if (context.boundReadBuf != INITIAL) {
-                gl2.glReadBuffer(context.initialReadBuf);
-                context.boundReadBuf = INITIAL;
-            }
-        } else {
+        if (fb != null) {
+          
             if (fb.getNumColorBuffers() == 0) {
                 // make sure to select NONE as draw buf
-                // no color buffer attached.
-                if (context.boundDrawBuf != NONE) {
-                    gl2.glDrawBuffer(GL.GL_NONE);
-                    context.boundDrawBuf = NONE;
-                }
-                if (context.boundReadBuf != NONE) {
-                    gl2.glReadBuffer(GL.GL_NONE);
-                    context.boundReadBuf = NONE;
-                }
+                // no color buffer attached.                
+                gl2.glDrawBuffer(GL.GL_NONE);             
+                gl2.glReadBuffer(GL.GL_NONE);                 
             } else {
                 if (fb.getNumColorBuffers() > limits.get(Limits.FrameBufferAttachments)) {
                     throw new RendererException("Framebuffer has more color "
@@ -2042,15 +2027,12 @@ public final class GLRenderer implements Renderer {
 
                     intBuf16.flip();
                     glext.glDrawBuffers(intBuf16);
-                    context.boundDrawBuf = MRT_OFF + fb.getNumColorBuffers();
-
                 } else {
                     RenderBuffer rb = fb.getColorBuffer(fb.getTargetIndex());
                     // select this draw buffer
-                    if (context.boundDrawBuf != rb.getSlot()) {
-                        gl2.glDrawBuffer(GLFbo.GL_COLOR_ATTACHMENT0_EXT + rb.getSlot());
-                        context.boundDrawBuf = rb.getSlot();
-                    }
+                    gl2.glDrawBuffer(GLFbo.GL_COLOR_ATTACHMENT0_EXT + rb.getSlot());
+                    // select this read buffer
+                    gl2.glReadBuffer(GLFbo.GL_COLOR_ATTACHMENT0_EXT + rb.getSlot());
                 }
             }
         }
@@ -2098,13 +2080,11 @@ public final class GLRenderer implements Renderer {
 
         if (fb == null) {
             bindFrameBuffer(null);
-            setReadDrawBuffers(null);
         } else {
             if (fb.isUpdateNeeded()) {
                 updateFrameBuffer(fb);
             } else {
                 bindFrameBuffer(fb);
-                setReadDrawBuffers(fb);
             }
 
             // update viewport to reflect framebuffer's resolution
@@ -2131,12 +2111,7 @@ public final class GLRenderer implements Renderer {
             }
 
             setFrameBuffer(fb);
-            if (gl2 != null) {
-                if (context.boundReadBuf != rb.getSlot()) {
-                    gl2.glReadBuffer(GLFbo.GL_COLOR_ATTACHMENT0_EXT + rb.getSlot());
-                    context.boundReadBuf = rb.getSlot();
-                }
-            }
+         
 
         } else {
             setFrameBuffer(null);


### PR DESCRIPTION
This is an issue in the way glDrawBuffer/glReadBuffer are used in the engine: the state is cached as if it was a global state change, while they actually [change the current bound framebuffer's state ](https://www.khronos.org/opengl/wiki/Framebuffer#Draw_color_buffers).
The issue prevents FrameBuffer.setTargetIndex(int) from working correctly in some circumstances. 

I am leaving this open for a while to make sure this patch doesn't have any weird side effect before merging it.
