### PR TITLE
Fix #1945 (IllegalStateException when running TestAWTPanels with LWJGL 3)

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/system/awt/AwtPanelsContext.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/awt/AwtPanelsContext.java
@@ -41,8 +41,11 @@ import com.jme3.opencl.Context;
 import com.jme3.renderer.Renderer;
 import com.jme3.system.*;
 import java.util.ArrayList;
+import java.util.logging.Logger;
 
 public class AwtPanelsContext implements JmeContext {
+
+    private static final Logger logger = Logger.getLogger(AwtPanelsContext.class.getName());
 
     protected JmeContext actualContext;
     protected AppSettings settings = new AppSettings(true);
@@ -64,12 +67,12 @@ public class AwtPanelsContext implements JmeContext {
 
         @Override
         public void reshape(int width, int height) {
-            throw new IllegalStateException();
+            logger.severe("reshape is not supported.");
         }
 
         @Override
         public void rescale(float x, float y) {
-            throw new IllegalStateException();
+            logger.severe("rescale is not supported.");
         }
 
         @Override


### PR DESCRIPTION
Log a "not supported" error on AwtPanelsListener.reshape/rescale method instead of throwing an exception. 

Fix #1945