### PR TITLE
jme3-jogg: remove dependency on Java Media Framework

### DIFF
--- a/jme3-jogg/build.gradle
+++ b/jme3-jogg/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
     api project(':jme3-core')
-    api 'com.github.stephengold:j-ogg-all:1.0.2'
+    api 'com.github.stephengold:j-ogg-vorbis:1.0.3'
 }


### PR DESCRIPTION
The jme3-jogg library currently depends on the open-source j-ogg-all library. In turn, j-ogg-all depends on the Java Media Framework (JMF), which is large (about 1.9 MBytes), unmaintained, not open-source, and not available for all platforms.

In fact, jme3-jogg uses just a fraction of the j-ogg-all functionality: specifically, the Ogg-container reader and the Vorbis decoder.

Version 1.0.3 of the j-ogg-all project includes a new library ("j-ogg-vorbis") without decoders for the FLAC and Theora formats. This PR substitutes "j-ogg-vorbis" for "j-ogg-all", which should result in more compact applications with fewer dependencies.