### PR TITLE
Partial fix for Issue #2087 (NegativeScaleTest)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/material/Material.java
+++ b/jme3-core/src/main/java/com/jme3/material/Material.java
@@ -46,7 +46,6 @@ import com.jme3.renderer.Renderer;
 import com.jme3.renderer.TextureUnitException;
 import com.jme3.renderer.queue.RenderQueue.Bucket;
 import com.jme3.scene.Geometry;
-import com.jme3.scene.Spatial.CullHint;
 import com.jme3.shader.*;
 import com.jme3.texture.Image;
 import com.jme3.texture.Texture;

--- a/jme3-core/src/main/java/com/jme3/material/Material.java
+++ b/jme3-core/src/main/java/com/jme3/material/Material.java
@@ -897,30 +897,32 @@ public class Material implements CloneableSmartAsset, Cloneable, Savable {
                 renderer.applyRenderState(renderManager.getForcedRenderState());
             }
             else {
-                RenderState rs = renderManager.getForcedRenderState();
-                rs.flipFaceCull();
-                renderer.applyRenderState(rs);
+                RenderState flipped = renderManager.getForcedRenderState().clone();
+                flipped.flipFaceCull();
+                renderer.applyRenderState(flipped);
             }
         } else {
             if (techniqueDef.getRenderState() != null) {
+                // copyMergedTo writes to mergedRenderState
                 techniqueDef.getRenderState().copyMergedTo(additionalState, mergedRenderState);
             } else {
                 RenderState.DEFAULT.copyMergedTo(additionalState, mergedRenderState);
             }
+            // test if the face cull mode should be flipped before render
             if (!mergedRenderState.isFaceCullFlippable() || !isNormalsBackward(geometry.getWorldScale())) {
                 renderer.applyRenderState(mergedRenderState);
             }
             else {
-                RenderState rs = mergedRenderState.clone();
-                rs.flipFaceCull();
-                renderer.applyRenderState(rs);
+                RenderState flipped = mergedRenderState.clone();
+                flipped.flipFaceCull();
+                renderer.applyRenderState(flipped);
             }
         }
     }
     
     /**
-     * Returns true if the given scalar indicates that normals will be backward.
-     * @param scalar
+     * Returns true if the geometry world scale indicates that normals will be backward.
+     * @param scalar geometry world scale
      * @return 
      */
     private boolean isNormalsBackward(Vector3f scalar) {
@@ -929,7 +931,7 @@ public class Material implements CloneableSmartAsset, Cloneable, Savable {
         if (scalar.x < 0) n++;
         if (scalar.y < 0) n++;
         if (scalar.z < 0) n++;
-        // an odd number of components means the vectors are backward
+        // an odd number of components means the normal vectors are backward
         return n == 1 || n == 3;
     }
     

--- a/jme3-core/src/main/java/com/jme3/material/Material.java
+++ b/jme3-core/src/main/java/com/jme3/material/Material.java
@@ -931,7 +931,8 @@ public class Material implements CloneableSmartAsset, Cloneable, Savable {
         if (scalar.x < 0) n++;
         if (scalar.y < 0) n++;
         if (scalar.z < 0) n++;
-        // an odd number of components means the normal vectors are backward
+        // An odd number of negative components means the normal vectors
+        // are backward to what they should be.
         return n == 1 || n == 3;
     }
     

--- a/jme3-core/src/main/java/com/jme3/material/RenderState.java
+++ b/jme3-core/src/main/java/com/jme3/material/RenderState.java
@@ -1711,4 +1711,29 @@ public class RenderState implements Cloneable, Savable {
                 + (blendMode.equals(BlendMode.Custom)? "\ncustomBlendFactors=("+sfactorRGB+", "+dfactorRGB+", "+sfactorAlpha+", "+dfactorAlpha+")":"")
                 +"\n]";
     }
+    
+    /**
+     * Flips the given face cull mode so that {@code Back} becomes
+     * {@code Front} and {@code Front} becomes {@code Back}.
+     * <p>{@code FrontAndBack} and {@code Off} are unaffected. This is important
+     * for flipping the cull mode when normal vectors are found to be backward.
+     * @param cull
+     * @return flipped cull mode
+     */
+    public void flipFaceCull() {
+        switch (cullMode) {
+            case Back:  cullMode = FaceCullMode.Front; break;
+            case Front: cullMode = FaceCullMode.Back;  break;
+        }
+    }
+    
+    /**
+     * Checks if the face cull mode is "flippable".
+     * <p>The cull mode is flippable when it is either {@code Front} or {@code Back}.
+     * @return 
+     */
+    public boolean isFaceCullFlippable() {
+        return cullMode == FaceCullMode.Front || cullMode == FaceCullMode.Back;
+    }
+    
 }

