### PR TITLE
Solve issue #2127 (excessive memory use while loading GLB)

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -754,12 +754,17 @@ public class GltfLoader implements AssetLoader {
         Integer textureIndex = getAsInteger(texture, "index");
         assertNotNull(textureIndex, "Texture has no index");
         assertNotNull(textures, "There are no textures, yet one is referenced by a material");
+
+        Texture2D texture2d = fetchFromCache("textures", textureIndex, Texture2D.class);
+        if (texture2d != null) {
+            return texture2d;
+        }
         
         JsonObject textureData = textures.get(textureIndex).getAsJsonObject();
         Integer sourceIndex = getAsInteger(textureData, "source");
         Integer samplerIndex = getAsInteger(textureData, "sampler");
 
-        Texture2D texture2d = readImage(sourceIndex, flip);
+        texture2d = readImage(sourceIndex, flip);
 
         if (samplerIndex != null) {
             texture2d = readSampler(samplerIndex, texture2d);
@@ -768,6 +773,8 @@ public class GltfLoader implements AssetLoader {
         }
 
         texture2d = customContentManager.readExtensionAndExtras("texture", texture, texture2d);
+
+        addToCache("textures", textureIndex, texture2d, textures.size());
 
         return texture2d;
     }

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -470,7 +470,7 @@ public class GltfLoader implements AssetLoader {
                     geom.setMaterial(defaultMat);
                 } else {
                     useNormalsFlag = false;
-                    geom.setMaterial(readMaterial(materialIndex));
+                    geom.setMaterial(getMaterial(materialIndex));
                     if (geom.getMaterial().getAdditionalRenderState().getBlendMode()
                             == RenderState.BlendMode.Alpha) {
                         // Alpha blending is enabled for this material. Let's place the geom in the transparent bucket.
@@ -614,6 +614,21 @@ public class GltfLoader implements AssetLoader {
             throw new AssetLoadException("Buffer " + bufferIndex + " has no uri");
         }
         return data;
+    }
+
+    public Material getMaterial(int materialIndex) throws IOException {
+
+        // Get from cache
+        Material material = fetchFromCache("Material", materialIndex, Material.class);
+        if (material != null) {
+            return material;
+        }
+
+        material = readMaterial(materialIndex);
+
+        addToCache("Material", materialIndex, material, materials.size());
+
+        return material;
     }
 
     public Material readMaterial(int materialIndex) throws IOException {

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -621,7 +621,7 @@ public class GltfLoader implements AssetLoader {
 
         Material material = fetchFromCache("materials", materialIndex, Material.class);
         if (material != null) {
-            return material;
+            return material.clone();
         }
 
         JsonObject matData = materials.get(materialIndex).getAsJsonObject();

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -619,14 +619,14 @@ public class GltfLoader implements AssetLoader {
     public Material getMaterial(int materialIndex) throws IOException {
 
         // Get from cache
-        Material material = fetchFromCache("Material", materialIndex, Material.class);
+        Material material = fetchFromCache("materials", materialIndex, Material.class);
         if (material != null) {
             return material;
         }
 
         material = readMaterial(materialIndex);
 
-        addToCache("Material", materialIndex, material, materials.size());
+        addToCache("materials", materialIndex, material, materials.size());
 
         return material;
     }

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -470,7 +470,7 @@ public class GltfLoader implements AssetLoader {
                     geom.setMaterial(defaultMat);
                 } else {
                     useNormalsFlag = false;
-                    geom.setMaterial(getMaterial(materialIndex));
+                    geom.setMaterial(readMaterial(materialIndex));
                     if (geom.getMaterial().getAdditionalRenderState().getBlendMode()
                             == RenderState.BlendMode.Alpha) {
                         // Alpha blending is enabled for this material. Let's place the geom in the transparent bucket.
@@ -616,23 +616,13 @@ public class GltfLoader implements AssetLoader {
         return data;
     }
 
-    public Material getMaterial(int materialIndex) throws IOException {
+    public Material readMaterial(int materialIndex) throws IOException {
+        assertNotNull(materials, "There is no material defined yet a mesh references one");
 
-        // Get from cache
         Material material = fetchFromCache("materials", materialIndex, Material.class);
         if (material != null) {
             return material;
         }
-
-        material = readMaterial(materialIndex);
-
-        addToCache("materials", materialIndex, material, materials.size());
-
-        return material;
-    }
-
-    public Material readMaterial(int materialIndex) throws IOException {
-        assertNotNull(materials, "There is no material defined yet a mesh references one");
 
         JsonObject matData = materials.get(materialIndex).getAsJsonObject();
         JsonObject pbrMat = matData.getAsJsonObject("pbrMetallicRoughness");
@@ -703,7 +693,10 @@ public class GltfLoader implements AssetLoader {
 
         adapter.setParam("emissiveTexture", readTexture(matData.getAsJsonObject("emissiveTexture")));
 
-        return adapter.getMaterial();
+        material = adapter.getMaterial();
+        addToCache("materials", materialIndex, material, materials.size());
+
+        return material;
     }
 
     public void readCameras() throws IOException {

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -605,9 +605,9 @@ public class GltfLoader implements AssetLoader {
                 BinDataKey key = new BinDataKey(info.getKey().getFolder() + decoded);
                 InputStream input = (InputStream) info.getManager().loadAsset(key);
                 data = new byte[bufferLength];
-                DataInputStream dataStream = new DataInputStream(input);
-                dataStream.readFully(data);
-                dataStream.close();
+                try (DataInputStream dataStream = new DataInputStream(input)) {
+                    dataStream.readFully(data);
+                }
             }
         } else {
             // no URI, this should not happen in a gltf file, only in glb files.


### PR DESCRIPTION
Ok, GLB with the textures included easily causes LWJGL to run out of memory. As we might upload the same texture many times (we also read it many times...). 32Gb of RAM is nothing then. Also slowdowns and if one is into geometry batching.. no can do.

So this caches all the materials read to re-use them. Note that this affects both GLTF and GLB.

Resolves #2127 