### PR TITLE
solve issue #1809 (GltfLoader is not thread-safe)

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -96,7 +96,7 @@ public class GltfLoader implements AssetLoader {
     Map<SkinData, List<Spatial>> skinnedSpatials = new HashMap<>();
     IntMap<SkinBuffers> skinBuffers = new IntMap<>();
 
-    static {
+    public GltfLoader() {
         defaultMaterialAdapters.put("pbrMetallicRoughness", new PBRMetalRoughMaterialAdapter());
     }
 

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -89,7 +89,7 @@ public class GltfLoader implements AssetLoader {
     private Vector3fArrayPopulator vector3fArrayPopulator = new Vector3fArrayPopulator();
     private QuaternionArrayPopulator quaternionArrayPopulator = new QuaternionArrayPopulator();
     private Matrix4fArrayPopulator matrix4fArrayPopulator = new Matrix4fArrayPopulator();
-    private static Map<String, MaterialAdapter> defaultMaterialAdapters = new HashMap<>();
+    private Map<String, MaterialAdapter> defaultMaterialAdapters = new HashMap<>();
     private CustomContentManager customContentManager = new CustomContentManager();
     private boolean useNormalsFlag = false;
 


### PR DESCRIPTION
In order to ensure initialization of the `defaultMaterialAdapters` map, I created a no-arg constructor for the loader. Otherwise this is a straightforward fix.