### PR TITLE
Fix #1871 (vertex colors not loaded in gltf models)

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -1282,8 +1282,7 @@ public class GltfLoader implements AssetLoader {
         public VertexBuffer populate(Integer bufferViewIndex, int componentType, String type, int count,
                 int byteOffset, boolean normalized) throws IOException {
             if (bufferType == null) {
-                logger.log(Level.WARNING,
-                        "could not assign data to any VertexBuffer type for buffer view " + bufferViewIndex);
+                logger.log(Level.WARNING, "could not assign data to any VertexBuffer type for buffer view {0}", bufferViewIndex);
                 return null;
             }
 

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
@@ -389,8 +389,8 @@ public class GltfUtils {
                 b = stream.readByte();
                 return Math.max(b / 127f, -1f);
             case UnsignedByte:
-                b = stream.readByte();
-                return b / 255f;
+                s = stream.readUnsignedByte();
+                return s / 255f;
             case Short:
                 s = stream.readShort();
                 return Math.max(s / 32767f, -1f);

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
@@ -382,21 +382,20 @@ public class GltfUtils {
         // 5121 (UNSIGNED_BYTE)      f = c / 255.0               c = round(f * 255.0)
         // 5122 (SHORT)              f = max(c / 32767.0, -1.0)  c = round(f * 32767.0)
         // 5123 (UNSIGNED_SHORT)     f = c / 65535.0             c = round(f * 65535.0)
-        byte b;
-        int s;
+        int c;
         switch (format) {
             case Byte:
-                b = stream.readByte();
-                return Math.max(b / 127f, -1f);
+                c = stream.readByte();
+                return Math.max(c / 127f, -1f);
             case UnsignedByte:
-                s = stream.readUnsignedByte();
-                return s / 255f;
+                c = stream.readUnsignedByte();
+                return c / 255f;
             case Short:
-                s = stream.readShort();
-                return Math.max(s / 32767f, -1f);
+                c = stream.readShort();
+                return Math.max(c / 32767f, -1f);
             case UnsignedShort:
-                s = stream.readUnsignedShort();
-                return s / 65535f;
+                c = stream.readUnsignedShort();
+                return c / 65535f;
             default:
                 //we have a regular float
                 return stream.readFloat();

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
@@ -38,7 +38,6 @@ import com.jme3.math.*;
 import com.jme3.scene.*;
 import com.jme3.texture.Texture;
 import com.jme3.util.*;
-
 import java.io.*;
 import java.nio.*;
 import java.util.*;
@@ -384,6 +383,7 @@ public class GltfUtils {
         // 5122 (SHORT)              f = max(c / 32767.0, -1.0)  c = round(f * 32767.0)
         // 5123 (UNSIGNED_SHORT)     f = c / 65535.0             c = round(f * 65535.0)
         byte b;
+        int s;
         switch (format) {
             case Byte:
                 b = stream.readByte();
@@ -392,11 +392,11 @@ public class GltfUtils {
                 b = stream.readByte();
                 return b / 255f;
             case Short:
-                b = stream.readByte();
-                return Math.max(b / 32767f, -1f);
+                s = stream.readShort();
+                return Math.max(s / 32767f, -1f);
             case UnsignedShort:
-                b = stream.readByte();
-                return b / 65535f;
+                s = stream.readUnsignedShort();
+                return s / 65535f;
             default:
                 //we have a regular float
                 return stream.readFloat();


### PR DESCRIPTION
Fixes #1871

With @Ali-RS doing the heavy lifting, this was very trivial to figure out. We just read the wrong amount of bytes when reading as float from arrays of short. Tested with the Duck and the Girl supplied in the issue. Both still work. Only the Girl has these normalized ushort float buffers though.