### PR TITLE
refactor to avoid invoking AppSettings.getBoolean() directly

### DIFF
--- a/jme3-core/src/main/java/com/jme3/app/LegacyApplication.java
+++ b/jme3-core/src/main/java/com/jme3/app/LegacyApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -343,7 +343,7 @@ public class LegacyApplication implements Application, SystemListener {
         if (touchInput != null)
             touchInput.initialize();
 
-        if (!settings.getBoolean("DisableJoysticks")) {
+        if (settings.useJoysticks()) {
             joyInput = context.getJoyInput();
             if (joyInput != null)
                 joyInput.initialize();

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -295,7 +295,7 @@ public abstract class LwjglContext implements JmeContext {
                     glext = (GLExt) GLDebug.createProxy(gl, glext, GLExt.class);
                     glfbo = (GLFbo) GLDebug.createProxy(gl, glfbo, GLFbo.class);
                 }
-                if (settings.getBoolean("GraphicsTiming")) {
+                if (settings.isGraphicsTiming()) {
                     GLTimingState timingState = new GLTimingState();
                     gl = (GL) GLTiming.createGLTiming(gl, timingState, GL.class, GL2.class, GL3.class, GL4.class);
                     glext = (GLExt) GLTiming.createGLTiming(glext, timingState, GLExt.class);

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -159,7 +159,7 @@ public abstract class LwjglContext implements JmeContext {
 
     protected ContextAttribs createContextAttribs() {
         int vers[] = getGLVersion(settings.getRenderer());
-        if (settings.getBoolean("GraphicsDebug") || (vers != null && vers[0] != 2)) {
+        if (settings.isGraphicsDebug() || (vers != null && vers[0] != 2)) {
             ContextAttribs attr;
             if (vers != null && vers[0] != 2) {
                 attr = new ContextAttribs(vers[0], vers[1]);
@@ -167,7 +167,7 @@ public abstract class LwjglContext implements JmeContext {
             } else {
                 attr = new ContextAttribs();
             }
-            if (settings.getBoolean("GraphicsDebug")) {
+            if (settings.isGraphicsDebug()) {
                 attr = attr.withDebug(true);
             }
             return attr;
@@ -290,7 +290,7 @@ public abstract class LwjglContext implements JmeContext {
                     glfbo = new LwjglGLFboEXT();
                 }
 
-                if (settings.getBoolean("GraphicsDebug")) {
+                if (settings.isGraphicsDebug()) {
                     gl = (GL) GLDebug.createProxy(gl, gl, GL.class, GL2.class, GL3.class, GL4.class);
                     glext = (GLExt) GLDebug.createProxy(gl, glext, GLExt.class);
                     glfbo = (GLFbo) GLDebug.createProxy(gl, glfbo, GLFbo.class);
@@ -312,7 +312,7 @@ public abstract class LwjglContext implements JmeContext {
         } else {
             throw new UnsupportedOperationException("Unsupported renderer: " + settings.getRenderer());
         }
-        if (GLContext.getCapabilities().GL_ARB_debug_output && settings.getBoolean("GraphicsDebug")) {
+        if (GLContext.getCapabilities().GL_ARB_debug_output && settings.isGraphicsDebug()) {
             ARBDebugOutput.glDebugMessageCallbackARB(new ARBDebugOutputCallback(new LwjglGLDebugOutputHandler()));
         }
         renderer.setMainFrameBufferSrgb(settings.isGammaCorrection());

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -301,7 +301,7 @@ public abstract class LwjglContext implements JmeContext {
                     glext = (GLExt) GLTiming.createGLTiming(glext, timingState, GLExt.class);
                     glfbo = (GLFbo) GLTiming.createGLTiming(glfbo, timingState, GLFbo.class);
                 }
-                if (settings.getBoolean("GraphicsTrace")) {
+                if (settings.isGraphicsTrace()) {
                     gl = (GL) GLTracer.createDesktopGlTracer(gl, GL.class, GL2.class, GL3.class, GL4.class);
                     glext = (GLExt) GLTracer.createDesktopGlTracer(glext, GLExt.class);
                     glfbo = (GLFbo) GLTracer.createDesktopGlTracer(glfbo, GLFbo.class);

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -223,7 +223,7 @@ public abstract class LwjglContext implements JmeContext {
                 glfbo = (GLFbo) GLDebug.createProxy(gl, glfbo, GLFbo.class);
             }
 
-            if (settings.getBoolean("GraphicsTiming")) {
+            if (settings.isGraphicsTiming()) {
                 GLTimingState timingState = new GLTimingState();
                 gl = (GL) GLTiming.createGLTiming(gl, timingState, GL.class, GL2.class, GL3.class, GL4.class);
                 glext = (GLExt) GLTiming.createGLTiming(glext, timingState, GLExt.class);

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -217,7 +217,7 @@ public abstract class LwjglContext implements JmeContext {
                 glfbo = new LwjglGLFboEXT();
             }
 
-            if (settings.getBoolean("GraphicsDebug")) {
+            if (settings.isGraphicsDebug()) {
                 gl = (GL) GLDebug.createProxy(gl, gl, GL.class, GL2.class, GL3.class, GL4.class);
                 glext = (GLExt) GLDebug.createProxy(gl, glext, GLExt.class);
                 glfbo = (GLFbo) GLDebug.createProxy(gl, glfbo, GLFbo.class);
@@ -240,7 +240,7 @@ public abstract class LwjglContext implements JmeContext {
         }
         this.renderer.initialize();
 
-        if (capabilities.GL_ARB_debug_output && settings.getBoolean("GraphicsDebug")) {
+        if (capabilities.GL_ARB_debug_output && settings.isGraphicsDebug()) {
             ARBDebugOutput.glDebugMessageCallbackARB(new LwjglGLDebugOutputHandler(), 0);
         }
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -230,7 +230,7 @@ public abstract class LwjglContext implements JmeContext {
                 glfbo = (GLFbo) GLTiming.createGLTiming(glfbo, timingState, GLFbo.class);
             }
 
-            if (settings.getBoolean("GraphicsTrace")) {
+            if (settings.isGraphicsTrace()) {
                 gl = (GL) GLTracer.createDesktopGlTracer(gl, GL.class, GL2.class, GL3.class, GL4.class);
                 glext = (GLExt) GLTracer.createDesktopGlTracer(glext, GLExt.class);
                 glfbo = (GLFbo) GLTracer.createDesktopGlTracer(glfbo, GLFbo.class);

--- a/jme3-vr/src/main/java/com/jme3/app/VRApplication.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VRApplication.java
@@ -1289,7 +1289,7 @@ public abstract class VRApplication implements Application, SystemListener {
         if (touchInput != null)
             touchInput.initialize();
 
-        if (!settings.getBoolean("DisableJoysticks")){
+        if (settings.useJoysticks()){
             joyInput = context.getJoyInput();
             if (joyInput != null)
                 joyInput.initialize();

--- a/jme3-vr/src/main/java/com/jme3/system/lwjgl/LwjglContextVR.java
+++ b/jme3-vr/src/main/java/com/jme3/system/lwjgl/LwjglContextVR.java
@@ -179,7 +179,7 @@ public abstract class LwjglContextVR implements JmeContext {
                 glfbo = (GLFbo) GLTiming.createGLTiming(glfbo, timingState, GLFbo.class);
             }
 
-            if (settings.getGraphicsTrace()) {
+            if (settings.isGraphicsTrace()) {
                 gl = (GL) GLTracer.createDesktopGlTracer(gl, GL.class, GL2.class, GL3.class, GL4.class);
                 glext = (GLExt) GLTracer.createDesktopGlTracer(glext, GLExt.class);
                 glfbo = (GLFbo) GLTracer.createDesktopGlTracer(glfbo, GLFbo.class);

--- a/jme3-vr/src/main/java/com/jme3/system/lwjgl/LwjglContextVR.java
+++ b/jme3-vr/src/main/java/com/jme3/system/lwjgl/LwjglContextVR.java
@@ -172,7 +172,7 @@ public abstract class LwjglContextVR implements JmeContext {
                 glfbo = (GLFbo) GLDebug.createProxy(gl, glfbo, GLFbo.class);
             }
 
-            if (settings.getBoolean("GraphicsTiming")) {
+            if (settings.isGraphicsTiming()) {
                 GLTimingState timingState = new GLTimingState();
                 gl = (GL) GLTiming.createGLTiming(gl, timingState, GL.class, GL2.class, GL3.class, GL4.class);
                 glext = (GLExt) GLTiming.createGLTiming(glext, timingState, GLExt.class);

--- a/jme3-vr/src/main/java/com/jme3/system/lwjgl/LwjglContextVR.java
+++ b/jme3-vr/src/main/java/com/jme3/system/lwjgl/LwjglContextVR.java
@@ -1,7 +1,7 @@
 package com.jme3.system.lwjgl;
 
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -166,7 +166,7 @@ public abstract class LwjglContextVR implements JmeContext {
                 glfbo = new LwjglGLFboEXT();
             }
 
-            if (settings.getBoolean("GraphicsDebug")) {
+            if (settings.isGraphicsDebug()) {
                 gl = (GL) GLDebug.createProxy(gl, gl, GL.class, GL2.class, GL3.class, GL4.class);
                 glext = (GLExt) GLDebug.createProxy(gl, glext, GLExt.class);
                 glfbo = (GLFbo) GLDebug.createProxy(gl, glfbo, GLFbo.class);
@@ -191,7 +191,7 @@ public abstract class LwjglContextVR implements JmeContext {
             throw new UnsupportedOperationException("Unsupported renderer: " + settings.getRenderer());
         }
 
-        if (capabilities.GL_ARB_debug_output && settings.getBoolean("GraphicsDebug")) {
+        if (capabilities.GL_ARB_debug_output && settings.isGraphicsDebug()) {
             ARBDebugOutput.glDebugMessageCallbackARB(new LwjglGLDebugOutputHandler(), 0);
         }
 

--- a/jme3-vr/src/main/java/com/jme3/system/lwjgl/LwjglContextVR.java
+++ b/jme3-vr/src/main/java/com/jme3/system/lwjgl/LwjglContextVR.java
@@ -179,7 +179,7 @@ public abstract class LwjglContextVR implements JmeContext {
                 glfbo = (GLFbo) GLTiming.createGLTiming(glfbo, timingState, GLFbo.class);
             }
 
-            if (settings.getBoolean("GraphicsTrace")) {
+            if (settings.getGraphicsTrace()) {
                 gl = (GL) GLTracer.createDesktopGlTracer(gl, GL.class, GL2.class, GL3.class, GL4.class);
                 glext = (GLExt) GLTracer.createDesktopGlTracer(glext, GLExt.class);
                 glfbo = (GLFbo) GLTracer.createDesktopGlTracer(glfbo, GLFbo.class);


### PR DESCRIPTION
Invoking `AppSettings.getBoolean()` directly is error-prone. Ideally, its use would be limited to custom settings.

This PR refactors some invocations to use special-purpose methods already defined in the `AppSettings` class.