### PR TITLE
jme3-core: make PrimitiveAllocator default

### DIFF
--- a/jme3-core/src/main/java/com/jme3/util/BufferAllocatorFactory.java
+++ b/jme3-core/src/main/java/com/jme3/util/BufferAllocatorFactory.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2023 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.util;
 
 import com.jme3.system.Annotations.Internal;
@@ -25,7 +56,7 @@ public class BufferAllocatorFactory {
     @Internal
     protected static BufferAllocator create() {
 
-        final String className = System.getProperty(PROPERTY_BUFFER_ALLOCATOR_IMPLEMENTATION, ReflectionAllocator.class.getName());
+        final String className = System.getProperty(PROPERTY_BUFFER_ALLOCATOR_IMPLEMENTATION, PrimitiveAllocator.class.getName());
         try {
             return (BufferAllocator) Class.forName(className).getDeclaredConstructor().newInstance();
         } catch (final Throwable e) {

--- a/jme3-core/src/main/java/com/jme3/util/PrimitiveAllocator.java
+++ b/jme3-core/src/main/java/com/jme3/util/PrimitiveAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,12 +33,17 @@ package com.jme3.util;
 
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This class contains a primitive allocator with no special logic, should work
  * on any jvm
  */
 public final class PrimitiveAllocator implements BufferAllocator {
+
+    private static final Logger logger = Logger.getLogger(PrimitiveAllocator.class.getName());
+
     /**
      * De-allocate a direct buffer.
      *
@@ -48,7 +53,9 @@ public final class PrimitiveAllocator implements BufferAllocator {
     public void destroyDirectBuffer(Buffer toBeDestroyed) {
         // no exception by intent, as this way naively written java7/8
         // applications won't crash on 9 assuming they can dispose buffers
-        System.err.println("Warning destroyBuffer not supported");
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "destroyBuffer not supported");
+        }
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/util/PrimitiveAllocator.java
+++ b/jme3-core/src/main/java/com/jme3/util/PrimitiveAllocator.java
@@ -54,7 +54,7 @@ public final class PrimitiveAllocator implements BufferAllocator {
         // no exception by intent, as this way naively written java7/8
         // applications won't crash on 9 assuming they can dispose buffers
         if (logger.isLoggable(Level.FINE)) {
-            logger.log(Level.FINE, "destroyBuffer not supported");
+            logger.log(Level.FINE, "Destroy buffer not supported. It will be cleaned by GC.");
         }
     }
 


### PR DESCRIPTION
 The ReflectionAllocator uses unsafe and needs to add special flags to work on java 11+ ("--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED", "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"). It might break again in the future.

Related forum post:
https://hub.jmonkeyengine.org/t/deprecating-reflectionallocator/46350

Related issue: #1674 