### PR TITLE
jme3-lwjgl: bump to lwjgl 2.9.5 

### DIFF
--- a/jme3-lwjgl/build.gradle
+++ b/jme3-lwjgl/build.gradle
@@ -2,8 +2,8 @@ dependencies {
     api project(':jme3-core')
     api project(':jme3-desktop')
 
-    api 'org.jmonkeyengine:lwjgl:2.9.4'
-    runtimeOnly 'org.jmonkeyengine:lwjgl-platform:2.9.4'
+    api 'org.jmonkeyengine:lwjgl:2.9.5'
+    runtimeOnly 'org.jmonkeyengine:lwjgl-platform:2.9.5'
 
     /*
      * Upgrades the default jinput-2.0.5 to jinput-2.0.9 to fix a bug with gamepads on Linux.


### PR DESCRIPTION
It added the missing natives for windows and mac.

Fix #1908 