### PR TITLE
Implementation of a glTF extension loader for KHR_texture_transform

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/CustomContentManager.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/CustomContentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,6 +57,7 @@ public class CustomContentManager {
         defaultExtensionLoaders.put("KHR_materials_pbrSpecularGlossiness", new PBRSpecGlossExtensionLoader());
         defaultExtensionLoaders.put("KHR_lights_punctual", new LightsPunctualExtensionLoader());
         defaultExtensionLoaders.put("KHR_materials_unlit", new UnlitExtensionLoader());
+        defaultExtensionLoaders.put("KHR_texture_transform", new TextureTransformExtensionLoader());     
     }
 
     void init(GltfLoader gltfLoader) {

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -96,9 +96,6 @@ public class GltfLoader implements AssetLoader {
     Map<SkinData, List<Spatial>> skinnedSpatials = new HashMap<>();
     IntMap<SkinBuffers> skinBuffers = new IntMap<>();
 
-    // Last created geometry
-    private Geometry lastCreatedGeom = null;
-    
     public GltfLoader() {
         defaultMaterialAdapters.put("pbrMetallicRoughness", new PBRMetalRoughMaterialAdapter());
     }
@@ -467,7 +464,10 @@ public class GltfLoader implements AssetLoader {
             // Read mesh extras
             mesh = customContentManager.readExtensionAndExtras("primitive", meshObject, mesh);
             Geometry geom = new Geometry(null, mesh);
-            lastCreatedGeom = geom;
+            // Cached data about the geometry needed by TextureTransformExtensionLoader.class
+            addToCache("lastCreatedGeom", 0, geom, 3); // Last created geometry
+            addToCache("lastCreatedGeom", 1, null, 3); // Last processed geometry
+            addToCache("lastCreatedGeom", 2, null, 3); // Last applied transformation matrix (inverted)
 
             Integer materialIndex = getAsInteger(meshObject, "material");
             if (materialIndex == null) {
@@ -1210,11 +1210,6 @@ public class GltfLoader implements AssetLoader {
     public Node getRootNode() {
         return rootNode;
     }
-    
-    // Getter for the last created geometry
-    public Geometry getLastCreatedGeom() {
-        return lastCreatedGeom;
-    }    
 
     private String decodeUri(String uri) {
         try {

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -382,6 +382,7 @@ public class GltfLoader implements AssetLoader {
         for (JsonElement primitive : primitives) {
             JsonObject meshObject = primitive.getAsJsonObject();
             Mesh mesh = new Mesh();
+            addToCache("mesh", 0, mesh, 1);
             Integer mode = getAsInteger(meshObject, "mode");
             mesh.setMode(getMeshMode(mode));
             Integer indices = getAsInteger(meshObject, "indices");
@@ -464,10 +465,6 @@ public class GltfLoader implements AssetLoader {
             // Read mesh extras
             mesh = customContentManager.readExtensionAndExtras("primitive", meshObject, mesh);
             Geometry geom = new Geometry(null, mesh);
-            // Cached data about the geometry needed by TextureTransformExtensionLoader.class
-            addToCache("lastCreatedGeom", 0, geom, 3); // Last created geometry
-            addToCache("lastCreatedGeom", 1, null, 3); // Last processed geometry
-            addToCache("lastCreatedGeom", 2, null, 3); // Last applied transformation matrix (inverted)
 
             Integer materialIndex = getAsInteger(meshObject, "material");
             if (materialIndex == null) {

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -96,6 +96,9 @@ public class GltfLoader implements AssetLoader {
     Map<SkinData, List<Spatial>> skinnedSpatials = new HashMap<>();
     IntMap<SkinBuffers> skinBuffers = new IntMap<>();
 
+    // Last created geometry
+    private Geometry lastCreatedGeom = null;
+    
     public GltfLoader() {
         defaultMaterialAdapters.put("pbrMetallicRoughness", new PBRMetalRoughMaterialAdapter());
     }
@@ -464,6 +467,7 @@ public class GltfLoader implements AssetLoader {
             // Read mesh extras
             mesh = customContentManager.readExtensionAndExtras("primitive", meshObject, mesh);
             Geometry geom = new Geometry(null, mesh);
+            lastCreatedGeom = geom;
 
             Integer materialIndex = getAsInteger(meshObject, "material");
             if (materialIndex == null) {
@@ -1206,6 +1210,11 @@ public class GltfLoader implements AssetLoader {
     public Node getRootNode() {
         return rootNode;
     }
+    
+    // Getter for the last created geometry
+    public Geometry getLastCreatedGeom() {
+        return lastCreatedGeom;
+    }    
 
     private String decodeUri(String uri) {
         try {

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/TextureTransformExtensionLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/TextureTransformExtensionLoader.java
@@ -65,7 +65,7 @@ public class TextureTransformExtensionLoader implements ExtensionLoader {
      * @param transform The matrix containing the scale/rotate/translate transformations
      */    
     private void uvTransform(Mesh mesh, Matrix3f transform) {
-        if (!transform.isIdentity()) { // if m is the identity matrix, there's nothing to do
+        if (!transform.isIdentity()) { // if transform is the identity matrix, there's nothing to do
             VertexBuffer tc = mesh.getBuffer(VertexBuffer.Type.TexCoord);
             if (tc == null) {
                 throw new IllegalStateException("The mesh has no texture coordinates");
@@ -105,8 +105,8 @@ public class TextureTransformExtensionLoader implements ExtensionLoader {
             JsonObject jsonObject = extension.getAsJsonObject();
             if (jsonObject.has("offset")) {
                 JsonArray jsonArray = jsonObject.getAsJsonArray("offset");
-                translation.set(2, 0, jsonArray.get(0).getAsFloat());
-                translation.set(2, 1, jsonArray.get(1).getAsFloat());                    
+                translation.set(0, 2, jsonArray.get(0).getAsFloat());
+                translation.set(1, 2, jsonArray.get(1).getAsFloat());                    
             }
             if (jsonObject.has("rotation")) {
                 float rad = jsonObject.get("rotation").getAsFloat();

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/TextureTransformExtensionLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/TextureTransformExtensionLoader.java
@@ -137,8 +137,12 @@ public class TextureTransformExtensionLoader implements ExtensionLoader {
                 // at this point, we're processing a new mesh or the same mesh as before but for a different UV set
                 if (mesh != meshLast) { // it's a new mesh
                     loader.addToCache("textureTransformData", 0, mesh, 2);
-                    transformMap = new HashMap<>(); // initialize transformMap
-                    loader.addToCache("textureTransformData", 1, transformMap, 2);
+                    if (transformMap == null) {
+                        transformMap = new HashMap<>(); // initialize transformMap
+                        loader.addToCache("textureTransformData", 1, transformMap, 2);
+                    } else {
+                        transformMap.clear(); // reset transformMap
+                    }
                 }
                 transformMap.put(texCoord, transform); // store the transformation matrix applied to this UV set
                 uvTransform(mesh, transform, getVertexBufferType("TEXCOORD_" + texCoord));

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/TextureTransformExtensionLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/TextureTransformExtensionLoader.java
@@ -132,7 +132,7 @@ public class TextureTransformExtensionLoader implements ExtensionLoader {
             }                 
             Matrix3f transform = translation.mult(rotation).mult(scale);
             Mesh meshLast = loader.fetchFromCache("textureTransformData", 0, Mesh.class);
-            Map transformMap = loader.fetchFromCache("textureTransformData", 1, HashMap.class);
+            Map<Integer, Matrix3f> transformMap = loader.fetchFromCache("textureTransformData", 1, HashMap.class);
             if (mesh != meshLast || (transformMap != null && transformMap.get(texCoord) == null)) {
                 // at this point, we're processing a new mesh or the same mesh as before but for a different UV set
                 if (mesh != meshLast) { // it's a new mesh
@@ -150,7 +150,7 @@ public class TextureTransformExtensionLoader implements ExtensionLoader {
             }
             else {
                 // at this point, we're processing the same mesh as before for an already transformed UV set
-                Matrix3f transformLast = (Matrix3f) transformMap.get(texCoord);
+                Matrix3f transformLast = transformMap.get(texCoord);
                 if (!transform.equals(transformLast)) {
                     logger.log(Level.WARNING, "KHR_texture_transform extension: use of different texture transforms for the same mesh's UVs is not supported, the loaded scene result will be unexpected.");
                 }

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/TextureTransformExtensionLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/TextureTransformExtensionLoader.java
@@ -89,7 +89,7 @@ public class TextureTransformExtensionLoader implements ExtensionLoader {
                 fb.put(v.getX()).put(v.getY());
             }
             fb.clear();
-            tc.updateData(fb);         
+            tc.updateData(fb);   
         }
     }
     
@@ -137,7 +137,7 @@ public class TextureTransformExtensionLoader implements ExtensionLoader {
             }
             else {
                 Matrix3f transformLast = loader.fetchFromCache("textureTransformData", 1, Matrix3f.class);
-                if (!transform.toString().equals(transformLast.toString())) {
+                if (!transform.equals(transformLast)) {
                     logger.log(Level.WARNING, "KHR_texture_transform extension: use of different texture transforms for the same mesh is not supported, the loaded scene result will be unexpected.");
                 }
             }

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/TextureTransformExtensionLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/TextureTransformExtensionLoader.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2009-2022 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.scene.plugins.gltf;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.jme3.asset.AssetLoadException;
+import com.jme3.math.Matrix3f;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Mesh;
+import com.jme3.scene.VertexBuffer;
+import com.jme3.texture.Texture2D;
+import java.io.IOException;
+import java.nio.FloatBuffer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Extension loader for KHR_texture_transform, which allows for
+ * UV coordinates to be scaled/rotated/translated based on 
+ * transformation properties from textures in the glTF model.
+ *
+ * See spec at https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_transform
+ *
+ * @author manuelrmo - Created on 11/20/2022
+ */
+public class TextureTransformExtensionLoader implements ExtensionLoader {
+    
+    private final static Logger logger = Logger.getLogger(TextureTransformExtensionLoader.class.getName());
+    
+    private Geometry geomLast = null; // Last geometry created by the GltfLoader.class object
+    private Matrix3f mInvLast = null; // Last transformation matrix (inverted) that was applied
+        
+    /**
+     * Scale/rotate/translate UV coordinates based on a transformation matrix.
+     * Code adapted from scaleTextureCoordinates(Vector2f) in jme3-core/src/main/java/com/jme3/scene/Mesh.java
+     * @param mesh The mesh holding the UV coordinates
+     * @param m The matrix containing the scale/rotate/translate transformations
+     */    
+    private void uvTransform(Mesh mesh, Matrix3f m) {
+        VertexBuffer tc = mesh.getBuffer(VertexBuffer.Type.TexCoord);
+        if (tc == null) {
+            throw new IllegalStateException("The mesh has no texture coordinates");
+        }
+        if (tc.getFormat() != VertexBuffer.Format.Float) {
+            throw new UnsupportedOperationException("Only float texture coord format is supported");
+        }
+        if (tc.getNumComponents() != 2) {
+            throw new UnsupportedOperationException("Only 2D texture coords are supported");
+        }
+        FloatBuffer fb = (FloatBuffer) tc.getData();
+        fb.clear();
+        for (int i = 0; i < fb.limit() / 2; i++) {
+            float x = fb.get();
+            float y = fb.get();
+            fb.position(fb.position() - 2);
+            Vector3f v = m.mult(new Vector3f(x, y, 1));
+            fb.put(v.getX()).put(v.getY());
+        }
+        fb.clear();
+        tc.updateData(fb);        
+    }
+    
+    @Override
+    public Object handleExtension(GltfLoader loader, String parentName, JsonElement parent, JsonElement extension, Object input) throws IOException {
+        if (input instanceof Texture2D) {
+            Geometry geom = loader.getLastCreatedGeom();
+            if (geom != null) {
+                Matrix3f t = new Matrix3f();
+                Matrix3f r = new Matrix3f();
+                Matrix3f s = new Matrix3f();
+                JsonObject jsonObject = extension.getAsJsonObject();
+                if (jsonObject.has("offset")) {
+                    JsonArray jsonArray = jsonObject.getAsJsonArray("offset");
+                    t.set(2, 0, jsonArray.get(0).getAsFloat());
+                    t.set(2, 1, jsonArray.get(1).getAsFloat());                    
+                }
+                if (jsonObject.has("rotation")) {
+                    float rad = jsonObject.get("rotation").getAsFloat();
+                    r.set(0, 0, (float) Math.cos(rad));
+                    r.set(0, 1, (float) Math.sin(rad));
+                    r.set(1, 0, (float) -Math.sin(rad));
+                    r.set(1, 1, (float) Math.cos(rad));
+                }                
+                if (jsonObject.has("scale")) {
+                    JsonArray jsonArray = jsonObject.getAsJsonArray("scale");
+                    s.set(0, 0, jsonArray.get(0).getAsFloat());
+                    s.set(1, 1, jsonArray.get(1).getAsFloat());
+                }     
+                if (jsonObject.has("texCoord")) {
+                    logger.log(Level.WARNING, "KHR_texture_transform extension: the texCoord property is not supported");                
+                }                 
+                Matrix3f m = t.mult(r).mult(s);
+                if (geom != geomLast) {
+                    geomLast = geom;
+                    mInvLast = m.invert();
+                    uvTransform(geom.getMesh(), m);
+                    logger.log(Level.FINE, "KHR_texture_transform extension successfully applied"); 
+                }
+                else {
+                    if (!m.mult(mInvLast).isIdentity()) {
+                        logger.log(Level.WARNING, "KHR_texture_transform extension: use of different texture transforms for the same geometry is not supported");
+                    }
+                }
+                return input;
+            }
+            else {
+                throw new AssetLoadException("KHR_texture_transform extension applied to a null geometry");
+            }
+        } 
+        else {
+            throw new AssetLoadException("KHR_texture_transform extension added on an unsupported element");
+        }        
+    }
+}


### PR DESCRIPTION
Implementation of a glTF extension loader for KHR_texture_transform, which allows for UV coordinates to be scaled/rotated/translated based on transformation properties from textures in the glTF model.

The extension will avoid the following warning messages:

Extension KHR_texture_transform is not supported, please provide your own implementation in the GltfModelKey
Extension KHR_texture_transform is mandatory for this file, the loaded scene result will be unexpected.
Could not find loader for extension KHR_texture_transform