### PR TITLE
add debug groups for shadow draw calls

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
@@ -967,9 +967,7 @@ public class RenderManager {
         if (prof != null) {
             prof.vpStep(VpStep.RenderBucket, vp, Bucket.Opaque);
         }
-        this.renderer.pushDebugGroup(Bucket.Opaque.name());
         rq.renderQueue(Bucket.Opaque, this, cam, flush);
-        this.renderer.popDebugGroup();
 
         // render the sky, with depth range set to the farthest
         if (!rq.isQueueEmpty(Bucket.Sky)) {
@@ -977,9 +975,7 @@ public class RenderManager {
                 prof.vpStep(VpStep.RenderBucket, vp, Bucket.Sky);
             }
             renderer.setDepthRange(1, 1);
-            this.renderer.pushDebugGroup(Bucket.Sky.name());
             rq.renderQueue(Bucket.Sky, this, cam, flush);
-            this.renderer.popDebugGroup();
             depthRangeChanged = true;
         }
 
@@ -995,9 +991,7 @@ public class RenderManager {
                 renderer.setDepthRange(0, 1);
                 depthRangeChanged = false;
             }
-            this.renderer.pushDebugGroup(Bucket.Transparent.name());
             rq.renderQueue(Bucket.Transparent, this, cam, flush);
-            this.renderer.popDebugGroup();
         }
 
         if (!rq.isQueueEmpty(Bucket.Gui)) {
@@ -1006,9 +1000,7 @@ public class RenderManager {
             }
             renderer.setDepthRange(0, 0);
             setCamera(cam, true);
-            this.renderer.pushDebugGroup(Bucket.Gui.name());
             rq.renderQueue(Bucket.Gui, this, cam, flush);
-            this.renderer.popDebugGroup();
             setCamera(cam, false);
             depthRangeChanged = true;
         }

--- a/jme3-core/src/main/java/com/jme3/renderer/queue/RenderQueue.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/queue/RenderQueue.java
@@ -279,7 +279,9 @@ public class RenderQueue {
     }
 
     public void renderShadowQueue(GeometryList list, RenderManager rm, Camera cam, boolean clear) {
+        rm.getRenderer().pushDebugGroup("ShadowQueue");
         renderGeometryList(list, rm, cam, clear);
+        rm.getRenderer().popDebugGroup();
     }
 
     public boolean isQueueEmpty(Bucket bucket) {
@@ -304,6 +306,7 @@ public class RenderQueue {
     }
 
     public void renderQueue(Bucket bucket, RenderManager rm, Camera cam, boolean clear) {
+        rm.getRenderer().pushDebugGroup(bucket.name());
         switch (bucket) {
             case Gui:
                 renderGeometryList(guiList, rm, cam, clear);
@@ -324,6 +327,7 @@ public class RenderQueue {
             default:
                 throw new UnsupportedOperationException("Unsupported bucket type: " + bucket);
         }
+        rm.getRenderer().popDebugGroup();
     }
 
     public void clear() {


### PR DESCRIPTION
Moves the pushDebugGroup calls into RenderQueue so all call-sites are covered automatically.
And adds a ShadowQueue group for all shadow-related draw calls.