### PR TITLE
BlendAction: resolve slow-motion side effect caused by stretching actions

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendAction.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2022 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.anim.tween.action;
 
 import com.jme3.anim.util.HasLocalTransform;

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendAction.java
@@ -137,8 +137,8 @@ public class BlendAction extends BlendableAction {
      * nullify the slow animation side effect caused by stretching. BlendAction will use the
      * blend weight taken from BlendSpace to interpolate the speed factor for current frame.
      *
-     * @param blendAction
-     * @return
+     * @param blendAction The blend action used to generate speed factors for it
+     * @return new array
      */
     public static double[] calculateSpeedFactors(BlendAction blendAction) {
         Action[] actions = blendAction.getActions();

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendAction.java
@@ -82,9 +82,9 @@ public class BlendAction extends BlendableAction {
             }
         }
 
-        // Generate speed factors used to resolve slow motion effect on stretched
-        // actions by dynamically calculating speed.
-        speedFactors = calculateSpeedFactors(this);
+        // Calculate default factors that dynamically adjust speed to resolve
+        // slow motion effect on stretched actions.
+        applyDefaultSpeedFactors();
     }
 
     @Override
@@ -163,19 +163,16 @@ public class BlendAction extends BlendableAction {
 
     /**
      * BlendAction will stretch it's child actions if they don't have the same length.
-     * This might cause stretched animations to run slowly. This method generates the factor
+     * This might cause stretched animations to run slowly. This method generates factors
      * based on how much actions are stretched. Multiplying this factor to base speed will
-     * nullify the slow animation side effect caused by stretching. BlendAction will use the
+     * resolve the slow-motion side effect caused by stretching. BlendAction will use the
      * blend weight taken from BlendSpace to interpolate the speed factor for current frame.
-     *
-     * @param blendAction The blend action used to generate speed factors for it
-     * @return new array
      */
-    public static double[] calculateSpeedFactors(BlendAction blendAction) {
-        Action[] actions = blendAction.getActions();
-        return Arrays.stream(actions)
-                .mapToDouble(action -> blendAction.getLength() / action.getLength())
+    public void applyDefaultSpeedFactors() {
+        double[] factors = Arrays.stream(getActions())
+                .mapToDouble(action -> getLength() / action.getLength())
                 .toArray();
+        setSpeedFactors(factors);
     }
 
     protected void setFirstActiveIndex(int index) {

--- a/jme3-examples/src/main/java/jme3test/model/anim/TestAnimMigration.java
+++ b/jme3-examples/src/main/java/jme3test/model/anim/TestAnimMigration.java
@@ -173,13 +173,13 @@ public class TestAnimMigration extends SimpleApplication {
                     blendValue += value;
                     blendValue = FastMath.clamp(blendValue, 1, 4);
                     action.getBlendSpace().setValue(blendValue);
-                    action.setSpeed(blendValue);
+                    //action.setSpeed(blendValue);
                 }
                 if (name.equals("blendDown")) {
                     blendValue -= value;
                     blendValue = FastMath.clamp(blendValue, 1, 4);
                     action.getBlendSpace().setValue(blendValue);
-                    action.setSpeed(blendValue);
+                    //action.setSpeed(blendValue);
                 }
                 //System.err.println(blendValue);
             }


### PR DESCRIPTION
This resolves slow-motion side effects caused by BlendAction stretching any animation that doesn't have the same length. It generates speed factors for each child animation that are dynamically interpolated and applied to base speed based on the blend weight taken from blend space.

This is a breaking change, as the speed returned by `BlendAction.getSpeed()` used to be a static value but now it returns a dynamic value that is changed as blend weight is changed. Unless `speedFactors` is cleared out or factors are equal. (i.e. clips have the same length).