### PR TITLE
add 4 getters to JmeContext for screen position and frame-buffer size

### DIFF
--- a/jme3-android/src/main/java/com/jme3/system/android/OGLESContext.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/OGLESContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,10 +37,13 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.ConfigurationInfo;
 import android.graphics.PixelFormat;
+import android.graphics.Rect;
 import android.opengl.GLSurfaceView;
 import android.os.Build;
 import android.text.InputType;
 import android.view.Gravity;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.EditText;
@@ -483,5 +486,62 @@ public class OGLESContext implements JmeContext, GLSurfaceView.Renderer, SoftTex
     public com.jme3.opencl.Context getOpenCLContext() {
         logger.warning("OpenCL is not yet supported on android");
         return null;
+    }
+
+    /**
+     * Returns the height of the input surface.
+     *
+     * @return the height (in pixels)
+     */
+    @Override
+    public int getFramebufferHeight() {
+        Rect rect = getSurfaceFrame();
+        int result = rect.height();
+        return result;
+    }
+
+    /**
+     * Returns the width of the input surface.
+     *
+     * @return the width (in pixels)
+     */
+    @Override
+    public int getFramebufferWidth() {
+        Rect rect = getSurfaceFrame();
+        int result = rect.width();
+        return result;
+    }
+
+    /**
+     * Returns the screen X coordinate of the left edge of the content area.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getWindowXPosition() {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
+    /**
+     * Returns the screen Y coordinate of the top edge of the content area.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getWindowYPosition() {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+    
+    /**
+     * Retrieves the dimensions of the input surface. Note: do not modify the
+     * returned object.
+     * 
+     * @return the dimensions (in pixels, left and top are 0)
+     */
+    private Rect getSurfaceFrame() {
+        SurfaceView view = (SurfaceView) androidInput.getView();
+        SurfaceHolder holder = view.getHolder();
+        Rect result = holder.getSurfaceFrame();
+        return result;
     }
 }

--- a/jme3-core/src/main/java/com/jme3/system/JmeContext.java
+++ b/jme3-core/src/main/java/com/jme3/system/JmeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -187,4 +187,35 @@ public interface JmeContext {
      */
     public void destroy(boolean waitFor);
 
+    /**
+     * Returns the height of the framebuffer.
+     *
+     * @return the height (in pixels)
+     * @throws IllegalStateException for a headless or null context
+     */
+    public int getFramebufferHeight();
+
+    /**
+     * Returns the width of the framebuffer.
+     *
+     * @return the width (in pixels)
+     * @throws IllegalStateException for a headless or null context
+     */
+    public int getFramebufferWidth();
+
+    /**
+     * Returns the screen X coordinate of the left edge of the content area.
+     *
+     * @return the screen X coordinate
+     * @throws IllegalStateException for a headless or null context
+     */
+    public int getWindowXPosition();
+
+    /**
+     * Returns the screen Y coordinate of the top edge of the content area.
+     *
+     * @return the screen Y coordinate
+     * @throws IllegalStateException for a headless or null context
+     */
+    public int getWindowYPosition();
 }

