### PR TITLE
PBRLighting: fix comment describing packed MetallicRoughnessMap

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -28,7 +28,7 @@ MaterialDef PBR Lighting {
         Texture2D RoughnessMap -LINEAR
 
         //Metallic and Roughness are packed respectively in the b and g channel of a single map
-        // r: unspecified
+        // r: AO (if AoPackedInMRMap is true)
         // g: Roughness
         // b: Metallic
         Texture2D MetallicRoughnessMap -LINEAR


### PR DESCRIPTION
Updated a comment about the MetallicRoughness map that previously said the Red channel is unused - changed to instead say that the red channel of MR map can store the AO value if AoPackedInMRMap is true.