### PR TITLE
correctly handle negative IDs in getUniqueId() methods

### DIFF
--- a/jme3-core/src/main/java/com/jme3/audio/AudioBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/audio/AudioBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -132,6 +132,6 @@ public class AudioBuffer extends AudioData {
 
     @Override
     public long getUniqueId() {
-        return ((long) OBJTYPE_AUDIOBUFFER << 32) | ((long) id);
+        return ((long) OBJTYPE_AUDIOBUFFER << 32) | (0xffffffffL & (long) id);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/audio/AudioStream.java
+++ b/jme3-core/src/main/java/com/jme3/audio/AudioStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -222,6 +222,6 @@ public class AudioStream extends AudioData implements Closeable {
 
     @Override
     public long getUniqueId() {
-        return ((long) OBJTYPE_AUDIOSTREAM << 32) | ((long) ids[0]);
+        return ((long) OBJTYPE_AUDIOSTREAM << 32) | (0xffffffffL & (long) ids[0]);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/audio/LowPassFilter.java
+++ b/jme3-core/src/main/java/com/jme3/audio/LowPassFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -99,6 +99,6 @@ public class LowPassFilter extends Filter {
 
     @Override
     public long getUniqueId() {
-        return ((long) OBJTYPE_FILTER << 32) | ((long) id);
+        return ((long) OBJTYPE_FILTER << 32) | (0xffffffffL & (long) id);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/scene/VertexBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/VertexBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1116,7 +1116,7 @@ public class VertexBuffer extends NativeObject implements Savable, Cloneable {
 
     @Override
     public long getUniqueId() {
-        return ((long) OBJTYPE_VERTEXBUFFER << 32) | ((long) id);
+        return ((long) OBJTYPE_VERTEXBUFFER << 32) | (0xffffffffL & (long) id);
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/shader/BufferObject.java
+++ b/jme3-core/src/main/java/com/jme3/shader/BufferObject.java
@@ -829,6 +829,6 @@ public class BufferObject extends NativeObject {
 
     @Override
     public long getUniqueId() {
-        return ((long) OBJTYPE_BO << 32) | ((long) id);
+        return ((long) OBJTYPE_BO << 32) | (0xffffffffL & (long) id);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/shader/Shader.java
+++ b/jme3-core/src/main/java/com/jme3/shader/Shader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -189,7 +189,7 @@ public final class Shader extends NativeObject {
 
         @Override
         public long getUniqueId() {
-            return ((long)OBJTYPE_SHADERSOURCE << 32) | ((long)id);
+            return ((long)OBJTYPE_SHADERSOURCE << 32) | (0xffffffffL & (long)id);
         }
 
         @Override
@@ -462,6 +462,6 @@ public final class Shader extends NativeObject {
 
     @Override
     public long getUniqueId() {
-        return ((long)OBJTYPE_SHADER << 32) | ((long)id);
+        return ((long)OBJTYPE_SHADER << 32) | (0xffffffffL & (long)id);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/texture/FrameBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/texture/FrameBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -806,7 +806,7 @@ public class FrameBuffer extends NativeObject {
 
     @Override
     public long getUniqueId() {
-        return ((long) OBJTYPE_FRAMEBUFFER << 32) | ((long) id);
+        return ((long) OBJTYPE_FRAMEBUFFER << 32) | (0xffffffffL & (long) id);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/texture/Image.java
+++ b/jme3-core/src/main/java/com/jme3/texture/Image.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -698,7 +698,7 @@ public class Image extends NativeObject implements Savable /*, Cloneable*/ {
 
     @Override
     public long getUniqueId() {
-        return ((long)OBJTYPE_TEXTURE << 32) | ((long)id);
+        return ((long)OBJTYPE_TEXTURE << 32) | (0xffffffffL & (long)id);
     }
     
     /**


### PR DESCRIPTION
As I mentioned at issue #1982, one issue with negative native IDs is the encoding scheme used to implement `NativeObject.getUniqueId()`. To generate a unique ID, the object type is stored in the upper 32 bits. For a negative ID, sign extension during conversion from `int` to `long` obliterates the type information.

This PR masks off the upper 32 bits before adding the object type. It is merely the first of *many* changes that will be needed to handle negative native IDs in JMonkeyEngine.