--- a/jme3-core/src/main/java/com/jme3/system/NullContext.java
+++ b/jme3-core/src/main/java/com/jme3/system/NullContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -255,5 +255,45 @@ public class NullContext implements JmeContext, Runnable {
     @Override
     public Context getOpenCLContext() {
         return null;
+    }
+
+    /**
+     * Returns the height of the framebuffer.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getFramebufferHeight() {
+        throw new UnsupportedOperationException("null context");
+    }
+
+    /**
+     * Returns the width of the framebuffer.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getFramebufferWidth() {
+        throw new UnsupportedOperationException("null context");
+    }
+
+    /**
+     * Returns the screen X coordinate of the left edge of the content area.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getWindowXPosition() {
+        throw new UnsupportedOperationException("null context");
+    }
+
+    /**
+     * Returns the screen Y coordinate of the top edge of the content area.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getWindowYPosition() {
+        throw new UnsupportedOperationException("null context");
     }
 }

--- a/jme3-desktop/src/main/java/com/jme3/system/AWTContext.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/AWTContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,11 +38,6 @@ import com.jme3.input.JoyInput;
 import com.jme3.input.TouchInput;
 import com.jme3.opencl.Context;
 import com.jme3.renderer.Renderer;
-import com.jme3.system.AppSettings;
-import com.jme3.system.JmeContext;
-import com.jme3.system.JmeSystem;
-import com.jme3.system.SystemListener;
-import com.jme3.system.Timer;
 
 /**
  * A JMonkey {@link JmeContext context} that is dedicated to AWT component rendering.
@@ -231,4 +226,43 @@ public class AWTContext implements JmeContext {
       backgroundContext.destroy(waitFor);
 }
 
+    /**
+     * Returns the height of the framebuffer.
+     *
+     * @return the height (in pixels)
+     */
+    @Override
+    public int getFramebufferHeight() {
+        return height;
+    }
+
+    /**
+     * Returns the width of the framebuffer.
+     *
+     * @return the width (in pixels)
+     */
+    @Override
+    public int getFramebufferWidth() {
+        return width;
+    }
+
+    /**
+     * Returns the screen X coordinate of the left edge of the content area.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getWindowXPosition() {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
+    /**
+     * Returns the screen Y coordinate of the top edge of the content area.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getWindowYPosition() {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
 }

--- a/jme3-desktop/src/main/java/com/jme3/system/awt/AwtPanelsContext.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/awt/AwtPanelsContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -276,4 +276,43 @@ public class AwtPanelsContext implements JmeContext {
         // only relevant if changing pixel format.
     }
 
+    /**
+     * Returns the height of the input panel.
+     *
+     * @return the height (in pixels)
+     */
+    @Override
+    public int getFramebufferHeight() {
+        return inputSource.getHeight();
+    }
+
+    /**
+     * Returns the width of the input panel.
+     *
+     * @return the width (in pixels)
+     */
+    @Override
+    public int getFramebufferWidth() {
+        return inputSource.getWidth();
+    }
+
+    /**
+     * Returns the screen X coordinate of the left edge of the input panel.
+     *
+     * @return the screen X coordinate
+     */
+    @Override
+    public int getWindowXPosition() {
+        return inputSource.getX();
+    }
+
+    /**
+     * Returns the screen Y coordinate of the top edge of the input panel.
+     *
+     * @return the screen Y coordinate
+     */
+    @Override
+    public int getWindowYPosition() {
+        return inputSource.getY();
+    }
 }

--- a/jme3-ios/src/main/java/com/jme3/system/ios/IGLESContext.java
+++ b/jme3-ios/src/main/java/com/jme3/system/ios/IGLESContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -215,5 +215,45 @@ public class IGLESContext implements JmeContext {
     public Context getOpenCLContext() {
         logger.warning("OpenCL not yet supported on this platform");
         return null;
+    }
+
+    /**
+     * Returns the height of the framebuffer.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getFramebufferHeight() {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
+    /**
+     * Returns the width of the framebuffer.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getFramebufferWidth() {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
+    /**
+     * Returns the screen X coordinate of the left edge of the content area.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getWindowXPosition() {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
+    /**
+     * Returns the screen Y coordinate of the top edge of the content area.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getWindowYPosition() {
+        throw new UnsupportedOperationException("not implemented yet");
     }
 }

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -508,5 +508,49 @@ public abstract class LwjglContext implements JmeContext {
     @Override
     public com.jme3.opencl.Context getOpenCLContext() {
         return clContext;
+    }
+
+    /**
+     * Returns the height of the framebuffer.
+     *
+     * @return the height (in pixels)
+     */
+    @Override
+    public int getFramebufferHeight() {
+        int result = Display.getHeight();
+        return result;
+    }
+
+    /**
+     * Returns the width of the framebuffer.
+     *
+     * @return the width (in pixels)
+     */
+    @Override
+    public int getFramebufferWidth() {
+        int result = Display.getWidth();
+        return result;
+    }
+
+    /**
+     * Returns the screen X coordinate of the left edge of the content area.
+     *
+     * @return the screen X coordinate
+     */
+    @Override
+    public int getWindowXPosition() {
+        int result = Display.getX();
+        return result;
+    }
+
+    /**
+     * Returns the screen Y coordinate of the top edge of the content area.
+     *
+     * @return the screen Y coordinate
+     */
+    @Override
+    public int getWindowYPosition() {
+        int result = Display.getY();
+        return result;
     }
 }

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -798,5 +798,53 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         store.y /= height[0];
 
         return store;
