### PR TITLE
Deploy master branch commits as snapshot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -296,7 +296,7 @@ jobs:
     needs: [BuildJMonkey]
     name: Deploy Java Snapshot
     runs-on: ubuntu-latest
-    if: github.ref_name == 'master'
+    if: github.event_name == 'push' && github.ref_name == 'master'
     steps:
 
       # We need to clone everything again for uploadToMaven.sh ...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -356,6 +356,13 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      # Download all the stuff...
+      - name: Download maven artifacts
+        uses: actions/download-artifact@master
+        with:
+          name: maven
+          path: dist/maven
+
       - name: Download release
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -312,13 +312,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      # Download all the stuff...
-      - name: Download maven artifacts
-        uses: actions/download-artifact@master
-        with:
-          name: maven
-          path: dist/maven
-
       - name: Download natives for android
         uses: actions/download-artifact@master
         with:
@@ -362,13 +355,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-
-      # Download all the stuff...
-      - name: Download maven artifacts
-        uses: actions/download-artifact@master
-        with:
-          name: maven
-          path: dist/maven
 
       - name: Download release
         uses: actions/download-artifact@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -296,7 +296,7 @@ jobs:
     needs: [BuildJMonkey]
     name: Deploy Java Snapshot
     runs-on: ubuntu-latest
-    if: GITHUB_EVENT_NAME == 'push' && GITHUB_REF_NAME == 'master'
+    if: github.ref_name == 'master'
     steps:
 
       # We need to clone everything again for uploadToMaven.sh ...
@@ -318,12 +318,6 @@ jobs:
         with:
           name: maven
           path: dist/maven
-
-      - name: Download release
-        uses: actions/download-artifact@master
-        with:
-          name: release
-          path: dist/release
 
       - name: Download natives for android
         uses: actions/download-artifact@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,9 +206,9 @@ jobs:
   # The snapshot is downloaded when people build the engine without setting buildNativeProject
   # this is useful for people that want to build only the java part and don't have
   # all the stuff needed to compile natives.
-  DeploySnapshot:
+  DeployNativeSnapshot:
     needs: [BuildJMonkey]
-    name: "Deploy snapshot"
+    name: "Deploy native snapshot"
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
@@ -290,6 +290,63 @@ jobs:
               fi
             fi
           fi
+
+  # This job deploys snapshots on the master branch
+  DeployJavaSnapshot:
+    needs: [BuildJMonkey]
+    name: Deploy Java Snapshot
+    runs-on: ubuntu-latest
+    if: GITHUB_EVENT_NAME == 'push' && GITHUB_REF_NAME == 'master'
+    steps:
+
+      # We need to clone everything again for uploadToMaven.sh ...
+      - name: Clone the repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      # Setup jdk 17 used for building Maven-style artifacts
+      - name: Setup the java environment
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      # Download all the stuff...
+      - name: Download maven artifacts
+        uses: actions/download-artifact@master
+        with:
+          name: maven
+          path: dist/maven
+
+      - name: Download release
+        uses: actions/download-artifact@master
+        with:
+          name: release
+          path: dist/release
+
+      - name: Download natives for android
+        uses: actions/download-artifact@master
+        with:
+          name: android-natives
+          path: build/native
+
+      - name: Rebuild the maven artifacts and deploy them to the Sonatype repository
+        run: |
+          if [ "${{ secrets.OSSRH_PASSWORD }}" = "" ];
+          then
+            echo "Configure the following secrets to enable deployment to Sonatype:"
+            echo "OSSRH_PASSWORD, OSSRH_USERNAME, SIGNING_KEY, SIGNING_PASSWORD"
+          else
+            ./gradlew publishMavenPublicationToSNAPSHOTRepository \
+            -PossrhPassword=${{ secrets.OSSRH_PASSWORD }} \
+            -PossrhUsername=${{ secrets.OSSRH_USERNAME }} \
+            -PsigningKey='${{ secrets.SIGNING_KEY }}' \
+            -PsigningPassword='${{ secrets.SIGNING_PASSWORD }}' \
+            -PuseCommitHashAsVersionName=true \
+            --console=plain --stacktrace
+          fi
+
 
   # This job deploys the release
   DeployRelease:

--- a/common.gradle
+++ b/common.gradle
@@ -171,6 +171,14 @@ publishing {
             name = 'OSSRH'
             url = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2'
         }
+	maven {
+	    credentials {
+                username = gradle.rootProject.hasProperty('ossrhUsername') ? ossrhUsername : 'Unknown user'
+                password = gradle.rootProject.hasProperty('ossrhPassword') ? ossrhPassword : 'Unknown password'
+	    }
+	    name = 'SNAPSHOT'
+	    url = 'https://oss.sonatype.org/content/repositories/snapshots/'
+	}
     }
 }
 


### PR DESCRIPTION
In response to this discussion:
https://hub.jmonkeyengine.org/t/adding-nightly-builds-to-engine/46560

This is mostly just a copy-paste of the relevant parts of the existing release deployment mechanism. It should not require manual intervention at any step.

I do not have a deployment account for Sonatype, so this branch is only partially tested. (The gradle script call returns "401: Unauthorized" when run from the command line. This is what I would expect without an account.)

Users who want to use the snapshot will need to add `https://oss.sonatype.org/content/repositories/snapshots/` to their build scripts' repository list, and then target version `<Major_Version>-SNAPSHOT`. Not sure where to document that.
