### PR TITLE
solve issue #1798 (filtered scenes are squeezed)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -453,7 +453,7 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
         //this has no effect at first init but is useful when resizing the canvas with multi views
         cam.setViewPort(left, right, bottom, top);
         //resizing the camera to fit the new viewport and saving original dimensions
-        cam.resize(w, h, false);
+        cam.resize(w, h, true);
         left = cam.getViewPortLeft();
         right = cam.getViewPortRight();
         top = cam.getViewPortTop();


### PR DESCRIPTION
I've verified this fix on Linux using the `TestIssue1798` app in jme3-examples. I also tested with no filters in the FPP and without the FPP to ensure I did not break those situations.