### PR TITLE
Fix #1890 (crashes attempting to run example apps in fullscreen with LWJGL v2)

### DIFF
--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
@@ -53,6 +53,16 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
     private final AtomicBoolean needRestart = new AtomicBoolean(false);
     private PixelFormat pixelFormat;
 
+    /**
+     * @param width The required display width
+     * @param height The required display height
+     * @param bpp The required bits per pixel. If -1 is passed it will return
+     *           whatever bpp is found
+     * @param freq The required frequency, if -1 is passed it will return
+     *             whatever frequency is found
+     * @return The {@link DisplayMode} matches with specified settings or
+     *         return null if no matching display mode is found
+     */
     protected DisplayMode getFullscreenDisplayMode(int width, int height, int bpp, int freq){
         try {
             DisplayMode[] modes = Display.getAvailableDisplayModes();
@@ -60,6 +70,10 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
                 if (mode.getWidth() == width
                         && mode.getHeight() == height
                         && (mode.getBitsPerPixel() == bpp || (bpp == 24 && mode.getBitsPerPixel() == 32) || bpp == -1)
+                        // Looks like AWT uses mathematical round to convert floating point
+                        // frequency values to int while lwjgl 2 uses mathematical floor.
+                        // For example if frequency is 59.83, AWT will return 60 but lwjgl2
+                        // will return 59. This is what I observed on Linux.  - Ali-RS 2023-1-10
                         && (Math.abs(mode.getFrequency() - freq) <= 1 || freq == -1)) {
                     return mode;
                 }

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
@@ -60,7 +60,7 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
                 if (mode.getWidth() == width
                         && mode.getHeight() == height
                         && (mode.getBitsPerPixel() == bpp || (bpp == 24 && mode.getBitsPerPixel() == 32) || bpp == -1)
-                        && (mode.getFrequency() == freq || (freq == 60 && mode.getFrequency() == 59) || freq == -1)) {
+                        && (Math.abs(mode.getFrequency() - freq) <= 1 || (freq == 60 && mode.getFrequency() == 59) || freq == -1)) {
                     return mode;
                 }
             }
@@ -80,12 +80,12 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
             displayMode = getFullscreenDisplayMode(settings.getWidth(), settings.getHeight(),
                     settings.getBitsPerPixel(), settings.getFrequency());
             if (displayMode == null) {
-                // Fall back to whatever is available to the specified width & height
+                // Fall back to whatever mode is available at the specified width & height
                 displayMode = getFullscreenDisplayMode(settings.getWidth(), settings.getHeight(), -1, -1);
                 if (displayMode == null) {
                     throw new RuntimeException("Unable to find fullscreen display mode matching settings");
                 } else {
-                    logger.warning("Unable to find fullscreen display mode matching settings, falling back to " + displayMode);
+                    logger.log(Level.WARNING, "Unable to find fullscreen display mode matching settings, falling back to: {0}", displayMode);
                 }
             }
         } else {

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
@@ -37,6 +37,9 @@ import com.jme3.system.JmeContext.Type;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -70,16 +73,23 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
     @Override
     protected void createContext(AppSettings settings) throws LWJGLException{
         DisplayMode displayMode;
-        if (settings.getWidth() <= 0 || settings.getHeight() <= 0){
+        if (settings.getWidth() <= 0 || settings.getHeight() <= 0) {
             displayMode = Display.getDesktopDisplayMode();
             settings.setResolution(displayMode.getWidth(), displayMode.getHeight());
-        }else if (settings.isFullscreen()){
+        } else if (settings.isFullscreen()) {
             displayMode = getFullscreenDisplayMode(settings.getWidth(), settings.getHeight(),
-                                                   settings.getBitsPerPixel(), settings.getFrequency());
+                    settings.getBitsPerPixel(), settings.getFrequency());
             if (displayMode == null) {
-                throw new RuntimeException("Unable to find fullscreen display mode matching settings");
+                // Fallback to standard 60Hz mode if available
+                displayMode = getFullscreenDisplayMode(settings.getWidth(), settings.getHeight(),
+                        settings.getBitsPerPixel(), 60);
+                if (displayMode == null) {
+                    throw new RuntimeException("Unable to find fullscreen display mode matching settings");
+                } else {
+                    logger.warning("Unable to find fullscreen display mode matching specified frequency, using 60Hz mode instead");
+                }
             }
-        }else{
+        } else {
             displayMode = new DisplayMode(settings.getWidth(), settings.getHeight());
         }
 

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -59,8 +59,8 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
             for (DisplayMode mode : modes) {
                 if (mode.getWidth() == width
                         && mode.getHeight() == height
-                        && (mode.getBitsPerPixel() == bpp || (bpp == 24 && mode.getBitsPerPixel() == 32))
-                        && (mode.getFrequency() == freq || (freq == 60 && mode.getFrequency() == 59))) {
+                        && (mode.getBitsPerPixel() == bpp || (bpp == 24 && mode.getBitsPerPixel() == 32) || bpp == -1)
+                        && (mode.getFrequency() == freq || (freq == 60 && mode.getFrequency() == 59) || freq == -1)) {
                     return mode;
                 }
             }
@@ -80,13 +80,12 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
             displayMode = getFullscreenDisplayMode(settings.getWidth(), settings.getHeight(),
                     settings.getBitsPerPixel(), settings.getFrequency());
             if (displayMode == null) {
-                // Fallback to standard 60Hz mode if available
-                displayMode = getFullscreenDisplayMode(settings.getWidth(), settings.getHeight(),
-                        settings.getBitsPerPixel(), 60);
+                // Fall back to whatever is available to the specified width & height
+                displayMode = getFullscreenDisplayMode(settings.getWidth(), settings.getHeight(), -1, -1);
                 if (displayMode == null) {
                     throw new RuntimeException("Unable to find fullscreen display mode matching settings");
                 } else {
-                    logger.warning("Unable to find fullscreen display mode matching specified frequency, using 60Hz mode instead");
+                    logger.warning("Unable to find fullscreen display mode matching settings, falling back to " + displayMode);
                 }
             }
         } else {

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
@@ -60,7 +60,7 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
                 if (mode.getWidth() == width
                         && mode.getHeight() == height
                         && (mode.getBitsPerPixel() == bpp || (bpp == 24 && mode.getBitsPerPixel() == 32) || bpp == -1)
-                        && (Math.abs(mode.getFrequency() - freq) <= 1 || (freq == 60 && mode.getFrequency() == 59) || freq == -1)) {
+                        && (Math.abs(mode.getFrequency() - freq) <= 1 || freq == -1)) {
                     return mode;
                 }
             }


### PR DESCRIPTION
It fallback to standard 60Hz fullscreen display mode if the specified frequency in the AppSettings is not available and logs a warning when using jme3-lwjgl.

This is a shallow fix to just get rid of the preventing exception and let the app continue running.

Partially address #1890 , #947