### PR TITLE
Add support for NormalScale in PBRLighting & GltfLoader

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -89,6 +89,9 @@ varying vec3 wPosition;
   uniform sampler2D m_NormalMap;   
   varying vec4 wTangent;
 #endif
+#ifdef NORMALSCALE
+  uniform float m_NormalScale;
+#endif
 varying vec3 wNormal;
 
 #ifdef DISCARD_ALPHA
@@ -170,7 +173,11 @@ void main(){
       //as it's compliant with normal maps generated with blender.
       //see http://hub.jmonkeyengine.org/forum/topic/parallax-mapping-fundamental-bug/#post-256898
       //for more explanation.
-      vec3 normal = normalize((normalHeight.xyz * vec3(2.0, NORMAL_TYPE * 2.0, 2.0) - vec3(1.0, NORMAL_TYPE * 1.0, 1.0)));
+      #ifdef NORMALSCALE
+        vec3 normal = normalize((normalHeight.xyz * vec3(2.0, NORMAL_TYPE * 2.0, 2.0) - vec3(1.0, NORMAL_TYPE * 1.0, 1.0)) * vec3(m_NormalScale, m_NormalScale, 1.0));
+      #else
+        vec3 normal = normalize((normalHeight.xyz * vec3(2.0, NORMAL_TYPE * 2.0, 2.0) - vec3(1.0, NORMAL_TYPE * 1.0, 1.0)));
+      #endif
       normal = normalize(tbnMat * normal);
       //normal = normalize(normal * inverse(tbnMat));
     #else

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -38,6 +38,8 @@ MaterialDef PBR Lighting {
 
         // Normal map
         Texture2D NormalMap -LINEAR
+        // The scalar parameter applied to each normal vector of the normal map
+        Float NormalScale
 
         //The type of normal map: -1.0 (DirectX), 1.0 (OpenGl)
         Float NormalType : -1.0
@@ -138,6 +140,7 @@ MaterialDef PBR Lighting {
         Defines {         
             BASECOLORMAP : BaseColorMap            
             NORMALMAP : NormalMap
+            NORMALSCALE : NormalScale
             METALLICMAP : MetallicMap
             ROUGHNESSMAP : RoughnessMap
             EMISSIVEMAP : EmissiveMap

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -659,6 +659,12 @@ public class GltfLoader implements AssetLoader {
         adapter.setParam("normalTexture", normal);
         if (normal != null) {
             useNormalsFlag = true;
+
+            JsonObject normalTexture = matData.getAsJsonObject("normalTexture");
+            Float normalScale = getAsFloat(normalTexture, "scale");
+            if (normalScale != null) {
+                adapter.setParam("normalScale", normalScale);
+            }
         }
         JsonObject occlusionJson = matData.getAsJsonObject("occlusionTexture");
         Integer occlusionIndex = occlusionJson != null ? getAsInteger(occlusionJson, "index") : null;

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/MaterialAdapter.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/MaterialAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,7 @@ import java.util.Map;
  */
 public abstract class MaterialAdapter {
 
-    private Map<String, String> paramsMapping = new HashMap<>();
+    private final Map<String, String> paramsMapping = new HashMap<>();
     private Material mat;
     private AssetManager assetManager;
 

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/PBRMaterialAdapter.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/PBRMaterialAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,7 @@ public abstract class PBRMaterialAdapter extends MaterialAdapter {
 
     public PBRMaterialAdapter() {
         addParamMapping("normalTexture", "NormalMap");
+        addParamMapping("normalScale", "NormalScale");
         addParamMapping("occlusionTexture", "LightMap");
         addParamMapping("emissiveTexture", "EmissiveMap");
         addParamMapping("emissiveFactor", "Emissive");


### PR DESCRIPTION
Based on Gltf specs 
https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/material.normalTextureInfo.schema.json

and as issued on the forum https://hub.jmonkeyengine.org/t/khr-transform/46524/39?u=ali_rs 

I added a `NormalScale` factor in PBRLighting. The scalar parameter is applied to each normal vector of the normal map. This value scales the normal vector in X and Y directions using the formula: `scaledNormal = normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. (from the above gltf spec)

and updated GltfLoader to support this.