### PR TITLE
Fix #1412 (GltfLoader does not support AO packed in MetallicRoughnessMap)

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -635,6 +635,7 @@ public class GltfLoader implements AssetLoader {
             setDefaultParams(adapter.getMaterial());
         }
 
+        Integer metallicRoughnessIndex = null;
         if (pbrMat != null) {
             adapter.setParam("baseColorFactor", getAsColor(pbrMat, "baseColorFactor", ColorRGBA.White));
             adapter.setParam("metallicFactor", getAsFloat(pbrMat, "metallicFactor", 1f));
@@ -642,6 +643,8 @@ public class GltfLoader implements AssetLoader {
             adapter.setParam("baseColorTexture", readTexture(pbrMat.getAsJsonObject("baseColorTexture")));
             adapter.setParam("metallicRoughnessTexture",
                     readTexture(pbrMat.getAsJsonObject("metallicRoughnessTexture")));
+            JsonObject metallicRoughnessJson = pbrMat.getAsJsonObject("metallicRoughnessTexture");
+            metallicRoughnessIndex = metallicRoughnessJson != null ? getAsInteger(metallicRoughnessJson, "index") : null;            
         }
 
         adapter.getMaterial().setName(getAsString(matData, "name"));
@@ -657,7 +660,13 @@ public class GltfLoader implements AssetLoader {
         if (normal != null) {
             useNormalsFlag = true;
         }
-        adapter.setParam("occlusionTexture", readTexture(matData.getAsJsonObject("occlusionTexture")));
+        JsonObject occlusionJson = matData.getAsJsonObject("occlusionTexture");
+        Integer occlusionIndex = occlusionJson != null ? getAsInteger(occlusionJson, "index") : null;
+        if (occlusionIndex != null && occlusionIndex.equals(metallicRoughnessIndex)) {
+            adapter.getMaterial().setBoolean("AoPackedInMRMap", true);
+        } else {        
+            adapter.setParam("occlusionTexture", readTexture(matData.getAsJsonObject("occlusionTexture")));
+        }
         adapter.setParam("emissiveTexture", readTexture(matData.getAsJsonObject("emissiveTexture")));
 
         return adapter.getMaterial();


### PR DESCRIPTION
This is an update for the glTF loader to be able to detect that an occlusion texture is packed in the metallic-roughness texture, so the loader can enable the `AoPackedInMRMap` parameter from the material and avoid double-loading the same texture.

The update consists of few lines added to `GltfLoader` that retrieve the `index` (if any) of each texture from the glTF model and compare them: if they exist and are the same, `AoPackedInMRMap` will be enabled and no texture will be loaded for occlusion. 

See for example the WaterBottle test model:
https://github.com/KhronosGroup/glTF-Sample-Models/blob/master/2.0/WaterBottle/glTF/WaterBottle.gltf

```
  "materials": [
    {
      "pbrMetallicRoughness": {
        "baseColorTexture": {
          "index": 0
        },
        "metallicRoughnessTexture": {
          "index": 1
        }
      },
      "normalTexture": {
        "index": 2
      },
      "occlusionTexture": {
        "index": 1
      },
      "emissiveFactor": [
        1.0,
        1.0,
        1.0
      ],
      "emissiveTexture": {
        "index": 3
      },
      "name": "BottleMat"
    }
  ],
```

In the glTF code, when AO map is packed in MR map, the `index` value for `"occlusionTexture"` is the same as the `index` value for `"metallicRoughnessTexture",` which means that they refer to the same texture image. Note that the clauses `"pbrMetallicRoughness"` and `"occlusionTexture"` can appear in any order.

This PR resolves Issue #1412.