### PR TITLE
com.jme3.anim.tween.action.BaseAction: basic javadoc

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
@@ -103,7 +103,7 @@ public class BaseAction extends Action {
      * the mask attribute will not affect the actions under this base action. Setting this to 'null' will animate
      * the entire model.
      *
-     * @param mask an animation mask to be applied to this action.
+     * @param mask an animation mask to be applied to this action (nullable).
      * @see com.jme3.anim.AnimLayer to adjust the animation mask to control which part will be animated
      * @see BaseAction#setMaskPropagationEnabled(boolean)
      */

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
@@ -55,7 +55,8 @@ import java.util.List;
  * //run the action within this layer
  * animComposer.setCurrentAction("basicAction", ActionState.class.getSimpleName());
  * </pre>
- * <b>Created by Nehon.</b>
+ * </p>
+ * Created by Nehon.
  */
 public class BaseAction extends Action {
 

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 jMonkeyEngine
+ * Copyright (c) 2009-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,14 +35,38 @@ import com.jme3.anim.AnimationMask;
 import com.jme3.anim.tween.ContainsTweens;
 import com.jme3.anim.tween.Tween;
 import com.jme3.util.SafeArrayList;
-
 import java.util.List;
 
+/**
+ * A simple implementation for the interface {@link Action} to provide a wrapper for a {@link Tween}.
+ * Internally, it is used as a helper class for {@link Action} to extract and gather actions from a tween and interpolate it.
+ * <p>
+ * An example showing two clip actions running in parallel at 2x of their ordinary speed
+ * by the help of BaseAction on a new Animation Layer :
+ * <pre class="prettyprint">
+ * //create a base action from a tween.
+ * final BaseAction action = new BaseAction(Tweens.parallel(clipAction0, clipAction1));
+ * //set the action properties - utilized within the #{@link Action} class.
+ * baseAction.setSpeed(2f);
+ * //register the action as an observer to the animComposer control.
+ * animComposer.addAction("basicAction", action);
+ * //make a new Layer for a basic armature mask
+ * animComposer.makeLayer(ActionState.class.getSimpleName(), new ArmatureMask());
+ * //run the action within this layer
+ * animComposer.setCurrentAction("basicAction", ActionState.class.getSimpleName());
+ * </pre>
+ * <b>Created by Nehon.</b>
+ */
 public class BaseAction extends Action {
 
     final private Tween tween;
     private boolean maskPropagationEnabled = true;
 
+    /**
+     * Instantiates an action from a tween.
+     *
+     * @param tween a tween to extract the actions from.
+     */
     public BaseAction(Tween tween) {
         this.tween = tween;
         setLength(tween.getLength());
@@ -52,33 +76,31 @@ public class BaseAction extends Action {
         subActions.toArray(actions);
     }
 
-    private void gatherActions(Tween tween, List<Action> subActions) {
-        if (tween instanceof Action) {
-            subActions.add((Action) tween);
-        } else if (tween instanceof ContainsTweens) {
-            Tween[] tweens = ((ContainsTweens) tween).getTweens();
-            for (Tween t : tweens) {
-                gatherActions(t, subActions);
-            }
-        }
-    }
-
     /**
-     * @return true if mask propagation to child actions is enabled else returns false
+     * Tests whether the animation mask is applied to the wrapped actions {@link BaseAction#actions}.
+     *
+     * @return true if mask propagation to child actions is enabled else returns false.
      */
     public boolean isMaskPropagationEnabled() {
         return maskPropagationEnabled;
     }
 
     /**
+     * Determines whether to apply the animation mask to the wrapped or child actions {@link BaseAction#actions}.
      *
      * @param maskPropagationEnabled If true, then mask set by AnimLayer will be
-     *                               forwarded to all child actions (Default=true)
+     *                               forwarded to all child actions (Default=true).
      */
     public void setMaskPropagationEnabled(boolean maskPropagationEnabled) {
         this.maskPropagationEnabled = maskPropagationEnabled;
     }
 
+    /**
+     * Applies an animation mask to this action, if the {@link BaseAction#maskPropagationEnabled} is 
+     * enabled, the animation mask is propagated to the child actions (or wrapped actions).
+     * 
+     * @param mask an animation mask to be applied to this action.
+     */
     @Override
     public void setMask(AnimationMask mask) {
         super.setMask(mask);
@@ -93,5 +115,22 @@ public class BaseAction extends Action {
     @Override
     public boolean interpolate(double t) {
         return tween.interpolate(t);
+    }
+    
+    /**
+     * Extracts the actions from a tween into a list.
+     *
+     * @param tween      the tween to extract the actions from.
+     * @param subActions a collection to gather the extracted actions.
+     */
+    private void gatherActions(Tween tween, List<Action> subActions) {
+        if (tween instanceof Action) {
+            subActions.add((Action) tween);
+        } else if (tween instanceof ContainsTweens) {
+            Tween[] tweens = ((ContainsTweens) tween).getTweens();
+            for (Tween t : tweens) {
+                gatherActions(t, subActions);
+            }
+        }
     }
 }

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
@@ -66,7 +66,7 @@ public class BaseAction extends Action {
     /**
      * Instantiates an action from a tween.
      *
-     * @param tween a tween to extract the actions from.
+     * @param tween a tween to extract the actions from (not null).
      */
     public BaseAction(Tween tween) {
         this.tween = tween;
@@ -121,8 +121,8 @@ public class BaseAction extends Action {
     /**
      * Extracts the actions from a tween into a list.
      *
-     * @param tween      the tween to extract the actions from.
-     * @param subActions a collection to gather the extracted actions.
+     * @param tween      the tween to extract the actions from (not null).
+     * @param subActions a collection to gather the extracted actions (not null).
      */
     private void gatherActions(Tween tween, List<Action> subActions) {
         if (tween instanceof Action) {

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
@@ -97,7 +97,7 @@ public class BaseAction extends Action {
     }
 
     /**
-     * Internal use only.
+     * Internal use-only.
      *
      * Dispatched from {@link com.jme3.anim.AnimLayer#update(float)}. Applies an animation mask to this action, 
      * if the {@link BaseAction#maskPropagationEnabled} is enabled, the animation mask is propagated to the child actions (or wrapped actions).

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
@@ -64,7 +64,8 @@ public class BaseAction extends Action {
     private boolean maskPropagationEnabled = true;
 
     /**
-     * Instantiates an action from a tween.
+     * Instantiates an action from a tween by extracting the actions from a tween
+     * to a list of sub-actions to be interpolated later.
      *
      * @param tween a tween to extract the actions from (not null).
      */

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023 jMonkeyEngine
+ * Copyright (c) 2009-2024 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
@@ -98,10 +98,12 @@ public class BaseAction extends Action {
 
     /**
      * Internal use-only.
-     *
-     * Dispatched from {@link com.jme3.anim.AnimLayer#update(float)}. Applies an animation mask to this action, 
-     * if the {@link BaseAction#maskPropagationEnabled} is enabled, the animation mask is propagated to the child actions (or wrapped actions).
      * 
+     * <p> 
+     * Note: This method can be invoked from the user code only if this Action is wrapped by a {@link BaseAction} and
+     * the {@link BaseAction#isMaskPropagationEnabled()} is false.
+     * </p>
+     *
      * @param mask an animation mask to be applied to this action.
      * @see com.jme3.anim.AnimLayer to adjust the animation mask to control which part will be animated
      */

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
@@ -97,15 +97,14 @@ public class BaseAction extends Action {
     }
 
     /**
-     * Internal use-only.
-     * 
-     * <p> 
-     * Note: This method can be invoked from the user code only if this Action is wrapped by a {@link BaseAction} and
-     * the {@link BaseAction#isMaskPropagationEnabled()} is false.
-     * </p>
+     * Sets the animation mask which determines which part of the model will 
+     * be animated by the animation layer. If the {@link BaseAction#isMaskPropagationEnabled()} is false, setting
+     * the mask attribute will not affect the actions under this base action. Setting this to 'null' will animate
+     * the entire model.
      *
      * @param mask an animation mask to be applied to this action.
      * @see com.jme3.anim.AnimLayer to adjust the animation mask to control which part will be animated
+     * @see BaseAction#setMaskPropagationEnabled(boolean)
      */
     @Override
     public void setMask(AnimationMask mask) {

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
@@ -38,7 +38,7 @@ import com.jme3.util.SafeArrayList;
 import java.util.List;
 
 /**
- * A simple implementation for the interface {@link Action} to provide a wrapper for a {@link Tween}.
+ * A simple implementation for the abstract class {@link Action} to provide a wrapper for a {@link Tween}.
  * Internally, it is used as a helper class for {@link Action} to extract and gather actions from a tween and interpolate it.
  * <p>
  * An example showing two clip actions running in parallel at 2x of their ordinary speed

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
@@ -103,6 +103,7 @@ public class BaseAction extends Action {
      * if the {@link BaseAction#maskPropagationEnabled} is enabled, the animation mask is propagated to the child actions (or wrapped actions).
      * 
      * @param mask an animation mask to be applied to this action.
+     * @see com.jme3.anim.AnimLayer to adjust the animation mask to control which part will be animated
      */
     @Override
     public void setMask(AnimationMask mask) {

--- a/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
+++ b/jme3-core/src/main/java/com/jme3/anim/tween/action/BaseAction.java
@@ -97,8 +97,10 @@ public class BaseAction extends Action {
     }
 
     /**
-     * Applies an animation mask to this action, if the {@link BaseAction#maskPropagationEnabled} is 
-     * enabled, the animation mask is propagated to the child actions (or wrapped actions).
+     * Internal use only.
+     *
+     * Dispatched from {@link com.jme3.anim.AnimLayer#update(float)}. Applies an animation mask to this action, 
+     * if the {@link BaseAction#maskPropagationEnabled} is enabled, the animation mask is propagated to the child actions (or wrapped actions).
      * 
      * @param mask an animation mask to be applied to this action.
      */


### PR DESCRIPTION
This PR provides basic javadoc for the class `com.jme3.anim.tween.action.BaseAction`.