### PR TITLE
1877: Add checkstyle to project

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -7,6 +7,8 @@ apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
+apply plugin: 'checkstyle'
+
 eclipse.jdt.file.withProperties { props ->
     props.setProperty "org.eclipse.jdt.core.circularClasspath", "warning"
 }
@@ -199,4 +201,24 @@ signing {
 }
 tasks.withType(Sign) {
     onlyIf { gradle.rootProject.hasProperty('signingKey') }
+}
+
+checkstyle {
+    toolVersion '10.12.1'
+    configFile file("${gradle.rootProject.rootDir}/config/checkstyle/checkstyle.xml")
+}
+
+checkstyleMain {
+    source ='src/main/java'
+}
+
+checkstyleTest {
+    source ='src/test/java'
+}
+
+tasks.withType(Checkstyle) {
+    reports {
+        xml.enabled true
+        html.enabled true
+    }
 }

--- a/common.gradle
+++ b/common.gradle
@@ -218,7 +218,7 @@ checkstyleTest {
 
 tasks.withType(Checkstyle) {
     reports {
-        xml.enabled true
+        xml.enabled false
         html.enabled true
     }
 }

--- a/common.gradle
+++ b/common.gradle
@@ -221,4 +221,5 @@ tasks.withType(Checkstyle) {
         xml.enabled false
         html.enabled true
     }
+    include("**/com/jme3/renderer/*.java")
 }

--- a/common.gradle
+++ b/common.gradle
@@ -221,5 +221,5 @@ tasks.withType(Checkstyle) {
         xml.enabled false
         html.enabled true
     }
-    include("**/com/jme3/renderer/*.java")
+    include("**/com/jme3/renderer/**/*.java")
 }

--- a/common.gradle
+++ b/common.gradle
@@ -204,7 +204,7 @@ tasks.withType(Sign) {
 }
 
 checkstyle {
-    toolVersion '10.12.1'
+    toolVersion '9.3'
     configFile file("${gradle.rootProject.rootDir}/config/checkstyle/checkstyle.xml")
 }
 

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN" "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <!-- https://checkstyle.org/filters/suppressionfilter.html -->
+</suppressions>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -198,7 +198,7 @@
                 value="Catch parameter name ''{0}'' must match pattern ''{1}''." />
         </module>
         <module name="LocalVariableName">
-            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+            <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$" />
             <message key="name.invalidPattern"
                 value="Local variable name ''{0}'' must match pattern ''{1}''." />
         </module>
@@ -253,14 +253,13 @@
         </module>
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false" />
-            <property name="allowedAbbreviationLength" value="0" />
+            <property name="allowedAbbreviationLength" value="1" />
             <property name="tokens"
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
                     PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
                     RECORD_COMPONENT_DEF" />
         </module>
         <module name="NoWhitespaceBeforeCaseDefaultColon" />
-        <module name="OverloadMethodsDeclarationOrder" />
         <module name="VariableDeclarationUsageDistance" />
         <module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true" />
@@ -358,9 +357,5 @@
         <module name="EmptyCatchBlock">
             <property name="exceptionVariableName" value="expected" />
         </module>
-        <module name="CommentsIndentation">
-            <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN" />
-        </module>
-
     </module>
 </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
     that can be found at https://google.github.io/styleguide/javaguide.html. 
@@ -8,21 +10,13 @@
 
     Adapted for changes by the jMonkeyEngine contribution guidelines document.
  -->
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
-
-<!-- This is a checkstyle configuration file. For descriptions of
-what the following rules do, please see the checkstyle configuration
-page at http://checkstyle.sourceforge.net/config.html -->
 
 <module name="Checker">
-    <module name="SuppressWarningsFilter" />
-
     <property name="charset" value="UTF-8" />
 
     <property name="severity" value="warning" />
 
     <property name="fileExtensions" value="java, properties, xml" />
-
     <!-- Excludes all 'module-info.java' files              -->
     <!-- See https://checkstyle.org/filefilters/index.html -->
     <module name="BeforeExecutionExclusionFileFilter">
@@ -31,18 +25,18 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
     <!-- https://checkstyle.org/filters/suppressionfilter.html -->
     <module name="SuppressionFilter">
