### PR TITLE
Add WaterFilter.getReflectionView method

### DIFF
--- a/jme3-effects/src/main/java/com/jme3/water/WaterFilter.java
+++ b/jme3-effects/src/main/java/com/jme3/water/WaterFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -514,6 +514,16 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
      */
     public Spatial getReflectionScene() {
         return reflectionScene;
+    }
+
+    /**
+     * Gets the view port used to render refraction scene in the
+     * reflection map.
+     *
+     * @return the reflection view port.
+     */
+    public ViewPort getReflectionView() {
+        return reflectionView;
     }
 
     /**

--- a/jme3-effects/src/main/java/com/jme3/water/WaterFilter.java
+++ b/jme3-effects/src/main/java/com/jme3/water/WaterFilter.java
@@ -517,8 +517,7 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
     }
 
     /**
-     * Gets the view port used to render refraction scene in the
-     * reflection map.
+     * Gets the view port used to render reflection scene.
      *
      * @return the reflection view port.
      */


### PR DESCRIPTION
I use this to grab and hook the water reflection ViewPort into SkyControl for automatically updating the day/night color.

```
WaterFilter water = fpp.getFilter(WaterFilter.class);
if (water != null) {
     skyControl.getUpdater().addViewPort(water.getReflectionView());
}
```

What do you think, is this a good addition? 

Edit:
In my case, I am setting an empty node as a "reflection scene" (I am doing a cartoon-style water and realistic reflection is not needed also it is a bit expensive) but I still need to be able to reflect the day/night color which I control by the viewport color via SkyControl.