### PR TITLE
BlendableAction: Fix JavaDoc for setMaxTransitionWeight & replace assert with IllegalArgumentException

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendableAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BlendableAction.java
@@ -114,10 +114,13 @@ public abstract class BlendableAction extends Action {
     }
 
     /**
-     * @param maxTransitionWeight The max transition weight. Must be &gt;0 and &lt;1 (default=1)
+     * @param maxTransitionWeight The max transition weight. Must be &gt;=0 and &lt;=1 (default=1)
+     * @throws IllegalArgumentException If maxTransitionWeight is not between 0 and 1.
      */
     public void setMaxTransitionWeight(double maxTransitionWeight) {
-        assert maxTransitionWeight >= 0 && maxTransitionWeight <= 1;
+        if (maxTransitionWeight < 0.0 || maxTransitionWeight > 1.0) {
+            throw new IllegalArgumentException("maxTransitionWeight must be between 0 and 1");
+        }
 
         this.maxTransitionWeight = maxTransitionWeight;
     }


### PR DESCRIPTION
I happened to spot a small mistake in the following commit: https://github.com/jMonkeyEngine/jmonkeyengine/commit/9d5eeee8923c27495c948be7e7c91276e739da51
Based on the assertion in the method and the fact that the default value is 1, it's clear that the 0 and 1 bounds are inclusive.