### PR TITLE
solve issue #1939 [NPE in FbxMesh.applyCluster()]

### DIFF
--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/FbxLoader.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/FbxLoader.java
@@ -343,6 +343,9 @@ public class FbxLoader implements AssetLoader {
         
         // At this point we can construct the animation for all pairs ...
         for (FbxToJmeTrack pair : pairs.values()) {
+            if (pair.countKeyframes() == 0) {
+                continue;
+            }
             String animName = pair.animStack.getName();
             float duration    = pair.animStack.getDuration();
             

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/FbxCluster.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/FbxCluster.java
@@ -93,6 +93,12 @@ public class FbxCluster extends FbxObject {
                 }
             }
         }
+
+        if (indexes == null && weights == null) {
+            // The cluster doesn't contain any keyframes!
+            this.indexes = new int[0];
+            this.weights = new double[0];
+        }
     }
 
     public int[] getVertexIndices() {

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/FbxToJmeTrack.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/FbxToJmeTrack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -91,7 +91,23 @@ public final class FbxToJmeTrack {
     public SpatialTrack toJmeSpatialTrack() {
         return (SpatialTrack) toJmeTrackInternal(-1, null);
     }
-    
+
+    /**
+     * Counts how many keyframes there are in the included curves.
+     *
+     * @return the total number of keyframes (&ge;0)
+     */
+    public int countKeyframes() {
+        int count = 0;
+        for (FbxAnimCurveNode curveNode : animCurves.values()) {
+            for (FbxAnimCurve curve : curveNode.getCurves()) {
+                count += curve.getKeyTimes().length;
+            }
+        }
+
+        return count;
+    }
+
     public float getDuration() {
         long[] keyframes = getKeyTimes();
         return (float) (keyframes[keyframes.length - 1] * FbxAnimUtil.SECONDS_PER_UNIT);


### PR DESCRIPTION
Cleanly handle the absence of animation data in 2 places:
+ in `FbxCluster.fromElement()`, create empty arrays of weights and indices
+ in `FbxLoader.constructAnimations()`, skip over any animations without keyframes