### PR TITLE
SettingsDialog: LAF fix

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/app/SettingsDialog.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/SettingsDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-desktop/src/main/java/com/jme3/app/SettingsDialog.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/SettingsDialog.java
@@ -297,12 +297,6 @@ public final class SettingsDialog extends JFrame {
         GridBagConstraints gbc;
         
         JPanel mainPanel = new JPanel(new GridBagLayout());
-        
-        try {
-            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-        } catch (Exception e) {
-            logger.warning("Could not set native look and feel.");
-        }
 
         addWindowListener(new WindowAdapter() {
 


### PR DESCRIPTION
Fixed issue #1824  swing look and feel to be defaulted to swing LAF, if you want to change the LAF on your own use this at your `SimpleApplication`: 
```java
static {
  try {
      UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
  } catch (Exception e) {
      Logger.getLogger(MyClass.class.getName()).severe("Cannot set the LAF, defaulting back to System LAF");
  }
}
```
This is a test for this PR: 
![Screenshot from 2022-05-30 16-36-43](https://user-images.githubusercontent.com/60224159/171016601-c5b25549-e8f6-428a-8d12-40916d7ae898.png)

When setting the LAF at the static initializer (as a user code):
![Screenshot from 2022-05-30 16-39-17](https://user-images.githubusercontent.com/60224159/171016549-bea94294-a75c-4074-95dc-f82f7d29bad9.png)
