### PR TITLE
Fix #1882 (J3MLoader always generates mips ignoring MinFilter)

### DIFF
--- a/jme3-core/src/plugins/java/com/jme3/material/plugins/J3MLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/material/plugins/J3MLoader.java
@@ -222,6 +222,7 @@ public class J3MLoader implements AssetLoader {
         // If there is only one token on the value, it must be the path to the texture.
         if (textureValues.size() == 1) {
             textureKey = new TextureKey(textureValues.get(0), false);
+            textureKey.setGenerateMips(true);
         } else {
             String texturePath = value.trim();
 
@@ -255,6 +256,8 @@ public class J3MLoader implements AssetLoader {
             if (textureKey == null) {
                 textureKey = new TextureKey(textureValues.get(textureValues.size() - 1), false);
             }
+
+            textureKey.setGenerateMips(true);
 
             // Apply texture options to the texture key
             if (!textureOptionValues.isEmpty()) {

--- a/jme3-core/src/plugins/java/com/jme3/material/plugins/J3MLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/material/plugins/J3MLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-core/src/plugins/java/com/jme3/material/plugins/J3MLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/material/plugins/J3MLoader.java
@@ -276,8 +276,6 @@ public class J3MLoader implements AssetLoader {
                 break;
         }
 
-        textureKey.setGenerateMips(true);
-
         Texture texture;
 
         try {
@@ -861,6 +859,13 @@ public class J3MLoader implements AssetLoader {
          * Applies a {@link com.jme3.texture.Texture.MinFilter} to the texture.
          */
         Min {
+
+            @Override
+            public void applyToTextureKey(final String option, final TextureKey textureKey) {
+                Texture.MinFilter minFilter = Texture.MinFilter.valueOf(option);
+                textureKey.setGenerateMips(minFilter.usesMipMapLevels());
+            }
+
             @Override
             public void applyToTexture(final String option, final Texture texture) {
                 texture.setMinFilter(Texture.MinFilter.valueOf(option));

--- a/jme3-core/src/test/java/com/jme3/material/plugins/J3MLoaderTest.java
+++ b/jme3-core/src/test/java/com/jme3/material/plugins/J3MLoaderTest.java
@@ -87,8 +87,8 @@ public class J3MLoaderTest {
         final Texture textureOldStyle = Mockito.mock(Texture.class);
         final Texture textureOldStyleUsingQuotes = Mockito.mock(Texture.class);
 
-        final TextureKey textureKeyUsingQuotes = setupMockForTexture("OldStyleUsingQuotes", "old style using quotes/texture.png", true, false, textureOldStyleUsingQuotes);
-        final TextureKey textureKeyOldStyle = setupMockForTexture("OldStyle", "old style/texture.png", true, false, textureOldStyle);
+        final TextureKey textureKeyUsingQuotes = setupMockForTexture("OldStyleUsingQuotes", "old style using quotes/texture.png", true, true, textureOldStyleUsingQuotes);
+        final TextureKey textureKeyOldStyle = setupMockForTexture("OldStyle", "old style/texture.png", true, true, textureOldStyle);
 
         j3MLoader.load(assetInfo);
 
@@ -111,14 +111,14 @@ public class J3MLoaderTest {
         final Texture textureCombined = Mockito.mock(Texture.class);
         final Texture textureLooksLikeOldStyle = Mockito.mock(Texture.class);
 
-        final TextureKey textureKeyNoParameters = setupMockForTexture("Empty", "empty.png", false, false, textureNoParameters);
-        final TextureKey textureKeyFlip = setupMockForTexture("Flip", "flip.png", true, false, textureFlip);
-        setupMockForTexture("Repeat", "repeat.png", false, false, textureRepeat);
-        setupMockForTexture("RepeatAxis", "repeat-axis.png", false, false, textureRepeatAxis);
+        final TextureKey textureKeyNoParameters = setupMockForTexture("Empty", "empty.png", false, true, textureNoParameters);
+        final TextureKey textureKeyFlip = setupMockForTexture("Flip", "flip.png", true, true, textureFlip);
+        setupMockForTexture("Repeat", "repeat.png", false, true, textureRepeat);
+        setupMockForTexture("RepeatAxis", "repeat-axis.png", false, true, textureRepeatAxis);
         setupMockForTexture("Min", "min.png", false, true, textureMin);
-        setupMockForTexture("Mag", "mag.png", false, false, textureMag);
+        setupMockForTexture("Mag", "mag.png", false, true, textureMag);
         setupMockForTexture("Combined", "combined.png", true, false, textureCombined);
-        setupMockForTexture("LooksLikeOldStyle", "oldstyle.png", true, false, textureLooksLikeOldStyle);
+        setupMockForTexture("LooksLikeOldStyle", "oldstyle.png", true, true, textureLooksLikeOldStyle);
 
         j3MLoader.load(assetInfo);
 

--- a/jme3-core/src/test/java/com/jme3/material/plugins/J3MLoaderTest.java
+++ b/jme3-core/src/test/java/com/jme3/material/plugins/J3MLoaderTest.java
@@ -87,8 +87,8 @@ public class J3MLoaderTest {
         final Texture textureOldStyle = Mockito.mock(Texture.class);
         final Texture textureOldStyleUsingQuotes = Mockito.mock(Texture.class);
 
-        final TextureKey textureKeyUsingQuotes = setupMockForTexture("OldStyleUsingQuotes", "old style using quotes/texture.png", true, textureOldStyleUsingQuotes);
-        final TextureKey textureKeyOldStyle = setupMockForTexture("OldStyle", "old style/texture.png", true, textureOldStyle);
+        final TextureKey textureKeyUsingQuotes = setupMockForTexture("OldStyleUsingQuotes", "old style using quotes/texture.png", true, false, textureOldStyleUsingQuotes);
+        final TextureKey textureKeyOldStyle = setupMockForTexture("OldStyle", "old style/texture.png", true, false, textureOldStyle);
 
         j3MLoader.load(assetInfo);
 
@@ -111,14 +111,14 @@ public class J3MLoaderTest {
         final Texture textureCombined = Mockito.mock(Texture.class);
         final Texture textureLooksLikeOldStyle = Mockito.mock(Texture.class);
 
-        final TextureKey textureKeyNoParameters = setupMockForTexture("Empty", "empty.png", false, textureNoParameters);
-        final TextureKey textureKeyFlip = setupMockForTexture("Flip", "flip.png", true, textureFlip);
-        setupMockForTexture("Repeat", "repeat.png", false, textureRepeat);
-        setupMockForTexture("RepeatAxis", "repeat-axis.png", false, textureRepeatAxis);
-        setupMockForTexture("Min", "min.png", false, textureMin);
-        setupMockForTexture("Mag", "mag.png", false, textureMag);
-        setupMockForTexture("Combined", "combined.png", true, textureCombined);
-        setupMockForTexture("LooksLikeOldStyle", "oldstyle.png", true, textureLooksLikeOldStyle);
+        final TextureKey textureKeyNoParameters = setupMockForTexture("Empty", "empty.png", false, false, textureNoParameters);
+        final TextureKey textureKeyFlip = setupMockForTexture("Flip", "flip.png", true, false, textureFlip);
+        setupMockForTexture("Repeat", "repeat.png", false, false, textureRepeat);
+        setupMockForTexture("RepeatAxis", "repeat-axis.png", false, false, textureRepeatAxis);
+        setupMockForTexture("Min", "min.png", false, true, textureMin);
+        setupMockForTexture("Mag", "mag.png", false, false, textureMag);
+        setupMockForTexture("Combined", "combined.png", true, false, textureCombined);
+        setupMockForTexture("LooksLikeOldStyle", "oldstyle.png", true, false, textureLooksLikeOldStyle);
 
         j3MLoader.load(assetInfo);
 
@@ -135,11 +135,11 @@ public class J3MLoaderTest {
         verify(textureCombined).setWrap(Texture.WrapMode.Repeat);
     }
 
-    private TextureKey setupMockForTexture(final String paramName, final String path, final boolean flipY, final Texture texture) {
+    private TextureKey setupMockForTexture(final String paramName, final String path, final boolean flipY, boolean generateMips, final Texture texture) {
         when(materialDef.getMaterialParam(paramName)).thenReturn(new MatParamTexture(VarType.Texture2D, paramName, texture, null));
 
         final TextureKey textureKey = new TextureKey(path, flipY);
-        textureKey.setGenerateMips(true);
+        textureKey.setGenerateMips(generateMips);
 
         when(assetManager.loadTexture(textureKey)).thenReturn(texture);
 

--- a/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MOutputCapsule.java
+++ b/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MOutputCapsule.java
@@ -140,11 +140,7 @@ public class J3MOutputCapsule implements OutputCapsule {
             ret.append(formatWrapMode(tex, Texture.WrapAxis.R));
 
             //Min and Mag filter
-            Texture.MinFilter def = Texture.MinFilter.BilinearNoMipMaps;
-            if (tex.getImage().hasMipmaps() || (key != null && key.isGenerateMips())) {
-                def = Texture.MinFilter.Trilinear;
-            }
-            if (tex.getMinFilter() != def) {
+            if (tex.getMinFilter() != Texture.MinFilter.Trilinear) {
                 ret.append("Min").append(tex.getMinFilter().name()).append(" ");
             }
 

--- a/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MOutputCapsule.java
+++ b/jme3-plugins/src/main/java/com/jme3/material/plugin/export/material/J3MOutputCapsule.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2022 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.material.plugin.export.material;
 
 import com.jme3.asset.TextureKey;

--- a/jme3-plugins/src/test/java/com/jme3/material/plugin/TestMaterialWrite.java
+++ b/jme3-plugins/src/test/java/com/jme3/material/plugin/TestMaterialWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2016 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-plugins/src/test/java/com/jme3/material/plugin/TestMaterialWrite.java
+++ b/jme3-plugins/src/test/java/com/jme3/material/plugin/TestMaterialWrite.java
@@ -34,6 +34,7 @@ package com.jme3.material.plugin;
 import com.jme3.asset.AssetInfo;
 import com.jme3.asset.AssetKey;
 import com.jme3.asset.AssetManager;
+import com.jme3.asset.TextureKey;
 import com.jme3.material.Material;
 import com.jme3.material.RenderState;
 import com.jme3.material.plugin.export.material.J3MExporter;
@@ -76,7 +77,7 @@ public class TestMaterialWrite {
 
         mat.setFloat("Shininess", 2.5f);
 
-        Texture tex = assetManager.loadTexture("Common/Textures/MissingTexture.png");
+        Texture tex = assetManager.loadTexture(new TextureKey("Common/Textures/MissingTexture.png", true));
         tex.setMagFilter(Texture.MagFilter.Nearest);
         tex.setMinFilter(Texture.MinFilter.BilinearNoMipMaps);
         tex.setWrap(Texture.WrapAxis.S, Texture.WrapMode.Repeat);


### PR DESCRIPTION
Updated J3MLoader to read texture mips generation flag from MinFilter. If no min filter is specified, texture will use the `BilinearNoMipMaps` by default.

Fixes #1882