-        <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
-            default="checkstyle-suppressions.xml" />
+        <property name="file" value="config/checkstyle-suppressions.xml"/>
         <property name="optional" value="true" />
     </module>
 
     <!-- Checks for whitespace                               -->
-    <!-- See http://checkstyle.org/checks/whitespace/index.html -->
+    <!-- See https://checkstyle.org/checks/whitespace/index.html -->
     <module name="FileTabCharacter">
         <property name="eachLine" value="true" />
     </module>
 
     <module name="LineLength">
+        <property name="fileExtensions" value="java" />
         <property name="max" value="110" />
         <property name="ignorePattern"
             value="^package.*|^import.*|a href|href|http://|https://|ftp://" />
@@ -96,7 +90,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
             <property name="tokens"
                 value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF, LITERAL_SWITCH" />
+                    COMPACT_CTOR_DEF" />
         </module>
         <module name="SuppressionXpathSingleFilter">
             <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
@@ -107,10 +101,8 @@ page at http://checkstyle.sourceforge.net/config.html -->
         </module>
         <module name="WhitespaceAfter">
             <property name="tokens"
-                value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_RETURN,
-                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, DO_WHILE, ELLIPSIS,
-                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_CATCH, LAMBDA,
-                    LITERAL_YIELD, LITERAL_CASE" />
+                value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, DO_WHILE" />
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true" />
@@ -128,8 +120,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
                     NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
                     SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND" />
             <message key="ws.notFollowed"
-                value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks
-               may only be represented as '{}' when not part of a multi-block statement (4.1.3)" />
+                value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)" />
             <message key="ws.notPreceded"
                 value="WhitespaceAround: ''{0}'' is not preceded with whitespace." />
         </module>
@@ -315,76 +306,67 @@ page at http://checkstyle.sourceforge.net/config.html -->
             <property name="allowSamelineMultipleAnnotations" value="true" />
         </module>
         <module name="NonEmptyAtclauseDescription" />
+
         <!--
 
         Commented out javadoc checks, these produce a lot (4k in jme3-core) of warnings so for now, might
         be too noisy
 
-    <module name="InvalidJavadocPosition"/>
-    <module name="JavadocTagContinuationIndentation"/>
-    <module name="SummaryJavadoc">
-      <property name="forbiddenSummaryFragments"
-               value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
-    </module>
-    <module name="JavadocParagraph"/>
-    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
-    <module name="AtclauseOrder">
-      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
-      <property name="target"
-               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
-    </module>
-    <module name="JavadocMethod">
-      <property name="accessModifiers" value="public"/>
-      <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingReturnTag" value="true"/>
-      <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
-    </module>
-    <module name="MissingJavadocMethod">
-      <property name="scope" value="public"/>
-      <property name="minLineCount" value="2"/>
-      <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
-                                   COMPACT_CTOR_DEF"/>
-    </module>
-    <module name="MissingJavadocType">
-      <property name="scope" value="protected"/>
-      <property name="tokens"
+        <module name="InvalidJavadocPosition" />
+        <module name="JavadocTagContinuationIndentation" />
+        <module name="SummaryJavadoc">
+            <property name="forbiddenSummaryFragments"
+                value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )" />
+        </module>
+        <module name="JavadocParagraph" />
+        <module name="RequireEmptyLineBeforeBlockTagGroup" />
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated" />
+            <property name="target"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF" />
+        </module>
+        <module name="JavadocMethod">
+            <property name="accessModifiers" value="public" />
+            <property name="allowMissingParamTags" value="true" />
+            <property name="allowMissingReturnTag" value="true" />
+            <property name="allowedAnnotations" value="Override, Test" />
+            <property name="tokens"
+                value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF" />
+        </module>
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="public" />
+            <property name="minLineCount" value="2" />
+            <property name="allowedAnnotations" value="Override, Test" />
+            <property name="tokens"
+                value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
+                                   COMPACT_CTOR_DEF" />
+        </module>
+        <module name="MissingJavadocType">
+            <property name="scope" value="protected" />
+            <property name="tokens"
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
-                      RECORD_DEF, ANNOTATION_DEF"/>
-      <property name="excludeScope" value="nothing"/>
-    </module>
-    -->
+                      RECORD_DEF, ANNOTATION_DEF" />
+            <property name="excludeScope" value="nothing" />
+        </module>
         <module name="MethodName">
