### PR TITLE
Add support for AoStrength in PBRLighting & GltfLoader

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -236,6 +236,7 @@ void main(){
 
     #ifdef AO_STRENGTH
        ao = 1.0 + m_AoStrength * (ao - 1.0);
+       ao = max(ao, 0.0);
     #endif
 
     float ndotv = max( dot( normal, viewDir ),0.0);

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -236,7 +236,8 @@ void main(){
 
     #ifdef AO_STRENGTH
        ao = 1.0 + m_AoStrength * (ao - 1.0);
-       ao = max(ao, 0.0);
+       // sanity check
+       ao = clamp(ao, 0.0, 1.0);
     #endif
 
     float ndotv = max( dot( normal, viewDir ),0.0);

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -235,7 +235,7 @@ void main(){
     #endif
 
     #ifdef AO_STRENGTH
-       ao *= m_AoStrength;
+       ao = 1.0 + m_AoStrength * (ao - 1.0);
     #endif
 
     float ndotv = max( dot( normal, viewDir ),0.0);

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -84,6 +84,10 @@ varying vec3 wPosition;
 #ifdef LIGHTMAP
   uniform sampler2D m_LightMap;
 #endif
+
+#ifdef AO_STRENGTH
+  uniform float m_AoStrength;
+#endif
   
 #if defined(NORMALMAP) || defined(PARALLAXMAP)
   uniform sampler2D m_NormalMap;   
@@ -228,6 +232,10 @@ void main(){
 
     #if defined(AO_PACKED_IN_MR_MAP) && defined(USE_PACKED_MR)
        ao = aoRoughnessMetallicValue.rrr;
+    #endif
+
+    #ifdef AO_STRENGTH
+       ao *= m_AoStrength;
     #endif
 
     float ndotv = max( dot( normal, viewDir ),0.0);

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -68,7 +68,8 @@ MaterialDef PBR Lighting {
         // Set to Use Lightmap
         Texture2D LightMap
 
-        // A scalar multiplier controlling the amount of occlusion applied
+        // A scalar multiplier controlling the amount of occlusion applied.
+        // A value of `0.0` means no occlusion. A value of `1.0` means full occlusion.
         Float AoStrength
 
         // Set to use TexCoord2 for the lightmap sampling

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -68,6 +68,9 @@ MaterialDef PBR Lighting {
         // Set to Use Lightmap
         Texture2D LightMap
 
+        // A scalar multiplier controlling the amount of occlusion applied
+        Float AoStrength
+
         // Set to use TexCoord2 for the lightmap sampling
         Boolean SeparateTexCoord
         // the light map is a grayscale ao map, only the r channel will be read.
@@ -159,6 +162,7 @@ MaterialDef PBR Lighting {
             VERTEX_COLOR : UseVertexColor
             AO_MAP: LightMapAsAOMap
             AO_PACKED_IN_MR_MAP : AoPackedInMRMap
+            AO_STRENGTH : AoStrength
             NUM_MORPH_TARGETS: NumberOfMorphTargets
             NUM_TARGETS_BUFFERS: NumberOfTargetsBuffers
             HORIZON_FADE: HorizonFade

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -667,6 +667,12 @@ public class GltfLoader implements AssetLoader {
         } else {        
             adapter.setParam("occlusionTexture", readTexture(matData.getAsJsonObject("occlusionTexture")));
         }
+
+        Float occlusionStrength = occlusionJson != null ? getAsFloat(occlusionJson, "strength") : null;
+        if (occlusionStrength != null) {
+            adapter.setParam("occlusionStrength", occlusionStrength);
+        }
+
         adapter.setParam("emissiveTexture", readTexture(matData.getAsJsonObject("emissiveTexture")));
 
         return adapter.getMaterial();

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/PBRMaterialAdapter.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/PBRMaterialAdapter.java
@@ -41,6 +41,7 @@ public abstract class PBRMaterialAdapter extends MaterialAdapter {
     public PBRMaterialAdapter() {
         addParamMapping("normalTexture", "NormalMap");
         addParamMapping("occlusionTexture", "LightMap");
+        addParamMapping("occlusionStrength", "AoStrength");
         addParamMapping("emissiveTexture", "EmissiveMap");
         addParamMapping("emissiveFactor", "Emissive");
         addParamMapping("alphaMode", "alpha");


### PR DESCRIPTION
Added a scalar multiplier controlling the amount of occlusion applied and updated GltfLoader to read it if present on "occlusionTexture".

Based on specs https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/material.occlusionTextureInfo.schema.json

the formula should be for final occlusion value as: `1.0 + strength * (<sampled occlusion texture value> - 1.0)` but in JME I used `ao *= strength` based on forum suggestion.

Forum topic: https://hub.jmonkeyengine.org/t/gltf-ao-strenght/46553