### PR TITLE
Application#stop(boolean): fix javadoc args issue

### DIFF
--- a/jme3-core/src/main/java/com/jme3/app/Application.java
+++ b/jme3-core/src/main/java/com/jme3/app/Application.java
@@ -226,7 +226,7 @@ public interface Application {
      * After the application has stopped, it cannot be used anymore.
      * 
      @param waitFor true&rarr;wait for the context to be fully destroyed,
-     * true&rarr;don't wait
+     * false&rarr;don't wait
      */
     public void stop(boolean waitFor);
 

--- a/jme3-core/src/main/java/com/jme3/app/LegacyApplication.java
+++ b/jme3-core/src/main/java/com/jme3/app/LegacyApplication.java
@@ -618,7 +618,7 @@ public class LegacyApplication implements Application, SystemListener {
      * After the application has stopped, it cannot be used anymore.
      *
      * @param waitFor true&rarr;wait for the context to be fully destroyed,
-     * true&rarr;don't wait
+     * false&rarr;don't wait
      */
     @Override
     public void stop(boolean waitFor) {


### PR DESCRIPTION
This PR fixes the javadoc of the `Application#stop(boolean)` argument.