### PR TITLE
Update build.gradle to use default Build Tools (30.0.2) required by A…

### DIFF
--- a/jme3-android-examples/build.gradle
+++ b/jme3-android-examples/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    buildToolsVersion "30.0.2"
 
     lintOptions {
         // Fix nifty gui referencing "java.awt" package.


### PR DESCRIPTION
…ndroid Gradle Plugin 4.2.0

Update build.gradle to use default Build Tools (30.0.2) required by Android Gradle Plugin 4.2.0