### PR TITLE
JmeContext:  add a getSystemListener() method

### DIFF
--- a/jme3-android/src/main/java/com/jme3/system/android/OGLESContext.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/OGLESContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -255,6 +255,16 @@ public class OGLESContext implements JmeContext, GLSurfaceView.Renderer, SoftTex
         } else {
             minFrameDuration = 0;
         }
+    }
+
+    /**
+     * Accesses the listener that receives events related to this context.
+     *
+     * @return the pre-existing instance
+     */
+    @Override
+    public SystemListener getSystemListener() {
+        return listener;
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/system/JmeContext.java
+++ b/jme3-core/src/main/java/com/jme3/system/JmeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -91,6 +91,13 @@ public interface JmeContext {
      * for the changes to be applied.
      */
     public void setSettings(AppSettings settings);
+
+    /**
+     * Accesses the listener that receives events related to this context.
+     *
+     * @return the pre-existing instance
+     */
+    public SystemListener getSystemListener();
 
     /**
      * Sets the listener that will receive events relating to context

--- a/jme3-core/src/main/java/com/jme3/system/NullContext.java
+++ b/jme3-core/src/main/java/com/jme3/system/NullContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -62,6 +62,16 @@ public class NullContext implements JmeContext, Runnable {
     @Override
     public Type getType() {
         return Type.Headless;
+    }
+
+    /**
+     * Accesses the listener that receives events related to this context.
+     *
+     * @return the pre-existing instance
+     */
+    @Override
+    public SystemListener getSystemListener() {
+        return listener;
     }
 
     @Override

--- a/jme3-desktop/src/main/java/com/jme3/system/AWTContext.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/AWTContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -148,6 +148,16 @@ public class AWTContext implements JmeContext {
       this.settings.setRenderer(AppSettings.LWJGL_OPENGL32);
       this.backgroundContext.setSettings(settings);
   }
+
+    /**
+     * Accesses the listener that receives events related to this context.
+    *
+     * @return the pre-existing instance
+     */
+    @Override
+    public SystemListener getSystemListener() {
+        return backgroundContext.getSystemListener();
+    }
 
   @Override
   public void setSystemListener(final SystemListener listener) {

--- a/jme3-desktop/src/main/java/com/jme3/system/awt/AwtPanelsContext.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/awt/AwtPanelsContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -118,6 +118,16 @@ public class AwtPanelsContext implements JmeContext {
     @Override
     public Type getType() {
         return Type.OffscreenSurface;
+    }
+
+    /**
+     * Accesses the listener that receives events related to this context.
+     *
+     * @return the pre-existing instance
+     */
+    @Override
+    public SystemListener getSystemListener() {
+        return listener;
     }
 
     @Override

--- a/jme3-ios/src/main/java/com/jme3/system/ios/IGLESContext.java
+++ b/jme3-ios/src/main/java/com/jme3/system/ios/IGLESContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -81,6 +81,17 @@ public class IGLESContext implements JmeContext {
         if (input != null) {
             input.loadSettings(settings);
         }
+    }
+
+    /**
+     * Accesses the listener that receives events related to this context.
+     *
+     * @return the pre-existing instance
+     */
+    @Override
+    public SystemListener getSystemListener() {
+        logger.log(Level.FINE, "IGLESContext getSystemListener");
+        return listener;
     }
 
     @Override

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -90,6 +90,16 @@ public abstract class LwjglContext implements JmeContext {
     
     protected LwjglPlatform clPlatform;
     protected com.jme3.opencl.lwjgl.LwjglContext clContext;
+
+    /**
+     * Accesses the listener that receives events related to this context.
+     *
+     * @return the pre-existing instance
+     */
+    @Override
+    public SystemListener getSystemListener() {
+        return listener;
+    }
 
     @Override
     public void setSystemListener(SystemListener listener) {

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -132,6 +132,16 @@ public abstract class LwjglContext implements JmeContext {
     protected SystemListener listener;
     
     protected com.jme3.opencl.lwjgl.LwjglContext clContext;
+
+    /**
+     * Accesses the listener that receives events related to this context.
+     *
+     * @return the pre-existing instance
+     */
+    @Override
+    public SystemListener getSystemListener() {
+        return listener;
+    }
 
     @Override
     public void setSystemListener(final SystemListener listener) {

--- a/jme3-vr/src/main/java/com/jme3/system/lwjgl/LwjglContextVR.java
+++ b/jme3-vr/src/main/java/com/jme3/system/lwjgl/LwjglContextVR.java
@@ -1,7 +1,7 @@
 package com.jme3.system.lwjgl;
 
 /*
- * Copyright (c) 2009-2022 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -78,6 +78,16 @@ public abstract class LwjglContextVR implements JmeContext {
     protected GlfwJoystickInput joyInput;
     protected Timer timer;
     protected SystemListener listener;
+
+    /**
+     * Accesses the listener that receives events related to this context.
+     *
+     * @return the pre-existing instance
+     */
+    @Override
+    public SystemListener getSystemListener() {
+        return listener;
+    }
 
     @Override
     public void setSystemListener(SystemListener listener) {


### PR DESCRIPTION
When implementing a graphical user interface, it's sometimes necessary to send notifications to the system listener. However, there is no API to access the listener.

This PR adds a getter, allowing applications to access the listener.