### PR TITLE
Fixes Issue #2070 (AssetKey overrides)

### DIFF
--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/AnimationList.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/AnimationList.java
@@ -33,6 +33,7 @@ package com.jme3.scene.plugins.fbx;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Defines animations set that will be created while loading FBX scene
@@ -72,11 +73,41 @@ public class AnimationList {
         cue.lastFrame = lastFrame;
         list.add(cue);
     }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final AnimationList other = (AnimationList)obj;
+        return Objects.equals(this.list, other.list);
+    }
+    
+    @Override
+    public int hashCode() {
+        return 119 + Objects.hashCode(this.list);
+    }    
 
     static class AnimInverval {
         String name;
         String layerName;
         int firstFrame;
         int lastFrame;
+        // hashCode generator, for good measure
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash = 29 * hash + Objects.hashCode(this.name);
+            hash = 29 * hash + Objects.hashCode(this.layerName);
+            hash = 29 * hash + this.firstFrame;
+            hash = 29 * hash + this.lastFrame;
+            return hash;
+        }
     }
 }

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneKey.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneKey.java
@@ -32,6 +32,7 @@
 package com.jme3.scene.plugins.fbx;
 
 import com.jme3.asset.ModelKey;
+import java.util.Objects;
 
 public class SceneKey extends ModelKey {
 
@@ -49,6 +50,29 @@ public class SceneKey extends ModelKey {
 
     public AnimationList getAnimations() {
         return this.animList;
+    }
+    
+    @Override
+    public boolean equals(Object object) {
+        if (object == null) {
+            return false;
+        }
+        if (getClass() != object.getClass()) {
+            return false;
+        }
+        final SceneKey other = (SceneKey)object;
+        if (!super.equals(other)) {
+            return false;
+        }
+        if (animList != other.animList && (animList == null || !animList.equals(other.animList))) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return 413 + Objects.hashCode(animList);
     }
 
 }

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneKey.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneKey.java
@@ -64,7 +64,7 @@ public class SceneKey extends ModelKey {
         if (!super.equals(other)) {
             return false;
         }
-        if (animList != other.animList && (animList == null || !animList.equals(other.animList))) {
+        if (!Objects.equals(animList, other.animList)) {
             return false;
         }
         return true;

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfModelKey.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfModelKey.java
@@ -35,6 +35,7 @@ import com.jme3.asset.ModelKey;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * An optional key to use when loading a glTF file
@@ -114,4 +115,35 @@ public class GltfModelKey extends ModelKey {
     public void setExtrasLoader(ExtrasLoader extrasLoader) {
         this.extrasLoader = extrasLoader;
     }
+    
+    @Override
+    public boolean equals(Object object) {
+        if (object == null) {
+            return false;
+        }
+        if (getClass() != object.getClass()) {
+            return false;
+        }
+        final GltfModelKey other = (GltfModelKey)object;
+        if (!super.equals(other)) {
+            return false;
+        }
+        if (materialAdapters != other.materialAdapters && !materialAdapters.equals(other.materialAdapters)) {
+            return false;
+        }
+        if (extrasLoader != other.extrasLoader && (extrasLoader == null || !extrasLoader.equals(other.extrasLoader))) {
+            return false;
+        }
+        return keepSkeletonPose == other.keepSkeletonPose;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 37 * hash + materialAdapters.hashCode();
+        hash = 37 * hash + Objects.hashCode(this.extrasLoader);
+        hash = 37 * hash + (this.keepSkeletonPose ? 1 : 0);
+        return hash;
+    }
+    
 }

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfModelKey.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfModelKey.java
@@ -128,10 +128,8 @@ public class GltfModelKey extends ModelKey {
         if (!super.equals(other)) {
             return false;
         }
-        if (materialAdapters != other.materialAdapters && !materialAdapters.equals(other.materialAdapters)) {
-            return false;
-        }
-        if (extrasLoader != other.extrasLoader && (extrasLoader == null || !extrasLoader.equals(other.extrasLoader))) {
+        if (!Objects.equals(materialAdapters, other.materialAdapters)
+                || !Objects.equals(extrasLoader, other.extrasLoader)) {
             return false;
         }
         return keepSkeletonPose == other.keepSkeletonPose;


### PR DESCRIPTION
This commit fixes the minor #2070 asset key issue by adding equals and hashcode methods to GltfModelKey and SceneKey.