### PR TITLE
Improve GL Debug

### DIFF
--- a/jme3-core/src/main/java/com/jme3/post/Filter.java
+++ b/jme3-core/src/main/java/com/jme3/post/Filter.java
@@ -108,7 +108,7 @@ public abstract class Filter implements Savable {
         public void init(Renderer renderer, int width, int height, Format textureFormat, Format depthBufferFormat, int numSamples, boolean renderDepth) {
             Collection<Caps> caps = renderer.getCaps();
             if (numSamples > 1 && caps.contains(Caps.FrameBufferMultisample) && caps.contains(Caps.OpenGL31)) {
-                renderFrameBuffer = new FrameBuffer(width, height, numSamples);                
+                renderFrameBuffer = new FrameBuffer(width, height, numSamples);
                 renderedTexture = new Texture2D(width, height, numSamples, textureFormat);
                 renderFrameBuffer.setDepthTarget(FrameBufferTarget.newTarget(depthBufferFormat));
                 if (renderDepth) {
@@ -126,7 +126,7 @@ public abstract class Filter implements Savable {
             }
 
             renderFrameBuffer.addColorTarget(FrameBufferTarget.newTarget(renderedTexture));
-
+            renderFrameBuffer.setName(getClass().getSimpleName());      
 
         }
 

--- a/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
@@ -295,7 +295,7 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
                 if (msDepth && filter.isRequiresDepthTexture()) {
                     mat.setInt("NumSamplesDepth", depthTexture.getImage().getMultiSamples());
                 }
-
+                
                 if (filter.isRequiresSceneTexture()) {
                     mat.setTexture("Texture", tex);
                     if (tex.getImage().getMultiSamples() > 1) {
@@ -506,6 +506,14 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
             renderFrameBuffer.setDepthTarget(FrameBufferTarget.newTarget(depthFormat));
             filterTexture = new Texture2D(width, height, fbFormat);
             renderFrameBuffer.addColorTarget(FrameBufferTarget.newTarget(filterTexture));
+        }
+
+        if (renderFrameBufferMS != null) {
+            renderFrameBufferMS.setName("FilterPostProcessor MS");
+        }
+
+        if (renderFrameBuffer != null) {
+            renderFrameBuffer.setName("FilterPostProcessor");
         }
 
         for (Filter filter : filters.getArray()) {

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -616,7 +616,7 @@ public final class GLRenderer implements Renderer {
             caps.add(Caps.UnpackRowLength);
         }
 
-        if (caps.contains(Caps.OpenGL43) || hasExtension("GL_KHR_debug")) {
+        if (caps.contains(Caps.OpenGL43) || hasExtension("GL_KHR_debug") || caps.contains(Caps.WebGL)) {
             caps.add(Caps.GLDebug);
         }
 


### PR DESCRIPTION
- Enable GLDebug for webgl.
- Name framebuffers in postprocessing: this is used to tag framebuffers in debuggers when GLDebug is enabled.