### PR TITLE
LwjglContext: re-initialize renderer on context restart (lwjgl 2)

### DIFF
--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -317,8 +317,8 @@ public abstract class LwjglContext implements JmeContext {
                     glfbo = (GLFbo) GLTracer.createDesktopGlTracer(glfbo, GLFbo.class);
                 }
                 renderer = new GLRenderer(gl, glext, glfbo);
-                renderer.initialize();
             }
+            renderer.initialize();
         } else {
             throw new UnsupportedOperationException("Unsupported renderer: " + settings.getRenderer());
         }

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
@@ -150,6 +150,7 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
         Display.setVSyncEnabled(settings.isVSync());
         
         if (created.get() && !pixelFormatChanged) {
+            renderer.resetGLObjects();
             Display.releaseContext();
             Display.makeCurrent();
             Display.update();


### PR DESCRIPTION
[Like LWJGL 3](https://github.com/jMonkeyEngine/jmonkeyengine/blob/29e07614ec8d10ebc90f1a997382a267b6667e04/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java#L252), this re-initializes the renderer on context restarts on LWJGL 2, otherwise changing DepthBits or BitsPerPixel won't take effect and will result in a blank window after context restart (no spatial is rendered in the viewport).

I made a test case, it starts the app with BitsPerPixel=16 and after pressing key P on the keyboard it changes BitsPerPixel to 24 and restarts context. You will notice the stats view will be disappeared.

```

public class TestContextRestart extends SimpleApplication {

    public static void main(String[] args) {
        TestContextRestart app = new TestContextRestart();
        AppSettings settings = new AppSettings(true);
        settings.setBitsPerPixel(16);
        app.setSettings(settings);
        app.start();
    }

    @Override
    public void simpleInitApp() {
        inputManager.addMapping("restartContext", new KeyTrigger(KeyInput.KEY_P));
        ActionListener listener = new ActionListener() {
            @Override
            public void onAction(String name, boolean keyPressed, float tpf) {
                if (name.equals("restartContext") && keyPressed) {
                    restartContext();
                }
            }
        };
        inputManager.addListener(listener, "restartContext");
    }

    void restartContext() {
        settings.setFullscreen(false);
        settings.setBitsPerPixel(24);
        setSettings(settings);
        restart();
    }
}
```

This may also fix #798


