### PR TITLE
PBRLighting.j3md:  annotate LightMap as being a LINEAR texture

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -69,7 +69,7 @@ MaterialDef PBR Lighting {
         Boolean HorizonFade
 
         // Set to Use Lightmap
-        Texture2D LightMap
+        Texture2D LightMap -LINEAR
 
         // A scalar multiplier controlling the amount of occlusion applied.
         // A value of `0.0` means no occlusion. A value of `1.0` means full occlusion.


### PR DESCRIPTION
This PR should eliminate the distracting/confusing warnings currently generated when the same texture is specified for both LightMap and another PBR map.