+    }
+
+    /**
+     * Returns the height of the framebuffer.
+     *
+     * @return the height (in pixels)
+     */
+    @Override
+    public int getFramebufferHeight() {
+        glfwGetFramebufferSize(window, width, height);
+        int result = height[0];
+        return result;
+    }
+
+    /**
+     * Returns the width of the framebuffer.
+     *
+     * @return the width (in pixels)
+     */
+    @Override
+    public int getFramebufferWidth() {
+        glfwGetFramebufferSize(window, width, height);
+        int result = width[0];
+        return result;
+    }
+
+    /**
+     * Returns the screen X coordinate of the left edge of the content area.
+     *
+     * @return the screen X coordinate
+     */
+    @Override
+    public int getWindowXPosition() {
+        glfwGetWindowPos(window, width, height);
+        int result = width[0];
+        return result;
+    }
+
+    /**
+     * Returns the screen Y coordinate of the top edge of the content area.
+     *
+     * @return the screen Y coordinate
+     */
+    @Override
+    public int getWindowYPosition() {
+        glfwGetWindowPos(window, width, height);
+        int result = height[0];
+        return result;
     }
 }

--- a/jme3-vr/src/main/java/com/jme3/system/lwjgl/LwjglWindowVR.java
+++ b/jme3-vr/src/main/java/com/jme3/system/lwjgl/LwjglWindowVR.java
@@ -1,7 +1,7 @@
 package com.jme3.system.lwjgl;
 
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -80,6 +80,10 @@ public abstract class LwjglWindowVR extends LwjglContextVR implements Runnable {
     private GLFWWindowSizeCallback windowSizeCallback;
     private GLFWWindowFocusCallback windowFocusCallback;
     private Thread mainThread;
+
+    // reusable arrays for GLFW calls
+    final private int width[] = new int[1];
+    final private int height[] = new int[1];
 
     /**
      * Create a new wrapper class over the GLFW framework in LWJGL 3.
@@ -527,6 +531,53 @@ public abstract class LwjglWindowVR extends LwjglContextVR implements Runnable {
         return window;
     }
 
+    /**
+     * Returns the height of the framebuffer.
+     *
+     * @return the height (in pixels)
+     */
+    @Override
+    public int getFramebufferHeight() {
+        glfwGetFramebufferSize(window, width, height);
+        int result = height[0];
+        return result;
+    }
+
+    /**
+     * Returns the width of the framebuffer.
+     *
+     * @return the width (in pixels)
+     */
+    @Override
+    public int getFramebufferWidth() {
+        glfwGetFramebufferSize(window, width, height);
+        int result = width[0];
+        return result;
+    }
+
+    /**
+     * Returns the screen X coordinate of the left edge of the content area.
+     *
+     * @return the screen X coordinate
+     */
+    @Override
+    public int getWindowXPosition() {
+        glfwGetWindowPos(window, width, height);
+        int result = width[0];
+        return result;
+    }
+
+    /**
+     * Returns the screen Y coordinate of the top edge of the content area.
+     *
+     * @return the screen Y coordinate
+     */
+    @Override
+    public int getWindowYPosition() {
+        glfwGetWindowPos(window, width, height);
+        int result = height[0];
+        return result;
+    }
 
     // TODO: Implement support for window icon when GLFW supports it.
     /*


### PR DESCRIPTION
This addresses issue #1900.

The most important implementations are those for LWJGL, which are straightforward. However, there are many other implementations of `JmeContext`, and I couldn't figure out how to obtain the desired information from all of them; exceptions are thrown in those cases.