-            <property name="format" value="^[a-z][a-z0-9]\w*$" />
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$" />
             <message key="name.invalidPattern"
                 value="Method name ''{0}'' must match pattern ''{1}''." />
         </module>
         <module name="SingleLineJavadoc" />
+    -->
         <module name="EmptyCatchBlock">
             <property name="exceptionVariableName" value="expected" />
         </module>
         <module name="CommentsIndentation">
             <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN" />
         </module>
+
         <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
         <module name="SuppressionXpathFilter">
             <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
                 default="checkstyle-xpath-suppressions.xml" />
             <property name="optional" value="true" />
-        </module>
-        <module name="SuppressWarningsHolder" />
-        <module name="SuppressionCommentFilter">
-            <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)" />
-            <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)" />
-            <property name="checkFormat" value="$1" />
-        </module>
-        <module name="SuppressWithNearbyCommentFilter">
-            <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)" />
-            <!-- $1 refers to the first match group in the regex defined in commentFormat -->
-            <property name="checkFormat" value="$1" />
-            <!-- The check is suppressed in the next line of code after the comment -->
-            <property name="influenceFormat" value="1" />
         </module>
     </module>
 </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -32,12 +32,12 @@
     <!-- Checks for whitespace                               -->
     <!-- See https://checkstyle.org/checks/whitespace/index.html -->
     <module name="FileTabCharacter">
-        <property name="eachLine" value="true" />
+        <property name="eachLine" value="false" />
     </module>
 
     <module name="LineLength">
         <property name="fileExtensions" value="java" />
-        <property name="max" value="110" />
+        <property name="max" value="150" />
         <property name="ignorePattern"
             value="^package.*|^import.*|a href|href|http://|https://|ftp://" />
     </module>
@@ -105,6 +105,7 @@
                     LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, DO_WHILE" />
         </module>
         <module name="WhitespaceAround">
+            <property name="severity" value="ignore" />
             <property name="allowEmptyConstructors" value="true" />
             <property name="allowEmptyLambdas" value="true" />
             <property name="allowEmptyMethods" value="true" />
@@ -201,6 +202,7 @@
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
             <message key="name.invalidPattern"
                 value="Local variable name ''{0}'' must match pattern ''{1}''." />
+            <property name="severity" value="ignore" />
         </module>
         <module name="PatternVariableName">
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
@@ -250,6 +252,7 @@
             <property name="throwsIndent" value="4" />
             <property name="lineWrappingIndentation" value="8" />
             <property name="arrayInitIndent" value="4" />
+            <property name="severity" value="ignore" />
         </module>
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false" />

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -25,7 +25,7 @@
 
     <!-- https://checkstyle.org/filters/suppressionfilter.html -->
     <module name="SuppressionFilter">
-        <property name="file" value="config/checkstyle-suppressions.xml"/>
+        <property name="file" value="config/checkstyle/checkstyle-suppressions.xml"/>
         <property name="optional" value="true" />
     </module>
 
@@ -56,7 +56,9 @@
             <property name="allowByTailComment" value="true" />
             <property name="allowNonPrintableEscapes" value="true" />
         </module>
-        <module name="AvoidStarImport" />
+        <module name="AvoidStarImport">
+            <property name="severity" value="ignore"/>
+        </module>
         <module name="OneTopLevelClass" />
         <module name="NoLineWrap">
             <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT" />
@@ -363,13 +365,8 @@
         </module>
         <module name="CommentsIndentation">
             <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN" />
+            <property name="severity" value="ignore" />
         </module>
 
-        <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
-        <module name="SuppressionXpathFilter">
-            <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
-                default="checkstyle-xpath-suppressions.xml" />
-            <property name="optional" value="true" />
-        </module>
     </module>
 </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,390 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html. 
