### PR TITLE
By default use PrimitiveAllocator on Android

### DIFF
--- a/jme3-android/src/main/java/com/jme3/system/android/OGLESContext.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/OGLESContext.java
@@ -58,7 +58,8 @@ import com.jme3.renderer.android.AndroidGL;
 import com.jme3.renderer.opengl.*;
 import com.jme3.system.*;
 import com.jme3.util.BufferAllocatorFactory;
-import com.jme3.util.AndroidNativeBufferAllocator;
+import com.jme3.util.PrimitiveAllocator;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -85,7 +86,7 @@ public class OGLESContext implements JmeContext, GLSurfaceView.Renderer, SoftTex
         final String implementation = BufferAllocatorFactory.PROPERTY_BUFFER_ALLOCATOR_IMPLEMENTATION;
 
         if (System.getProperty(implementation) == null) {
-            System.setProperty(implementation, AndroidNativeBufferAllocator.class.getName());
+            System.setProperty(implementation, PrimitiveAllocator.class.getName());
         }
     }
 


### PR DESCRIPTION
This PR makes PrimitiveAllocator the default buffer allocator due to a memory leak issue with AndroidNativeBufferAllocator.

See issue https://github.com/jMonkeyEngine/jmonkeyengine/issues/1990

In the below link you can find out why direct byte buffers allocated via JNI (`env->NewDirectByteBuffer()`) are not cleaned when GCed but the ones created with `ByteBuffer.allocateDirect()` are cleaned with GC. 

https://stackoverflow.com/a/35364247