### PR TITLE
Fix issue #1558 (TestAWTPanels crashes with LWJGL v3 on Linux)

### DIFF
--- a/jme3-examples/src/main/java/jme3test/awt/TestAwtPanels.java
+++ b/jme3-examples/src/main/java/jme3test/awt/TestAwtPanels.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2023 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package jme3test.awt;
 
 import com.jme3.app.SimpleApplication;
@@ -16,10 +47,11 @@ import java.awt.event.WindowEvent;
 import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.swing.JFrame;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
 
 public class TestAwtPanels extends SimpleApplication {
+
+    private static final Logger logger = Logger.getLogger(TestAwtPanels.class.getName());
 
     final private static CountDownLatch panelsAreReady = new CountDownLatch(1);
     private static TestAwtPanels app;
@@ -46,7 +78,13 @@ public class TestAwtPanels extends SimpleApplication {
     
     public static void main(String[] args){
         Logger.getLogger("com.jme3").setLevel(Level.WARNING);
-        
+
+        try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        } catch (Exception e) {
+            logger.warning("Could not set native look and feel.");
+        }
+
         app = new TestAwtPanels();
         app.setShowSettings(false);
         AppSettings settings = new AppSettings(true);

--- a/jme3-examples/src/main/java/jme3test/awt/TestAwtPanels.java
+++ b/jme3-examples/src/main/java/jme3test/awt/TestAwtPanels.java
@@ -47,7 +47,9 @@ import java.awt.event.WindowEvent;
 import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.swing.*;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 
 public class TestAwtPanels extends SimpleApplication {
 


### PR DESCRIPTION
This resolves the JVM crash happening when running TestAWTPanels on Linux and LWJGL 3. Seems setting the Look And Feel on Swing UIManager prevents the crash.

Fix #1558 

Still need to figure out a solution for IllegalStateException happening on JME 3.6.0-beta1. See https://github.com/jMonkeyEngine/jmonkeyengine/issues/1558#issuecomment-1423951041 
But I think this should be in a separate PR.