### PR TITLE
main.yml: removed java-8 runner image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,8 +98,6 @@ jobs:
             osName: windows
           - os: macOS-latest
             osName: mac
-          - jdk: 11
-            deploy: false
           - jdk: 17
             deploy: false
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest,windows-2019,macOS-latest]
-        jdk: [8, 11, 17]
+        jdk: [11, 17]
         include:
           - os: ubuntu-latest
             osName: linux


### PR DESCRIPTION
### This PR attempts to remove the java-8 runner images since we are using gradle-7.6 with a release option 8:
- [x] Removed jdk 8 runner image.
- [ ] Migrate deploy to the jdk 17 image (wip).
  
For more refer to the gradle docs on building jvm applications:
https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_cross_compilation
