### PR TITLE
Allow use of Emissive color as a multiplier with EmissiveMap in PBRLighting

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -313,6 +313,9 @@ void main(){
     #if defined(EMISSIVE) || defined (EMISSIVEMAP)
         #ifdef EMISSIVEMAP
             vec4 emissive = texture2D(m_EmissiveMap, newTexCoord);
+            #ifdef EMISSIVE
+                emissive *= m_Emissive;
+            #endif
         #else
             vec4 emissive = m_Emissive;
         #endif


### PR DESCRIPTION
Similar to PR #1444 but for PBR.

Issued on the forum: https://hub.jmonkeyengine.org/t/khr-transform/46524/37?u=ali_rs
