### PR TITLE
resolve issue #1955 (Can not play vorbis audio on Android API 31+)

### DIFF
--- a/jme3-android-native/src/native/jme_decode/com_jme3_audio_plugins_NativeVorbisFile.c
+++ b/jme3-android-native/src/native/jme_decode/com_jme3_audio_plugins_NativeVorbisFile.c
@@ -251,7 +251,7 @@ JNIEXPORT void JNICALL Java_com_jme3_audio_plugins_NativeVorbisFile_seekTime
     }
 }
 
-JNIEXPORT jint JNICALL Java_com_jme3_audio_plugins_NativeVorbisFile_read
+JNIEXPORT jint JNICALL Java_com_jme3_audio_plugins_NativeVorbisFile_readIntoArray
   (JNIEnv *env, jobject nvf, jbyteArray buf, jint off, jint len)
 {
     int bitstream = -1;
@@ -293,7 +293,7 @@ JNIEXPORT jint JNICALL Java_com_jme3_audio_plugins_NativeVorbisFile_read
     return result;
 }
 
-JNIEXPORT void JNICALL Java_com_jme3_audio_plugins_NativeVorbisFile_readFully
+JNIEXPORT void JNICALL Java_com_jme3_audio_plugins_NativeVorbisFile_readIntoBuffer
   (JNIEnv *env, jobject nvf, jobject buf)
 {
     int bitstream = -1;

--- a/jme3-android-native/src/native/jme_decode/com_jme3_audio_plugins_NativeVorbisFile.c
+++ b/jme3-android-native/src/native/jme_decode/com_jme3_audio_plugins_NativeVorbisFile.c
@@ -179,7 +179,7 @@ JNIEXPORT void JNICALL Java_com_jme3_audio_plugins_NativeVorbisFile_preInit
 JNIEXPORT void JNICALL Java_com_jme3_audio_plugins_NativeVorbisFile_init
   (JNIEnv *env, jobject nvf, jint fd, jlong off, jlong len)
 {
-    LOGI("open: fd = %d, off = %lld, len = %lld", fd, off, len);
+    LOGI("init: fd = %d, off = %lld, len = %lld", fd, off, len);
     
     OggVorbis_File* ovf = (OggVorbis_File*) malloc(sizeof(OggVorbis_File));
     
@@ -194,19 +194,19 @@ JNIEXPORT void JNICALL Java_com_jme3_audio_plugins_NativeVorbisFile_init
     
     if (result != 0)
     {
-        LOGI("ov_open fail");
+        LOGI("init fail");
         
         free(ovf);
         free(wrapper);
     
         char err[512];
-        sprintf(err, "ov_open failed: %d", result);
+        sprintf(err, "init failed: %d", result);
         throwIOException(env, err);
         
         return;
     }
     
-    LOGI("ov_open OK");
+    LOGI("init OK");
     jobject ovfBuf = (*env)->NewDirectByteBuffer(env, ovf, sizeof(OggVorbis_File));
     
     vorbis_info* info = ov_info(ovf, -1);

--- a/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisFile.java
+++ b/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisFile.java
@@ -1,8 +1,49 @@
+/*
+ * Copyright (c) 2009-2023 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.audio.plugins;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+/**
+ * Represents the android implementation for the native <a href="https://xiph.org"/> vorbis file decoder.
+ * This decoder initializes an OggVorbis_File from an already opened file designated by the {@link NativeVorbisFile#fd}.
+ * <br/>
+ * 
+ * Code by Kirill Vainer.
+ * <br/>
+ * 
+ * Modified by pavl_g.
+ */
 public class NativeVorbisFile {
     
     public int fd;
@@ -20,29 +61,64 @@ public class NativeVorbisFile {
     }
     
     /**
-     * Initializes an ogg vorbis native file from a file descriptor [fd].
+     * Initializes an ogg vorbis native file from a file descriptor [fd] of an already opened file.
      * 
      * @param fd an integer representing the file descriptor 
-     * @param offset an integer representing the start of the 
-     * @param length an integer representing the length of the 
-     * @throws IOException
+     * @param offset an integer indicating the start of the buffer
+     * @param length an integer indicating the end of the buffer
+     * @throws IOException in cases of a failure to initialize the vorbis file 
      */
     public NativeVorbisFile(int fd, long offset, long length) throws IOException {
         init(fd, offset, length);
     }
     
-    private native void init(int fd, long offset, long length) throws IOException;
-    
+    /**
+     * Seeks to a playback time relative to the decompressed pcm (Pulse-code modulation) stream.
+     * 
+     * @param time the playback seek time
+     * @throws IOException if the seek is not successful
+     */
     public native void seekTime(double time) throws IOException;
     
-    public native int read(byte[] buf, int off, int len) throws IOException;
-    
-    public native void readFully(ByteBuffer out) throws IOException;
+    /**
+     * Reads the vorbis file into a primitive byte buffer [buf].
+     * 
+     * @param buffer a primitive byte buffer to read the data into it
+     * @param offset an integer representing the offset or the start of the data read
+     * @param length an integer representing the end of the data read
+     * @return the number of the read bytes, (-1) if the reading has failed indicating an EOF, 
+     *         returns (0) if the reading has failed or the primitive [buffer] passed is null
+     * @throws IOException if the library has failed to read the file into the [out] buffer
+     *                     or if the java primitive byte array [buffer] is inaccessible
+     */
+    public native int readIntoArray(byte[] buffer, int offset, int length) throws IOException;
     
     /**
-     * Clears the native resources by calling free() destroying the structure defining this buffer.
+     * Reads the vorbis file into a direct {@link java.nio.ByteBuffer}.
+     * 
+     * @param out a reference to the output direct buffer 
+     * @throws IOException if a premature EOF is encountered before reaching the end of the buffer
+     *                     or if the library has failed to read the file into the [out] buffer
+     */
+    public native void readIntoBuffer(ByteBuffer out) throws IOException;
+    
+    /**
+     * Clears the native resources and destroys the buffer {@link NativeVorbisFile#ovf} reference.
      */
     public native void clearResources();
     
-    public static native void preInit();
+    /**
+     * Prepares the java fields for the native environment.
+     */
+    private static native void preInit();
+    
+    /**
+     * Initializes an ogg vorbis native file from a file descriptor [fd] of an already opened file.
+     * 
+     * @param fd an integer representing the file descriptor 
+     * @param offset an integer representing the start of the buffer
+     * @param length an integer representing the length of the buffer
+     * @throws IOException in cases of a failure to initialize the vorbis file 
+     */
+    private native void init(int fd, long offset, long length) throws IOException;
 }

--- a/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisFile.java
+++ b/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisFile.java
@@ -81,7 +81,8 @@ public class NativeVorbisFile {
     public native void seekTime(double time) throws IOException;
     
     /**
-     * Reads the vorbis file into a primitive byte buffer [buf].
+     * Reads the vorbis file into a primitive byte buffer [buf] with an [offset] indicating the read start and a [length] indicating the read end on the output buffer.
+     * This is used for reading a particular chunk of data into a primitive array.
      * 
      * @param buffer a primitive byte buffer to read the data into it
      * @param offset an integer representing the offset or the start of the data read
@@ -94,7 +95,7 @@ public class NativeVorbisFile {
     public native int readIntoArray(byte[] buffer, int offset, int length) throws IOException;
     
     /**
-     * Reads the vorbis file into a direct {@link java.nio.ByteBuffer}, starting from offset [0] till the buffer capacity.
+     * Reads the vorbis file into a direct {@link java.nio.ByteBuffer}, starting from offset [0] till the buffer end on the output buffer.
      * 
      * @param out a reference to the output direct buffer 
      * @throws IOException if a premature EOF is encountered before reaching the end of the buffer

--- a/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisFile.java
+++ b/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisFile.java
@@ -16,14 +16,22 @@ public class NativeVorbisFile {
     
     static {
         System.loadLibrary("decodejme");
-        nativeInit();
+        preInit();
     }
     
-    public NativeVorbisFile(int fd, long off, long len) throws IOException {
-        open(fd, off, len);
+    /**
+     * Initializes an ogg vorbis native file from a file descriptor [fd].
+     * 
+     * @param fd an integer representing the file descriptor 
+     * @param offset an integer representing the start of the 
+     * @param length an integer representing the length of the 
+     * @throws IOException
+     */
+    public NativeVorbisFile(int fd, long offset, long length) throws IOException {
+        init(fd, offset, length);
     }
     
-    private native void open(int fd, long off, long len) throws IOException;
+    private native void init(int fd, long offset, long length) throws IOException;
     
     public native void seekTime(double time) throws IOException;
     
@@ -31,7 +39,10 @@ public class NativeVorbisFile {
     
     public native void readFully(ByteBuffer out) throws IOException;
     
-    public native void close();
+    /**
+     * Clears the native resources by calling free() destroying the structure defining this buffer.
+     */
+    public native void clearResources();
     
-    public static native void nativeInit();
+    public static native void preInit();
 }

--- a/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisFile.java
+++ b/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisFile.java
@@ -94,7 +94,7 @@ public class NativeVorbisFile {
     public native int readIntoArray(byte[] buffer, int offset, int length) throws IOException;
     
     /**
-     * Reads the vorbis file into a direct {@link java.nio.ByteBuffer}.
+     * Reads the vorbis file into a direct {@link java.nio.ByteBuffer}, starting from offset [0] till the buffer capacity.
      * 
      * @param out a reference to the output direct buffer 
      * @throws IOException if a premature EOF is encountered before reaching the end of the buffer

--- a/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisFile.java
+++ b/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisFile.java
@@ -81,12 +81,11 @@ public class NativeVorbisFile {
     public native void seekTime(double time) throws IOException;
     
     /**
-     * Reads the vorbis file into a primitive byte buffer [buf] with an [offset] indicating the read start and a [length] indicating the read end on the output buffer.
-     * This is used for reading a particular chunk of data into a primitive array.
+     * Reads the vorbis file into a primitive byte buffer [buf] with an [offset] indicating the start byte and a [length] indicating the end byte on the output buffer.
      * 
      * @param buffer a primitive byte buffer to read the data into it
-     * @param offset an integer representing the offset or the start of the data read
-     * @param length an integer representing the end of the data read
+     * @param offset an integer representing the offset or the start byte on the output buffer
+     * @param length an integer representing the end byte on the output buffer
      * @return the number of the read bytes, (-1) if the reading has failed indicating an EOF, 
      *         returns (0) if the reading has failed or the primitive [buffer] passed is null
      * @throws IOException if the library has failed to read the file into the [out] buffer

--- a/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisLoader.java
+++ b/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisLoader.java
@@ -33,12 +33,12 @@ public class NativeVorbisLoader implements AssetLoader {
         
         @Override
         public int read(byte[] buf) throws IOException {
-            return file.read(buf, 0, buf.length);
+            return file.readIntoArray(buf, 0, buf.length);
         }
         
         @Override
         public int read(byte[] buf, int off, int len) throws IOException {
-            return file.read(buf, off, len);
+            return file.readIntoArray(buf, off, len);
         }
         
         @Override
@@ -71,7 +71,7 @@ public class NativeVorbisLoader implements AssetLoader {
             int fd = afd.getParcelFileDescriptor().getFd();
             file = new NativeVorbisFile(fd, afd.getStartOffset(), afd.getLength());
             ByteBuffer data = BufferUtils.createByteBuffer(file.totalBytes);
-            file.readFully(data);
+            file.readIntoBuffer(data);
             AudioBuffer ab = new AudioBuffer();
             ab.setupFormat(file.channels, 16, file.sampleRate);
             ab.updateData(data);

--- a/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisLoader.java
+++ b/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisLoader.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2023 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.audio.plugins;
 
 import android.content.res.AssetFileDescriptor;

--- a/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisLoader.java
+++ b/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisLoader.java
@@ -57,7 +57,7 @@ public class NativeVorbisLoader implements AssetLoader {
         
         @Override
         public void close() throws IOException {
-            file.close();
+            file.clearResources();
             afd.close();
         }
     }
@@ -78,7 +78,7 @@ public class NativeVorbisLoader implements AssetLoader {
             return ab;
         } finally {
             if (file != null) {
-                file.close();
+                file.clearResources();
             }
             if (afd != null) {
                 afd.close();
@@ -107,7 +107,7 @@ public class NativeVorbisLoader implements AssetLoader {
         } finally {
             if (!success) {
                 if (file != null) {
-                    file.close();
+                    file.clearResources();
                 }
                 if (afd != null) {
                     afd.close();


### PR DESCRIPTION
### This PR fixes the following:
- [x] Issue [#1955] by delegating the file closure to the android [`ParcelFileDescriptor`](https://github.com/jMonkeyEngine/jmonkeyengine/blob/493195eae810c4a38744e6c34ea0e7e8c48542a9/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisLoader.java#L71), the original resource that opens the audio asset.

### This PR adds the following: 
- [x] Java documentation.
- [x] Native.

### This PR refactors the following: 
- [x] `NativeVorbisFile#open(int, long, long)` to `NativeVorbisFile#init(int, long, long)`.
- [x] `NativeVorbisFile#close()` to `NativeVorbisFile#clearResources()`. 
- [x] `NativeVorbisFile#read(byte[], int, int)` to `NativeVorbisFile#readIntoArray(byte[], int, int)`.
- [x] `NativeVorbisFile#readFully(ByteBuffer)` to `NativeVorbisFile#readIntoBuffer(ByteBuffer)`.