### PR TITLE
solve issue #2039 (DOM readIntSavableMap() doesn't check exceptions)

### DIFF
--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/DOMInputCapsule.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/DOMInputCapsule.java
@@ -1245,9 +1245,16 @@ public class DOMInputCapsule implements InputCapsule {
                                 if (n instanceof Element && n.getNodeName().equals("MapEntry")) {
                                         Element elem = (Element) n;
                                         currentElem = elem;
-                                        int key = Integer.parseInt(currentElem.getAttribute("key"));
-                                        Savable val = readSavable("Savable", null);
-                                        ret.put(key, val);
+                                        try {
+	                                        int key = Integer.parseInt(currentElem.getAttribute("key"));
+	                                        Savable val = readSavable("Savable", null);
+	                                        ret.put(key, val);
+                                        }catch (NumberFormatException nfe) {
+                                            IOException io = new IOException(nfe.toString());
+                                            io.initCause(nfe);
+                                            throw io;
+
+                                        }
                                 }
                         }
         } else {


### PR DESCRIPTION
Integer.parseInt(currentElem.getAttribute("key")) can throw NumberFormatException, which is inconsistent with other parsing methods.