### PR TITLE
Fix #1883 (Image class wrongly setting GL mips flags inside the constructor)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/texture/Image.java
+++ b/jme3-core/src/main/java/com/jme3/texture/Image.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2022 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -807,11 +807,13 @@ public class Image extends NativeObject implements Savable /*, Cloneable*/ {
 
         this();
 
-        if (mipMapSizes != null && mipMapSizes.length <= 1) {
-            mipMapSizes = null;
-        } else {
-            needGeneratedMips = false;
-            mipsWereGenerated = true;
+        if (mipMapSizes != null) {
+            if (mipMapSizes.length <= 1) {
+                mipMapSizes = null;
+            } else {
+                needGeneratedMips = false;
+                mipsWereGenerated = true;
+            }
         }
 
         setFormat(format);


### PR DESCRIPTION
If we pass null for `int[] mipMapSizes` argument in the second constructor, this will wrongly set `mipsWereGenerated` flag to true. Fixed it to behave like the first constructor.

Fixes #1883