### PR TITLE
work around missing reshape() callbacks from LWJGL v3 (issue #1793)

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -296,7 +296,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         if (window == NULL) {
             throw new RuntimeException("Failed to create the GLFW window");
         }
-        updateSizes();
 
         glfwSetWindowFocusCallback(window, windowFocusCallback = new GLFWWindowFocusCallback() {
 
@@ -318,8 +317,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             if (settings.getCenterWindow()) {
                 // Center the window
                 glfwSetWindowPos(window,
-                        (videoMode.width() - settings.getWidth()) / 2,
-                        (videoMode.height() - settings.getHeight()) / 2);
+                        (videoMode.width() - requestWidth) / 2,
+                        (videoMode.height() - requestHeight) / 2);
             } else {
                 glfwSetWindowPos(window,
                         settings.getWindowXPosition(),
@@ -368,6 +367,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         if (settings.isOpenCLSupport()) {
             initOpenCL(window);
         }
+
+        updateSizes();
     }
 
     private void updateSizes() {

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -384,17 +384,18 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         updateDefaultFramebufferSize(false, false);
 
         /*
-         * XXX workaround:  When transitioning from fullscreen to windowed,
-         * GLFW skips the window-size callback, so invoke it now.
+         * XXX workaround:  When transitioning between fullscreen and windowed,
+         * GLFW may skip the window-size callback, so invoke it now.
          * For more information, see JME issue #1793.
          */
-        if (isFullscreen && !settings.isFullscreen()) {
+        if (isFullscreen != settings.isFullscreen()) {
             int[] widthArray = new int[1];
             int[] heightArray = new int[1];
             glfwGetWindowSize(window, widthArray, heightArray);
             windowSizeCallback.invoke(window, widthArray[0], heightArray[0]);
+
+            isFullscreen = settings.isFullscreen();
         }
-        isFullscreen = settings.isFullscreen();
     }
 
     private void updateDefaultFramebufferSize(boolean invokeReshape, boolean invokeRescale) {

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -379,6 +379,9 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         if (settings.getWindowWidth() != windowWidth
                 || settings.getWindowHeight() != windowHeight) {
             settings.setWindowSize(windowWidth, windowHeight);
+            for (WindowSizeListener wsListener : windowSizeListeners.getArray()) {
+                wsListener.onWindowSizeChanged(windowWidth, windowHeight);
+            }
         }
 
         glfwGetFramebufferSize(window, width, height);

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -389,7 +389,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         int framebufferHeight = height[0];
         if (framebufferWidth != oldFramebufferWidth
                 || framebufferHeight != oldFramebufferHeight) {
-            settings.setResolution(framebufferWidth, framebufferWidth);
+            settings.setResolution(framebufferWidth, framebufferHeight);
             listener.reshape(framebufferWidth, framebufferHeight);
 
             oldFramebufferWidth = framebufferWidth;

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -141,7 +141,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
     private Thread mainThread;
 
-    private boolean isFullscreen = false;
     private long window = NULL;
     private int frameRateLimit = -1;
 


### PR DESCRIPTION
Based on the observations documented in #1793, the key issue is that transitions between windowed mode and fullscreen mode in LWJGL v3 don't always generate `reshape()` callbacks. This spoils GUI layouts that need updating each time the dimensions of the graphics context change. The user sees a layout generated for a different-sized framebuffer.

(There's also an issue with the initial `reshape()` callback, which occurs on Windows, but not Linux, when the initial context is created. However, that's an easy issue for apps to work around.)

The key issue manifests differently on Linux than on Windows:
+ On Linux LWJGL v3, windowed-to-fullscreen causes a callback, but not fullscreen-to-windowed.
+ On Windows LWJGL v3, neither transition causes a callback.

This PR proposes that jme3-lwjgl3's  `LwjglWindow` should explicitly invoke `reshape()` on both windowed-to-fullscreen and fullscreen-to-windowed transitions. This results in some redundant callbacks (multiple callbacks for a single `createContext()`). However, I expect most `reshape()` callbacks perform idempotent operations. Also, filtering out redundant callbacks is much easier that compensating for missing callbacks.