+
+    Based on google_checks.xml found in the checkstyle repository:
+    https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml
+
+    Adapted for changes by the jMonkeyEngine contribution guidelines document.
+ -->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!-- This is a checkstyle configuration file. For descriptions of
+what the following rules do, please see the checkstyle configuration
+page at http://checkstyle.sourceforge.net/config.html -->
+
+<module name="Checker">
+    <module name="SuppressWarningsFilter" />
+
+    <property name="charset" value="UTF-8" />
+
+    <property name="severity" value="warning" />
+
+    <property name="fileExtensions" value="java, properties, xml" />
+
+    <!-- Excludes all 'module-info.java' files              -->
+    <!-- See https://checkstyle.org/filefilters/index.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$" />
+    </module>
+
+    <!-- https://checkstyle.org/filters/suppressionfilter.html -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+            default="checkstyle-suppressions.xml" />
+        <property name="optional" value="true" />
+    </module>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.org/checks/whitespace/index.html -->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true" />
+    </module>
+
+    <module name="LineLength">
+        <property name="max" value="110" />
+        <property name="ignorePattern"
+            value="^package.*|^import.*|a href|href|http://|https://|ftp://" />
+    </module>
+
+    <module name="TreeWalker">
+        <module name="OuterTypeFilename" />
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL" />
+            <property name="format"
+                value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)" />
+            <property name="message"
+                value="Consider using special escape sequence instead of octal value or Unicode escaped value." />
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true" />
+            <property name="allowByTailComment" value="true" />
+            <property name="allowNonPrintableEscapes" value="true" />
+        </module>
+        <module name="AvoidStarImport" />
+        <module name="OneTopLevelClass" />
+        <module name="NoLineWrap">
+            <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT" />
+        </module>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT" />
+            <property name="tokens"
+                value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH" />
+        </module>
+        <module name="NeedBraces">
+            <property name="tokens"
+                value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE" />
+        </module>
+        <module name="LeftCurly">
+            <property name="tokens"
+                value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT,
+                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
+                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF" />
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlySame" />
+            <property name="tokens"
+                value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO" />
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlyAlone" />
+            <property name="option" value="alone" />
+            <property name="tokens"
+                value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH" />
+        </module>
+        <module name="SuppressionXpathSingleFilter">
+            <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
+            <property name="id" value="RightCurlyAlone" />
+            <property name="query"
+                value="//RCURLY[parent::SLIST[count(./*)=1]
+                                     or preceding-sibling::*[last()][self::LCURLY]]" />
+        </module>
+        <module name="WhitespaceAfter">
+            <property name="tokens"
+                value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_RETURN,
+                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, DO_WHILE, ELLIPSIS,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_CATCH, LAMBDA,
+                    LITERAL_YIELD, LITERAL_CASE" />
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true" />
+            <property name="allowEmptyLambdas" value="true" />
+            <property name="allowEmptyMethods" value="true" />
+            <property name="allowEmptyTypes" value="true" />
+            <property name="allowEmptyLoops" value="true" />
+            <property name="ignoreEnhancedForColon" value="false" />
+            <property name="tokens"
+                value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
+                    LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
+                    LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
+                    LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                    NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
+                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND" />
+            <message key="ws.notFollowed"
+                value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks
+               may only be represented as '{}' when not part of a multi-block statement (4.1.3)" />
+            <message key="ws.notPreceded"
+                value="WhitespaceAround: ''{0}'' is not preceded with whitespace." />
+        </module>
+        <module name="OneStatementPerLine" />
+        <module name="MultipleVariableDeclarations" />
+        <module name="ArrayTypeStyle" />
+        <module name="MissingSwitchDefault" />
+        <module name="FallThrough" />
+        <module name="UpperEll" />
+        <module name="ModifierOrder" />
+        <module name="EmptyLineSeparator">
+            <property name="tokens"
+                value="IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF" />
+            <property name="allowNoEmptyLineBetweenFields" value="true" />
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapDot" />
+            <property name="tokens" value="DOT" />
+            <property name="option" value="nl" />
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapComma" />
+            <property name="tokens" value="COMMA" />
+            <property name="option" value="EOL" />
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/259 -->
+            <property name="id" value="SeparatorWrapEllipsis" />
+            <property name="tokens" value="ELLIPSIS" />
+            <property name="option" value="EOL" />
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/258 -->
+            <property name="id" value="SeparatorWrapArrayDeclarator" />
+            <property name="tokens" value="ARRAY_DECLARATOR" />
+            <property name="option" value="EOL" />
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapMethodRef" />
+            <property name="tokens" value="METHOD_REF" />
+            <property name="option" value="nl" />
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$" />
+            <message key="name.invalidPattern"
+                value="Package name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="TypeName">
+            <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    ANNOTATION_DEF, RECORD_DEF" />
+            <message key="name.invalidPattern"
+                value="Type name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$" />
+            <message key="name.invalidPattern"
+                value="Member name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+            <message key="name.invalidPattern"
+                value="Parameter name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="LambdaParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+            <message key="name.invalidPattern"
+                value="Lambda parameter name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+            <message key="name.invalidPattern"
+                value="Catch parameter name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="LocalVariableName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+            <message key="name.invalidPattern"
+                value="Local variable name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="PatternVariableName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+            <message key="name.invalidPattern"
+                value="Pattern variable name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+            <message key="name.invalidPattern"
+                value="Class type name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="RecordComponentName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+            <message key="name.invalidPattern"
+                value="Record component name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="RecordTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+            <message key="name.invalidPattern"
+                value="Record type name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+            <message key="name.invalidPattern"
+                value="Method type name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+            <message key="name.invalidPattern"
+                value="Interface type name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="NoFinalizer" />
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+                value="GenericWhitespace ''{0}'' is followed by whitespace." />
+            <message key="ws.preceded"
+                value="GenericWhitespace ''{0}'' is preceded with whitespace." />
+            <message key="ws.illegalFollow"
+                value="GenericWhitespace ''{0}'' should followed by whitespace." />
+            <message key="ws.notPreceded"
+                value="GenericWhitespace ''{0}'' is not preceded with whitespace." />
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="4" />
+            <property name="braceAdjustment" value="4" />
+            <property name="caseIndent" value="4" />
+            <property name="throwsIndent" value="4" />
+            <property name="lineWrappingIndentation" value="8" />
+            <property name="arrayInitIndent" value="4" />
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false" />
+            <property name="allowedAbbreviationLength" value="0" />
+            <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
+                    RECORD_COMPONENT_DEF" />
+        </module>
+        <module name="NoWhitespaceBeforeCaseDefaultColon" />
+        <module name="OverloadMethodsDeclarationOrder" />
+        <module name="VariableDeclarationUsageDistance" />
+        <module name="CustomImportOrder">
+            <property name="sortImportsInGroupAlphabetically" value="true" />
+            <property name="separateLineBetweenGroups" value="true" />
+            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE" />
+            <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF" />
+        </module>
+        <module name="MethodParamPad">
+            <property name="tokens"
+                value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF" />
+        </module>
+        <module name="NoWhitespaceBefore">
+            <property name="tokens"
+                value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
+                    LABELED_STAT, METHOD_REF" />
+            <property name="allowLineBreaks" value="true" />
+        </module>
+        <module name="ParenPad">
+            <property name="tokens"
+                value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
+                    RECORD_DEF" />
+        </module>
+        <module name="OperatorWrap">
+            <property name="option" value="NL" />
+            <property name="tokens"
+                value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF,
+                    TYPE_EXTENSION_AND " />
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationMostCases" />
+            <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
+                      RECORD_DEF, COMPACT_CTOR_DEF" />
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationVariables" />
+            <property name="tokens" value="VARIABLE_DEF" />
+            <property name="allowSamelineMultipleAnnotations" value="true" />
+        </module>
+        <module name="NonEmptyAtclauseDescription" />
+        <!--
+
+        Commented out javadoc checks, these produce a lot (4k in jme3-core) of warnings so for now, might
+        be too noisy
+
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocTagContinuationIndentation"/>
+    <module name="SummaryJavadoc">
+      <property name="forbiddenSummaryFragments"
+               value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+    </module>
+    <module name="JavadocParagraph"/>
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+      <property name="target"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+    </module>
+    <module name="JavadocMethod">
+      <property name="accessModifiers" value="public"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="MissingJavadocMethod">
+      <property name="scope" value="public"/>
+      <property name="minLineCount" value="2"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
+                                   COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="MissingJavadocType">
+      <property name="scope" value="protected"/>
+      <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                      RECORD_DEF, ANNOTATION_DEF"/>
+      <property name="excludeScope" value="nothing"/>
+    </module>
+    -->
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9]\w*$" />
+            <message key="name.invalidPattern"
+                value="Method name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="SingleLineJavadoc" />
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected" />
+        </module>
+        <module name="CommentsIndentation">
+            <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN" />
+        </module>
+        <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+                default="checkstyle-xpath-suppressions.xml" />
+            <property name="optional" value="true" />
+        </module>
+        <module name="SuppressWarningsHolder" />
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)" />
+            <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)" />
+            <property name="checkFormat" value="$1" />
+        </module>
+        <module name="SuppressWithNearbyCommentFilter">
+            <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)" />
+            <!-- $1 refers to the first match group in the regex defined in commentFormat -->
+            <property name="checkFormat" value="$1" />
+            <!-- The check is suppressed in the next line of code after the comment -->
+            <property name="influenceFormat" value="1" />
+        </module>
+    </module>
+</module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -37,7 +37,7 @@
 
     <module name="LineLength">
         <property name="fileExtensions" value="java" />
