### PR TITLE
Catch and log all uncaught exceptions propagated from simpleUpdate().

### DIFF
--- a/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java
+++ b/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java
@@ -267,6 +267,7 @@ public abstract class SimpleApplication extends LegacyApplication {
             simpleUpdate(tpf);
         }catch(Exception e){
             logger.log(Level.WARNING, "Uncaught exception in simpleUpdate():", e);
+            throw e;
         }
 
         if (prof != null)

--- a/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java
+++ b/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java
@@ -49,6 +49,9 @@ import com.jme3.system.AppSettings;
 import com.jme3.system.JmeContext.Type;
 import com.jme3.system.JmeSystem;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * <code>SimpleApplication</code> is the base class for all jME3 Applications.
  * <code>SimpleApplication</code> will display a statistics view
@@ -64,6 +67,8 @@ import com.jme3.system.JmeSystem;
  * be removed by calling <code>stateManager.detach(stateManager.getState(FlyCamAppState.class));</code>
  */
 public abstract class SimpleApplication extends LegacyApplication {
+
+    private static final Logger logger = Logger.getLogger(SimpleApplication.class.getName());
 
     public static final String INPUT_MAPPING_EXIT = "SIMPLEAPP_Exit";
     public static final String INPUT_MAPPING_CAMERA_POS = DebugKeysAppState.INPUT_MAPPING_CAMERA_POS;
@@ -258,7 +263,11 @@ public abstract class SimpleApplication extends LegacyApplication {
         stateManager.update(tpf);
 
         // simple update and root node
-        simpleUpdate(tpf);
+        try{
+            simpleUpdate(tpf);
+        }catch(Exception e){
+            logger.log(Level.WARNING, "Uncaught exception in simpleUpdate():", e);
+        }
 
         if (prof != null)
             prof.appStep(AppStep.SpatialUpdate);


### PR DESCRIPTION
I recently encountered an issue where exceptions were propagating out of my code and silently being swallowed without the usual "uncaught exception" window being shown or any logging. Since jME already tries to handle this case, I was surprised after a couple of hours of debugging to find that the origin was an exception coming from within `simpleUpdate()` (in my case it happened in a subtle and rather difficult to debug scenario).

The solution I added in my codebase was wrapping the body of `simpleUpdate()` in a try-catch block and logging the stack trace. Since `SimpleApplication` aims to be a consistent and easy to use one-stop-shop for app-level concerns, it would be nice if it handled this situation as well.

I'm not entirely convinced that this is the best way to do this (especially given jME's existing uncaught exception handling), but it seems a reasonable starting point for further discussion - feedback is welcomed.