### PR TITLE
JmeSurfaceView: Removed explicit nullifying GlSurfaceView onDestroy

### DIFF
--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
@@ -511,7 +511,6 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
         appSettings = null;
         oglesContext = null;
         configurationInfo = null;
-        glSurfaceView = null;
         /*extra data instances*/
         crashLogWriter = null;
         crashLog = null;

--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
@@ -338,6 +338,14 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
         }
     }
 
+    private void removeGlSurfaceView() {
+        ((Activity)getContext()).runOnUiThread(() -> {
+            if (glSurfaceView != null) {
+                JmeSurfaceView.this.removeView(glSurfaceView);
+            }
+        });
+    }
+
     //******************Overridden methods by the implemented interfaces************************
 
     @Override
@@ -505,6 +513,7 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
         }
         /*stop the application immediately if the GL thread is not visible otherwise wait for the context to be fully destroyed*/
         legacyApplication.stop(!isGLThreadPaused());
+        removeGlSurfaceView();
         /*help the Dalvik Garbage collector to destruct the pointers, by making them nullptr*/
         /*context instances*/
         legacyApplication = null;

--- a/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
+++ b/jme3-android/src/main/java/com/jme3/app/jmeSurfaceView/JmeSurfaceView.java
@@ -511,13 +511,8 @@ public class JmeSurfaceView extends RelativeLayout implements SystemListener, Di
         if (legacyApplication == null) {
             return;
         }
-
-        /*stop the application immediately if the GL thread is not visible otherwise wait for the context to be fully destroyed*/
-        legacyApplication.stop(!isGLThreadPaused());
         removeGlSurfaceView();
-
         legacyApplication.destroy();
-
         /*help the Dalvik Garbage collector to destruct the pointers, by making them nullptr*/
         /*context instances*/
         legacyApplication = null;


### PR DESCRIPTION
This exception is an android native exception issue #1804 , raised due to trying to use the nullified object before being recycled : 
```java
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.jme3.hellojmesurfaceview, PID: 12825
    java.lang.IllegalArgumentException: Cannot add a null child view to a ViewGroup
        at android.view.ViewGroup.addView(ViewGroup.java:4994)
        at android.view.ViewGroup.addView(ViewGroup.java:4976)
        at com.jme3.app.jmeSurfaceView.JmeSurfaceView.addGlSurfaceView(JmeSurfaceView.java:551)
        at com.jme3.app.jmeSurfaceView.JmeSurfaceView$RendererThread.run(JmeSurfaceView.java:207)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7664)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
 ```