### PR TITLE
Add java types to VarType and type checks to MatParam

### DIFF
--- a/jme3-core/src/main/java/com/jme3/material/MatParam.java
+++ b/jme3-core/src/main/java/com/jme3/material/MatParam.java
@@ -80,6 +80,13 @@ public class MatParam implements Savable, Cloneable {
         return typeCheck;
     }
 
+
+    /**
+     * Enable type check for this param.
+     * When type check is enabled a RuntimeException is thrown if 
+     * an object of the wrong type is passed to setValue.
+     * @param v (default = true)
+     */
     public void setTypeCheckEnabled(boolean v) {
         typeCheck = v;
     }

--- a/jme3-core/src/main/java/com/jme3/shader/VarType.java
+++ b/jme3-core/src/main/java/com/jme3/shader/VarType.java
@@ -31,7 +31,6 @@
  */
 package com.jme3.shader;
 import com.jme3.math.*;
-import com.jme3.shader.bufferobject.BufferObject;
 import com.jme3.texture.*;
 public enum VarType {
 

--- a/jme3-core/src/main/java/com/jme3/shader/VarType.java
+++ b/jme3-core/src/main/java/com/jme3/shader/VarType.java
@@ -90,6 +90,11 @@ public enum VarType {
         }
     }
     
+    /**
+     * Check if the passed object is of a type mapped to this VarType
+     * @param o Object to check
+     * @return true if the object type is mapped to this VarType
+     */
     public boolean isOfType(Object o){
         for(Class<?> c : javaTypes){
             if(c.isAssignableFrom(o.getClass()))return true;
@@ -97,6 +102,11 @@ public enum VarType {
         return false;
     }
     
+
+    /**
+     * Get the java types mapped to this VarType
+     * @return an array of classes mapped to this VarType
+     */
     public Class<?>[] getJavaType(){
         return javaTypes;
     }

--- a/jme3-core/src/main/java/com/jme3/shader/VarType.java
+++ b/jme3-core/src/main/java/com/jme3/shader/VarType.java
@@ -32,6 +32,7 @@
 package com.jme3.shader;
 import com.jme3.math.*;
 import com.jme3.texture.*;
+import com.jme3.shader.BufferObject;
 public enum VarType {
 
     Float("float",float.class,Float.class),
@@ -59,8 +60,8 @@ public enum VarType {
     TextureArray(false,true,"sampler2DArray|sampler2DArrayShadow",TextureArray.class,Texture.class),
     TextureCubeMap(false,true,"samplerCube",TextureCubeMap.class,Texture.class),
     Int("int",int.class,Integer.class),
-    UniformBufferObject(false, false, "custom",BufferObject.class),
-    ShaderStorageBufferObject(false, false, "custom",BufferObject.class)  ;
+    BufferObject(false, false, "custom", BufferObject.class);
+
 
     private boolean usesMultiData = false;
     private boolean textureType = false;

--- a/jme3-core/src/main/java/com/jme3/shader/VarType.java
+++ b/jme3-core/src/main/java/com/jme3/shader/VarType.java
@@ -30,49 +30,75 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.jme3.shader;
-
+import com.jme3.math.*;
+import com.jme3.shader.bufferobject.BufferObject;
+import com.jme3.texture.*;
 public enum VarType {
 
-    Float("float"),
-    Vector2("vec2"),
-    Vector3("vec3"),
-    Vector4("vec4"),
+    Float("float",float.class,Float.class),
+    Vector2("vec2",Vector2f.class),
+    Vector3("vec3",Vector3f.class),
+    Vector4("vec4",Vector4f.class, ColorRGBA.class),
 
-    IntArray(true,false,"int"),
-    FloatArray(true,false,"float"),
-    Vector2Array(true,false,"vec2"),
-    Vector3Array(true,false,"vec3"),
-    Vector4Array(true,false,"vec4"),
+    IntArray(true,false,"int",int[].class,Integer[].class),
+    FloatArray(true,false,"float",float[].class,Float[].class),
+    Vector2Array(true,false,"vec2",Vector2f[].class),
+    Vector3Array(true,false,"vec3",Vector3f[].class),
+    Vector4Array(true,false,"vec4",Vector4f[].class),
 
-    Boolean("bool"),
+    Boolean("bool",Boolean.class,boolean.class),
 
-    Matrix3(true,false,"mat3"),
-    Matrix4(true,false,"mat4"),
+    Matrix3(true,false,"mat3",Matrix3f.class),
+    Matrix4(true,false,"mat4",Matrix4f.class),
 
-    Matrix3Array(true,false,"mat3"),
-    Matrix4Array(true,false,"mat4"),
+    Matrix3Array(true,false,"mat3",Matrix3f[].class),
+    Matrix4Array(true,false,"mat4",Matrix4f[].class),
     
-    TextureBuffer(false,true,"sampler1D|sampler1DShadow"),
-    Texture2D(false,true,"sampler2D|sampler2DShadow"),
-    Texture3D(false,true,"sampler3D"),
-    TextureArray(false,true,"sampler2DArray|sampler2DArrayShadow"),
-    TextureCubeMap(false,true,"samplerCube"),
-    Int("int"),
-    BufferObject(false, false, "custom");
+    TextureBuffer(false,true,"sampler1D|sampler1DShadow"), 
+    Texture2D(false,true,"sampler2D|sampler2DShadow",Texture2D.class,Texture.class),
+    Texture3D(false,true,"sampler3D",Texture3D.class,Texture.class),
+    TextureArray(false,true,"sampler2DArray|sampler2DArrayShadow",TextureArray.class,Texture.class),
+    TextureCubeMap(false,true,"samplerCube",TextureCubeMap.class,Texture.class),
+    Int("int",int.class,Integer.class),
+    UniformBufferObject(false, false, "custom",BufferObject.class),
+    ShaderStorageBufferObject(false, false, "custom",BufferObject.class)  ;
 
     private boolean usesMultiData = false;
     private boolean textureType = false;
     final private String glslType;
-
+    private Class<?> javaTypes[];
     
-    VarType(String glslType){
+    VarType(String glslType,Class<?> ...javaTypes){
         this.glslType = glslType;
+        if (javaTypes != null) {
+            this.javaTypes = javaTypes;
+        } else {
+            this.javaTypes = new Class<?>[0];
+        }
+        
     }
 
-    VarType(boolean multiData, boolean textureType,String glslType){
+
+    VarType(boolean multiData, boolean textureType, String glslType, Class<?>... javaTypes) {
         usesMultiData = multiData;
         this.textureType = textureType;
         this.glslType = glslType;
+        if (javaTypes != null) {
+            this.javaTypes = javaTypes;
+        } else {
+            this.javaTypes = new Class<?>[0];
+        }
+    }
+    
+    public boolean isOfType(Object o){
+        for(Class<?> c : javaTypes){
+            if(c.isAssignableFrom(o.getClass()))return true;
+        }
+        return false;
+    }
+    
+    public Class<?>[] getJavaType(){
+        return javaTypes;
     }
 
     public boolean isTextureType() {


### PR DESCRIPTION
This PR adds the matching java types to VarTypes and uses them to perform runtime type checks on MatParam.setValue().
Should be merged after https://github.com/jMonkeyEngine/jmonkeyengine/pull/1759