### PR TITLE
solve issue #1933 (unsupported operation in FbxNode)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Matrix4f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Matrix4f.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -2458,6 +2458,75 @@ public final class Matrix4f implements Savable, Cloneable, java.io.Serializable 
         Matrix4f matrix4f = new Matrix4f();
         matrix4f.fromAngleAxis(angle, axis);
         multLocal(matrix4f);
+    }
+
+    /**
+     * Tests for approximate equality with the specified matrix, using the
+     * specified tolerance. If {@code other} is null, false is returned. Either
+     * way, the current instance is unaffected.
+     *
+     * @param other the matrix to compare (unaffected) or null for none
+     * @param epsilon the tolerance for each element
+     * @return true if all 16 elements are within tolerance, otherwise false
+     */
+    public boolean isSimilar(Matrix4f other, float epsilon) {
+        if (other == null) {
+            return false;
+        }
+
+        if (Float.compare(Math.abs(other.m00 - m00), epsilon) > 0) {
+            return false;
+        }
+        if (Float.compare(Math.abs(other.m01 - m01), epsilon) > 0) {
+            return false;
+        }
+        if (Float.compare(Math.abs(other.m02 - m02), epsilon) > 0) {
+            return false;
+        }
+        if (Float.compare(Math.abs(other.m03 - m03), epsilon) > 0) {
+            return false;
+        }
+
+        if (Float.compare(Math.abs(other.m10 - m10), epsilon) > 0) {
+            return false;
+        }
+        if (Float.compare(Math.abs(other.m11 - m11), epsilon) > 0) {
+            return false;
+        }
+        if (Float.compare(Math.abs(other.m12 - m12), epsilon) > 0) {
+            return false;
+        }
+        if (Float.compare(Math.abs(other.m13 - m13), epsilon) > 0) {
+            return false;
+        }
+
+        if (Float.compare(Math.abs(other.m20 - m20), epsilon) > 0) {
+            return false;
+        }
+        if (Float.compare(Math.abs(other.m21 - m21), epsilon) > 0) {
+            return false;
+        }
+        if (Float.compare(Math.abs(other.m22 - m22), epsilon) > 0) {
+            return false;
+        }
+        if (Float.compare(Math.abs(other.m23 - m23), epsilon) > 0) {
+            return false;
+        }
+
+        if (Float.compare(Math.abs(other.m30 - m30), epsilon) > 0) {
+            return false;
+        }
+        if (Float.compare(Math.abs(other.m31 - m31), epsilon) > 0) {
+            return false;
+        }
+        if (Float.compare(Math.abs(other.m32 - m32), epsilon) > 0) {
+            return false;
+        }
+        if (Float.compare(Math.abs(other.m33 - m33), epsilon) > 0) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/node/FbxNode.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/node/FbxNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -159,7 +159,7 @@ public class FbxNode extends FbxObject<Spatial> {
     
     public void setWorldBindPose(Matrix4f worldBindPose) {
         if (cachedWorldBindPose != null) {
-            if (!cachedWorldBindPose.equals(worldBindPose)) {
+            if (!cachedWorldBindPose.isSimilar(worldBindPose, 1e-6f)) {
                 throw new UnsupportedOperationException("Bind poses don't match");
             }
         }


### PR DESCRIPTION
Added the `isSimilar()` method to `Matrix4f` since that seems the best place for it. The implementation is closely based on that of `Vector3f.isSimilar()`.

Hardcoded the tolerance to `1e-6f`, even though the largest difference seen so far was `< 1e-19`. I suspect that differences smaller than `1e-6f` will be imperceptible.
