### PR TITLE
Autoformat workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --tab-width 4 --print-width 180 --write **/**/*.java
+          prettier_options: --tab-width 4 --print-width 110 --write **/**/*.java
           prettier_version: "2.8.8"
           only_changed: True
           commit_message:  "auto-format"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --tab-width 4 --write **/**/*.java
+          prettier_options: --tab-width 4 --print-width 180 --write **/**/*.java
           prettier_version: "2.8.8"
           only_changed: True
           commit_message:  "auto-format"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write **/**/*.java
+          prettier_options: --tab-width 4 --write **/**/*.java
           prettier_version: "2.8.8"
           only_changed: True
           commit_message:  "auto-format"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,23 @@
+name: auto-format
+on:
+  pull_request:
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # Make sure the actual branch is checked out when running on pull requests
+          ref: ${{ github.head_ref }}
+          # This is important to fetch the changes to the previous commit
+          fetch-depth: 0
+      - name: Prettify code
+        uses: creyD/prettier_action@v4.3
+        with:
+          prettier_options: --write **/**/*.java
+          prettier_version: "2.8.8"
+          only_changed: True
+          commit_message:  "[skip ci] auto-format"
+          prettier_plugins: "prettier-plugin-java"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,5 +19,5 @@ jobs:
           prettier_options: --write **/**/*.java
           prettier_version: "2.8.8"
           only_changed: True
-          commit_message:  "[skip ci] auto-format"
+          commit_message:  "auto-format"
           prettier_plugins: "prettier-plugin-java"


### PR DESCRIPTION
A github action workflow that applies [prettifier](https://prettier.io/) to pull requests (if needed) to automatically fix formatting issues.

## Why prettifier?
- It is standalone
- The rules are similar to jme style but standardized (the only custom option used is tabsize=4)
- It is supported by many editors and can be used as git pre commit hook
- It supports many languages 

The goal is to make pr integration faster by resolving all sort of formatting issues automatically, since sometimes, even with a properly configured editor it is possible to miss some. (Unless you configure your editor to format on save, but can pollute the commit since most of our code was not formatted properly from the start.).

With this workflow contributors can simply pr changes  and have github action attach a formatting commit for the changed files, only if necessary.

I won't hide the fact that i am proposing this also because i am starting to believe i have developed some form of *formatting blindness*, since despite putting in 101% effort my PRs  always have formatting issues :crab: . 


