### PR TITLE
solve issue #1879 (compile-time error in Skinning.glsllib)

### DIFF
--- a/jme3-core/src/main/resources/Common/ShaderLib/Skinning.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/Skinning.glsllib
@@ -50,10 +50,12 @@ void Skinning_Compute(inout vec4 position, inout vec3 normal, inout vec3 tangent
     if (inHWBoneWeight.x != 0.0) {
 #if NUM_WEIGHTS_PER_VERT == 1
         position = m_BoneMatrices[int(inHWBoneIndex.x)] * position;
-        tangent = m_BoneMatrices[int(inHWBoneIndex.x)] * tangent;
-        normal = (mat3(m_BoneMatrices[int(inHWBoneIndex.x)][0].xyz,
+
+        mat3 rotMat = mat3(m_BoneMatrices[int(inHWBoneIndex.x)][0].xyz,
                        m_BoneMatrices[int(inHWBoneIndex.x)][1].xyz,
-                       m_BoneMatrices[int(inHWBoneIndex.x)][2].xyz) * normal);
+                       m_BoneMatrices[int(inHWBoneIndex.x)][2].xyz);
+        tangent = rotMat * tangent;
+        normal = rotMat * normal;
 #else
         mat4 mat = mat4(0.0);
         mat += m_BoneMatrices[int(inHWBoneIndex.x)] * inHWBoneWeight.x;


### PR DESCRIPTION
A straightforward fix for issue #1879, rotating tangents using the same matrix that's used to rotate normals.

I've run "TestJaime.java" as a sanity check, however I don't see a way to test this fix. That's because I don't see how the `#if NUM_WEIGHTS_PER_VERT == 1` code in "Skinning.glsllib" ever gets compiled.

@zzuegg could you please test this fix or explain how it should be tested?