### PR TITLE
Adds SingleLayerInfluenceMask

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/AlertArmatureMask.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AlertArmatureMask.java
@@ -1,0 +1,190 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package com.jme3.anim;
+
+import com.jme3.scene.Spatial;
+import java.util.Iterator;
+
+/**
+ * Extension of {@link ArmatureMask}.
+ * 
+ * <p>Provides a feature which checks higher layers for joint use before it
+ * approves the layer to use a joint.
+ * 
+ * @author codex
+ */
+public class AlertArmatureMask extends ArmatureMask {
+    
+    private final String layer;
+    private final AnimComposer anim;
+    private final SkinningControl skin;
+    private boolean checkUpperLayers = true;
+    
+    /**
+     * @param layer The layer this mask is targeted for. It is extremely important
+     * that this match the name of the layer this mask is (or will be) part of. You
+     * can use {@link makeLayer} to ensure this.
+     * @param spatial Spatial containing necessary controls ({@link AnimComposer} and {@link SkinningControl})
+     */
+    public AlertArmatureMask(String layer, Spatial spatial) {
+        super();
+        this.layer = layer;
+        anim = spatial.getControl(AnimComposer.class);
+        skin = spatial.getControl(SkinningControl.class);
+    }
+    public AlertArmatureMask(String layer, AnimComposer anim, SkinningControl skin) {
+        super();
+        this.layer = layer;
+        this.anim = anim;
+        this.skin = skin;
+    }
+    
+    /**
+     * Creates a copyFor of this {@code AlertArmatureMask} for the given layer.
+     * @param layer
+     * @return copyFor of this {@code AlertArmatureMask} for the layer
+     */
+    public AlertArmatureMask copyFor(String layer) {
+        return new AlertArmatureMask(layer, anim, skin);
+    }
+    /**
+     * Makes a layer for this mask.
+     */
+    public void makeLayer() {
+        anim.makeLayer(layer, this);
+    }
+    
+    /**
+     * Adds all joints to this mask.
+     * @return 
+     */
+    public AlertArmatureMask addAll() {
+        for (Joint j : skin.getArmature().getJointList()) {
+            super.addBones(skin.getArmature(), j.getName());
+        }
+        return this;
+    }
+    /**
+     * Adds the given joint and all its children to this mask.
+     * @param joint
+     * @return 
+     */
+    public AlertArmatureMask addFromJoint(String joint) {
+        super.addFromJoint(skin.getArmature(), joint);
+        return this;
+    }
+    /**
+     * Adds the given joints to this mask.
+     * @param joints
+     * @return 
+     */
+    public AlertArmatureMask addJoints(String... joints) {
+        super.addBones(skin.getArmature(), joints);
+        return this;
+    }
+    
+    /**
+     * Makes this mask check if each joint is being used by a higher layer
+     * before it uses them.
+     * <p>Not checking is more efficient, but checking can avoid some
+     * interpolation issues between layers. Default=true
+     * @param check 
+     */
+    public void setCheckUpperLayers(boolean check) {
+        checkUpperLayers = check;
+    }
+    
+    /**
+     * Get the layer this mask is targeted for.
+     * <p>It is extremely important that this value match the actual layer
+     * this is included in, because checking upper layers may not work if
+     * they are different.
+     * @return target layer
+     */
+    public String getTargetLayer() {
+        return layer;
+    }
+    /**
+     * Get the {@link AnimComposer} this mask is for.
+     * @return 
+     */
+    public AnimComposer getAnimComposer() {
+        return anim;
+    }
+    /**
+     * Get the {@link SkinningControl} this mask is for.
+     * @return 
+     */
+    public SkinningControl getSkinningControl() {
+        return skin;
+    }
+    /**
+     * Returns true if this mask is checking upper layers for joint use.
+     * @return 
+     */
+    public boolean isCheckUpperLayers() {
+        return checkUpperLayers;
+    }
+    
+    @Override
+    public boolean contains(Object target) {
+        return simpleContains(target) && (!checkUpperLayers || !isAffectedByUpperLayers(target));
+    }
+    private boolean simpleContains(Object target) {
+        return super.contains(target);
+    }
+    private boolean isAffectedByUpperLayers(Object target) {
+        boolean higher = false;
+        /**
+         * ... Since AnimComposer does not provide a Collection that
+         * has a decending iterator, we will just have to skip over
+         * a bunch of lower layers before we actually need to do anything.
+         */
+        for (String name : anim.getLayerNames()) {
+            if (name.equals(layer)) {
+                higher = true;
+                continue;
+            }
+            if (!higher) {
+                continue;
+            }
+            AnimLayer lyr = anim.getLayer(name);  
+            // if there is no action playing, no joints are used, so we can skip
+            if (lyr.getCurrentAction() == null) continue;
+            if (lyr.getMask() instanceof AlertArmatureMask) {
+                // dodge some needless recursion by calling a simpler method
+                if (((AlertArmatureMask)lyr.getMask()).simpleContains(target)) {
+                    return true;
+                }
+            }
+            else if (lyr.getMask().contains(target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    /**
+     * Creates an {@code AlertArmatureMask} for all joints.
+     * @param layer
+     * @param spatial
+     * @return 
+     */
+    public static AlertArmatureMask all(String layer, Spatial spatial) {
+        return new AlertArmatureMask(layer, spatial).addAll();
+    }
+    /**
+     * Creates an {@code AlertArmatureMask} for all joints.
+     * @param layer
+     * @param anim
+     * @param skin
+     * @return 
+     */
+    public static AlertArmatureMask all(String layer, AnimComposer anim, SkinningControl skin) {
+        return new AlertArmatureMask(layer, anim, skin).addAll();
+    }
+    
+}
+

--- a/jme3-core/src/main/java/com/jme3/anim/AlertArmatureMask.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AlertArmatureMask.java
@@ -42,14 +42,6 @@ public class AlertArmatureMask extends ArmatureMask {
     }
     
     /**
-     * Creates a copyFor of this {@code AlertArmatureMask} for the given layer.
-     * @param layer
-     * @return copy of this {@code AlertArmatureMask} for the layer
-     */
-    public AlertArmatureMask copyFor(String layer) {
-        return new AlertArmatureMask(layer, anim, skin);
-    }
-    /**
      * Makes a layer for this mask.
      */
     public void makeLayer() {
@@ -186,21 +178,6 @@ public class AlertArmatureMask extends ArmatureMask {
      */
     public static AlertArmatureMask all(String layer, AnimComposer anim, SkinningControl skin) {
         return new AlertArmatureMask(layer, anim, skin).addAll();
-    }
-    /**
-     * Creates an array of masks all sharing the same joint masking as {@code base}.
-     * <p>This is useful, for example, when you want to create several layers that all cover
-     * the entire armature.
-     * @param base base mask used to create other masks
-     * @param layers layer names to use
-     * @return array of new masks
-     */
-    public static AlertArmatureMask[] create(AlertArmatureMask base, String... layers) {
-        AlertArmatureMask[] masks = new AlertArmatureMask[layers.length];
-        for (int i = 0; i < layers.length; i++) {
-            masks[i] = base.copyFor(layers[i]);
-        }
-        return masks;
     }
     
 }

--- a/jme3-core/src/main/java/com/jme3/anim/AlertArmatureMask.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AlertArmatureMask.java
@@ -34,10 +34,8 @@ package com.jme3.anim;
 import com.jme3.scene.Spatial;
 
 /**
- * Extension of {@link ArmatureMask}.
- * 
- * <p>Provides a feature which checks higher layers for joint use before it
- * approves the layer to use a joint.
+ * Mask that excludes joints from participating in the layer
+ * if a higher layer is using those joints in an animation.
  * 
  * @author codex
  */
@@ -49,7 +47,7 @@ public class AlertArmatureMask extends ArmatureMask {
     private boolean checkUpperLayers = true;
     
     /**
-     * @param layer The layer this mask is targeted for. It is extremely important
+     * @param layer The layer this mask is targeted for. It is important
      * that this match the name of the layer this mask is (or will be) part of. You
      * can use {@link makeLayer} to ensure this.
      * @param spatial Spatial containing necessary controls ({@link AnimComposer} and {@link SkinningControl})
@@ -60,6 +58,13 @@ public class AlertArmatureMask extends ArmatureMask {
         anim = spatial.getControl(AnimComposer.class);
         skin = spatial.getControl(SkinningControl.class);
     }
+    /**
+     * @param layer The layer this mask is targeted for. It is important
+     * that this match the name of the layer this mask is (or will be) part of. You
+     * can use {@link makeLayer} to ensure this.
+     * @param anim anim composer this mask is assigned to
+     * @param skin skinning control complimenting the anim composer.
+     */
     public AlertArmatureMask(String layer, AnimComposer anim, SkinningControl skin) {
         super();
         this.layer = layer;
@@ -68,7 +73,7 @@ public class AlertArmatureMask extends ArmatureMask {
     }
     
     /**
-     * Makes a layer for this mask.
+     * Makes a layer from this mask.
      */
     public void makeLayer() {
         anim.makeLayer(layer, this);
@@ -76,7 +81,7 @@ public class AlertArmatureMask extends ArmatureMask {
     
     /**
      * Adds all joints to this mask.
-     * @return 
+     * @return this.instance
      */
     public AlertArmatureMask addAll() {
         for (Joint j : skin.getArmature().getJointList()) {
@@ -88,7 +93,7 @@ public class AlertArmatureMask extends ArmatureMask {
     /**
      * Adds the given joint and all its children to this mask.
      * @param joint
-     * @return 
+     * @return this instance
      */
     public AlertArmatureMask addFromJoint(String joint) {
         super.addFromJoint(skin.getArmature(), joint);
@@ -98,7 +103,7 @@ public class AlertArmatureMask extends ArmatureMask {
     /**
      * Adds the given joints to this mask.
      * @param joints
-     * @return 
+     * @return this instance
      */
     public AlertArmatureMask addJoints(String... joints) {
         super.addBones(skin.getArmature(), joints);
@@ -111,7 +116,7 @@ public class AlertArmatureMask extends ArmatureMask {
      * <p>Not checking is more efficient, but checking can avoid some
      * interpolation issues between layers. Default=true
      * @param check 
-     * @return 
+     * @return this instance
      */
     public AlertArmatureMask setCheckUpperLayers(boolean check) {
         checkUpperLayers = check;
@@ -131,7 +136,7 @@ public class AlertArmatureMask extends ArmatureMask {
     
     /**
      * Get the {@link AnimComposer} this mask is for.
-     * @return 
+     * @return anim composer
      */
     public AnimComposer getAnimComposer() {
         return anim;
@@ -139,7 +144,7 @@ public class AlertArmatureMask extends ArmatureMask {
     
     /**
      * Get the {@link SkinningControl} this mask is for.
-     * @return 
+     * @return skinning control
      */
     public SkinningControl getSkinningControl() {
         return skin;
@@ -190,9 +195,9 @@ public class AlertArmatureMask extends ArmatureMask {
     
     /**
      * Creates an {@code AlertArmatureMask} for all joints.
-     * @param layer
-     * @param spatial
-     * @return 
+     * @param layer layer the returned mask is, or will be, be assigned to
+     * @param spatial spatial containing anim composer and skinning control
+     * @return new mask
      */
     public static AlertArmatureMask all(String layer, Spatial spatial) {
         return new AlertArmatureMask(layer, spatial).addAll();
@@ -200,10 +205,10 @@ public class AlertArmatureMask extends ArmatureMask {
     
     /**
      * Creates an {@code AlertArmatureMask} for all joints.
-     * @param layer
-     * @param anim
-     * @param skin
-     * @return 
+     * @param layer layer the returned mask is, or will be, assigned to
+     * @param anim anim composer
+     * @param skin skinning control
+     * @return new mask
      */
     public static AlertArmatureMask all(String layer, AnimComposer anim, SkinningControl skin) {
         return new AlertArmatureMask(layer, anim, skin).addAll();

--- a/jme3-core/src/main/java/com/jme3/anim/AlertArmatureMask.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AlertArmatureMask.java
@@ -1,11 +1,37 @@
 /*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ * Copyright (c) 2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.jme3.anim;
 
 import com.jme3.scene.Spatial;
-import java.util.Iterator;
 
 /**
  * Extension of {@link ArmatureMask}.
@@ -58,6 +84,7 @@ public class AlertArmatureMask extends ArmatureMask {
         }
         return this;
     }
+    
     /**
      * Adds the given joint and all its children to this mask.
      * @param joint
@@ -67,6 +94,7 @@ public class AlertArmatureMask extends ArmatureMask {
         super.addFromJoint(skin.getArmature(), joint);
         return this;
     }
+    
     /**
      * Adds the given joints to this mask.
      * @param joints
@@ -100,6 +128,7 @@ public class AlertArmatureMask extends ArmatureMask {
     public String getTargetLayer() {
         return layer;
     }
+    
     /**
      * Get the {@link AnimComposer} this mask is for.
      * @return 
@@ -107,6 +136,7 @@ public class AlertArmatureMask extends ArmatureMask {
     public AnimComposer getAnimComposer() {
         return anim;
     }
+    
     /**
      * Get the {@link SkinningControl} this mask is for.
      * @return 
@@ -114,6 +144,7 @@ public class AlertArmatureMask extends ArmatureMask {
     public SkinningControl getSkinningControl() {
         return skin;
     }
+    
     /**
      * Returns true if this mask is checking upper layers for joint use.
      * @return 
@@ -126,16 +157,13 @@ public class AlertArmatureMask extends ArmatureMask {
     public boolean contains(Object target) {
         return simpleContains(target) && (!checkUpperLayers || !isAffectedByUpperLayers(target));
     }
+    
     private boolean simpleContains(Object target) {
         return super.contains(target);
     }
+    
     private boolean isAffectedByUpperLayers(Object target) {
         boolean higher = false;
-        /**
-         * ... Since AnimComposer does not provide a Collection that
-         * has a decending iterator, we will just have to skip over
-         * a bunch of lower layers before we actually need to do anything.
-         */
         for (String name : anim.getLayerNames()) {
             if (name.equals(layer)) {
                 higher = true;
@@ -169,6 +197,7 @@ public class AlertArmatureMask extends ArmatureMask {
     public static AlertArmatureMask all(String layer, Spatial spatial) {
         return new AlertArmatureMask(layer, spatial).addAll();
     }
+    
     /**
      * Creates an {@code AlertArmatureMask} for all joints.
      * @param layer

--- a/jme3-core/src/main/java/com/jme3/anim/AlertArmatureMask.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AlertArmatureMask.java
@@ -91,9 +91,11 @@ public class AlertArmatureMask extends ArmatureMask {
      * <p>Not checking is more efficient, but checking can avoid some
      * interpolation issues between layers. Default=true
      * @param check 
+     * @return 
      */
-    public void setCheckUpperLayers(boolean check) {
+    public AlertArmatureMask setCheckUpperLayers(boolean check) {
         checkUpperLayers = check;
+        return this;
     }
     
     /**

--- a/jme3-core/src/main/java/com/jme3/anim/AlertArmatureMask.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AlertArmatureMask.java
@@ -44,7 +44,7 @@ public class AlertArmatureMask extends ArmatureMask {
     /**
      * Creates a copyFor of this {@code AlertArmatureMask} for the given layer.
      * @param layer
-     * @return copyFor of this {@code AlertArmatureMask} for the layer
+     * @return copy of this {@code AlertArmatureMask} for the layer
      */
     public AlertArmatureMask copyFor(String layer) {
         return new AlertArmatureMask(layer, anim, skin);
@@ -184,6 +184,21 @@ public class AlertArmatureMask extends ArmatureMask {
      */
     public static AlertArmatureMask all(String layer, AnimComposer anim, SkinningControl skin) {
         return new AlertArmatureMask(layer, anim, skin).addAll();
+    }
+    /**
+     * Creates an array of masks all sharing the same joint masking as {@code base}.
+     * <p>This is useful, for example, when you want to create several layers that all cover
+     * the entire armature.
+     * @param base base mask used to create other masks
+     * @param layers layer names to use
+     * @return array of new masks
+     */
+    public static AlertArmatureMask[] create(AlertArmatureMask base, String... layers) {
+        AlertArmatureMask[] masks = new AlertArmatureMask[layers.length];
+        for (int i = 0; i < layers.length; i++) {
+            masks[i] = base.copyFor(layers[i]);
+        }
+        return masks;
     }
     
 }

--- a/jme3-core/src/main/java/com/jme3/anim/SingleLayerInfluenceMask.java
+++ b/jme3-core/src/main/java/com/jme3/anim/SingleLayerInfluenceMask.java
@@ -39,7 +39,7 @@ import com.jme3.scene.Spatial;
  * 
  * @author codex
  */
-public class AlertArmatureMask extends ArmatureMask {
+public class SingleLayerInfluenceMask extends ArmatureMask {
     
     private final String layer;
     private final AnimComposer anim;
@@ -52,7 +52,7 @@ public class AlertArmatureMask extends ArmatureMask {
      * can use {@link makeLayer} to ensure this.
      * @param spatial Spatial containing necessary controls ({@link AnimComposer} and {@link SkinningControl})
      */
-    public AlertArmatureMask(String layer, Spatial spatial) {
+    public SingleLayerInfluenceMask(String layer, Spatial spatial) {
         super();
         this.layer = layer;
         anim = spatial.getControl(AnimComposer.class);
@@ -65,7 +65,7 @@ public class AlertArmatureMask extends ArmatureMask {
      * @param anim anim composer this mask is assigned to
      * @param skin skinning control complimenting the anim composer.
      */
-    public AlertArmatureMask(String layer, AnimComposer anim, SkinningControl skin) {
+    public SingleLayerInfluenceMask(String layer, AnimComposer anim, SkinningControl skin) {
         super();
         this.layer = layer;
         this.anim = anim;
@@ -83,7 +83,7 @@ public class AlertArmatureMask extends ArmatureMask {
      * Adds all joints to this mask.
      * @return this.instance
      */
-    public AlertArmatureMask addAll() {
+    public SingleLayerInfluenceMask addAll() {
         for (Joint j : skin.getArmature().getJointList()) {
             super.addBones(skin.getArmature(), j.getName());
         }
@@ -95,7 +95,7 @@ public class AlertArmatureMask extends ArmatureMask {
      * @param joint
      * @return this instance
      */
-    public AlertArmatureMask addFromJoint(String joint) {
+    public SingleLayerInfluenceMask addFromJoint(String joint) {
         super.addFromJoint(skin.getArmature(), joint);
         return this;
     }
@@ -105,7 +105,7 @@ public class AlertArmatureMask extends ArmatureMask {
      * @param joints
      * @return this instance
      */
-    public AlertArmatureMask addJoints(String... joints) {
+    public SingleLayerInfluenceMask addJoints(String... joints) {
         super.addBones(skin.getArmature(), joints);
         return this;
     }
@@ -118,7 +118,7 @@ public class AlertArmatureMask extends ArmatureMask {
      * @param check 
      * @return this instance
      */
-    public AlertArmatureMask setCheckUpperLayers(boolean check) {
+    public SingleLayerInfluenceMask setCheckUpperLayers(boolean check) {
         checkUpperLayers = check;
         return this;
     }
@@ -180,9 +180,9 @@ public class AlertArmatureMask extends ArmatureMask {
             AnimLayer lyr = anim.getLayer(name);  
             // if there is no action playing, no joints are used, so we can skip
             if (lyr.getCurrentAction() == null) continue;
-            if (lyr.getMask() instanceof AlertArmatureMask) {
+            if (lyr.getMask() instanceof SingleLayerInfluenceMask) {
                 // dodge some needless recursion by calling a simpler method
-                if (((AlertArmatureMask)lyr.getMask()).simpleContains(target)) {
+                if (((SingleLayerInfluenceMask)lyr.getMask()).simpleContains(target)) {
                     return true;
                 }
             }
@@ -194,24 +194,24 @@ public class AlertArmatureMask extends ArmatureMask {
     }
     
     /**
-     * Creates an {@code AlertArmatureMask} for all joints.
+     * Creates an {@code SingleLayerInfluenceMask} for all joints.
      * @param layer layer the returned mask is, or will be, be assigned to
      * @param spatial spatial containing anim composer and skinning control
      * @return new mask
      */
-    public static AlertArmatureMask all(String layer, Spatial spatial) {
-        return new AlertArmatureMask(layer, spatial).addAll();
+    public static SingleLayerInfluenceMask all(String layer, Spatial spatial) {
+        return new SingleLayerInfluenceMask(layer, spatial).addAll();
     }
     
     /**
-     * Creates an {@code AlertArmatureMask} for all joints.
+     * Creates an {@code SingleLayerInfluenceMask} for all joints.
      * @param layer layer the returned mask is, or will be, assigned to
      * @param anim anim composer
      * @param skin skinning control
      * @return new mask
      */
-    public static AlertArmatureMask all(String layer, AnimComposer anim, SkinningControl skin) {
-        return new AlertArmatureMask(layer, anim, skin).addAll();
+    public static SingleLayerInfluenceMask all(String layer, AnimComposer anim, SkinningControl skin) {
+        return new SingleLayerInfluenceMask(layer, anim, skin).addAll();
     }
     
 }


### PR DESCRIPTION
This is my first pull request ever, so take it easy on me :)

The main element of this class (~~AlertArmatureMask~~ SingleLayerInfluenceMask) is the ability to check if a joint is currently being used by a higher layer before approving it for personal use via `contains(Object target)`. This can help smooth some interpolation issues that may arise between layers with looped/sequenced animations (see [here](https://hub.jmonkeyengine.org/t/solved-animation-transition-not-seamless-as-expected/46941/8) for more details on the problem).

This class also provides several helper methods to make mask creation easier.