### PR TITLE
Added an smart stretching option to BlendAction

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendAction.java
@@ -49,11 +49,21 @@ public class BlendAction extends BlendableAction {
     final private Tween[] scaledActions;
     final private Map<HasLocalTransform, Transform> targetMap = new HashMap<>();
 
+    /**
+     * Creates an action that uses the given blend space to blend to blend between
+     * specified action. It will stretch the actions that doesn't have the same length.
+     *
+     * @param blendSpace The blend space used for calculating blend weight
+     * @param actions The actions to blend
+     */
     public BlendAction(BlendSpace blendSpace, BlendableAction... actions) {
         this(blendSpace, false, actions);
     }
 
     /**
+     * Creates an action that uses the given blend space to blend to blend between
+     * specified action. It will stretch the actions that doesn't have the same length.
+     * If smart stretching is enabled it will try to loop actions before stretching.
      *
      * @param blendSpace The blend space used for calculating blend weight
      * @param smartStretch If smart stretch it is false, actions that do not have the same length will

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendAction.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2022 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.anim.tween.action;
 
 import com.jme3.anim.tween.Tween;


### PR DESCRIPTION
By default, BlendAction will stretch any action that doesn't have the same length. This will cause stretched actions to end up playing slowly so one needs to manually speed up action to resolve this. What smart stretching does is that it tries to loop the action when possible before stretching to resolve the slow animation effect.

Gives the best result when the max transition weight is set to something lower than 1 (e.g. 0.5)