### PR TITLE
Fix #1923 (OSSRH artifacts are build with different java version)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -302,6 +302,13 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Setup jdk 17 used for building Sonatype OSSRH artifacts
+      - name: Setup the java environment
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       # Download all the stuff...
       - name: Download maven artifacts
         uses: actions/download-artifact@master


### PR DESCRIPTION
Deploy OSSRH artifacts with jdk17.

Fix #1923 