### PR TITLE
solve issue #1806 (global FrameInterpolator violates threading model)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,7 +52,11 @@ public class MorphTrack implements AnimTrack<float[]> {
      * Weights and times for track.
      */
     private float[] weights;
-    private FrameInterpolator interpolator = FrameInterpolator.DEFAULT;
+    /**
+     * The interpolator to use, or null to always use the default interpolator
+     * of the current thread.
+     */
+    private FrameInterpolator interpolator = null;
     private float[] times;
     private int nbMorphTargets;
 
@@ -219,7 +223,9 @@ public class MorphTrack implements AnimTrack<float[]> {
                     / (times[endFrame] - times[startFrame]);
         }
 
-        interpolator.interpolateWeights(blend, startFrame, weights, nbMorphTargets, store);
+        FrameInterpolator fi = (interpolator == null)
+                ? FrameInterpolator.getThreadDefault() : interpolator;
+        fi.interpolateWeights(blend, startFrame, weights, nbMorphTargets, store);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,11 @@ import java.io.IOException;
 public class TransformTrack implements AnimTrack<Transform> {
 
     private double length;
-    private FrameInterpolator interpolator = FrameInterpolator.DEFAULT;
+    /**
+     * The interpolator to use, or null to always use the default interpolator
+     * of the current thread.
+     */
+    private FrameInterpolator interpolator = null;
     private HasLocalTransform target;
 
     /**
@@ -281,7 +285,10 @@ public class TransformTrack implements AnimTrack<Transform> {
                     / (times[endFrame] - times[startFrame]);
         }
 
-        Transform interpolated = interpolator.interpolate(blend, startFrame, translations, rotations, scales, times);
+        FrameInterpolator fi = (interpolator == null)
+                ? FrameInterpolator.getThreadDefault() : interpolator;
+        Transform interpolated = fi.interpolate(
+                blend, startFrame, translations, rotations, scales, times);
 
         if (translations != null) {
             transform.setTranslation(interpolated.getTranslation());

--- a/jme3-core/src/main/java/com/jme3/anim/interpolator/FrameInterpolator.java
+++ b/jme3-core/src/main/java/com/jme3/anim/interpolator/FrameInterpolator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,7 +38,16 @@ import com.jme3.math.*;
  * Created by nehon on 15/04/17.
  */
 public class FrameInterpolator {
+    /**
+     * A global default instance of this class, for compatibility with JME v3.5.
+     * Due to issue #1806, use of this instance is discouraged.
+     */
     public static final FrameInterpolator DEFAULT = new FrameInterpolator();
+    /**
+     * The per-thread default instances of this class.
+     */
+    private static final ThreadLocal<FrameInterpolator> THREAD_DEFAULT
+            = ThreadLocal.withInitial(() -> new FrameInterpolator());
 
     private AnimInterpolator<Float> timeInterpolator;
     private AnimInterpolator<Vector3f> translationInterpolator = AnimInterpolators.LinearVec3f;
@@ -51,6 +60,16 @@ public class FrameInterpolator {
     final private TrackTimeReader timesReader = new TrackTimeReader();
 
     final private Transform transforms = new Transform();
+
+    /**
+     * Obtain the default interpolator for the current thread.
+     *
+     * @return the pre-existing instance (not null)
+     */
+    public static FrameInterpolator getThreadDefault() {
+        FrameInterpolator result = THREAD_DEFAULT.get();
+        return result;
+    }
 
     public Transform interpolate(float t, int currentIndex, CompactVector3Array translations,
             CompactQuaternionArray rotations, CompactVector3Array scales, float[] times) {

--- a/jme3-core/src/main/java/com/jme3/anim/interpolator/FrameInterpolator.java
+++ b/jme3-core/src/main/java/com/jme3/anim/interpolator/FrameInterpolator.java
@@ -41,7 +41,10 @@ public class FrameInterpolator {
     /**
      * A global default instance of this class, for compatibility with JME v3.5.
      * Due to issue #1806, use of this instance is discouraged.
+     *
+     * @deprecated use {@link #getThreadDefault()}
      */
+    @Deprecated
     public static final FrameInterpolator DEFAULT = new FrameInterpolator();
     /**
      * The per-thread default instances of this class.


### PR DESCRIPTION
Instead of a `FrameInterpolator` instance for each `AnimComposer`/`SkinningControl`, this solution provides an instance for each thread. The per-thread instances are allocated using `ThreadLocal.withInitial()`.

To maximize compatibility with JME v3.5, the public `FrameInterpolator.DEFAULT` field is retained, however it is deprecated and no longer used in the Engine.

Similarly, the `setFrameInterpolator()` methods in `MorphTrack` and `TransformTrack` are retained. However, a `null` interpolator now has special meaning to these classes, namely that the per-thread default instance should be used.