-        <property name="max" value="150" />
+        <property name="max" value="110" />
         <property name="ignorePattern"
             value="^package.*|^import.*|a href|href|http://|https://|ftp://" />
     </module>
@@ -56,9 +56,7 @@
             <property name="allowByTailComment" value="true" />
             <property name="allowNonPrintableEscapes" value="true" />
         </module>
-        <module name="AvoidStarImport">
-            <property name="severity" value="ignore"/>
-        </module>
+        <module name="AvoidStarImport"/>
         <module name="OneTopLevelClass" />
         <module name="NoLineWrap">
             <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT" />
@@ -107,7 +105,6 @@
                     LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, DO_WHILE" />
         </module>
         <module name="WhitespaceAround">
-            <property name="severity" value="ignore" />
             <property name="allowEmptyConstructors" value="true" />
             <property name="allowEmptyLambdas" value="true" />
             <property name="allowEmptyMethods" value="true" />
@@ -204,7 +201,6 @@
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
             <message key="name.invalidPattern"
                 value="Local variable name ''{0}'' must match pattern ''{1}''." />
-            <property name="severity" value="ignore" />
         </module>
         <module name="PatternVariableName">
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
@@ -254,7 +250,6 @@
             <property name="throwsIndent" value="4" />
             <property name="lineWrappingIndentation" value="8" />
             <property name="arrayInitIndent" value="4" />
