### PR TITLE
Fixes GLTF Import of Morph Animations

### DIFF
--- a/jme3-examples/src/main/java/jme3test/model/TestGltfLoading.java
+++ b/jme3-examples/src/main/java/jme3test/model/TestGltfLoading.java
@@ -31,6 +31,7 @@
  */
 package jme3test.model;
 
+import com.jme3.anim.AnimClip;
 import com.jme3.anim.AnimComposer;
 import com.jme3.anim.SkinningControl;
 import com.jme3.app.*;
@@ -111,6 +112,10 @@ public class TestGltfLoading extends SimpleApplication {
 //        PointLight pl1 = new PointLight(new Vector3f(-5.0f, -5.0f, -5.0f), ColorRGBA.White.mult(0.5f), 50);
 //        rootNode.addLight(pl1);
 
+        assetManager.registerLocator("/home/codex/Downloads", FileLocator.class);
+
+        loadModel("MorphStressTest.gltf", new Vector3f(), 1f);
+        //loadModel("MorphPrimitivesTest.gltf", new Vector3f(), 1f);
         //loadModel("Models/gltf/polly/project_polly.gltf", new Vector3f(0, 0, 0), 0.5f);
         //loadModel("Models/gltf/zophrac/scene.gltf", new Vector3f(0, 0, 0), 0.01f);
     //    loadModel("Models/gltf/scifigirl/scene.gltf", new Vector3f(0, -1, 0), 0.1f);
@@ -133,7 +138,7 @@ public class TestGltfLoading extends SimpleApplication {
         //loadModel("Models/gltf/manta/scene.gltf", Vector3f.ZERO, 0.2f);
         //loadModel("Models/gltf/bone/scene.gltf", Vector3f.ZERO, 0.1f);
 //        loadModel("Models/gltf/box/box.gltf", Vector3f.ZERO, 1);
-        loadModel("Models/gltf/duck/Duck.gltf", new Vector3f(0, -1, 0), 1);
+        //loadModel("Models/gltf/duck/Duck.gltf", new Vector3f(0, -1, 0), 1);
 //        loadModel("Models/gltf/DamagedHelmet/glTF/DamagedHelmet.gltf", Vector3f.ZERO, 1);
 //        loadModel("Models/gltf/hornet/scene.gltf", new Vector3f(0, -0.5f, 0), 0.4f);
 ////        loadModel("Models/gltf/adamHead/adamHead.gltf", Vector3f.ZERO, 0.6f);
@@ -151,11 +156,8 @@ public class TestGltfLoading extends SimpleApplication {
 
 //        loadModel("Models/gltf/Corset/glTF/Corset.gltf", new Vector3f(0, -1, 0), 20f);
 //        loadModel("Models/gltf/BoxInterleaved/glTF/BoxInterleaved.gltf", new Vector3f(0, 0, 0), 1f);
-
-
+        
         probeNode.attachChild(assets.get(0));
-
-        // setMorphTarget(morphIndex);
 
         ChaseCameraAppState chaseCam = new ChaseCameraAppState();
         chaseCam.setTarget(probeNode);

--- a/jme3-examples/src/main/java/jme3test/model/TestGltfLoading.java
+++ b/jme3-examples/src/main/java/jme3test/model/TestGltfLoading.java
@@ -112,10 +112,6 @@ public class TestGltfLoading extends SimpleApplication {
 //        PointLight pl1 = new PointLight(new Vector3f(-5.0f, -5.0f, -5.0f), ColorRGBA.White.mult(0.5f), 50);
 //        rootNode.addLight(pl1);
 
-        assetManager.registerLocator("/home/codex/Downloads", FileLocator.class);
-
-        loadModel("MorphStressTest.gltf", new Vector3f(), 1f);
-        //loadModel("MorphPrimitivesTest.gltf", new Vector3f(), 1f);
         //loadModel("Models/gltf/polly/project_polly.gltf", new Vector3f(0, 0, 0), 0.5f);
         //loadModel("Models/gltf/zophrac/scene.gltf", new Vector3f(0, 0, 0), 0.01f);
     //    loadModel("Models/gltf/scifigirl/scene.gltf", new Vector3f(0, -1, 0), 0.1f);
@@ -138,7 +134,7 @@ public class TestGltfLoading extends SimpleApplication {
         //loadModel("Models/gltf/manta/scene.gltf", Vector3f.ZERO, 0.2f);
         //loadModel("Models/gltf/bone/scene.gltf", Vector3f.ZERO, 0.1f);
 //        loadModel("Models/gltf/box/box.gltf", Vector3f.ZERO, 1);
-        //loadModel("Models/gltf/duck/Duck.gltf", new Vector3f(0, -1, 0), 1);
+        loadModel("Models/gltf/duck/Duck.gltf", new Vector3f(0, -1, 0), 1);
 //        loadModel("Models/gltf/DamagedHelmet/glTF/DamagedHelmet.gltf", Vector3f.ZERO, 1);
 //        loadModel("Models/gltf/hornet/scene.gltf", new Vector3f(0, -0.5f, 0), 0.4f);
 ////        loadModel("Models/gltf/adamHead/adamHead.gltf", Vector3f.ZERO, 0.6f);

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -1201,6 +1201,12 @@ public class GltfLoader implements AssetLoader {
         JsonObject meshData = meshes.get(meshIndex).getAsJsonObject();
         return getAsString(meshData, "name");
     }
+    
+    private MorphTrack toMorphTrack(TrackData data, Spatial spatial) {
+        Geometry g = (Geometry) spatial;
+        int nbMorph = g.getMesh().getMorphTargets().length;
+        return new MorphTrack(g, data.times, data.weights, nbMorph);
+    }
 
     public <T> T fetchFromCache(String name, int index, Class<T> type) {
         Object[] data = dataCache.get(name);

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -906,17 +906,11 @@ public class GltfLoader implements AssetLoader {
                     if (s instanceof Node) {
                         s.depthFirstTraversal((Spatial spatial) -> {
                             if (spatial instanceof Geometry) {
-                                Geometry g = (Geometry) spatial;
-                                int nbMorph = g.getMesh().getMorphTargets().length;
-                                MorphTrack track = new MorphTrack(g, trackData.times, trackData.weights, nbMorph);
-                                aTracks.add(track);
+                                aTracks.add(toMorphTrack(trackData, spatial));
                             }
                         });
                     } else if (s instanceof Geometry) {
-                        Geometry g = (Geometry) s;
-                        int nbMorph = g.getMesh().getMorphTargets().length;
-                        MorphTrack track = new MorphTrack(g, trackData.times, trackData.weights, nbMorph);
-                        aTracks.add(track);
+                        aTracks.add(toMorphTrack(trackData, s));
                     }
                 }
             } else if (node instanceof JointWrapper) {


### PR DESCRIPTION
This PR fixes #2092 where morph animation clips were loaded without tracks. The problem was occurs because the animation channels were assigned to a node instead of a geometry in the gltf file, which excluded those channels from being properly loaded.

My solution is if the target spatial is a node, traverse over that node's children and apply the morphs to the geometries found, otherwise apply morphs as before. This allows the engine to pass the [Morph Stress Test](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/MorphStressTest) where it couldn't before.