### PR TITLE
Refactored PBR Terrain to use new for-loops. Fix #1785

### DIFF
--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.frag
@@ -2,18 +2,27 @@
 #import "Common/ShaderLib/PBR.glsllib"
 #import "Common/ShaderLib/Parallax.glsllib"
 #import "Common/ShaderLib/Lighting.glsllib"
+#import "MatDefs/ShaderLib/AfflictionLib.glsllib"
 
-#import "Common/MatDefs/Terrain/AfflictionLib.glsllib"
+varying vec3 wPosition;
+varying vec3 vNormal;
+varying vec2 texCoord;
+uniform vec3 g_CameraPosition;
+varying vec3 vPosition;
+varying vec3 vnPosition;
+varying vec3 vViewDir;
+varying vec4 vLightDir;
+varying vec4 vnLightDir;
+varying vec3 lightVec;
+varying vec3 inNormal;
+varying vec3 wNormal;
 
 #ifdef DEBUG_VALUES_MODE
-  uniform int m_DebugValuesMode;
+    uniform int m_DebugValuesMode;
 #endif
-
 
 uniform vec4 g_LightData[NB_LIGHTS];
 uniform vec4 g_AmbientLightColor;
-
-varying vec3 wPosition;
 
 #if NB_PROBES >= 1
     uniform samplerCube g_PrefEnvMap;
@@ -31,195 +40,28 @@ varying vec3 wPosition;
     uniform mat4 g_LightProbeData3;
 #endif
 
-
-varying vec3 vNormal;
-varying vec2 texCoord;
-
-uniform vec3 g_CameraPosition;
-
-
-vec3 norm;
-
-
-
-#ifdef USE_FOG
-#import "Common/ShaderLib/MaterialFog.glsllib"
-    uniform vec4 m_FogColor;
-    float fogDistance;
-
-    uniform vec2 m_LinearFog;
+#ifdef TRI_PLANAR_MAPPING
+  varying vec4 wVertex; 
 #endif
 
-#ifdef FOG_EXP
-    uniform float m_ExpFog;
-#endif
+//texture-slot params for 12 unique texture slots (0-11) :
+#for i=0..12 ( $0 )
+    uniform int m_AfflictionMode_$i;
+    uniform float m_Roughness_$i;
+    uniform float m_Metallic_$i;
+    
+    #ifdef ALBEDOMAP_$i
+        uniform sampler2D m_AlbedoMap_$i;
+    #endif
+    #ifdef ALBEDOMAP_$i_SCALE    
+        uniform float m_AlbedoMap_$i_scale;
+    #endif
+    #ifdef NORMALMAP_$i
+        uniform sampler2D m_NormalMap_$i;
+    #endif    
+#endfor 
 
-#ifdef FOG_EXPSQ
-    uniform  float m_ExpSqFog;
-#endif
-
-
-varying vec3 vPosition;
-varying vec3 vnPosition;
-varying vec3 vViewDir;
-varying vec4 vLightDir;
-varying vec4 vnLightDir;
-varying vec3 lightVec;
-varying vec3 inNormal;
-
-uniform int m_AfflictionMode_0;
-uniform int m_AfflictionMode_1;
-uniform int m_AfflictionMode_2;
-uniform int m_AfflictionMode_3;
-uniform int m_AfflictionMode_4;
-uniform int m_AfflictionMode_5;
-uniform int m_AfflictionMode_6;
-uniform int m_AfflictionMode_7;
-uniform int m_AfflictionMode_8;
-uniform int m_AfflictionMode_9;
-uniform int m_AfflictionMode_10;
-uniform int m_AfflictionMode_11;
-
-uniform float m_Roughness_0;
-uniform float m_Roughness_1;
-uniform float m_Roughness_2;
-uniform float m_Roughness_3;
-uniform float m_Roughness_4;
-uniform float m_Roughness_5;
-uniform float m_Roughness_6;
-uniform float m_Roughness_7;
-uniform float m_Roughness_8;
-uniform float m_Roughness_9;
-uniform float m_Roughness_10;
-uniform float m_Roughness_11;
-
-uniform float m_Metallic_0;
-uniform float m_Metallic_1;
-uniform float m_Metallic_2;
-uniform float m_Metallic_3;
-uniform float m_Metallic_4;
-uniform float m_Metallic_5;
-uniform float m_Metallic_6;
-uniform float m_Metallic_7;
-uniform float m_Metallic_8;
-uniform float m_Metallic_9;
-uniform float m_Metallic_10;
-uniform float m_Metallic_11;
-
-
-#ifdef AFFLICTIONTEXTURE
-    uniform sampler2D m_AfflictionAlphaMap;
-#endif
-
-#ifdef USE_SPLAT_NOISE
-     uniform float m_SplatNoiseVar;
-#endif
-
-//defined for sub terrains that arent equal to each map tile size when AfflictionAlphaMap is defined 
-#ifdef TILELOCATION
-    uniform float m_TileWidth;
-    uniform vec3 m_TileLocation;
-#endif
-
-uniform int m_AfflictionSplatScale;
-#ifdef AFFLICTIONALBEDOMAP
-    uniform sampler2D m_SplatAlbedoMap;
-#endif
-
-#ifdef AFFLICTIONNORMALMAP
-    uniform sampler2D m_SplatNormalMap;
-#endif
-
-#ifdef AFFLICTIONROUGHNESSMETALLICMAP
-    uniform sampler2D m_SplatRoughnessMetallicMap;
-#endif
-
-#ifdef AFFLICTIONEMISSIVEMAP
-    uniform sampler2D m_SplatEmissiveMap;
-#endif
-
-uniform float m_AfflictionRoughnessValue;
-uniform float m_AfflictionMetallicValue;
-uniform float m_AfflictionEmissiveValue;
-uniform vec4 m_AfflictionEmissiveColor;
-
-
-#ifdef ALBEDOMAP_0
-  uniform sampler2D m_AlbedoMap_0;
-#endif
-#ifdef ALBEDOMAP_1
-  uniform sampler2D m_AlbedoMap_1;
-#endif
-#ifdef ALBEDOMAP_2
-  uniform sampler2D m_AlbedoMap_2;
-#endif
-#ifdef ALBEDOMAP_3
-  uniform sampler2D m_AlbedoMap_3;
-#endif
-#ifdef ALBEDOMAP_4
-  uniform sampler2D m_AlbedoMap_4;
-#endif
-#ifdef ALBEDOMAP_5
-  uniform sampler2D m_AlbedoMap_5;
-#endif
-#ifdef ALBEDOMAP_6
-  uniform sampler2D m_AlbedoMap_6;
-#endif
-#ifdef ALBEDOMAP_7
-  uniform sampler2D m_AlbedoMap_7;
-#endif
-#ifdef ALBEDOMAP_8
-  uniform sampler2D m_AlbedoMap_8;
-#endif
-#ifdef ALBEDOMAP_9
-  uniform sampler2D m_AlbedoMap_9;
-#endif
-#ifdef ALBEDOMAP_10
-  uniform sampler2D m_AlbedoMap_10;
-#endif
-#ifdef ALBEDOMAP_11
-  uniform sampler2D m_AlbedoMap_11;
-#endif
-
-
-#ifdef ALBEDOMAP_0_SCALE
-  uniform float m_AlbedoMap_0_scale;
-#endif
-#ifdef ALBEDOMAP_1_SCALE
-  uniform float m_AlbedoMap_1_scale;
-#endif
-#ifdef ALBEDOMAP_2_SCALE
-  uniform float m_AlbedoMap_2_scale;
-#endif
-#ifdef ALBEDOMAP_3_SCALE
-  uniform float m_AlbedoMap_3_scale;
-#endif
-#ifdef ALBEDOMAP_4_SCALE
-  uniform float m_AlbedoMap_4_scale;
-#endif
-#ifdef ALBEDOMAP_5_SCALE
-  uniform float m_AlbedoMap_5_scale;
-#endif
-#ifdef ALBEDOMAP_6_SCALE
-  uniform float m_AlbedoMap_6_scale;
-#endif
-#ifdef ALBEDOMAP_7_SCALE
-  uniform float m_AlbedoMap_7_scale;
-#endif
-#ifdef ALBEDOMAP_8_SCALE
-  uniform float m_AlbedoMap_8_scale;
-#endif
-#ifdef ALBEDOMAP_9_SCALE
-  uniform float m_AlbedoMap_9_scale;
-#endif
-#ifdef ALBEDOMAP_10_SCALE
-  uniform float m_AlbedoMap_10_scale;
-#endif
-#ifdef ALBEDOMAP_11_SCALE
-  uniform float m_AlbedoMap_11_scale;
-#endif
-
-
+//3 alpha maps :
 #ifdef ALPHAMAP
   uniform sampler2D m_AlphaMap;
 #endif
