### PR TITLE
Mesh:  add constants for initial/default values of fields

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -153,16 +153,17 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
     /**
      * Default Variables
      */
+    private static final int DEFAULT_VERTEXT_ARRAY_ID = -1;
     private static final CollisionData DEFAULT_COLLECTION_TREE = null;
 
     private static final float DEFAULT_POINT_SIZE = 1.0f;
     private static final float DEFAULT_LINE_WIDTH = 1.0f;
 
-    private static final int DEFAULT_VERT_COUNT = 0;
-    private static final int DEFAULT_ELEMENT_COUNT = 0;
-    private static final int DEFAULT_INSTANCE_COUNT = 0;
+    private static final int DEFAULT_VERT_COUNT = -1;
+    private static final int DEFAULT_ELEMENT_COUNT = -1;
+    private static final int DEFAULT_INSTANCE_COUNT = -1;
     private static final int DEFAULT_PATCH_VERTEX_COUNT = 3;
-    private static final int DEFAULT_MAX_NUM_WEIGHTS = 0;
+    private static final int DEFAULT_MAX_NUM_WEIGHTS = -1;
     
     /**
      * The bounding volume that contains the mesh entirely.
@@ -175,10 +176,11 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
     private SafeArrayList<VertexBuffer> buffersList = new SafeArrayList<>(VertexBuffer.class);
     private IntMap<VertexBuffer> buffers = new IntMap<>();
     private VertexBuffer[] lodLevels;
+    
     private float pointSize = DEFAULT_POINT_SIZE;
     private float lineWidth = DEFAULT_LINE_WIDTH;
 
-    private transient int vertexArrayID = -1;
+    private transient int vertexArrayID = DEFAULT_VERTEXT_ARRAY_ID;
 
     private int vertCount = DEFAULT_VERT_COUNT;
     private int elementCount = DEFAULT_ELEMENT_COUNT;
@@ -214,7 +216,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
             clone.collisionTree = collisionTree != null ? collisionTree : null;
             clone.buffers = buffers.clone();
             clone.buffersList = new SafeArrayList<>(VertexBuffer.class, buffersList);
-            clone.vertexArrayID = -1;
+            clone.vertexArrayID = DEFAULT_VERTEXT_ARRAY_ID;
             if (elementLengths != null) {
                 clone.elementLengths = elementLengths.clone();
             }
@@ -251,7 +253,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
                 clone.buffersList.add(bufClone);
             }
 
-            clone.vertexArrayID = -1;
+            clone.vertexArrayID = DEFAULT_VERTEXT_ARRAY_ID;
             clone.vertCount = vertCount;
             clone.elementCount = elementCount;
             clone.instanceCount = instanceCount;
@@ -311,7 +313,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
     public Mesh jmeClone() {
         try {
             Mesh clone = (Mesh) super.clone();
-            clone.vertexArrayID = -1;
+            clone.vertexArrayID = DEFAULT_VERTEXT_ARRAY_ID;
             return clone;
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
@@ -984,7 +986,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
      * @param id the array ID
      */
     public void setId(int id) {
-        if (vertexArrayID != -1) {
+        if (vertexArrayID != DEFAULT_VERTEXT_ARRAY_ID) {
             throw new IllegalStateException("ID has already been set.");
         }
 

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -129,6 +129,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
          * for each patch (default is 3 for triangle tessellation)
          */
         Patch(true);
+
         private boolean listMode = false;
 
         private Mode(boolean listMode) {
@@ -148,28 +149,42 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
             return listMode;
         }
     }
+    
+    /**
+     * Default Variables
+     */
+    private static final CollisionData DEFAULT_COLLECTION_TREE = null;
 
+    private static final float DEFAULT_POINT_SIZE = 1.0f;
+    private static final float DEFAULT_LINE_WIDTH = 1.0f;
+
+    private static final int DEFAULT_VERT_COUNT = 0;
+    private static final int DEFAULT_ELEMENT_COUNT = 0;
+    private static final int DEFAULT_INSTANCE_COUNT = 0;
+    private static final int DEFAULT_PATCH_VERTEX_COUNT = 3;
+    private static final int DEFAULT_MAX_NUM_WEIGHTS = 0;
+    
     /**
      * The bounding volume that contains the mesh entirely.
      * By default a BoundingBox (AABB).
      */
     private BoundingVolume meshBound = new BoundingBox();
 
-    private CollisionData collisionTree = null;
+    private CollisionData collisionTree = DEFAULT_COLLECTION_TREE;
 
     private SafeArrayList<VertexBuffer> buffersList = new SafeArrayList<>(VertexBuffer.class);
     private IntMap<VertexBuffer> buffers = new IntMap<>();
     private VertexBuffer[] lodLevels;
-    private float pointSize = 1;
-    private float lineWidth = 1;
+    private float pointSize = DEFAULT_POINT_SIZE;
+    private float lineWidth = DEFAULT_LINE_WIDTH;
 
     private transient int vertexArrayID = -1;
 
-    private int vertCount = -1;
-    private int elementCount = -1;
-    private int instanceCount = -1;
-    private int patchVertexCount = 3; //only used for tessellation
-    private int maxNumWeights = -1; // only if using skeletal animation
+    private int vertCount = DEFAULT_VERT_COUNT;
+    private int elementCount = DEFAULT_ELEMENT_COUNT;
+    private int instanceCount = DEFAULT_INSTANCE_COUNT;
+    private int patchVertexCount = DEFAULT_PATCH_VERTEX_COUNT; //only used for tessellation
+    private int maxNumWeights = DEFAULT_MAX_NUM_WEIGHTS; // only if using skeletal animation
 
     private int[] elementLengths;
     private int[] modeStart;
@@ -226,7 +241,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
 
             // TODO: Collision tree cloning
             //clone.collisionTree = collisionTree != null ? collisionTree : null;
-            clone.collisionTree = null; // it will get re-generated in any case
+            clone.collisionTree = DEFAULT_COLLECTION_TREE; // it will get re-generated in any case
 
             clone.buffers = new IntMap<>();
             clone.buffersList = new SafeArrayList<>(VertexBuffer.class);
@@ -309,7 +324,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
     @Override
     public void cloneFields(Cloner cloner, Object original) {
         // Probably could clone this now but it will get regenerated anyway.
-        this.collisionTree = null;
+        this.collisionTree = DEFAULT_COLLECTION_TREE;
 
         this.meshBound = cloner.clone(meshBound);
         this.buffersList = cloner.clone(buffersList);
@@ -616,7 +631,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
      */
     @Deprecated
     public float getPointSize() {
-        return 1.0f;
+        return DEFAULT_POINT_SIZE;
     }
 
     /**
@@ -995,7 +1010,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
      * generated BIHTree.
      */
     public void clearCollisionData() {
-        collisionTree = null;
+        collisionTree = DEFAULT_COLLECTION_TREE;
     }
 
     /**
@@ -1620,15 +1635,15 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
         OutputCapsule out = ex.getCapsule(this);
 
         out.write(meshBound, "modelBound", null);
-        out.write(vertCount, "vertCount", -1);
-        out.write(elementCount, "elementCount", -1);
-        out.write(instanceCount, "instanceCount", -1);
-        out.write(maxNumWeights, "max_num_weights", -1);
+        out.write(vertCount, "vertCount", DEFAULT_VERT_COUNT);
+        out.write(elementCount, "elementCount", DEFAULT_ELEMENT_COUNT);
+        out.write(instanceCount, "instanceCount", DEFAULT_INSTANCE_COUNT);
+        out.write(maxNumWeights, "max_num_weights", DEFAULT_MAX_NUM_WEIGHTS);
         out.write(mode, "mode", Mode.Triangles);
-        out.write(collisionTree, "collisionTree", null);
+        out.write(collisionTree, "collisionTree", DEFAULT_COLLECTION_TREE);
         out.write(elementLengths, "elementLengths", null);
         out.write(modeStart, "modeStart", null);
-        out.write(pointSize, "pointSize", 1f);
+        out.write(pointSize, "pointSize", DEFAULT_POINT_SIZE);
 
         //Removing HW skinning buffers to not save them
         VertexBuffer hwBoneIndex = null;
@@ -1663,17 +1678,17 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
     public void read(JmeImporter im) throws IOException {
         InputCapsule in = im.getCapsule(this);
         meshBound = (BoundingVolume) in.readSavable("modelBound", null);
-        vertCount = in.readInt("vertCount", -1);
-        elementCount = in.readInt("elementCount", -1);
-        instanceCount = in.readInt("instanceCount", -1);
-        maxNumWeights = in.readInt("max_num_weights", -1);
+        vertCount = in.readInt("vertCount", DEFAULT_VERT_COUNT);
+        elementCount = in.readInt("elementCount", DEFAULT_ELEMENT_COUNT);
+        instanceCount = in.readInt("instanceCount", DEFAULT_INSTANCE_COUNT);
+        maxNumWeights = in.readInt("max_num_weights", DEFAULT_MAX_NUM_WEIGHTS);
         mode = in.readEnum("mode", Mode.class, Mode.Triangles);
         elementLengths = in.readIntArray("elementLengths", null);
         modeStart = in.readIntArray("modeStart", null);
-        collisionTree = (BIHTree) in.readSavable("collisionTree", null);
+        collisionTree = (BIHTree) in.readSavable("collisionTree", DEFAULT_COLLECTION_TREE);
         elementLengths = in.readIntArray("elementLengths", null);
         modeStart = in.readIntArray("modeStart", null);
-        pointSize = in.readFloat("pointSize", 1f);
+        pointSize = in.readFloat("pointSize", DEFAULT_POINT_SIZE);
 
 //        in.readStringSavableMap("buffers", null);
         buffers = (IntMap<VertexBuffer>) in.readIntSavableMap("buffers", null);

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -153,8 +153,8 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
     /**
      * Default Variables
      */
-    private static final int DEFAULT_VERTEXT_ARRAY_ID = -1;
-    private static final CollisionData DEFAULT_COLLECTION_TREE = null;
+    private static final int DEFAULT_VERTEX_ARRAY_ID = -1;
+    private static final CollisionData DEFAULT_COLLISION_TREE = null;
 
     private static final float DEFAULT_POINT_SIZE = 1.0f;
     private static final float DEFAULT_LINE_WIDTH = 1.0f;

--- a/jme3-core/src/main/java/com/jme3/scene/Mesh.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Mesh.java
@@ -171,7 +171,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
      */
     private BoundingVolume meshBound = new BoundingBox();
 
-    private CollisionData collisionTree = DEFAULT_COLLECTION_TREE;
+    private CollisionData collisionTree = DEFAULT_COLLISION_TREE;
 
     private SafeArrayList<VertexBuffer> buffersList = new SafeArrayList<>(VertexBuffer.class);
     private IntMap<VertexBuffer> buffers = new IntMap<>();
@@ -180,7 +180,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
     private float pointSize = DEFAULT_POINT_SIZE;
     private float lineWidth = DEFAULT_LINE_WIDTH;
 
-    private transient int vertexArrayID = DEFAULT_VERTEXT_ARRAY_ID;
+    private transient int vertexArrayID = DEFAULT_VERTEX_ARRAY_ID;
 
     private int vertCount = DEFAULT_VERT_COUNT;
     private int elementCount = DEFAULT_ELEMENT_COUNT;
@@ -216,7 +216,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
             clone.collisionTree = collisionTree != null ? collisionTree : null;
             clone.buffers = buffers.clone();
             clone.buffersList = new SafeArrayList<>(VertexBuffer.class, buffersList);
-            clone.vertexArrayID = DEFAULT_VERTEXT_ARRAY_ID;
+            clone.vertexArrayID = DEFAULT_VERTEX_ARRAY_ID;
             if (elementLengths != null) {
                 clone.elementLengths = elementLengths.clone();
             }
@@ -243,7 +243,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
 
             // TODO: Collision tree cloning
             //clone.collisionTree = collisionTree != null ? collisionTree : null;
-            clone.collisionTree = DEFAULT_COLLECTION_TREE; // it will get re-generated in any case
+            clone.collisionTree = DEFAULT_COLLISION_TREE; // it will get re-generated in any case
 
             clone.buffers = new IntMap<>();
             clone.buffersList = new SafeArrayList<>(VertexBuffer.class);
@@ -253,7 +253,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
                 clone.buffersList.add(bufClone);
             }
 
-            clone.vertexArrayID = DEFAULT_VERTEXT_ARRAY_ID;
+            clone.vertexArrayID = DEFAULT_VERTEX_ARRAY_ID;
             clone.vertCount = vertCount;
             clone.elementCount = elementCount;
             clone.instanceCount = instanceCount;
@@ -313,7 +313,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
     public Mesh jmeClone() {
         try {
             Mesh clone = (Mesh) super.clone();
-            clone.vertexArrayID = DEFAULT_VERTEXT_ARRAY_ID;
+            clone.vertexArrayID = DEFAULT_VERTEX_ARRAY_ID;
             return clone;
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
@@ -326,7 +326,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
     @Override
     public void cloneFields(Cloner cloner, Object original) {
         // Probably could clone this now but it will get regenerated anyway.
-        this.collisionTree = DEFAULT_COLLECTION_TREE;
+        this.collisionTree = DEFAULT_COLLISION_TREE;
 
         this.meshBound = cloner.clone(meshBound);
         this.buffersList = cloner.clone(buffersList);
@@ -986,7 +986,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
      * @param id the array ID
      */
     public void setId(int id) {
-        if (vertexArrayID != DEFAULT_VERTEXT_ARRAY_ID) {
+        if (vertexArrayID != DEFAULT_VERTEX_ARRAY_ID) {
             throw new IllegalStateException("ID has already been set.");
         }
 
@@ -1012,7 +1012,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
      * generated BIHTree.
      */
     public void clearCollisionData() {
-        collisionTree = DEFAULT_COLLECTION_TREE;
+        collisionTree = DEFAULT_COLLISION_TREE;
     }
 
     /**
@@ -1642,7 +1642,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
         out.write(instanceCount, "instanceCount", DEFAULT_INSTANCE_COUNT);
         out.write(maxNumWeights, "max_num_weights", DEFAULT_MAX_NUM_WEIGHTS);
         out.write(mode, "mode", Mode.Triangles);
-        out.write(collisionTree, "collisionTree", DEFAULT_COLLECTION_TREE);
+        out.write(collisionTree, "collisionTree", DEFAULT_COLLISION_TREE);
         out.write(elementLengths, "elementLengths", null);
         out.write(modeStart, "modeStart", null);
         out.write(pointSize, "pointSize", DEFAULT_POINT_SIZE);
@@ -1687,7 +1687,7 @@ public class Mesh implements Savable, Cloneable, JmeCloneable {
         mode = in.readEnum("mode", Mode.class, Mode.Triangles);
         elementLengths = in.readIntArray("elementLengths", null);
         modeStart = in.readIntArray("modeStart", null);
-        collisionTree = (BIHTree) in.readSavable("collisionTree", DEFAULT_COLLECTION_TREE);
+        collisionTree = (BIHTree) in.readSavable("collisionTree", DEFAULT_COLLISION_TREE);
         elementLengths = in.readIntArray("elementLengths", null);
         modeStart = in.readIntArray("modeStart", null);
         pointSize = in.readFloat("pointSize", DEFAULT_POINT_SIZE);

--- a/jme3-core/src/test/java/com/jme3/scene/mesh/MeshTest.java
+++ b/jme3-core/src/test/java/com/jme3/scene/mesh/MeshTest.java
@@ -1,0 +1,16 @@
+package com.jme3.scene.mesh;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.jme3.scene.Mesh;
+
+public class MeshTest {
+       @Test
+    public void testEmptyMesh() {
+        final Mesh mesh = new Mesh();
+
+        assertEquals(0, mesh.getVertexCount());;
+    }
+}

--- a/jme3-core/src/test/java/com/jme3/scene/mesh/MeshTest.java
+++ b/jme3-core/src/test/java/com/jme3/scene/mesh/MeshTest.java
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2023 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package com.jme3.scene.mesh;
 
 import static org.junit.Assert.assertEquals;
@@ -6,9 +38,18 @@ import org.junit.Test;
 
 import com.jme3.scene.Mesh;
 
+/**
+ * Tests selected methods of the Mesh class.
+ *
+ * @author Melvyn Linke
+ */
 public class MeshTest {
+
+    /**
+     * Tests getVertexCount() on a empty Mesh.
+     */
     @Test
-    public void testEmptyMesh() {
+    public void testVertexCountOfEmptyMesh() {
         final Mesh mesh = new Mesh();
 
         assertEquals(-1, mesh.getVertexCount());

--- a/jme3-core/src/test/java/com/jme3/scene/mesh/MeshTest.java
+++ b/jme3-core/src/test/java/com/jme3/scene/mesh/MeshTest.java
@@ -11,6 +11,6 @@ public class MeshTest {
     public void testEmptyMesh() {
         final Mesh mesh = new Mesh();
 
-        assertEquals(0, mesh.getVertexCount());;
+        assertEquals(-1, mesh.getVertexCount());;
     }
 }

--- a/jme3-core/src/test/java/com/jme3/scene/mesh/MeshTest.java
+++ b/jme3-core/src/test/java/com/jme3/scene/mesh/MeshTest.java
@@ -7,10 +7,10 @@ import org.junit.Test;
 import com.jme3.scene.Mesh;
 
 public class MeshTest {
-       @Test
+    @Test
     public void testEmptyMesh() {
         final Mesh mesh = new Mesh();
 
-        assertEquals(-1, mesh.getVertexCount());;
+        assertEquals(-1, mesh.getVertexCount());
     }
 }


### PR DESCRIPTION
Changed default values to "0" instead of "-1" and moved them to private constant class variables.
I guess "-1" was used as an fail/error-state but i didn't seen any checks besides ">=0", "!=0" and "==0".

Also after reading the request which also fixes #334 I am not sure if this a useful solution. 

Unittests -> ok
Handpicked examples(Scenes, Animation) ->  #ok

