### PR TITLE
Add toggleable framebuffer mipmaps generation. Fix #1788

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -100,6 +100,7 @@ public final class GLRenderer implements Renderer {
     private int defaultAnisotropicFilter = 1;
     private boolean linearizeSrgbImages;
     private HashSet<String> extensions;
+    private boolean generateMipmapsForFramebuffers = true;
 
     private final GL gl;
     private final GL2 gl2;
@@ -118,13 +119,21 @@ public final class GLRenderer implements Renderer {
         this.glext = glext;
         this.texUtil = new TextureUtil(gl, gl2, glext);
     }
+    
+    /**
+     * Enable/Disable default automatic generation of mipmaps for framebuffers
+     * @param v  Default is true
+     */
+    public void setGenerateMipmapsForFrameBuffer(boolean v) {
+        generateMipmapsForFramebuffers = v;
+    }
 
     @Override
     public Statistics getStatistics() {
         return statistics;
     }
 
-    @Override
+    @Override 
     public EnumSet<Caps> getCaps() {
         return caps;
     }
@@ -2075,7 +2084,7 @@ public final class GLRenderer implements Renderer {
         }
 
         // generate mipmaps for last FB if needed
-        if (context.boundFB != null) {
+        if (context.boundFB != null && (context.boundFB.getMipMapsGenerationHint()!=null?context.boundFB.getMipMapsGenerationHint():generateMipmapsForFramebuffers)) {
             for (int i = 0; i < context.boundFB.getNumColorBuffers(); i++) {
                 RenderBuffer rb = context.boundFB.getColorBuffer(i);
                 Texture tex = rb.getTexture();

--- a/jme3-core/src/main/java/com/jme3/texture/FrameBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/texture/FrameBuffer.java
@@ -84,6 +84,7 @@ public class FrameBuffer extends NativeObject {
     private RenderBuffer depthBuf = null;
     private int colorBufIndex = 0;
     private boolean srgb;
+    private Boolean mipsGenerationHint = null;
 
     /**
      * <code>RenderBuffer</code> represents either a texture or a
@@ -841,5 +842,18 @@ public class FrameBuffer extends NativeObject {
      */
     public boolean isSrgb() {
         return srgb;
+    }
+
+
+    /**
+     * Hints the renderer to generate mipmaps for this framebuffer if necessary
+     * @param v true to enable, null to use the default value for the renderer (default to null)
+     */
+    public void setMipMapsGenerationHint(Boolean v) {
+        mipsGenerationHint = v;
+    }
+
+    public Boolean getMipMapsGenerationHint() {
+        return mipsGenerationHint;
     }
 }


### PR DESCRIPTION
This PR solves the issue #1788 by adding a way to hint the renderer to generate or not generate mipmaps for a specific framebuffer by using:
`FrameBuffer.setMipMapsGenerationHint(true);`
`FrameBuffer.setMipMapsGenerationHint(false);`
If no hint is given it will fallback to the default that is configurable with
`GLRenderer.setGenerateMipmapsForFramebuffer(boolean)`
and is true by default.

Leaving everything to its default will maintain the current behavior.