### PR TITLE
AreaUtils: Migrated package to `com.jme3.util`

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/control/AreaUtils.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/AreaUtils.java
@@ -61,6 +61,6 @@ public class AreaUtils {
     * @return The area in pixels on the screen of the bounding volume.
     */
     public static float calcScreenArea(BoundingVolume bound, float distance, float screenWidth) {
-        return com.jme3.utils.AreaUtils.calcScreenArea(bound, distance, screenWidth);
+        return com.jme3.util.AreaUtils.calcScreenArea(bound, distance, screenWidth);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/scene/control/AreaUtils.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/AreaUtils.java
@@ -51,39 +51,16 @@ public class AreaUtils {
     private AreaUtils() {
     }
 
-  /**
-   * Estimate the screen area of a bounding volume. If the volume isn't a
-   * BoundingSphere, BoundingBox, or OrientedBoundingBox, 0 is returned.
-   *
-   * @param bound The bounds to calculate the volume from.
-   * @param distance The distance from camera to object.
-   * @param screenWidth The width of the screen.
-   * @return The area in pixels on the screen of the bounding volume.
-   */
-  public static float calcScreenArea(BoundingVolume bound, float distance, float screenWidth) {
-      if (bound.getType() == BoundingVolume.Type.Sphere){
-          return calcScreenArea((BoundingSphere) bound, distance, screenWidth);
-      }else if (bound.getType() == BoundingVolume.Type.AABB){
-          return calcScreenArea((BoundingBox) bound, distance, screenWidth);
-      }
-      return 0.0f;
-  }
-
-  private static float calcScreenArea(BoundingSphere bound, float distance, float screenWidth) {
-    // Where is the center point and a radius point that lies in a plan parallel to the view plane?
-//    // Calc radius based on these two points and plug into circle area formula.
-//    Vector2f centerSP = null;
-//    Vector2f outerSP = null;
-//    float radiusSq = centerSP.subtract(outerSP).lengthSquared();
-      float radius = (bound.getRadius() * screenWidth) / (distance * 2);
-      return radius * radius * FastMath.PI;
-  }
-
-  private static float calcScreenArea(BoundingBox bound, float distance, float screenWidth) {
-      // Calc as if we are a BoundingSphere for now...
-      float radiusSquare = bound.getXExtent() * bound.getXExtent()
-                         + bound.getYExtent() * bound.getYExtent()
-                         + bound.getZExtent() * bound.getZExtent();
-      return ((radiusSquare * screenWidth * screenWidth) / (distance * distance * 4)) * FastMath.PI;
-  }
+    /**
+    * Estimate the screen area of a bounding volume. If the volume isn't a
+    * BoundingSphere, BoundingBox, or OrientedBoundingBox, 0 is returned.
+    *
+    * @param bound The bounds to calculate the volume from.
+    * @param distance The distance from camera to object.
+    * @param screenWidth The width of the screen.
+    * @return The area in pixels on the screen of the bounding volume.
+    */
+    public static float calcScreenArea(BoundingVolume bound, float distance, float screenWidth) {
+        return com.jme3.utils.AreaUtils.calcScreenArea(bound, distance, screenWidth);
+    }
 }

--- a/jme3-core/src/main/java/com/jme3/util/AreaUtils.java
+++ b/jme3-core/src/main/java/com/jme3/util/AreaUtils.java
@@ -49,17 +49,40 @@ public final class AreaUtils {
      */
     private AreaUtils() {
     }
-
+    
     /**
-     * Estimate the screen area of a bounding volume. If the volume isn't a
-     * BoundingSphere, BoundingBox, or OrientedBoundingBox, 0 is returned.
-     *
-     * @param bound       The bounds to calculate the volume from.
-     * @param distance    The distance from camera to object.
-     * @param screenWidth The width of the screen.
-     * @return The area in pixels on the screen of the bounding volume.
-     */
+    * Estimate the screen area of a bounding volume. If the volume isn't a
+    * BoundingSphere, BoundingBox, or OrientedBoundingBox, 0 is returned.
+    *
+    * @param bound The bounds to calculate the volume from.
+    * @param distance The distance from camera to object.
+    * @param screenWidth The width of the screen.
+    * @return The area in pixels on the screen of the bounding volume.
+    */
     public static float calcScreenArea(BoundingVolume bound, float distance, float screenWidth) {
-        return com.jme3.scene.control.AreaUtils.calcScreenArea(bound, distance, screenWidth);
+        if (bound.getType() == BoundingVolume.Type.Sphere) {
+            return calcScreenArea((BoundingSphere) bound, distance, screenWidth);
+        } else if (bound.getType() == BoundingVolume.Type.AABB) {
+            return calcScreenArea((BoundingBox) bound, distance, screenWidth);
+        }
+        return 0.0f;
+    }
+
+    private static float calcScreenArea(BoundingSphere bound, float distance, float screenWidth) {
+        // Where is the center point and a radius point that lies in a plan parallel to the view plane?
+        //    // Calc radius based on these two points and plug into circle area formula.
+        //    Vector2f centerSP = null;
+        //    Vector2f outerSP = null;
+        //    float radiusSq = centerSP.subtract(outerSP).lengthSquared();
+        float radius = (bound.getRadius() * screenWidth) / (distance * 2);
+        return radius * radius * FastMath.PI;
+    }
+
+    private static float calcScreenArea(BoundingBox bound, float distance, float screenWidth) {
+        // Calc as if we are a BoundingSphere for now...
+        float radiusSquare = bound.getXExtent() * bound.getXExtent()
+                         + bound.getYExtent() * bound.getYExtent()
+                         + bound.getZExtent() * bound.getZExtent();
+        return ((radiusSquare * screenWidth * screenWidth) / (distance * distance * 4)) * FastMath.PI;
     }
 }

--- a/jme3-core/src/main/java/com/jme3/util/AreaUtils.java
+++ b/jme3-core/src/main/java/com/jme3/util/AreaUtils.java
@@ -35,7 +35,6 @@ import com.jme3.bounding.BoundingBox;
 import com.jme3.bounding.BoundingSphere;
 import com.jme3.bounding.BoundingVolume;
 import com.jme3.math.FastMath;
-import com.jme3.scene.control.AreaUtils;
 
 /**
  * <code>AreaUtils</code> is used to calculate the area of various objects, such as bounding volumes.  These
@@ -61,6 +60,6 @@ public final class AreaUtils {
      * @return The area in pixels on the screen of the bounding volume.
      */
     public static float calcScreenArea(BoundingVolume bound, float distance, float screenWidth) {
-        return AreaUtils.calcScreenArea(bound, distance, screenWidth);
+        return com.jme3.scene.control.AreaUtils.calcScreenArea(bound, distance, screenWidth);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/util/AreaUtils.java
+++ b/jme3-core/src/main/java/com/jme3/util/AreaUtils.java
@@ -29,7 +29,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.jme3.scene.control;
+package com.jme3.util;
 
 import com.jme3.bounding.BoundingBox;
 import com.jme3.bounding.BoundingSphere;
@@ -39,11 +39,10 @@ import com.jme3.math.FastMath;
 /**
  * <code>AreaUtils</code> is used to calculate the area of various objects, such as bounding volumes.  These
  * functions are very loose approximations.
+ *
  * @author Joshua Slack
  * @version $Id: AreaUtils.java 4131 2009-03-19 20:15:28Z blaine.dev $
- * @deprecated use {@link com.jme3.util.AreaUtils} instead, due to wrong package
  */
-@Deprecated
 public class AreaUtils {
     /**
      * A private constructor to inhibit instantiation of this class.
@@ -51,39 +50,39 @@ public class AreaUtils {
     private AreaUtils() {
     }
 
-  /**
-   * Estimate the screen area of a bounding volume. If the volume isn't a
-   * BoundingSphere, BoundingBox, or OrientedBoundingBox, 0 is returned.
-   *
-   * @param bound The bounds to calculate the volume from.
-   * @param distance The distance from camera to object.
-   * @param screenWidth The width of the screen.
-   * @return The area in pixels on the screen of the bounding volume.
-   */
-  public static float calcScreenArea(BoundingVolume bound, float distance, float screenWidth) {
-      if (bound.getType() == BoundingVolume.Type.Sphere){
-          return calcScreenArea((BoundingSphere) bound, distance, screenWidth);
-      }else if (bound.getType() == BoundingVolume.Type.AABB){
-          return calcScreenArea((BoundingBox) bound, distance, screenWidth);
-      }
-      return 0.0f;
-  }
+    /**
+     * Estimate the screen area of a bounding volume. If the volume isn't a
+     * BoundingSphere, BoundingBox, or OrientedBoundingBox, 0 is returned.
+     *
+     * @param bound       The bounds to calculate the volume from.
+     * @param distance    The distance from camera to object.
+     * @param screenWidth The width of the screen.
+     * @return The area in pixels on the screen of the bounding volume.
+     */
+    public static float calcScreenArea(BoundingVolume bound, float distance, float screenWidth) {
+        if (bound.getType() == BoundingVolume.Type.Sphere) {
+            return calcScreenArea((BoundingSphere) bound, distance, screenWidth);
+        } else if (bound.getType() == BoundingVolume.Type.AABB) {
+            return calcScreenArea((BoundingBox) bound, distance, screenWidth);
+        }
+        return 0.0f;
+    }
 
-  private static float calcScreenArea(BoundingSphere bound, float distance, float screenWidth) {
-    // Where is the center point and a radius point that lies in a plan parallel to the view plane?
+    private static float calcScreenArea(BoundingSphere bound, float distance, float screenWidth) {
+        // Where is the center point and a radius point that lies in a plan parallel to the view plane?
 //    // Calc radius based on these two points and plug into circle area formula.
 //    Vector2f centerSP = null;
 //    Vector2f outerSP = null;
 //    float radiusSq = centerSP.subtract(outerSP).lengthSquared();
-      float radius = (bound.getRadius() * screenWidth) / (distance * 2);
-      return radius * radius * FastMath.PI;
-  }
+        float radius = (bound.getRadius() * screenWidth) / (distance * 2);
+        return radius * radius * FastMath.PI;
+    }
 
-  private static float calcScreenArea(BoundingBox bound, float distance, float screenWidth) {
-      // Calc as if we are a BoundingSphere for now...
-      float radiusSquare = bound.getXExtent() * bound.getXExtent()
-                         + bound.getYExtent() * bound.getYExtent()
-                         + bound.getZExtent() * bound.getZExtent();
-      return ((radiusSquare * screenWidth * screenWidth) / (distance * distance * 4)) * FastMath.PI;
-  }
+    private static float calcScreenArea(BoundingBox bound, float distance, float screenWidth) {
+        // Calc as if we are a BoundingSphere for now...
+        float radiusSquare = bound.getXExtent() * bound.getXExtent()
+                + bound.getYExtent() * bound.getYExtent()
+                + bound.getZExtent() * bound.getZExtent();
+        return ((radiusSquare * screenWidth * screenWidth) / (distance * distance * 4)) * FastMath.PI;
+    }
 }

--- a/jme3-core/src/main/java/com/jme3/util/AreaUtils.java
+++ b/jme3-core/src/main/java/com/jme3/util/AreaUtils.java
@@ -35,6 +35,7 @@ import com.jme3.bounding.BoundingBox;
 import com.jme3.bounding.BoundingSphere;
 import com.jme3.bounding.BoundingVolume;
 import com.jme3.math.FastMath;
+import com.jme3.scene.control.AreaUtils;
 
 /**
  * <code>AreaUtils</code> is used to calculate the area of various objects, such as bounding volumes.  These
@@ -43,7 +44,7 @@ import com.jme3.math.FastMath;
  * @author Joshua Slack
  * @version $Id: AreaUtils.java 4131 2009-03-19 20:15:28Z blaine.dev $
  */
-public class AreaUtils {
+public final class AreaUtils {
     /**
      * A private constructor to inhibit instantiation of this class.
      */
@@ -60,29 +61,6 @@ public class AreaUtils {
      * @return The area in pixels on the screen of the bounding volume.
      */
     public static float calcScreenArea(BoundingVolume bound, float distance, float screenWidth) {
-        if (bound.getType() == BoundingVolume.Type.Sphere) {
-            return calcScreenArea((BoundingSphere) bound, distance, screenWidth);
-        } else if (bound.getType() == BoundingVolume.Type.AABB) {
-            return calcScreenArea((BoundingBox) bound, distance, screenWidth);
-        }
-        return 0.0f;
-    }
-
-    private static float calcScreenArea(BoundingSphere bound, float distance, float screenWidth) {
-        // Where is the center point and a radius point that lies in a plan parallel to the view plane?
-//    // Calc radius based on these two points and plug into circle area formula.
-//    Vector2f centerSP = null;
-//    Vector2f outerSP = null;
-//    float radiusSq = centerSP.subtract(outerSP).lengthSquared();
-        float radius = (bound.getRadius() * screenWidth) / (distance * 2);
-        return radius * radius * FastMath.PI;
-    }
-
-    private static float calcScreenArea(BoundingBox bound, float distance, float screenWidth) {
-        // Calc as if we are a BoundingSphere for now...
-        float radiusSquare = bound.getXExtent() * bound.getXExtent()
-                + bound.getYExtent() * bound.getYExtent()
-                + bound.getZExtent() * bound.getZExtent();
-        return ((radiusSquare * screenWidth * screenWidth) / (distance * distance * 4)) * FastMath.PI;
+        return AreaUtils.calcScreenArea(bound, distance, screenWidth);
     }
 }


### PR DESCRIPTION
This PR includes: 
- Migrating the `AreaUtils` class from `com.jme3.scene.control` to `com.jme3.util`.
- Deprecating `com.jme3.scene.control.AreaUtils`.
- Jme3 copyright update.

EDIT: 
- Targeting this issue #1825 