@@ -230,408 +72,27 @@ uniform vec4 m_AfflictionEmissiveColor;
   uniform sampler2D m_AlphaMap_2;
 #endif
 
-#ifdef NORMALMAP_0
-  uniform sampler2D m_NormalMap_0;
-#endif
-#ifdef NORMALMAP_1
-  uniform sampler2D m_NormalMap_1;
-#endif
-#ifdef NORMALMAP_2
-  uniform sampler2D m_NormalMap_2;
-#endif
-#ifdef NORMALMAP_3
-  uniform sampler2D m_NormalMap_3;
-#endif
-#ifdef NORMALMAP_4
-  uniform sampler2D m_NormalMap_4;
-#endif
-#ifdef NORMALMAP_5
-  uniform sampler2D m_NormalMap_5;
-#endif
-#ifdef NORMALMAP_6
-  uniform sampler2D m_NormalMap_6;
-#endif
-#ifdef NORMALMAP_7
-  uniform sampler2D m_NormalMap_7;
-#endif
-#ifdef NORMALMAP_8
-  uniform sampler2D m_NormalMap_8;
-#endif
-#ifdef NORMALMAP_9
-  uniform sampler2D m_NormalMap_9;
-#endif
-#ifdef NORMALMAP_10
-  uniform sampler2D m_NormalMap_10;
-#endif
-#ifdef NORMALMAP_11
-  uniform sampler2D m_NormalMap_11;
-#endif
-
 #ifdef DISCARD_ALPHA
     uniform float m_AlphaDiscardThreshold;
 #endif
 
+//fog vars for basic fog :
+#ifdef USE_FOG
+#import "Common/ShaderLib/MaterialFog.glsllib"
+    uniform vec4 m_FogColor;
+    float fogDistance;
 
-
-
-vec4 afflictionVector;
-
-varying vec3 wNormal;
-
-#ifdef TRI_PLANAR_MAPPING
-  varying vec4 wVertex;
- 
+    uniform vec2 m_LinearFog;
 #endif