--- a/jme3-examples/src/main/java/jme3test/model/TestGltfLoading.java
+++ b/jme3-examples/src/main/java/jme3test/model/TestGltfLoading.java
@@ -133,7 +133,7 @@ public class TestGltfLoading extends SimpleApplication {
         //loadModel("Models/gltf/manta/scene.gltf", Vector3f.ZERO, 0.2f);
         //loadModel("Models/gltf/bone/scene.gltf", Vector3f.ZERO, 0.1f);
 //        loadModel("Models/gltf/box/box.gltf", Vector3f.ZERO, 1);
-        loadModel("Models/gltf/duck/Duck.gltf", new Vector3f(0, -1, 0), 1);
+        loadModel("Models/gltf/duck/Duck.gltf", new Vector3f(0, -1, 0), -1);
 //        loadModel("Models/gltf/DamagedHelmet/glTF/DamagedHelmet.gltf", Vector3f.ZERO, 1);
 //        loadModel("Models/gltf/hornet/scene.gltf", new Vector3f(0, -0.5f, 0), 0.4f);
 ////        loadModel("Models/gltf/adamHead/adamHead.gltf", Vector3f.ZERO, 0.6f);
@@ -154,6 +154,8 @@ public class TestGltfLoading extends SimpleApplication {
 
 
         probeNode.attachChild(assets.get(0));
+        
+        probeNode.getChild(0).setLocalTranslation(0f, 1f, 0f);
 
         // setMorphTarget(morphIndex);
 

--- a/jme3-examples/src/main/java/jme3test/model/TestGltfLoading.java
+++ b/jme3-examples/src/main/java/jme3test/model/TestGltfLoading.java
@@ -133,7 +133,7 @@ public class TestGltfLoading extends SimpleApplication {
         //loadModel("Models/gltf/manta/scene.gltf", Vector3f.ZERO, 0.2f);
         //loadModel("Models/gltf/bone/scene.gltf", Vector3f.ZERO, 0.1f);
 //        loadModel("Models/gltf/box/box.gltf", Vector3f.ZERO, 1);
-        loadModel("Models/gltf/duck/Duck.gltf", new Vector3f(0, -1, 0), -1);
+        loadModel("Models/gltf/duck/Duck.gltf", new Vector3f(0, 1, 0), 1);
 //        loadModel("Models/gltf/DamagedHelmet/glTF/DamagedHelmet.gltf", Vector3f.ZERO, 1);
 //        loadModel("Models/gltf/hornet/scene.gltf", new Vector3f(0, -0.5f, 0), 0.4f);
 ////        loadModel("Models/gltf/adamHead/adamHead.gltf", Vector3f.ZERO, 0.6f);
@@ -154,8 +154,6 @@ public class TestGltfLoading extends SimpleApplication {
 
 
         probeNode.attachChild(assets.get(0));
-        
-        probeNode.getChild(0).setLocalTranslation(0f, 1f, 0f);
 
         // setMorphTarget(morphIndex);
 
@@ -230,10 +228,13 @@ public class TestGltfLoading extends SimpleApplication {
     }
 
     private void loadModel(String path, Vector3f offset, float scale) {
+        loadModel(path, offset, new Vector3f(scale, scale, scale));
+    }
+    private void loadModel(String path, Vector3f offset, Vector3f scale) {
         GltfModelKey k = new GltfModelKey(path);
         //k.setKeepSkeletonPose(true);
         Spatial s = assetManager.loadModel(k);
-        s.scale(scale);
+        s.scale(scale.x, scale.y, scale.z);
         s.move(offset);
         assets.add(s);
         if (playAnim) {


### PR DESCRIPTION
This PR partially fixes #2087 by "flipping" the face cull mode as the render state is applied to the renderer if the geometry world scale is found to be negative. This does not alter the normal vectors, so shaders still receive backwards normals and models still may not appear quite right (especially with normal maps), but this fixes the face culling issue, at least.