### PR TITLE
Add Color param to SkyBox

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Misc/Sky.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Misc/Sky.frag
@@ -3,10 +3,12 @@
 
 uniform ENVMAP m_Texture;
 
+uniform vec4 m_Color;
+
 varying vec3 direction;
 
 void main() {
     vec3 dir = normalize(direction);
-    gl_FragColor = Optics_GetEnvColor(m_Texture, dir);
+    gl_FragColor = Optics_GetEnvColor(m_Texture, dir).mult(m_Color);
 }
 


### PR DESCRIPTION
Currently, JME scenes with a skybox can't achieve a realistic day/night cycle because the AmbientLight and DirectionalLight do not affect the skyBox's brightness or color.

This small addition would allow basic skyboxes to work with day/night cycles, as well as any other special effects that could benefit from changing the distant sky color/brightness.

If this addition sounds like a good idea to core devs and is approved, I can add the rest of the code for the new color param to the .jj3md files and make any other adjustments so its mergable.