### PR TITLE
docs(README) - fix: broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ Read our [contribution guide](https://github.com/jMonkeyEngine/jmonkeyengine/blo
 
 ### License
 
-[New BSD (3-clause) License](https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/LICENSE)
+[New BSD (3-clause) License](https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/LICENSE.md)
 


### PR DESCRIPTION
### Docs - style
* Fixed broken link in the `README.md` file.

Related issue: #1857

Closes: #1857

If possible I would like to do this here fix as part of the "Hacktoberfest".  I guess that we need to add a tag that it is accepted as such if that is ok?
