### PR TITLE
solve issue #2003 (ParticleDepositionHeightMap.load return value)

### DIFF
--- a/jme3-terrain/src/main/java/com/jme3/terrain/heightmap/ParticleDepositionHeightMap.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/heightmap/ParticleDepositionHeightMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -321,8 +321,7 @@ public class ParticleDepositionHeightMap extends AbstractHeightMap {
 
         logger.fine("Created heightmap using Particle Deposition");
 
-
-        return false;
+        return true; // success
     }
 
     /**


### PR DESCRIPTION
As issue #2003 says, there's no reason for `load()` to return `false` in this case.

One reason the issue went undetected so long:  all uses of the `load()` method in jme3-terrain and jme3-examples ignore the return value. However, Minie (taking the javadoc literally) *does* check the value, so returning the correct value is important.

I quickly checked the other known implementations of `load()` and none of them seemed to have similar issues.
