### PR TITLE
Read bytes more efficiently

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
@@ -427,7 +427,9 @@ public class GltfUtils {
         stream.skipBytes(byteOffset);
 
         if (dataLength == stride) {
-            stream.read(array, 0, end - index);
+            int length = end - index;
+            int read = stream.read(array, 0, length);
+            assertReadLength(read, length);
 
             return;
         }
@@ -435,13 +437,21 @@ public class GltfUtils {
         int arrayIndex = 0;
         byte[] buffer = new byte[numComponents];
         while (index < end) {
-            stream.read(buffer, 0, numComponents);
+            int read = stream.read(buffer, 0, numComponents);
+            assertReadLength(read, numComponents);
+
             System.arraycopy(buffer, 0, array, arrayIndex, numComponents);
             arrayIndex += numComponents;
             if (dataLength < stride) {
                 stream.skipBytes(stride - dataLength);
             }
             index += stride;
+        }
+    }
+
+    private static void assertReadLength(int read, int length) {
+        if (read < length) {
+            throw new AssetLoadException("Data ended prematurely");
         }
     }
 

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
@@ -427,15 +427,7 @@ public class GltfUtils {
         stream.skipBytes(byteOffset);
 
         if (dataLength == stride) {
-            int length = end - index;
-            int n = 0;
-            while (n < length) {
-                int cnt = stream.read(array, n, length - n);
-                if (cnt < 0) {
-                    throw new AssetLoadException("Data ended prematurely");
-                }
-                n += cnt;
-            }
+            read(stream, array, end - index);
 
             return;
         }
@@ -443,20 +435,24 @@ public class GltfUtils {
         int arrayIndex = 0;
         byte[] buffer = new byte[numComponents];
         while (index < end) {
-            int n = 0;
-            while (n < numComponents) {
-                int cnt = stream.read(buffer, n, numComponents - n);
-                if (cnt < 0) {
-                    throw new AssetLoadException("Data ended prematurely");
-                }
-                n += cnt;
-            }
+            read(stream, buffer, numComponents);
             System.arraycopy(buffer, 0, array, arrayIndex, numComponents);
             arrayIndex += numComponents;
             if (dataLength < stride) {
                 stream.skipBytes(stride - dataLength);
             }
             index += stride;
+        }
+    }
+
+    private static void read(LittleEndien stream, byte[] buffer, int length) throws IOException {
+        int n = 0;
+        while (n < length) {
+            int cnt = stream.read(buffer, n, length - n);
+            if (cnt < 0) {
+                throw new AssetLoadException("Data ended prematurely");
+            }
+            n += cnt;
         }
     }
 

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
@@ -744,30 +744,24 @@ public class GltfUtils {
         }
     }
 
-//    public static boolean equalBindAndLocalTransforms(Joint b) {
-//        return equalsEpsilon(b.getBindPosition(), b.getLocalPosition())
-//                && equalsEpsilon(b.getBindRotation(), b.getLocalRotation())
-//                && equalsEpsilon(b.getBindScale(), b.getLocalScale());
-//    }
-
-    private static float epsilon = 0.0001f;
+    private static final float EPSILON = 0.0001f;
 
     public static boolean equalsEpsilon(Vector3f v1, Vector3f v2) {
-        return FastMath.abs(v1.x - v2.x) < epsilon
-                && FastMath.abs(v1.y - v2.y) < epsilon
-                && FastMath.abs(v1.z - v2.z) < epsilon;
+        return FastMath.abs(v1.x - v2.x) < EPSILON
+                && FastMath.abs(v1.y - v2.y) < EPSILON
+                && FastMath.abs(v1.z - v2.z) < EPSILON;
     }
 
     public static boolean equalsEpsilon(Quaternion q1, Quaternion q2) {
-        return (FastMath.abs(q1.getX() - q2.getX()) < epsilon
-                && FastMath.abs(q1.getY() - q2.getY()) < epsilon
-                && FastMath.abs(q1.getZ() - q2.getZ()) < epsilon
-                && FastMath.abs(q1.getW() - q2.getW()) < epsilon)
+        return (FastMath.abs(q1.getX() - q2.getX()) < EPSILON
+                && FastMath.abs(q1.getY() - q2.getY()) < EPSILON
+                && FastMath.abs(q1.getZ() - q2.getZ()) < EPSILON
+                && FastMath.abs(q1.getW() - q2.getW()) < EPSILON)
                 ||
-                (FastMath.abs(q1.getX() + q2.getX()) < epsilon
-                        && FastMath.abs(q1.getY() + q2.getY()) < epsilon
-                        && FastMath.abs(q1.getZ() + q2.getZ()) < epsilon
-                        && FastMath.abs(q1.getW() + q2.getW()) < epsilon);
+ (FastMath.abs(q1.getX() + q2.getX()) < EPSILON
+                && FastMath.abs(q1.getY() + q2.getY()) < EPSILON
+                && FastMath.abs(q1.getZ() + q2.getZ()) < EPSILON
+                && FastMath.abs(q1.getW() + q2.getW()) < EPSILON);
     }
 
 

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
@@ -427,9 +427,7 @@ public class GltfUtils {
         stream.skipBytes(byteOffset);
 
         if (dataLength == stride) {
-            byte[] buffer = new byte[end - index];
-            stream.read(buffer, 0, buffer.length);
-            System.arraycopy(buffer, 0, array, 0, buffer.length);
+            stream.read(array, 0, end - index);
 
             return;
         }

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
@@ -443,7 +443,14 @@ public class GltfUtils {
         int arrayIndex = 0;
         byte[] buffer = new byte[numComponents];
         while (index < end) {
-            stream.read(buffer, 0, numComponents);
+            int n = 0;
+            while (n < numComponents) {
+                int cnt = stream.read(buffer, n, numComponents - n);
+                if (cnt < 0) {
+                    throw new AssetLoadException("Data ended prematurely");
+                }
+                n += cnt;
+            }
             System.arraycopy(buffer, 0, array, arrayIndex, numComponents);
             arrayIndex += numComponents;
             if (dataLength < stride) {

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
@@ -428,8 +428,14 @@ public class GltfUtils {
 
         if (dataLength == stride) {
             int length = end - index;
-            int read = stream.read(array, 0, length);
-            assertReadLength(read, length);
+            int n = 0;
+            while (n < length) {
+                int cnt = stream.read(array, n, length - n);
+                if (cnt < 0) {
+                    throw new AssetLoadException("Data ended prematurely");
+                }
+                n += cnt;
+            }
 
             return;
         }
@@ -437,21 +443,13 @@ public class GltfUtils {
         int arrayIndex = 0;
         byte[] buffer = new byte[numComponents];
         while (index < end) {
-            int read = stream.read(buffer, 0, numComponents);
-            assertReadLength(read, numComponents);
-
+            stream.read(buffer, 0, numComponents);
             System.arraycopy(buffer, 0, array, arrayIndex, numComponents);
             arrayIndex += numComponents;
             if (dataLength < stride) {
                 stream.skipBytes(stride - dataLength);
             }
             index += stride;
-        }
-    }
-
-    private static void assertReadLength(int read, int length) {
-        if (read < length) {
-            throw new AssetLoadException("Data ended prematurely");
         }
     }
 

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfUtils.java
@@ -425,12 +425,21 @@ public class GltfUtils {
         int stride = Math.max(dataLength, byteStride);
         int end = count * stride + byteOffset;
         stream.skipBytes(byteOffset);
+
+        if (dataLength == stride) {
+            byte[] buffer = new byte[end - index];
+            stream.read(buffer, 0, buffer.length);
+            System.arraycopy(buffer, 0, array, 0, buffer.length);
+
+            return;
+        }
+
         int arrayIndex = 0;
+        byte[] buffer = new byte[numComponents];
         while (index < end) {
-            for (int i = 0; i < numComponents; i++) {
-                array[arrayIndex] = stream.readByte();
-                arrayIndex++;
-            }
+            stream.read(buffer, 0, numComponents);
+            System.arraycopy(buffer, 0, array, arrayIndex, numComponents);
+            arrayIndex += numComponents;
             if (dataLength < stride) {
                 stream.skipBytes(stride - dataLength);
             }


### PR DESCRIPTION
Optimized version of reading bytes. Instead of reading one byte at the time... read multiple. With GLB, the whole file is in memory and with GLTF the reading is done from `BufferedReader` (meaning that there is never this catastrophic case where we would read a disk file a byte at a time). In latter case this would increase the reading speed even more than analyzed here. I just don't know does GLTF store anything in byte arrays. GLB seems to store the textures this way, which are potentially huge. So even reading from memory, calling this `readByte` billions of times causes significant overhead.

The same problem is with all the populate*Array but fixing those others is potentially more messy and yield in less gains as the units are already bigger. That being said, I only focus on this biggest offender.

I used https://developer.nvidia.com/orca/amazon-lumberyard-bistro (BistroExterior.glb) as a test case. Model loading took on average:
31 605ms (optimized)
47 824ms (old)

Resolves #2125 