-            <property name="severity" value="ignore" />
         </module>
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false" />
@@ -365,7 +360,6 @@
         </module>
         <module name="CommentsIndentation">
             <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN" />
-            <property name="severity" value="ignore" />
         </module>
 
     </module>

--- a/jme3-networking/build.gradle
+++ b/jme3-networking/build.gradle
@@ -8,3 +8,8 @@ javadoc {
         options.addStringOption('Xdoclint:none', '-quiet')
     }
 }
+
+//exclude the jme3-vr project from checkstyle
+checkstyleMain {
+    exclude "**/*.java"
+}

--- a/jme3-networking/build.gradle
+++ b/jme3-networking/build.gradle
@@ -8,8 +8,3 @@ javadoc {
         options.addStringOption('Xdoclint:none', '-quiet')
     }
 }
-
-//exclude the jme3-vr project from checkstyle
-checkstyleMain {
-    exclude "**/*.java"
-}

--- a/jme3-vr/build.gradle
+++ b/jme3-vr/build.gradle
@@ -27,3 +27,9 @@ javadoc {
         options.addStringOption('Xdoclint:none', '-quiet')
     }
 }
+
+
+checkstyleMain {
+    exclude "**/*.java"
+}
+

--- a/jme3-vr/build.gradle
+++ b/jme3-vr/build.gradle
@@ -28,8 +28,3 @@ javadoc {
     }
 }
 
-
-checkstyleMain {
-    exclude "**/*.java"
-}
-


### PR DESCRIPTION
Add checkstyle plugin to common.gradle
Add a checkstyle.xml based on google checkstyle xml with ammendments. 
Checkstyle errors do not fail the build since everything is marked as a warning.
modules can be refined over time as per comments in #1877.

Checkstyle can be run with `./gradlew checkstyleMain` - it runs for all projects.