### PR TITLE
solve issue #1930 (NPE in FbxLayerElement)

### DIFF
--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/mesh/FbxLayerElement.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/mesh/FbxLayerElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -196,7 +196,7 @@ public class FbxLayerElement {
                 layerElement.name = (String) child.properties.get(0);
             }
         }
-        if (layerElement.data == null) {
+        if (layerElement.data == null && layerElement.dataIndices != null) {
             // For Smoothing / Materials, data = dataIndices
             layerElement.refInfoType = ReferenceInformationType.Direct;
             layerElement.data = new Integer[layerElement.dataIndices.length];


### PR DESCRIPTION
Skip the copy if `dataIndices` is null.

This enables import of 2 models that used to crash due to issue #1930:
+ "Old_house_block_01.fbx"  (file version 7400) and
+ "Urban_communications.fbx" (file version 6100)