### PR TITLE
remove runtime dependency to lwjgl-platform:2.9.5 so mvn package does not fail

### DIFF
--- a/jme3-lwjgl/build.gradle
+++ b/jme3-lwjgl/build.gradle
@@ -3,7 +3,6 @@ dependencies {
     api project(':jme3-desktop')
 
     api 'org.jmonkeyengine:lwjgl:2.9.5'
-    runtimeOnly 'org.jmonkeyengine:lwjgl-platform:2.9.5'
 
     /*
      * Upgrades the default jinput-2.0.5 to jinput-2.0.9 to fix a bug with gamepads on Linux.


### PR DESCRIPTION
As mentioned [here](https://hub.jmonkeyengine.org/t/solved-failure-to-find-org-jmonkeyenginejar-2-9-5-after-upgrading-to-3-6-0/46838), the mvn package failed with the runtime dependency. 