### PR TITLE
Added setter for FilterPostProcessor.depthFormat

### DIFF
--- a/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
@@ -568,6 +568,15 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
         this.depthFormat = depthFormat;
     }
 
+    /**
+     * Returns the depth format currently used for the internal frame buffer's depth buffer
+     * 
+     * @return the depth format
+     */
+    public Format getFrameBufferDepthFormat() {
+        return depthFormat;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public void write(JmeExporter ex) throws IOException {

--- a/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
@@ -86,7 +86,7 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
     private AppProfiler prof;
 
     private Format fbFormat = Format.RGB111110F;
-    final private Format depthFormat = Format.Depth;
+    private Format depthFormat = Format.Depth;
 
     /**
      * Create a FilterProcessor
@@ -550,8 +550,22 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
         this.assetManager = assetManager;
     }
 
+    /**
+     * Sets the format to be used for the internal frame buffer's color buffer
+     *
+     * @param fbFormat the format
+     */
     public void setFrameBufferFormat(Format fbFormat) {
         this.fbFormat = fbFormat;
+    }
+
+    /**
+     * Sets the format to be used for the internal frame buffer's depth buffer
+     *
+     * @param depthFormat the format
+     */
+    public void setFrameBufferDepthFormat(Format depthFormat) {
+        this.depthFormat = depthFormat;
     }
 
     @Override


### PR DESCRIPTION
History: https://hub.jmonkeyengine.org/t/possible-to-use-stencil-buffer-with-filterpostprocessor/45840

In 2016, [Tiatin added the setFrameBufferFormat method to FilterPostProcessor.](https://hub.jmonkeyengine.org/t/ability-to-change-image-format-for-filterpostprocessor/36379)  This allows different formats to be used for the color render buffer.  I think the depth buffer needs the same treatment so that stencil operations can be performed while filters are in use.

This is the first PR I've made, so please let me know if I've done something wrong, thanks!