### PR TITLE
common.gradle: set class files compatible with Java 8 using "release" option

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -20,7 +20,7 @@ tasks.withType(JavaCompile) { // compile-time options:
     //options.compilerArgs << '-Xlint:deprecation' // to show deprecation warnings
     options.compilerArgs << '-Xlint:unchecked'
     options.encoding = 'UTF-8'
-    if( JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_10) ) {
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_10)) {
         options.release = 8
     }
 }

--- a/common.gradle
+++ b/common.gradle
@@ -20,6 +20,9 @@ tasks.withType(JavaCompile) { // compile-time options:
     //options.compilerArgs << '-Xlint:deprecation' // to show deprecation warnings
     options.compilerArgs << '-Xlint:unchecked'
     options.encoding = 'UTF-8'
+    if( JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_10) ) {
+        options.release = 8
+    }
 }
 
 ext {
@@ -38,15 +41,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.12.4'
     testImplementation 'org.codehaus.groovy:groovy-test:3.0.14'
-}
-
-compileJava { // compile-time options:
-    options.encoding = 'UTF-8'
-    options.compilerArgs << '-Xlint:unchecked'
-    options.deprecation = true
-    if( JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_10) ) {
-        options.release = 8
-    }
 }
 
 // Uncomment if you want to see the status of every test that is run and

--- a/common.gradle
+++ b/common.gradle
@@ -40,6 +40,14 @@ dependencies {
     testImplementation 'org.codehaus.groovy:groovy-test:3.0.14'
 }
 
+compileJava { // compile-time options:
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-Xlint:unchecked'
+    options.deprecation = true
+    if( JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_10) ) {
+        options.release = 8
+    }
+}
 
 // Uncomment if you want to see the status of every test that is run and
 // the test output.


### PR DESCRIPTION
This will keep java 8 compatibility when it is compiled with newer java versions.

Fix #1896 