### PR TITLE
When in VR attach the debug scene to the two eye's scenes. Fix #1795 

### DIFF
--- a/jme3-jbullet/build.gradle
+++ b/jme3-jbullet/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     api 'javax.vecmath:vecmath:1.5.2'
     api project(':jme3-core')
     api project(':jme3-terrain')
+    compileOnly project(':jme3-vr') //is selectively used if on classpath
     testRuntimeOnly project(':jme3-desktop')
     testRuntimeOnly project(':jme3-testdata')
 }

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/debug/BulletDebugAppState.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/debug/BulletDebugAppState.java
@@ -174,6 +174,8 @@ public class BulletDebugAppState extends AbstractAppState {
         physicsDebugRootNode.setCullHint(Spatial.CullHint.Never);
 
         if (isVr()) {
+            /* This is a less good solution than the non-vr version (as the debug shapes can be obscured by the regular
+            * geometry), however it is the best possible as VR does not currently support multiple viewports per eye */
             VRAppState vrAppState = stateManager.getState(VRAppState.ID, VRAppState.class);
             vrAppState.getLeftViewPort().attachScene(physicsDebugRootNode);
             vrAppState.getRightViewPort().attachScene(physicsDebugRootNode);

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/debug/BulletDebugAppState.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/debug/BulletDebugAppState.java
@@ -435,7 +435,7 @@ public class BulletDebugAppState extends AbstractAppState {
         public boolean displayObject(Object obj);
     }
 
-    private boolean isVr(){
+    private boolean isVr() {
         if (isVr == null) {
             try {
                 VRAppState vrAppState = app.getStateManager().getState(VRAppState.ID, VRAppState.class);

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/debug/BulletDebugAppState.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/debug/BulletDebugAppState.java
@@ -440,7 +440,7 @@ public class BulletDebugAppState extends AbstractAppState {
             try {
                 VRAppState vrAppState = app.getStateManager().getState(VRAppState.ID, VRAppState.class);
                 isVr = vrAppState != null && !vrAppState.DISABLE_VR;
-            } catch(NoClassDefFoundError e) {
+            } catch (NoClassDefFoundError e) {
                 //Vr isn't even on the classpath
                 isVr = false;
             }

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/debug/BulletDebugAppState.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/debug/BulletDebugAppState.java
@@ -32,6 +32,7 @@
 package com.jme3.bullet.debug;
 
 import com.jme3.app.Application;
+import com.jme3.app.VRAppState;
 import com.jme3.app.state.AbstractAppState;
 import com.jme3.app.state.AppStateManager;
 import com.jme3.asset.AssetManager;
@@ -67,6 +68,12 @@ public class BulletDebugAppState extends AbstractAppState {
      * message logger for this class
      */
     protected static final Logger logger = Logger.getLogger(BulletDebugAppState.class.getName());
+
+    /**
+     * caches the virtual reality state (null means not yet determined)
+     */
+    private Boolean isVr = null;
+
     /**
      * limit which objects are visualized, or null to visualize all objects
      */
@@ -165,9 +172,16 @@ public class BulletDebugAppState extends AbstractAppState {
         this.assetManager = app.getAssetManager();
         setupMaterials(app);
         physicsDebugRootNode.setCullHint(Spatial.CullHint.Never);
-        viewPort = rm.createMainView("Physics Debug Overlay", app.getCamera());
-        viewPort.setClearFlags(false, true, false);
-        viewPort.attachScene(physicsDebugRootNode);
+
+        if (isVr()){
+            VRAppState vrAppState = stateManager.getState(VRAppState.ID, VRAppState.class);
+            vrAppState.getLeftViewPort().attachScene(physicsDebugRootNode);
+            vrAppState.getRightViewPort().attachScene(physicsDebugRootNode);
+        }else{
+            viewPort = rm.createMainView("Physics Debug Overlay", app.getCamera());
+            viewPort.setClearFlags(false, true, false);
+            viewPort.attachScene(physicsDebugRootNode);
+        }
     }
 
     /**
@@ -178,7 +192,14 @@ public class BulletDebugAppState extends AbstractAppState {
      */
     @Override
     public void cleanup() {
-        rm.removeMainView(viewPort);
+        if (isVr()){
+            VRAppState vrAppState = app.getStateManager().getState(VRAppState.ID, VRAppState.class);
+            vrAppState.getLeftViewPort().detachScene(physicsDebugRootNode);
+            vrAppState.getRightViewPort().detachScene(physicsDebugRootNode);
+        }else{
+            rm.removeMainView(viewPort);
+        }
+
         super.cleanup();
     }
 
@@ -412,5 +433,18 @@ public class BulletDebugAppState extends AbstractAppState {
          * @return return true if the object should be displayed, false if not
          */
         public boolean displayObject(Object obj);
+    }
+
+    private boolean isVr(){
+        if (isVr == null){
+            try{
+                VRAppState vrAppState = app.getStateManager().getState(VRAppState.ID, VRAppState.class);
+                isVr = vrAppState != null && !vrAppState.DISABLE_VR;
+            } catch(NoClassDefFoundError e){
+                //Vr isn't even on the classpath
+                isVr = false;
+            }
+        }
+        return isVr;
     }
 }

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/debug/BulletDebugAppState.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/debug/BulletDebugAppState.java
@@ -173,11 +173,11 @@ public class BulletDebugAppState extends AbstractAppState {
         setupMaterials(app);
         physicsDebugRootNode.setCullHint(Spatial.CullHint.Never);
 
-        if (isVr()){
+        if (isVr()) {
             VRAppState vrAppState = stateManager.getState(VRAppState.ID, VRAppState.class);
             vrAppState.getLeftViewPort().attachScene(physicsDebugRootNode);
             vrAppState.getRightViewPort().attachScene(physicsDebugRootNode);
-        }else{
+        } else {
             viewPort = rm.createMainView("Physics Debug Overlay", app.getCamera());
             viewPort.setClearFlags(false, true, false);
             viewPort.attachScene(physicsDebugRootNode);
@@ -192,11 +192,11 @@ public class BulletDebugAppState extends AbstractAppState {
      */
     @Override
     public void cleanup() {
-        if (isVr()){
+        if (isVr()) {
             VRAppState vrAppState = app.getStateManager().getState(VRAppState.ID, VRAppState.class);
             vrAppState.getLeftViewPort().detachScene(physicsDebugRootNode);
             vrAppState.getRightViewPort().detachScene(physicsDebugRootNode);
-        }else{
+        } else {
             rm.removeMainView(viewPort);
         }
 
@@ -436,11 +436,11 @@ public class BulletDebugAppState extends AbstractAppState {
     }
 
     private boolean isVr(){
-        if (isVr == null){
-            try{
+        if (isVr == null) {
+            try {
                 VRAppState vrAppState = app.getStateManager().getState(VRAppState.ID, VRAppState.class);
                 isVr = vrAppState != null && !vrAppState.DISABLE_VR;
-            } catch(NoClassDefFoundError e){
+            } catch(NoClassDefFoundError e) {
                 //Vr isn't even on the classpath
                 isVr = false;
             }

--- a/jme3-vr/src/main/java/com/jme3/app/VRAppState.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VRAppState.java
@@ -74,6 +74,7 @@ import java.util.logging.Logger;
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  */
 public class VRAppState extends AbstractAppState {
+    public static final String ID = "VRAppState";
     private static final Logger logger = Logger.getLogger(VRAppState.class.getName());
 
     /**
@@ -105,7 +106,7 @@ public class VRAppState extends AbstractAppState {
      * @param environment the {@link VREnvironment VR environment} that this app state is using.
      */
     public VRAppState(VREnvironment environment) {
-        super();
+        super(ID);
 
         this.environment = environment;
 


### PR DESCRIPTION
This ensures they show up correctly, as the VRAppState uses totally separate cameras and viewports to the normal JME flow

Resolves issue [#1795](https://github.com/jMonkeyEngine/jmonkeyengine/issues/1795) 