### PR TITLE
jme3-lwjgl:updated to lwjgl v2.9.4 hosted by org.jmonkeyengine.

### DIFF
--- a/jme3-lwjgl/build.gradle
+++ b/jme3-lwjgl/build.gradle
@@ -1,7 +1,10 @@
 dependencies {
     api project(':jme3-core')
     api project(':jme3-desktop')
-    api 'org.lwjgl.lwjgl:lwjgl:2.9.3'
+
+    api 'org.jmonkeyengine:lwjgl:2.9.4'
+    runtimeOnly 'org.jmonkeyengine:lwjgl-platform:2.9.4'
+
     /*
      * Upgrades the default jinput-2.0.5 to jinput-2.0.9 to fix a bug with gamepads on Linux.
      * See https://hub.jmonkeyengine.org/t/linux-gamepad-input-on-jme3-lwjgl-splits-input-between-two-logical-gamepads


### PR DESCRIPTION
We now maintain our own lwjgl2 repo: https://github.com/jMonkeyEngine/lwjgl2

See the release page for what is changed in v2.9.4

Fixes #1247, #1215, and partially https://github.com/jMonkeyEngine/jmonkeyengine/issues/947