### PR TITLE
solve issue #1963 (TestMusicPlayer fails to load AL library on lwjgl2)

### DIFF
--- a/jme3-examples/src/main/java/jme3test/audio/TestMusicPlayer.java
+++ b/jme3-examples/src/main/java/jme3test/audio/TestMusicPlayer.java
@@ -62,6 +62,7 @@ public class TestMusicPlayer extends javax.swing.JFrame {
             // started but in this test we do not need a LwjglContext, so
             // we should handle loading natives ourselves.
             NativeLibraryLoader.loadNativeLibrary("lwjgl", true);
+            NativeLibraryLoader.loadNativeLibrary("openal", true);
         } catch (ClassNotFoundException exception) {
             // Not using lwjgl version 2
         }

--- a/jme3-examples/src/main/java/jme3test/audio/TestMusicPlayer.java
+++ b/jme3-examples/src/main/java/jme3test/audio/TestMusicPlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,8 @@ import com.jme3.audio.plugins.OGGLoader;
 import com.jme3.audio.plugins.WAVLoader;
 import com.jme3.system.AppSettings;
 import com.jme3.system.JmeSystem;
+import com.jme3.system.NativeLibraryLoader;
+
 import java.io.*;
 import javax.swing.JFileChooser;
 
@@ -51,6 +53,19 @@ public class TestMusicPlayer extends javax.swing.JFrame {
     private float musicLength = 0;
     private float curTime = 0;
     final private Listener listener = new Listener();
+
+    static {
+        try {
+            Class.forName("org.lwjgl.opengl.Display", false, ClassLoader.getSystemClassLoader());
+            // Using lwjgl version 2
+            // In case of lwjgl2, natives are loaded when LwjglContext is
+            // started but in this test we do not need a LwjglContext, so
+            // we should handle loading natives ourselves.
+            NativeLibraryLoader.loadNativeLibrary("lwjgl", true);
+        } catch (ClassNotFoundException exception) {
+            // Not using lwjgl version 2
+        }
+    }
 
     public TestMusicPlayer() {
         initComponents();

--- a/jme3-examples/src/main/java/jme3test/audio/TestMusicPlayer.java
+++ b/jme3-examples/src/main/java/jme3test/audio/TestMusicPlayer.java
@@ -55,17 +55,14 @@ public class TestMusicPlayer extends javax.swing.JFrame {
     final private Listener listener = new Listener();
 
     static {
-        try {
-            Class.forName("org.lwjgl.opengl.Display", false, ClassLoader.getSystemClassLoader());
-            // Using lwjgl version 2
-            // In case of lwjgl2, natives are loaded when LwjglContext is
-            // started but in this test we do not need a LwjglContext, so
-            // we should handle loading natives ourselves.
-            NativeLibraryLoader.loadNativeLibrary("lwjgl", true);
-            NativeLibraryLoader.loadNativeLibrary("openal", true);
-        } catch (ClassNotFoundException exception) {
-            // Not using lwjgl version 2
-        }
+        // Load lwjgl and openal natives if lwjgl 2 is in classpath.
+        //
+        // In case of lwjgl2, natives are loaded when LwjglContext is
+        // started but in this test we do not create a LwjglContext,
+        // so we should handle loading natives ourselves if running
+        // with lwjgl 2.
+        NativeLibraryLoader.loadNativeLibrary("lwjgl", false);
+        NativeLibraryLoader.loadNativeLibrary("openal", false);
     }
 
     public TestMusicPlayer() {

--- a/jme3-examples/src/main/java/jme3test/audio/TestMusicPlayer.java
+++ b/jme3-examples/src/main/java/jme3test/audio/TestMusicPlayer.java
@@ -55,10 +55,10 @@ public class TestMusicPlayer extends javax.swing.JFrame {
     final private Listener listener = new Listener();
 
     static {
-        // Load lwjgl and openal natives if lwjgl 2 is in classpath.
+        // Load lwjgl and openal natives if lwjgl version 2 is in classpath.
         //
-        // In case of lwjgl2, natives are loaded when LwjglContext is
-        // started but in this test we do not create a LwjglContext,
+        // In case of lwjgl 2, natives are loaded when LwjglContext is
+        // started, but in this test we do not create a LwjglContext,
         // so we should handle loading natives ourselves if running
         // with lwjgl 2.
         NativeLibraryLoader.loadNativeLibrary("lwjgl", false);


### PR DESCRIPTION
In the case of lwjgl2, natives are loaded when LwjglContext is started but in the TestMusicPlayer test we do not create a LwjglContext, so we should handle loading natives ourselves.

Fix #1963 