-
-
-vec3 viewDir;
-
-vec2 coord;
-vec4 albedo;
-vec3 normal = vec3(0.5,0.5,1);
-vec3 newNormal;
-float Metallic;
-float Roughness;
-float packedAoValue = 1.0;
-vec4 emissive;
-float emissiveIntensity = 1.0;
-
-vec4 packedMetallicRoughnessAoEiVec;
-vec4 packedNormalParallaxVec;
-
-vec4 tempAlbedo, tempNormal, tempEmissiveColor;
-float tempParallax, tempMetallic, tempRoughness, tempAo, tempEmissiveIntensity;
-
-float noiseHash;
-float livelinessValue;
-float afflictionValue;
-int afflictionMode = 1;
-   
-
-
-#define DEFINE_COORD(index) vec2 coord##index = texCoord * m_AlbedoMap##index##_scale;
-
-#define BLEND(index, ab)\
-    DEFINE_COORD(index)\
-    afflictionMode = m_AfflictionMode##index;\
-    tempAlbedo.rgb = texture2D(m_AlbedoMap##index, coord##index).rgb;\
-    tempAlbedo.rgb = alterLiveliness(tempAlbedo.rgb, livelinessValue, afflictionMode);\
-    albedo.rgb = mix( albedo.rgb, tempAlbedo.rgb ,ab );\
-    normal.rgb = mix(normal.xyz, wNormal.rgb, ab);\
-    Metallic = mix(Metallic, m_Metallic##index, ab);\
-    Roughness = mix(Roughness, m_Roughness##index, ab);
-
-    
-    
-
-#define BLEND_NORMAL(index, ab)\
-    DEFINE_COORD(index)\
-    afflictionMode = m_AfflictionMode##index;\
-    tempAlbedo.rgb = texture2D(m_AlbedoMap##index, coord##index).rgb;\
-    tempAlbedo.rgb = alterLiveliness(tempAlbedo.rgb, livelinessValue, afflictionMode);\
-    albedo.rgb = mix( albedo.rgb, tempAlbedo.rgb ,ab );\
-    Metallic = mix(Metallic, m_Metallic##index, ab);\
-    Roughness = mix(Roughness, m_Roughness##index, ab);\
-    tempNormal.xyz = texture2D(m_NormalMap##index, coord##index).xyz;\
-    tempNormal.rgb = calculateTangentsAndApplyToNormals(tempNormal.rgb, wNormal);\
-    normal.rgb = mix(normal.xyz, tempNormal.xyz, ab);
-
-//BLEND METHODS FOR TRIPLANAR...  
-#define TRI_BLEND(index, ab, worldCoords, blending)\
-    afflictionMode = m_AfflictionMode##index;\
-    tempAlbedo = getTriPlanarBlend(worldCoords, blending, m_AlbedoMap##index, m_AlbedoMap##index##_scale);\
-    tempAlbedo.rgb = alterLiveliness(tempAlbedo.rgb, livelinessValue, afflictionMode);\
-    albedo = mix( albedo, tempAlbedo ,ab );\
-    normal.rgb = mix(normal.rgb, wNormal.rgb, ab);\
-    Metallic = mix(Metallic, m_Metallic##index, ab);\
-    Roughness = mix(Roughness, m_Roughness##index, ab);    
-
-
-#define TRI_BLEND_NORMAL(index, ab, worldCoords, blending)\
-    afflictionMode = m_AfflictionMode##index;\
-    tempAlbedo.rgb = getTriPlanarBlend(worldCoords, blending, m_AlbedoMap##index, m_AlbedoMap##index##_scale).rgb;\
-    tempNormal.rgb = getTriPlanarBlend(worldCoords, blending, m_NormalMap##index, m_AlbedoMap##index##_scale).rgb;\
-    tempAlbedo.rgb = alterLiveliness(tempAlbedo.rgb, livelinessValue, afflictionMode);\
-    albedo.rgb = mix( albedo.rgb, tempAlbedo.rgb ,ab );\
-    tempNormal.rgb = calculateTangentsAndApplyToNormals(tempNormal.rgb, wNormal);\
-    normal.rgb = mix(normal.xyz, tempNormal.xyz, ab);\
-    Metallic = mix(Metallic, m_Metallic##index, ab);\
-    Roughness = mix(Roughness, m_Roughness##index, ab);
-
-#ifdef ALPHAMAP
-
-vec4 calculateAlbedoBlend(in vec2 texCoord) {
-    vec4 alphaBlend = texture2D( m_AlphaMap, texCoord.xy );
-    vec4 albedo = vec4(1.0);
-    
-    
-
-    Roughness = m_Roughness_0;
-    Metallic = m_Metallic_0 ;
-
- vec3 blending = abs( wNormal );
-        blending = (blending -0.2) * 0.7;
-        blending = normalize(max(blending, 0.00001));      // Force weights to sum to 1.0 (very important!)
-        float b = (blending.x + blending.y + blending.z);
-        blending /= vec3(b, b, b);
-
-
-    #ifdef ALPHAMAP_1
-      vec4 alphaBlend1   = texture2D( m_AlphaMap_1, texCoord.xy );
-    #endif
-    #ifdef ALPHAMAP_2
-      vec4 alphaBlend2   = texture2D( m_AlphaMap_2, texCoord.xy );
-    #endif
-    #ifdef ALBEDOMAP_0   
-                    //NOTE! the old (phong) terrain shaders do not have an "_0" for the first diffuse map, it is just "DiffuseMap"
-        #ifdef NORMALMAP_0
-            BLEND_NORMAL(_0,  alphaBlend.r)
-        #else
-            BLEND(_0,  alphaBlend.r)
-        #endif
-        
-    #endif
-    #ifdef ALBEDOMAP_1
-        #ifdef NORMALMAP_1
-            BLEND_NORMAL(_1,  alphaBlend.g)
-        #else
-            BLEND(_1,  alphaBlend.g)
-        #endif
-        
-    #endif
-    #ifdef ALBEDOMAP_2
-        #ifdef NORMALMAP_2
-            BLEND_NORMAL(_2,  alphaBlend.b)
-        #else
-            BLEND(_2,  alphaBlend.b)
-        #endif
-        
-    #endif
-    #ifdef ALBEDOMAP_3 
-        #ifdef NORMALMAP_3
-            BLEND_NORMAL(_3,  alphaBlend.a)
-        #else
-            BLEND(_3,  alphaBlend.a)
-        #endif
-       
-    #endif
-
-    #ifdef ALPHAMAP_1
-        #ifdef ALBEDOMAP_4
-            #ifdef NORMALMAP_4
-                BLEND_NORMAL(_4,  alphaBlend1.r)
-            #else
-                BLEND(_4,  alphaBlend1.r)
-            #endif
-           
-        #endif
-        #ifdef ALBEDOMAP_5
-            #ifdef NORMALMAP_5
-                BLEND_NORMAL(_5,  alphaBlend1.g)
-            #else
-                BLEND(_5,  alphaBlend1.g)
-            #endif
-             
-        #endif
-        #ifdef ALBEDOMAP_6
-            #ifdef NORMALMAP_6
-                BLEND_NORMAL(_6,  alphaBlend1.b)
-            #else
-                BLEND(_6,  alphaBlend1.b)
-            #endif
-             
-        #endif
-        #ifdef ALBEDOMAP_7
-            #ifdef NORMALMAP_7
-                BLEND_NORMAL(_7,  alphaBlend1.a)
-            #else
-                BLEND(_7,  alphaBlend1.a)
-            #endif
-             
-        #endif
-    #endif
-
-    #ifdef ALPHAMAP_2
-        #ifdef ALBEDOMAP_8
-             #ifdef NORMALMAP_8
-                BLEND_NORMAL(_8,  alphaBlend2.r)
-            #else
-                BLEND(_8,  alphaBlend2.r)
-            #endif
-             
-        #endif
-        #ifdef ALBEDOMAP_9
-             #ifdef NORMALMAP_9
-                BLEND_NORMAL(_9,  alphaBlend2.g)
-            #else
-                BLEND(_9,  alphaBlend2.g)
-            #endif
-             
-        #endif
-        #ifdef ALBEDOMAP_10
-            #ifdef NORMALMAP_10
-                BLEND_NORMAL(_10,  alphaBlend2.b)
-            #else
-                BLEND(_10,  alphaBlend2.b)
-            #endif
-             
-        #endif
-        #ifdef ALBEDOMAP_11
-             #ifdef NORMALMAP_11
-                BLEND_NORMAL(_11,  alphaBlend2.a)
-            #else
-                BLEND(_11,  alphaBlend2.a)
-            #endif
-             
-        #endif                   
-    #endif
-
-    return albedo;
-  }
-
-
-
-// TRI PLANAR ALPHA MAP TEXTURES_ _ _ _    \/
-
-  #ifdef TRI_PLANAR_MAPPING
-
-
-    vec4 calculateTriPlanarAlbedoBlend(in vec3 wNorm, in vec4 wVert, in vec2 texCoord, vec3 blending) {
-         vec4 alphaBlend = texture2D( m_AlphaMap, texCoord.xy );
-        vec4 albedo = vec4(1.0);
-
-
-
-        Roughness = m_Roughness_0;
-        Metallic = m_Metallic_0 ;
-
-    
-
-
-        #ifdef ALPHAMAP_1
-          vec4 alphaBlend1   = texture2D( m_AlphaMap_1, texCoord.xy );
-        #endif
-        #ifdef ALPHAMAP_2
-          vec4 alphaBlend2   = texture2D( m_AlphaMap_2, texCoord.xy );
-        #endif
-        #ifdef ALBEDOMAP_0   
-                        //NOTE! the old (phong) terrain shaders do not have an "_0" for the first diffuse map, it is just "DiffuseMap"
-            #ifdef NORMALMAP_0
-                TRI_BLEND_NORMAL(_0,  alphaBlend.r, wVertex, blending)
-            #else
-                TRI_BLEND(_0,  alphaBlend.r, wVertex, blending)
-            #endif
-
-        #endif
-        #ifdef ALBEDOMAP_1
-            #ifdef NORMALMAP_1
-                TRI_BLEND_NORMAL(_1,  alphaBlend.g, wVertex, blending)
-            #else
-                TRI_BLEND(_1,  alphaBlend.g, wVertex, blending)
-            #endif
-
-        #endif
-        #ifdef ALBEDOMAP_2
-            #ifdef NORMALMAP_2
-                TRI_BLEND_NORMAL(_2,  alphaBlend.b, wVertex, blending)
-            #else
-                TRI_BLEND(_2,  alphaBlend.b, wVertex, blending)
-            #endif
-
-        #endif
-        #ifdef ALBEDOMAP_3 
-            #ifdef NORMALMAP_3
-                TRI_BLEND_NORMAL(_3,  alphaBlend.a, wVertex, blending)
-            #else
-                TRI_BLEND(_3,  alphaBlend.a, wVertex, blending)
-            #endif
-
-        #endif
-
-        #ifdef ALPHAMAP_1
-            #ifdef ALBEDOMAP_4
-                #ifdef NORMALMAP_4
-                    TRI_BLEND_NORMAL(_4,  alphaBlend1.r, wVertex, blending)
-                #else
-                    TRI_BLEND(_4,  alphaBlend1.r, wVertex, blending)
-                #endif
-
-            #endif
-            #ifdef ALBEDOMAP_5
-                #ifdef NORMALMAP_5
-                    TRI_BLEND_NORMAL(_5,  alphaBlend1.g, wVertex, blending)
-                #else
-                    TRI_BLEND(_5,  alphaBlend1.g, wVertex, blending)
-                #endif
-
-            #endif
-            #ifdef ALBEDOMAP_6
-                #ifdef NORMALMAP_6
-                    TRI_BLEND_NORMAL(_6,  alphaBlend1.b, wVertex, blending)
-                #else
-                    TRI_BLEND(_6,  alphaBlend1.b, wVertex, blending)
-                #endif
-
-            #endif
-            #ifdef ALBEDOMAP_7
-                #ifdef NORMALMAP_7
-                    TRI_BLEND_NORMAL(_7,  alphaBlend1.a, wVertex, blending)
-                #else
-                    TRI_BLEND(_7,  alphaBlend1.a, wVertex, blending)
-                #endif
-
-            #endif
-        #endif
-
-        #ifdef ALPHAMAP_2
-            #ifdef ALBEDOMAP_8
-                 #ifdef NORMALMAP_8
-                    TRI_BLEND_NORMAL(_8,  alphaBlend2.r, wVertex, blending)
-                #else
-                    TRI_BLEND(_8,  alphaBlend2.r, wVertex, blending)
-                #endif
-
-            #endif
-            #ifdef ALBEDOMAP_9
-                 #ifdef NORMALMAP_9
-                    TRI_BLEND_NORMAL(_9,  alphaBlend2.g, wVertex, blending)
-                #else
-                    TRI_BLEND(_9,  alphaBlend2.g, wVertex, blending)
-                #endif
-
-            #endif
-            #ifdef ALBEDOMAP_10
-                #ifdef NORMALMAP_10
-                    TRI_BLEND_NORMAL(_10,  alphaBlend2.b, wVertex, blending)
-                #else
-                    TRI_BLEND(_10,  alphaBlend2.b, wVertex, blending)
-                #endif
-
-            #endif
-            #ifdef ALBEDOMAP_11
-                 #ifdef NORMALMAP_11
-                    TRI_BLEND_NORMAL(_11,  alphaBlend2.a, wVertex, blending)
-                #else
-                    TRI_BLEND(_11,  alphaBlend2.a, wVertex, blending)
-                #endif
-
-            #endif                   
-        #endif
-        
-
-
-        return albedo;
-    }
-
-    
-  #endif
-
+#ifdef FOG_EXP
+    uniform float m_ExpFog;
 #endif
-
-
+#ifdef FOG_EXPSQ
+    uniform  float m_ExpSqFog;
+#endif
 
 //sun intensity is a secondary AO value that can be painted per-vertex in the red channel of the 
-// vertex colors, or it can be set as a static value for an entire material with StaticSunIntensity float param 
+// vertex colors, or it can be set as a static value for an entire material with the StaticSunIntensity float param 
 #if defined(USE_VERTEX_COLORS_AS_SUN_INTENSITY) 
     varying vec4 vertColors; 
 #endif
@@ -640,50 +101,99 @@ vec4 calculateAlbedoBlend(in vec2 texCoord) {
     uniform float m_StaticSunIntensity;
 #endif
 //sun intensity AO value is only applied to the directional light, not to point lights, so it is important to track if the 
-//sun is more/less bright than the brightest point light to determine how the light probe's ambient light should be scaled later on..
+//sun is more/less bright than the brightest point light for each fragment to determine how the light probe's ambient light should be scaled later on in light calculation code
 float brightestPointLight = 0.0;
 
+//optional affliction paramaters that use the AfflictionAlphaMap's green channel for splatting m_SplatAlbedoMap and the red channel for splatting desaturation  :
+#ifdef AFFLICTIONTEXTURE 
+    uniform sampler2D m_AfflictionAlphaMap;
+#endif
+#ifdef USE_SPLAT_NOISE
+     uniform float m_SplatNoiseVar;
+#endif
+//only defined for non-terrain geoemtries and terrains that are not positioned nor sized in correlation to the 2d array of AfflictionAlphaMaps used for splatting accross large tile based scenes in a grid
+#ifdef TILELOCATION
+    uniform float m_TileWidth;
+    uniform vec3 m_TileLocation;
+#endif
+#ifdef AFFLICTIONALBEDOMAP
+    uniform sampler2D m_SplatAlbedoMap;
+#endif
+#ifdef AFFLICTIONNORMALMAP
+    uniform sampler2D m_SplatNormalMap;
+#endif
+#ifdef AFFLICTIONROUGHNESSMETALLICMAP
+    uniform sampler2D m_SplatRoughnessMetallicMap;
+#endif
+#ifdef AFFLICTIONEMISSIVEMAP
+    uniform sampler2D m_SplatEmissiveMap;
+#endif
 
+uniform int m_AfflictionSplatScale;
+uniform float m_AfflictionRoughnessValue;
+uniform float m_AfflictionMetallicValue;
+uniform float m_AfflictionEmissiveValue;
+uniform vec4 m_AfflictionEmissiveColor;
+
+vec4 afflictionVector;
+float noiseHash;
+float livelinessValue;
+float afflictionValue;
+int afflictionMode = 1;
+
+//general temp vars :
+vec4 tempAlbedo, tempNormal, tempEmissiveColor;
+float tempParallax, tempMetallic, tempRoughness, tempAo, tempEmissiveIntensity;
+
+vec3 viewDir;
+vec2 coord;
+vec4 albedo = vec4(1.0);
+vec3 normal = vec3(0.5,0.5,1);
+vec3 norm;
+float Metallic;
+float Roughness;
+float packedAoValue = 1.0;
+vec4 emissive;
+float emissiveIntensity = 1.0;
+float indoorSunLightExposure = 1.0;
+ 
+vec4 packedMetallicRoughnessAoEiVec;
+vec4 packedNormalParallaxVec;
 
 void main(){
-    
     
     #ifdef USE_FOG
         fogDistance = distance(g_CameraPosition, wPosition.xyz);
     #endif
     
-    float indoorSunLightExposure = 1.0;
+    indoorSunLightExposure = 1.0;
     
     viewDir = normalize(g_CameraPosition - wPosition);
 
     norm  = normalize(wNormal);
     normal = norm;
 
-
-    afflictionVector = vec4(1.0, 0.0, 1.0, 0.0); //r channel is saturation, g channel is affliction splat texture intensity, b and a unused (might use b channel for wetness eventually)
+    afflictionVector = vec4(1.0, 0.0, 1.0, 0.0); //r channel is sturation, g channel is affliction splat texture intensity, b and a unused (might use b channel for wetness eventually)
     
     #ifdef AFFLICTIONTEXTURE
     
         #ifdef TILELOCATION 
-        //subterrains that are not centred in tile or equal to tile width in total size need to have m_TileWidth pre-set. (tileWidth is the x,z dimensions that the AfflictionAlphaMap represents)..
+        //subterrains that are not centred in tile or equal to tile width in total size need to have m_TileWidth pre-set. (tileWidth is the x,z dimesnions that the AfflictionAlphaMap represents)
             vec2 tileCoords;
             float xPos, zPos;
 
             vec3 locInTile = (wPosition - m_TileLocation);
 
-             locInTile += vec3(m_TileWidth/2, 0, m_TileWidth/2);
+            locInTile += vec3(m_TileWidth/2, 0, m_TileWidth/2);
 
-             xPos = (locInTile.x / m_TileWidth);
-             zPos = 1 - (locInTile.z / m_TileWidth);
+            xPos = (locInTile.x / m_TileWidth);
+            zPos = 1 - (locInTile.z / m_TileWidth);
 
             tileCoords = vec2(xPos, zPos);
 
             afflictionVector = texture2D(m_AfflictionAlphaMap, tileCoords).rgba;
-        
-        
-     
         #else
-           // .. otherwise when terrain size matches tileWidth, the terrain's texCoords can be used for simple texel fetching of the AfflictionAlphaMap
+           // ..othrewise when terrain size matches tileWidth and location matches tileLocation, the terrain's texCoords can be used for simple texel fetching of the AfflictionAlphaMap
             afflictionVector = texture2D(m_AfflictionAlphaMap, texCoord.xy).rgba;
         #endif
     #endif
@@ -691,28 +201,96 @@ void main(){
     livelinessValue = afflictionVector.r;
     afflictionValue = afflictionVector.g;
 
-
-
-
-    vec3 blending;
     #ifdef ALBEDOMAP_0
-      #ifdef ALPHAMAP
-        #ifdef TRI_PLANAR_MAPPING
-             blending = abs( norm );
-                blending = (blending -0.2) * 0.7;
-                blending = normalize(max(blending, 0.00001));      // Force weights to sum to 1.0 (very important!)
-                float b = (blending.x + blending.y + blending.z);
-                blending /= vec3(b, b, b);
-
-
-            albedo = calculateTriPlanarAlbedoBlend(norm, wVertex, texCoord, blending);
+        #ifdef ALPHAMAP
             
-        #else
-            albedo = calculateAlbedoBlend(texCoord);
+            vec4 alphaBlend;
+            vec4 alphaBlend_0, alphaBlend_1, alphaBlend_2;
+            int texChannelForAlphaBlending;
+
+            alphaBlend_0 = texture2D( m_AlphaMap, texCoord.xy );
+           
+            #ifdef ALPHAMAP_1
+                alphaBlend_1 = texture2D( m_AlphaMap_1, texCoord.xy );
+            #endif
+            #ifdef ALPHAMAP_2
+                alphaBlend_2 = texture2D( m_AlphaMap_2, texCoord.xy );
+            #endif
+
+            vec2 texSlotCoords;   
+
+            float finalAlphaBlendForLayer = 1.0;
+
+            vec3 blending = abs( norm );
+            blending = (blending -0.2) * 0.7;
+            blending = normalize(max(blending, 0.00001));      // Force weights to sum to 1.0 (very important!)
+            float b = (blending.x + blending.y + blending.z);
+            blending /= vec3(b, b, b);
+
+            #for i=0..12 (#ifdef ALBEDOMAP_$i $0 #endif)
+
+                //assign texture slot's blending from index's correct alpha map
+                if($i <= 3){
+                    alphaBlend = alphaBlend_0;       
+                }else if($i <= 7){
+                    alphaBlend = alphaBlend_1;
+                }else if($i <= 11){
+                    alphaBlend = alphaBlend_2;
+                }
+
+                texChannelForAlphaBlending = int(mod($i, 4.0)); //pick the correct channel (r g b or a) based on the layer's index
+                switch(texChannelForAlphaBlending) {
+                    case 0:
+                        finalAlphaBlendForLayer = alphaBlend.r;
+                        break;
+                    case 1:
+                        finalAlphaBlendForLayer = alphaBlend.g;
+                        break;
+                    case 2:
+                        finalAlphaBlendForLayer = alphaBlend.b;
+                        break;
+                    case 3:
+                        finalAlphaBlendForLayer = alphaBlend.a;
+                        break;            
+                }
+
+                afflictionMode = m_AfflictionMode_$i;
+
+                #ifdef TRI_PLANAR_MAPPING   
+            //tri planar
+                    tempAlbedo = getTriPlanarBlend(wVertex, blending, m_AlbedoMap_$i, m_AlbedoMap_$i_scale);
+
+                    #ifdef NORMALMAP_$i
+                        tempNormal.rgb = getTriPlanarBlend(wVertex, blending, m_NormalMap_$i, m_AlbedoMap_$i_scale).rgb;
+                        tempNormal.rgb = calculateTangentsAndApplyToNormals(tempNormal.rgb, wNormal);// this gets rid of the need for pre-generating tangents for TerrainPatches, since doing so doesn't seem to work (tbnMat is always blank for terrains even with tangents pre-generated, not sure why...)
+                    #else
+                        tempNormal.rgb = wNormal.rgb;
+                    #endif
+                #else    
+                
+             // non triplanar
+                    texSlotCoords = texCoord * m_AlbedoMap_$i_scale;
+
+                    tempAlbedo.rgb = texture2D(m_AlbedoMap_$i, texSlotCoords).rgb;
+                    #ifdef NORMALMAP_$i
+                        tempNormal.xyz = texture2D(m_NormalMap_$i, texSlotCoords).xyz;
+                        tempNormal.rgb = calculateTangentsAndApplyToNormals(tempNormal.rgb, wNormal);
+                    #else
+                        tempNormal.rgb = wNormal.rgb;
+                    #endif
+                #endif        
+
+              //note: most of these functions can be found in AfflictionLib.glslib
+                tempAlbedo.rgb = alterLiveliness(tempAlbedo.rgb, livelinessValue, afflictionMode); //changes saturation of albedo for this layer; does nothing if not using AfflictionAlphaMap for affliction splatting        
+
+             //mix values from this index layer to final output values based on finalAlphaBlendForLayer 
+                albedo.rgb = mix(albedo.rgb, tempAlbedo.rgb , finalAlphaBlendForLayer);        
+                normal.rgb = mix(normal.rgb, tempNormal.rgb, finalAlphaBlendForLayer);        
+                Metallic = mix(Metallic, m_Metallic_$i, finalAlphaBlendForLayer);
+                Roughness = mix(Roughness, m_Roughness_$i, finalAlphaBlendForLayer);
+
+            #endfor            
         #endif
-      #else
-        albedo = texture2D(m_AlbedoMap_0, texCoord);
-      #endif
     #endif
 
 
@@ -728,10 +306,8 @@ void main(){
     #ifdef AFFLICTIONTEXTURE
         vec4 afflictionAlbedo;    
 
-
         float newAfflictionScale = m_AfflictionSplatScale; 
         vec2 newScaledCoords;
-
 
         #ifdef AFFLICTIONALBEDOMAP
             #ifdef TRI_PLANAR_MAPPING
@@ -784,25 +360,25 @@ void main(){
         #endif
 
         float adjustedAfflictionValue = afflictionValue;
-            #ifdef USE_SPLAT_NOISE
-                noiseHash = getStaticNoiseVar0(wPosition, afflictionValue * m_SplatNoiseVar);
+        #ifdef USE_SPLAT_NOISE
+            noiseHash = getStaticNoiseVar0(wPosition, afflictionValue * m_SplatNoiseVar);
 
-                adjustedAfflictionValue = getAdjustedAfflictionVar(afflictionValue);
-                if(afflictionValue >= 0.99){
-                    adjustedAfflictionValue = afflictionValue;
-                }
-            #else
-                noiseHash = 1.0;
-            #endif        
+            adjustedAfflictionValue = getAdjustedAfflictionVar(afflictionValue);
+            if(afflictionValue >= 0.99){
+                adjustedAfflictionValue = afflictionValue;
+            }
+        #else
+            noiseHash = 1.0;
+        #endif        
 
-            Roughness = alterAfflictionRoughness(adjustedAfflictionValue, Roughness, afflictionRoughness, noiseHash);
-            Metallic = alterAfflictionMetallic(adjustedAfflictionValue, Metallic,  afflictionMetallic, noiseHash);
-            albedo = alterAfflictionColor(adjustedAfflictionValue, albedo, afflictionAlbedo, noiseHash );
-            normal = alterAfflictionNormalsForTerrain(adjustedAfflictionValue, normal, afflictionNormal, noiseHash , wNormal);
-            emissive = alterAfflictionGlow(adjustedAfflictionValue, emissive, afflictionEmissive, noiseHash);
-            emissiveIntensity = alterAfflictionEmissiveIntensity(adjustedAfflictionValue, emissiveIntensity, afflictionEmissiveIntensity, noiseHash);
-            emissiveIntensity *= afflictionEmissive.a;
-            //affliction ao value blended below after specular calculation
+        Roughness = alterAfflictionRoughness(adjustedAfflictionValue, Roughness, afflictionRoughness, noiseHash);
+        Metallic = alterAfflictionMetallic(adjustedAfflictionValue, Metallic,  afflictionMetallic, noiseHash);
+        albedo = alterAfflictionColor(adjustedAfflictionValue, albedo, afflictionAlbedo, noiseHash );
+        normal = alterAfflictionNormalsForTerrain(adjustedAfflictionValue, normal, afflictionNormal, noiseHash , wNormal);
+        emissive = alterAfflictionGlow(adjustedAfflictionValue, emissive, afflictionEmissive, noiseHash);
+        emissiveIntensity = alterAfflictionEmissiveIntensity(adjustedAfflictionValue, emissiveIntensity, afflictionEmissiveIntensity, noiseHash);
+        emissiveIntensity *= afflictionEmissive.a;
+        //affliction ao value blended below after specular calculation
     #endif
 
 // spec gloss pipeline code would go here if supported, but likely will not be for terrain shaders as defines are limited and heavily used
@@ -813,10 +389,7 @@ vec4 specularColor = (nonMetalSpec - nonMetalSpec * Metallic) + albedo * Metalli
 vec4 diffuseColor = albedo - albedo * Metallic;
 vec3 fZero = vec3(specular);
 
-
 gl_FragColor.rgb = vec3(0.0);
-
-
  
 //simple ao calculation, no support for lightmaps like stock pbr shader.. (probably could add lightmap support with another texture array, but
 //                                                                         that would add another texture read per slot and require removing 12 other defines to make room...)
@@ -827,20 +400,19 @@ gl_FragColor.rgb = vec3(0.0);
     #endif
     ao.rgb = ao.rrr;
     specularColor.rgb *= ao;
- 
- 
   
     #ifdef STATIC_SUN_INTENSITY
         indoorSunLightExposure = m_StaticSunIntensity; //single float value to indicate percentage of
-                           //sunlight hitting the model (only works for small models or models with 100% consistent sunlight across every pixel)
+                           //sunlight hitting the model (only works for small models or models with 100% consistent sunlighting accross every pixel)
     #endif
     #ifdef USE_VERTEX_COLORS_AS_SUN_INTENSITY
         indoorSunLightExposure = vertColors.r * indoorSunLightExposure;      //use R channel of vertexColors for..       
     #endif 
-                                                               // similar purpose as above...
-                                                             //but uses r channel vert colors like an AO map specifically
-                                                                 //for sunlight (solution for scaling lighting for indoor
-                                                                  // and shady/dimly lit models, especially big ones with)
+                                                              // similar purpose as above...
+                                                               //but uses r channel vert colors like an AO map specifically
+                                                              //for sunlight (solution for scaling lighting for indoor
+                                                               // and shadey/dimly lit models, especially big ones that 
+                                                              // span accross varying directionalLight exposure)
     brightestPointLight = 0.0;
     
      
@@ -884,18 +456,14 @@ gl_FragColor.rgb = vec3(0.0);
           
            }
        #endif
-        
-        
-        
-        gl_FragColor.rgb += directLighting * fallOff;
-        
+       
+        gl_FragColor.rgb += directLighting * fallOff;       
      
     }
-    
-    
+        
     float minVertLighting;
     #ifdef BRIGHTEN_INDOOR_SHADOWS
-        minVertLighting = 0.0833; //brighten shadows so that caves which are naturally covered from the DL shadows are not way too dark compared to when shadows are off (mostly only necessary for naturally dark scenes, or dark areas when using the sun intensity code above)
+        minVertLighting = 0.0833; //brighten shadows so that caves/indoors which are naturally covered from the DL shadows are not way too dark compared to when shadows are off (mostly only necessary for naturally dark scenes, or dark areas when using the sun intensity code above)
     #else
         minVertLighting = 0.0533;
     
@@ -904,8 +472,6 @@ gl_FragColor.rgb = vec3(0.0);
     indoorSunLightExposure = max(indoorSunLightExposure, brightestPointLight);   
     indoorSunLightExposure = max(indoorSunLightExposure, minVertLighting);       //scale the indoorSunLightExposure back up to account for the brightest point light nearby before scaling light probes by this value below   
     
-
-
     #if NB_PROBES >= 1
         vec3 color1 = vec3(0.0);
         vec3 color2 = vec3(0.0);
@@ -955,26 +521,19 @@ gl_FragColor.rgb = vec3(0.0);
 // nearby point/spot lights ( will be multiplied by 1.0 and left unchanged if you are not defining any of the sunlight exposure variables for dimming indoors areas)
         color1.rgb *= indoorSunLightExposure;
         color2.rgb *= indoorSunLightExposure;
-        color3.rgb *= indoorSunLightExposure;
-        
+        color3.rgb *= indoorSunLightExposure;        
         
         gl_FragColor.rgb += color1 * clamp(weight1,0.0,1.0) + color2 * clamp(weight2,0.0,1.0) + color3 * clamp(weight3,0.0,1.0);
 
     #endif
 
-
-
-    if(emissive.a > 0){
-    
-        emissive = emissive * pow(emissive.a * 5, emissiveIntensity) * emissiveIntensity * 20 * emissive.a;
-    
+    if(emissive.a > 0){    
+        emissive = emissive * pow(emissive.a * 5, emissiveIntensity) * emissiveIntensity * 20 * emissive.a;    
     }
     
   //  emissive = emissive * pow(emissiveIntensity * 2.3, emissive.a);
 
     gl_FragColor += emissive;
-
-
    
      // add fog after the lighting because shadows will cause the fog to darken
     // which just results in the geometry looking like it's changed color
@@ -993,31 +552,24 @@ gl_FragColor.rgb = vec3(0.0);
     //outputs the final value of the selected layer as a color for debug purposes. 
     #ifdef DEBUG_VALUES_MODE
         if(m_DebugValuesMode == 0){
-                gl_FragColor.rgb = vec3(albedo);
-
+            gl_FragColor.rgb = vec3(albedo);
         }
         else if(m_DebugValuesMode == 1){
-                gl_FragColor.rgb = vec3(normal);
-
+            gl_FragColor.rgb = vec3(normal);
         }
         else if(m_DebugValuesMode == 2){
-                gl_FragColor.rgb = vec3(Roughness);
-
+            gl_FragColor.rgb = vec3(Roughness);
         }
         else if(m_DebugValuesMode == 3){
-                gl_FragColor.rgb = vec3(Metallic);
-
+            gl_FragColor.rgb = vec3(Metallic);
         }
         else if(m_DebugValuesMode == 4){
-                gl_FragColor.rgb = ao.rgb;
-
+            gl_FragColor.rgb = ao.rgb;
         }
         else if(m_DebugValuesMode == 5){
-                gl_FragColor.rgb = vec3(emissive.rgb);  
-        }
-        
+            gl_FragColor.rgb = vec3(emissive.rgb);  
+        }        
     #endif
-    
     gl_FragColor.a = albedo.a;
 
 }


### PR DESCRIPTION
Drastically reduced code by utilizing JME's new potential for define-compatible for-loops in shaders. Also cleaned up some other little things like indentations, comments, and code placement so that the code is much more organized and easier to understand. And this should also fix this issue: https://github.com/jMonkeyEngine/jmonkeyengine/issues/1785

I tested the updated shader in the PBR Terrain test case as well as my main project, and encountered no errors or framerate drops. But I have not tested it on a Mac device to personally ensure it fixes issue 1785, although I expect that this PR should resolve it.

If everything looks good, I will go ahead and make a second PR with the same changes applied to the other version of the PBR terrain shader that uses TextureArrays (AdvancedPbrTerrain.j3md)

I also did not refactor the .j3md file to use for-loops, only the .frag file. I considered it, and it would only take a minute if I decide to do it; however, I am not sure if reducing the code in the .j3md file is as important since it is merely a list of the MaterialParamaters, and it feels like putting the variable definitions for AlbedoMaps 0-11 into a for loop would make the .j3md harder for new users to look at and determine what params the terrain uses. But if anyone thinks otherwise feel free to speak up and I can add for-loops to reduce the code in the .j3md file as well.

