### PR TITLE
Fix #1843 (java.util.zip.ZipException in HttpZipLocator)

### DIFF
--- a/jme3-core/src/plugins/java/com/jme3/asset/plugins/HttpZipLocator.java
+++ b/jme3-core/src/plugins/java/com/jme3/asset/plugins/HttpZipLocator.java
@@ -236,7 +236,7 @@ public class HttpZipLocator implements AssetLocator {
 
         // We want the offset in the file data:
         // move the offset forward to skip the LOC header.
-        entry.offset += ZipEntry.LOCHDR + nameLen + extraLen;
+        entry.offset += ZipEntry.LOCHDR + nameLen;
 
         entries.put(entry.name, entry);
         

--- a/jme3-core/src/plugins/java/com/jme3/asset/plugins/HttpZipLocator.java
+++ b/jme3-core/src/plugins/java/com/jme3/asset/plugins/HttpZipLocator.java
@@ -42,7 +42,7 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.util.HashMap;
@@ -80,14 +80,9 @@ public class HttpZipLocator implements AssetLocator {
     private int tableLength;
     private HashMap<String, ZipEntry2> entries;
     
-    private static final ByteBuffer byteBuf = ByteBuffer.allocate(250);
-    private static final CharBuffer charBuf = CharBuffer.allocate(250);
-    private static final CharsetDecoder utf8Decoder;
-    
-    static {
-        Charset utf8 = Charset.forName("UTF-8");
-        utf8Decoder = utf8.newDecoder();
-    }
+    private final ByteBuffer byteBuf = ByteBuffer.allocate(250);
+    private final CharBuffer charBuf = CharBuffer.allocate(250);
+    private final CharsetDecoder utf8Decoder = StandardCharsets.UTF_8.newDecoder();
 
     private static class ZipEntry2 {
         String name;
@@ -129,7 +124,7 @@ public class HttpZipLocator implements AssetLocator {
              (((long)(b[off]&0xff)) << 24);
     }
 
-    private static String getUTF8String(byte[] b, int off, int len) throws CharacterCodingException {
+    private String getUTF8String(byte[] b, int off, int len) throws CharacterCodingException {
         StringBuilder sb = new StringBuilder();
         
         int read = 0;
@@ -147,7 +142,7 @@ public class HttpZipLocator implements AssetLocator {
             byteBuf.flip();
             
             // decode data in byteBuf
-            CoderResult result = utf8Decoder.decode(byteBuf, charBuf, endOfInput); 
+            CoderResult result = utf8Decoder.decode(byteBuf, charBuf, endOfInput);
             
             // If the result is not an underflow, it's an error
             // that cannot be handled.


### PR DESCRIPTION
Fix #1843

Reported on the forum: 
https://hub.jmonkeyengine.org/t/httpziplocator-questions/45859

```

com.jme3.asset.AssetLoadException: An error occurred loading Walk.gltf
	at com.jme3.scene.plugins.gltf.GltfLoader.loadFromStream(GltfLoader.java:181)
	at com.jme3.scene.plugins.gltf.GltfLoader.load(GltfLoader.java:106)
	at com.jme3.asset.DesktopAssetManager.loadLocatedAsset(DesktopAssetManager.java:272)
	at com.jme3.asset.DesktopAssetManager.loadAsset(DesktopAssetManager.java:388)
	at com.jme3.asset.DesktopAssetManager.loadModel(DesktopAssetManager.java:439)
	at asset.TestHttpLocator.simpleInitApp(TestHttpLocator.java:33)
	at com.jme3.app.SimpleApplication.initialize(SimpleApplication.java:240)
	at com.jme3.system.lwjgl.LwjglWindow.initInThread(LwjglWindow.java:548)
	at com.jme3.system.lwjgl.LwjglWindow.run(LwjglWindow.java:662)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: com.google.gson.JsonIOException: java.util.zip.ZipException: invalid code lengths set
	at com.google.gson.internal.Streams.parse(Streams.java:62)
	at com.google.gson.JsonParser.parse(JsonParser.java:84)
	at com.jme3.scene.plugins.gltf.GltfLoader.loadFromStream(GltfLoader.java:123)
	... 9 more
Caused by: java.util.zip.ZipException: invalid code lengths set
	at java.base/java.util.zip.InflaterInputStream.read(InflaterInputStream.java:164)
	at java.base/sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:270)
	at java.base/sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:313)
	at java.base/sun.nio.cs.StreamDecoder.read(StreamDecoder.java:188)
	at java.base/java.io.InputStreamReader.read(InputStreamReader.java:177)
Caused by: com.google.gson.JsonIOException: java.util.zip.ZipException: invalid code lengths set

	at com.google.gson.stream.JsonReader.fillBuffer(JsonReader.java:1295)
	at com.google.gson.stream.JsonReader.nextNonWhitespace(JsonReader.java:1333)
Caused by: java.util.zip.ZipException: invalid code lengths set

	at com.google.gson.stream.JsonReader.consumeNonExecutePrefix(JsonReader.java:1576)
	at com.google.gson.stream.JsonReader.doPeek(JsonReader.java:534)
	at com.google.gson.stream.JsonReader.peek(JsonReader.java:425)
	at com.google.gson.internal.Streams.parse(Streams.java:46)
	... 11 more


```


```
com.jme3.asset.AssetLoadException: An error occurred loading Stand.gltf
	at com.jme3.scene.plugins.gltf.GltfLoader.loadFromStream(GltfLoader.java:181)
	at com.jme3.scene.plugins.gltf.GltfLoader.load(GltfLoader.java:106)
	at com.jme3.asset.DesktopAssetManager.loadLocatedAsset(DesktopAssetManager.java:272)
	at com.jme3.asset.DesktopAssetManager.loadAsset(DesktopAssetManager.java:388)
	at net.jmecn.HelloArmature.model(HelloArmature.java:321)
	at net.jmecn.HelloArmature.initScene(HelloArmature.java:257)
	at net.jmecn.HelloArmature.simpleInitApp(HelloArmature.java:114)
	at com.jme3.app.SimpleApplication.initialize(SimpleApplication.java:240)
	at com.jme3.system.lwjgl.LwjglAbstractDisplay.initInThread(LwjglAbstractDisplay.java:139)
	at com.jme3.system.lwjgl.LwjglAbstractDisplay.run(LwjglAbstractDisplay.java:221)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: com.google.gson.JsonIOException: java.util.zip.ZipException: invalid distance too far back
	at com.google.gson.internal.Streams.parse(Streams.java:62)
	at com.google.gson.JsonParser.parse(JsonParser.java:84)
	at com.jme3.scene.plugins.gltf.GltfLoader.loadFromStream(GltfLoader.java:123)
	... 10 more
Caused by: java.util.zip.ZipException: invalid distance too far back
	at java.base/java.util.zip.InflaterInputStream.read(InflaterInputStream.java:164)
	at java.base/sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:270)
	at java.base/sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:313)
	at java.base/sun.nio.cs.StreamDecoder.read(StreamDecoder.java:188)
	at java.base/java.io.InputStreamReader.read(InputStreamReader.java:177)
	at com.google.gson.stream.JsonReader.fillBuffer(JsonReader.java:1295)
	at com.google.gson.stream.JsonReader.nextNonWhitespace(JsonReader.java:1333)
	at com.google.gson.stream.JsonReader.consumeNonExecutePrefix(JsonReader.java:1576)
	at com.google.gson.stream.JsonReader.doPeek(JsonReader.java:534)
	at com.google.gson.stream.JsonReader.peek(JsonReader.java:425)
	at com.google.gson.internal.Streams.parse(Streams.java:46)
	... 12 more
```


After comparing the two zips (one generated by [www.ezyzip.com](http://www.ezyzip.com/) and one by linux archive manager both from the same contents and with the same compression level), I noticed that their entry offsets are different in HttpZipLocator. 

Following it, I found that the "extraLen" (Central directory (CEN) header extra field length field offset) used here has different values on these two zip files:

https://github.com/jMonkeyEngine/jmonkeyengine/blob/5ae543cc6f35cd93b53eb511cb912f91e210749f/jme3-core/src/plugins/java/com/jme3/asset/plugins/HttpZipLocator.java#L239

in the zip file created by www.ezyzip.com (and also in the JME's "wildhouse.zip" that is on google storage), that value is 0 (which is why HttpZipLocator does not show an error) but in the zip file that @icyboxs uploaded and also I created in the Linux archive manager that value is non-zero (36 bytes).

Removing the "extraLen" fixed the issue.