### PR TITLE
resolve issue #1958 (jmf library coming with j-ogg-all is not required)

### DIFF
--- a/jme3-jogg/build.gradle
+++ b/jme3-jogg/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
     api project(':jme3-core')
-    api 'com.github.stephengold:j-ogg-all:1.0.2'
+    api ('com.github.stephengold:j-ogg-all:1.0.2') {
+        exclude module: "jmf"
+    }
 }


### PR DESCRIPTION
This PR excludes `javax.media:jmf` library from `jme3-jogg` module as it is not required for decoding ogg files in JME.

Fix issue #1958 