### PR TITLE
solve issue #2011 (app crashes when using OpenGL version 3.0 and 3.1 with LWJGL 3)

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -238,16 +238,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
         final String renderer = settings.getRenderer();
 
-        //Appsettings GL version below 3.2
-        if ((!RENDER_CONFIGS. containsKey (renderer))|| //OPENGL20
-                renderer.equals (AppSettings.LWJGL_OPENGL30)||renderer.equals (AppSettings.LWJGL_OPENGL31)
-        ) {
-            glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
-            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_ANY_PROFILE);
-        }else {
-            glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
-            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-        }
+        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
         RENDER_CONFIGS.computeIfAbsent(renderer, s -> () -> {
             glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE);

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -87,10 +87,16 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
     static {
         RENDER_CONFIGS.put(AppSettings.LWJGL_OPENGL30, () -> {
+            // Based on GLFW docs for OpenGL version below 3.2,
+            // GLFW_OPENGL_ANY_PROFILE must be used.
+            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_ANY_PROFILE);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
         });
         RENDER_CONFIGS.put(AppSettings.LWJGL_OPENGL31, () -> {
+            // Based on GLFW docs for OpenGL version below 3.2,
+            // GLFW_OPENGL_ANY_PROFILE must be used.
+            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_ANY_PROFILE);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
         });

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -238,8 +238,16 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
         final String renderer = settings.getRenderer();
 
-        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
-        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+        //Appsettings GL version below 3.2
+        if ((!RENDER_CONFIGS. containsKey (renderer))|| //OPENGL20
+                renderer.equals (AppSettings.LWJGL_OPENGL30)||renderer.equals (AppSettings.LWJGL_OPENGL31)
+        ) {
+            glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_ANY_PROFILE);
+        }else {
+            glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+        }
 
         RENDER_CONFIGS.computeIfAbsent(renderer, s -> () -> {
             glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE);


### PR DESCRIPTION
Solves #2011 

This PR is based on the JME hub thread :
[this](https://hub.jmonkeyengine.org/t/shadow-maybe-failed-in-gles2-and-appsetting-failed-to-choose-gl-version/46759/2#:~:text=Contributor-,2,choose%20version%20below%203.2%3A%0Asee%20this%20in%20stackoverflow%20and%20GLFW%20guide,-GLFW_OPENGL_PROFILE**%20specifies%20which)

It added a if branch to set GLFW to GLFW_OPENGL_ANY_PROFILE for there is no CORE-PROFILE below 3.2