### PR TITLE
Add Quaternion::rotateTowards

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -1429,7 +1429,7 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * See {@link #rotateTowardsLocal(Quaternion, float)} for details
      *
      * @param initial the initial rotation
-     * @param target the desired rotation
+     * @param target the desired rotation (may be modified)
      * @param maxRadDelta the maximum angular step taken during interpolation
      * @return the (modified) current instance (for chaining)
      */
@@ -1445,7 +1445,7 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * Note that the interpolation will NOT overshoot.
      * Negative values of maxRadDelta will move towards the opposite direction of target.
      *
-     * @param target the desired rotation
+     * @param target the desired rotation (may be modified)
      * @param maxRadDelta the maximum angular step taken during interpolation
      */
     public void rotateTowardsLocal(Quaternion target, float maxRadDelta) {

--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -1426,16 +1426,16 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
 
     /**
      * Interpolates between the specified quaternions and stores the result in the current instance.
-     * See {@link #rotateTowards(Quaternion, float)} for details
+     * See {@link #rotateTowardsLocal(Quaternion, float)} for details
      *
      * @param initial the initial rotation
      * @param target the desired rotation
      * @param maxRadDelta the maximum angular step taken during interpolation
      * @return the (modified) current instance (for chaining)
      */
-    public Quaternion rotateTowards(Quaternion initial, Quaternion target, float maxRadDelta) {
+    public Quaternion rotateTowardsLocal(Quaternion initial, Quaternion target, float maxRadDelta) {
         this.set(initial);
-        rotateTowards(target, maxRadDelta);
+        rotateTowardsLocal(target, maxRadDelta);
         return this;
     }
 
@@ -1448,7 +1448,7 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * @param target the desired rotation
      * @param maxRadDelta the maximum angular step taken during interpolation
      */
-    public void rotateTowards(Quaternion target, float maxRadDelta) {
+    public void rotateTowardsLocal(Quaternion target, float maxRadDelta) {
         float angle = angle(target);
         if (angle == 0) {
             return;

--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -1445,11 +1445,13 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * Note that the interpolation will NOT overshoot.
      * Negative values of maxRadianDelta will move towards the opposite direction of target.
      *
+     * The two quaternions are expected to be normalized.
+     *
      * @param target the desired rotation (may be modified)
      * @param maxRadianDelta the maximum angular step taken during interpolation
      */
     public void rotateTowardsLocal(Quaternion target, float maxRadianDelta) {
-        float angle = angleBetween(target);
+        float angle = angleBetweenNormal(target);
         if (angle == 0) {
             return;
         }
@@ -1461,10 +1463,23 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
     /**
      * Computes the angle between two quaternions.
      *
-     * @param other the other quaternion
+     * @param other the other quaternion (unaffected)
      * @return the angle between two quaternions, in radians
      */
     public float angleBetween(Quaternion other) {
+        Quaternion thisNormalized = new Quaternion(this).normalizeLocal();
+        Quaternion otherNormalized = new Quaternion(other).normalizeLocal();
+        return thisNormalized.angleBetweenNormal(otherNormalized);
+    }
+
+    /**
+     * Computes the angle between this quaternion and another one.
+     * Both quaternions are expected to be normalized.
+     *
+     * @param other the other pre-normalized quaternion (unaffected)
+     * @return the angle between two quaternions, in radians
+     */
+    public float angleBetweenNormal(Quaternion other) {
         float dot = dot(other);
         return FastMath.acos(Math.min(Math.abs(dot), 1f)) * 2f;
     }

--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -1430,12 +1430,12 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      *
      * @param initial the initial rotation
      * @param target the desired rotation (may be modified)
-     * @param maxRadDelta the maximum angular step taken during interpolation
+     * @param maxRadianDelta the maximum angular step taken during interpolation
      * @return the (modified) current instance (for chaining)
      */
-    public Quaternion rotateTowardsLocal(Quaternion initial, Quaternion target, float maxRadDelta) {
+    public Quaternion rotateTowardsLocal(Quaternion initial, Quaternion target, float maxRadianDelta) {
         this.set(initial);
-        rotateTowardsLocal(target, maxRadDelta);
+        rotateTowardsLocal(target, maxRadianDelta);
         return this;
     }
 
@@ -1443,18 +1443,18 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * Interpolates between the current instance and the target quaternion, then stores the result in the current instance.
      * Use this method over slerp if you want constant rotation speed.
      * Note that the interpolation will NOT overshoot.
-     * Negative values of maxRadDelta will move towards the opposite direction of target.
+     * Negative values of maxRadianDelta will move towards the opposite direction of target.
      *
      * @param target the desired rotation (may be modified)
-     * @param maxRadDelta the maximum angular step taken during interpolation
+     * @param maxRadianDelta the maximum angular step taken during interpolation
      */
-    public void rotateTowardsLocal(Quaternion target, float maxRadDelta) {
+    public void rotateTowardsLocal(Quaternion target, float maxRadianDelta) {
         float angle = angleBetween(target);
         if (angle == 0) {
             return;
         }
 
-        float t = Math.min(1f, maxRadDelta / angle);
+        float t = Math.min(1f, maxRadianDelta / angle);
         this.slerp(target, t);
     }
 
@@ -1462,7 +1462,7 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * Computes the angle between two quaternions.
      *
      * @param other the other quaternion
-     * @return the angle in radians between two quaternions
+     * @return the angle between two quaternions, in radians
      */
     public float angleBetween(Quaternion other) {
         float dot = dot(other);

--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -1425,6 +1425,51 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
     }
 
     /**
+     * Interpolates between the specified quaternions and stores the result in the current instance.
+     * See {@link #rotateTowards(Quaternion, float)} for details
+     *
+     * @param initial the initial rotation
+     * @param target the desired rotation
+     * @param maxRadDelta the maximum angular step taken during interpolation
+     * @return the (modified) current instance (for chaining)
+     */
+    public Quaternion rotateTowards(Quaternion initial, Quaternion target, float maxRadDelta) {
+        this.set(initial);
+        rotateTowards(target, maxRadDelta);
+        return this;
+    }
+
+    /**
+     * Interpolates between the current instance and the target quaternion, then stores the result in the current instance.
+     * Use this method over slerp if you want constant rotation speed.
+     * Note that the interpolation will NOT overshoot.
+     * Negative values of maxRadDelta will move towards the opposite direction of target.
+     *
+     * @param target the desired rotation
+     * @param maxRadDelta the maximum angular step taken during interpolation
+     */
+    public void rotateTowards(Quaternion target, float maxRadDelta) {
+        float angle = angle(target);
+        if (angle == 0) {
+            return;
+        }
+
+        float t = Math.min(1f, maxRadDelta / angle);
+        this.slerp(target, t);
+    }
+
+    /**
+     * Computes the angle between two quaternions.
+     *
+     * @param other the other quaternion
+     * @return the angle in radians between two quaternions
+     */
+    public float angle(Quaternion other) {
+        float dot = dot(other);
+        return FastMath.acos(Math.min(Math.abs(dot), 1f)) * 2f;
+    }
+
+    /**
      * Returns a hash code. If two quaternions are logically equivalent, they
      * will return the same hash code. The current instance is unaffected.
      *

--- a/jme3-core/src/main/java/com/jme3/math/Quaternion.java
+++ b/jme3-core/src/main/java/com/jme3/math/Quaternion.java
@@ -1449,7 +1449,7 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * @param maxRadDelta the maximum angular step taken during interpolation
      */
     public void rotateTowardsLocal(Quaternion target, float maxRadDelta) {
-        float angle = angle(target);
+        float angle = angleBetween(target);
         if (angle == 0) {
             return;
         }
@@ -1464,7 +1464,7 @@ public final class Quaternion implements Savable, Cloneable, java.io.Serializabl
      * @param other the other quaternion
      * @return the angle in radians between two quaternions
      */
-    public float angle(Quaternion other) {
+    public float angleBetween(Quaternion other) {
         float dot = dot(other);
         return FastMath.acos(Math.min(Math.abs(dot), 1f)) * 2f;
     }


### PR DESCRIPTION
It's basically this: https://docs.unity3d.com/ScriptReference/Quaternion.RotateTowards.html
I honestly don't know much about how Quaternions work, I took the code from: https://gist.github.com/aeroson/043001ca12fe29ee911e

Two things I don't know:
* The linked implementation uses slerpUnclamped. There's no such method in jMonkey. My test code worked with just clamp.
* I don't know if the angle() method requires the quaternions to be normalized.

I copied the naming convention that slerp uses, but I think they should be rotateTowards/rotateTowardsLocal (and slerp/slerpLocal) to match the other methods in the maths package.