### PR TITLE
Adding support for Specular-AA

### DIFF
--- a/jme3-core/src/main/java/com/jme3/texture/Texture.java
+++ b/jme3-core/src/main/java/com/jme3/texture/Texture.java
@@ -637,11 +637,11 @@ public abstract class Texture implements CloneableSmartAsset, Savable, Cloneable
             }
         }
 
-        anisotropicFilter = capsule.readInt("anisotropicFilter", 1);
-        minificationFilter = capsule.readEnum("minificationFilter",
+        setAnisotropicFilter(capsule.readInt("anisotropicFilter", 1));
+        setMinFilter(capsule.readEnum("minificationFilter",
                 MinFilter.class,
-                MinFilter.BilinearNoMipMaps);
-        magnificationFilter = capsule.readEnum("magnificationFilter",
-                MagFilter.class, MagFilter.Bilinear);
+                MinFilter.BilinearNoMipMaps));
+        setMagFilter(capsule.readEnum("magnificationFilter",
+                MagFilter.class, MagFilter.Bilinear));
     }
 }

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -100,10 +100,10 @@ varying vec3 wNormal;
 
 // Specular-AA
 #ifdef SCREEN_SPACE_VARIANCE
-  uniform float m_Sigma;
+  uniform float m_SpecularAASigma;
 #endif
 #ifdef THRESHOLD
-  uniform float m_Kappa;
+  uniform float m_SpecularAAKappa;
 #endif
 
 #ifdef DISCARD_ALPHA
@@ -259,10 +259,10 @@ void main(){
         float sigma = 1.0;
         float kappa = 0.18;
         #ifdef SCREEN_SPACE_VARIANCE
-            sigma = m_Sigma;
+            sigma = m_SpecularAASigma;
         #endif
         #ifdef THRESHOLD
-            kappa = m_Kappa;
+            kappa = m_SpecularAAKappa;
         #endif
     #endif
     float ndotv = max( dot( normal, viewDir ),0.0);

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -256,7 +256,7 @@ void main(){
     #endif
 
     #ifdef SPECULAR_AA
-        float sigma = 0.5f;
+        float sigma = 1.0f;
         float kappa = 0.18f;
         #ifdef SCREEN_SPACE_VARIANCE
             sigma = m_Sigma;
@@ -289,13 +289,17 @@ void main(){
         vec3 directDiffuse;
         vec3 directSpecular;
 
-        float hdotv = PBR_ComputeDirectLight(
         #ifdef SPECULAR_AA
-                            sigma, kappa,
+            float hdotv = PBR_ComputeDirectLightWithSpecularAA(
+                                normal, lightDir.xyz, viewDir,
+                                lightColor.rgb, fZero, Roughness, sigma, kappa, ndotv,
+                                directDiffuse,  directSpecular);
+        #else
+            float hdotv = PBR_ComputeDirectLight(
+                                normal, lightDir.xyz, viewDir,
+                                lightColor.rgb, fZero, Roughness, ndotv,
+                                directDiffuse,  directSpecular);
         #endif
-                            normal, lightDir.xyz, viewDir,
-                            lightColor.rgb, fZero, Roughness, ndotv,
-                            directDiffuse,  directSpecular);
 
         vec3 directLighting = diffuseColor.rgb *directDiffuse + directSpecular;
         

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -99,10 +99,10 @@ varying vec3 wPosition;
 varying vec3 wNormal;
 
 // Specular-AA
-#ifdef SCREEN_SPACE_VARIANCE
+#ifdef SPECULAR_AA_SCREEN_SPACE_VARIANCE
   uniform float m_SpecularAASigma;
 #endif
-#ifdef THRESHOLD
+#ifdef SPECULAR_AA_THRESHOLD
   uniform float m_SpecularAAKappa;
 #endif
 
@@ -258,10 +258,10 @@ void main(){
     #ifdef SPECULAR_AA
         float sigma = 1.0;
         float kappa = 0.18;
-        #ifdef SCREEN_SPACE_VARIANCE
+        #ifdef SPECULAR_AA_SCREEN_SPACE_VARIANCE
             sigma = m_SpecularAASigma;
         #endif
-        #ifdef THRESHOLD
+        #ifdef SPECULAR_AA_THRESHOLD
             kappa = m_SpecularAAKappa;
         #endif
     #endif

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -256,8 +256,8 @@ void main(){
     #endif
 
     #ifdef SPECULAR_AA
-        float sigma = 1.0f;
-        float kappa = 0.18f;
+        float sigma = 1.0;
+        float kappa = 0.18;
         #ifdef SCREEN_SPACE_VARIANCE
             sigma = m_Sigma;
         #endif

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -98,6 +98,14 @@ varying vec3 wPosition;
 #endif
 varying vec3 wNormal;
 
+// Specular-AA
+#ifdef SCREEN_SPACE_VARIANCE
+  uniform float m_Sigma;
+#endif
+#ifdef THRESHOLD
+  uniform float m_Kappa;
+#endif
+
 #ifdef DISCARD_ALPHA
   uniform float m_AlphaDiscardThreshold;
 #endif
@@ -247,6 +255,16 @@ void main(){
        ao = clamp(ao, 0.0, 1.0);
     #endif
 
+    #ifdef SPECULAR_AA
+        float sigma = 0.5f;
+        float kappa = 0.18f;
+        #ifdef SCREEN_SPACE_VARIANCE
+            sigma = m_Sigma;
+        #endif
+        #ifdef THRESHOLD
+            kappa = m_Kappa;
+        #endif
+    #endif
     float ndotv = max( dot( normal, viewDir ),0.0);
     for( int i = 0;i < NB_LIGHTS; i+=3){
         vec4 lightColor = g_LightData[i];
@@ -270,8 +288,12 @@ void main(){
         lightDir.xyz = normalize(lightDir.xyz);            
         vec3 directDiffuse;
         vec3 directSpecular;
-        
-        float hdotv = PBR_ComputeDirectLight(normal, lightDir.xyz, viewDir,
+
+        float hdotv = PBR_ComputeDirectLight(
+        #ifdef SPECULAR_AA
+                            sigma, kappa,
+        #endif
+                            normal, lightDir.xyz, viewDir,
                             lightColor.rgb, fZero, Roughness, ndotv,
                             directDiffuse,  directSpecular);
 

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -57,7 +57,11 @@ MaterialDef PBR Lighting {
         Texture2D ParallaxMap -LINEAR
 
         // Specular-AA
-        Boolean SpecularAA
+        Boolean UseSpecularAA : true
+        // screen space variance,Use the slider to set the strength of the geometric specular anti-aliasing effect between 0 and 1. Higher values produce a blurrier result with less aliasing.
+        Float Sigma : 1.0
+        // clamping threshold,Use the slider to set a maximum value for the offset that HDRP subtracts from the smoothness value to reduce artifacts.
+        Float Kappa : 0.18
 
         //Set to true if parallax map is stored in the alpha channel of the normal map
         Boolean PackedNormalParallax   
@@ -166,7 +170,9 @@ MaterialDef PBR Lighting {
             USE_PACKED_MR: MetallicRoughnessMap
             USE_PACKED_SG: SpecularGlossinessMap
             SPECULARMAP : SpecularMap
-            SPECULAR_AA : SpecularAA
+            SPECULAR_AA : UseSpecularAA
+            SCREEN_SPACE_VARIANCE : Sigma
+            THRESHOLD : Kappa
             GLOSSINESSMAP : GlossinessMap
             NORMAL_TYPE: NormalType
             VERTEX_COLOR : UseVertexColor

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -56,6 +56,9 @@ MaterialDef PBR Lighting {
         // Parallax/height map
         Texture2D ParallaxMap -LINEAR
 
+        // Specular-AA
+        Boolean SpecularAA
+
         //Set to true if parallax map is stored in the alpha channel of the normal map
         Boolean PackedNormalParallax   
 
@@ -163,6 +166,7 @@ MaterialDef PBR Lighting {
             USE_PACKED_MR: MetallicRoughnessMap
             USE_PACKED_SG: SpecularGlossinessMap
             SPECULARMAP : SpecularMap
+            SPECULAR_AA : SpecularAA
             GLOSSINESSMAP : GlossinessMap
             NORMAL_TYPE: NormalType
             VERTEX_COLOR : UseVertexColor

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -59,9 +59,9 @@ MaterialDef PBR Lighting {
         // Specular-AA
         Boolean UseSpecularAA : true
         // screen space variance,Use the slider to set the strength of the geometric specular anti-aliasing effect between 0 and 1. Higher values produce a blurrier result with less aliasing.
-        Float Sigma : 1.0
+        Float Sigma
         // clamping threshold,Use the slider to set a maximum value for the offset that HDRP subtracts from the smoothness value to reduce artifacts.
-        Float Kappa : 0.18
+        Float Kappa
 
         //Set to true if parallax map is stored in the alpha channel of the normal map
         Boolean PackedNormalParallax   

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -59,9 +59,9 @@ MaterialDef PBR Lighting {
         // Specular-AA
         Boolean UseSpecularAA : true
         // screen space variance,Use the slider to set the strength of the geometric specular anti-aliasing effect between 0 and 1. Higher values produce a blurrier result with less aliasing.
-        Float Sigma
+        Float SpecularAASigma
         // clamping threshold,Use the slider to set a maximum value for the offset that HDRP subtracts from the smoothness value to reduce artifacts.
-        Float Kappa
+        Float SpecularAAKappa
 
         //Set to true if parallax map is stored in the alpha channel of the normal map
         Boolean PackedNormalParallax   
@@ -171,8 +171,8 @@ MaterialDef PBR Lighting {
             USE_PACKED_SG: SpecularGlossinessMap
             SPECULARMAP : SpecularMap
             SPECULAR_AA : UseSpecularAA
-            SCREEN_SPACE_VARIANCE : Sigma
-            THRESHOLD : Kappa
+            SCREEN_SPACE_VARIANCE : SpecularAASigma
+            THRESHOLD : SpecularAAKappa
             GLOSSINESSMAP : GlossinessMap
             NORMAL_TYPE: NormalType
             VERTEX_COLOR : UseVertexColor

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -171,8 +171,8 @@ MaterialDef PBR Lighting {
             USE_PACKED_SG: SpecularGlossinessMap
             SPECULARMAP : SpecularMap
             SPECULAR_AA : UseSpecularAA
-            SCREEN_SPACE_VARIANCE : SpecularAASigma
-            THRESHOLD : SpecularAAKappa
+            SPECULAR_AA_SCREEN_SPACE_VARIANCE : SpecularAASigma
+            SPECULAR_AA_THRESHOLD : SpecularAAKappa
             GLOSSINESSMAP : GlossinessMap
             NORMAL_TYPE: NormalType
             VERTEX_COLOR : UseVertexColor

--- a/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
@@ -6,6 +6,43 @@
     #define NB_PROBES 0
 #endif
 
+// BEGIN-@jhonkkk,Specular AA --------------------------------------------------------------
+// see:http://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA(slides).pdf
+// https://docs.unity3d.com/Packages/com.unity.render-pipelines.high-definition@15.0/manual/Geometric-Specular-Anti-Aliasing.html
+void Specular_Anti_Aliasing(in vec3 normal, in vec3 half_vector,
+                           	inout float alpha_x)
+{
+
+    float sigma = 0.50f; 							//- screen space variance
+    float Kappa = 0.18f;								//- clamping treshold
+    vec2  H = half_vector.xy;
+    vec3 dndu = dFdx(normal);
+    vec3 dndv = dFdy(normal);
+    vec2  footprint_bounding_box = fwidth(H); 		//- abs(dfdx(slope_h)) + abs(dfdy(slope_h))
+	//vec2  variance = sigma*sigma*footprint_bounding_box*footprint_bounding_box;
+        float  variance = sigma*sigma*(dot(dndu, dndu) + dot(dndv, dndv));
+    float  kernel_roughness = min(Kappa, variance);
+    alpha_x = sqrt(alpha_x*alpha_x + kernel_roughness);
+}
+void Specular_Anti_Aliasing2(in vec3 normal, in vec3 half_vector,
+                           	inout float alpha_x)
+{
+
+    float sigma = 0.50f; 							//- screen space variance
+    float Kappa = 0.18f;								//- clamping treshold
+    vec3 h = TBN * half_vector;
+    vec2  H = h.xy;
+    vec3 dndu = dFdx(normal);
+    vec3 dndv = dFdy(normal);
+    vec2  footprint_bounding_box = fwidth(H); 		//- abs(dfdx(slope_h)) + abs(dfdy(slope_h))
+	vec2  variance = sigma*sigma*footprint_bounding_box*footprint_bounding_box;
+        //float  variance = sigma*sigma*(dot(dndu, dndu) + dot(dndv, dndv));
+    float  kernel_roughness = min(Kappa, variance.x);
+    alpha_x = sqrt(alpha_x*alpha_x + kernel_roughness);
+}
+// END-@jhonkkk
+
+
 //Specular fresnel computation
 vec3 F_Shlick(float vh,	vec3 F0){
 	float fresnelFact = pow(2.0, (-5.55473*vh - 6.98316) * vh);
@@ -54,6 +91,9 @@ float PBR_ComputeDirectLight(vec3 normal, vec3 lightDir, vec3 viewDir,
     //cook-torrence, microfacet BRDF : http://blog.selfshadow.com/publications/s2013-shading-course/karis/s2013_pbs_epic_notes_v2.pdf
    
     float alpha = roughness * roughness;
+    #ifdef SPECULAR_AA
+        Specular_Anti_Aliasing(normal, halfVec, alpha);
+    #endif
 
     //D, GGX normal Distribution function
     float alpha2 = alpha * alpha;

--- a/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
@@ -24,22 +24,6 @@ void Specular_Anti_Aliasing(in vec3 normal, in vec3 half_vector,
     float  kernel_roughness = min(Kappa, variance);
     alpha_x = sqrt(alpha_x*alpha_x + kernel_roughness);
 }
-void Specular_Anti_Aliasing2(in vec3 normal, in vec3 half_vector,
-                           	inout float alpha_x)
-{
-
-    float sigma = 0.50f; 							//- screen space variance
-    float Kappa = 0.18f;								//- clamping treshold
-    vec3 h = TBN * half_vector;
-    vec2  H = h.xy;
-    vec3 dndu = dFdx(normal);
-    vec3 dndv = dFdy(normal);
-    vec2  footprint_bounding_box = fwidth(H); 		//- abs(dfdx(slope_h)) + abs(dfdy(slope_h))
-	vec2  variance = sigma*sigma*footprint_bounding_box*footprint_bounding_box;
-        //float  variance = sigma*sigma*(dot(dndu, dndu) + dot(dndv, dndv));
-    float  kernel_roughness = min(Kappa, variance.x);
-    alpha_x = sqrt(alpha_x*alpha_x + kernel_roughness);
-}
 // END-@jhonkkk
 
 

--- a/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
@@ -18,9 +18,7 @@ void Specular_Anti_Aliasing(in vec3 normal, in vec3 half_vector,
     vec2  H = half_vector.xy;
     vec3 dndu = dFdx(normal);
     vec3 dndv = dFdy(normal);
-    vec2  footprint_bounding_box = fwidth(H); 		//- abs(dfdx(slope_h)) + abs(dfdy(slope_h))
-	//vec2  variance = sigma*sigma*footprint_bounding_box*footprint_bounding_box;
-        float  variance = sigma*sigma*(dot(dndu, dndu) + dot(dndv, dndv));
+    float  variance = sigma*sigma*(dot(dndu, dndu) + dot(dndv, dndv));
     float  kernel_roughness = min(Kappa, variance);
     alpha_x = sqrt(alpha_x*alpha_x + kernel_roughness);
 }

--- a/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
@@ -9,15 +9,15 @@
 // BEGIN-@jhonkkk,Specular AA --------------------------------------------------------------
 // see:http://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA(slides).pdf
 // https://docs.unity3d.com/Packages/com.unity.render-pipelines.high-definition@15.0/manual/Geometric-Specular-Anti-Aliasing.html
-void Specular_Anti_Aliasing(in vec3 normal, in vec3 half_vector,
-                           	inout float alpha_x, in float sigma, in float kappa)
+float Specular_Anti_Aliasing(in vec3 normal, in vec3 half_vector,
+                           	float alpha, in float sigma, in float kappa)
 {
 
     vec3 dndu = dFdx(normal);
     vec3 dndv = dFdy(normal);
     float  variance = sigma*sigma*(dot(dndu, dndu) + dot(dndv, dndv));
     float  kernel_roughness = min(kappa, variance);
-    alpha_x = sqrt(alpha_x*alpha_x + kernel_roughness);
+    return sqrt(alpha*alpha + kernel_roughness);
 }
 // END-@jhonkkk
 
@@ -50,16 +50,11 @@ vec3 sphericalHarmonics( const in vec3 normal, const vec3 sph[9] ){
     return max(result, vec3(0.0));
 }
 
-
-float PBR_ComputeDirectLight(
-#ifdef SPECULAR_AA
-                            in float sigma, in float kappa,
-#endif
-                            vec3 normal, vec3 lightDir, vec3 viewDir,
-                            vec3 lightColor, vec3 fZero, float roughness, float ndotv,
+// BEGIN-@jhonkkk,todo:Keeping the original PBR_ComputeDirectLight function signature is for backwards compatibility, but this adds an extra internal function call, theoretically here we should use a macro to define Inner_PBR_ComputeDirectLight, or best to calculate alpha externally and directly call the Inner_PBR_ComputeDirectLight function.
+float Inner_PBR_ComputeDirectLight(
+                            vec3 normal, vec3 halfVec, vec3 lightDir, vec3 viewDir,
+                            vec3 lightColor, vec3 fZero, float alpha, float ndotv,
                             out vec3 outDiffuse, out vec3 outSpecular){
-    // Compute halfway vector.
-    vec3 halfVec = normalize(lightDir + viewDir);
 
     // Compute ndotl, ndoth,  vdoth terms which are needed later.
     float ndotl = max( dot(normal,   lightDir), 0.0);
@@ -73,11 +68,6 @@ float PBR_ComputeDirectLight(
 
     //cook-torrence, microfacet BRDF : http://blog.selfshadow.com/publications/s2013-shading-course/karis/s2013_pbs_epic_notes_v2.pdf
    
-    float alpha = roughness * roughness;
-    #ifdef SPECULAR_AA
-        Specular_Anti_Aliasing(normal, halfVec, alpha, sigma, kappa);
-    #endif
-
     //D, GGX normal Distribution function
     float alpha2 = alpha * alpha;
     float sum  = ((ndoth * ndoth) * (alpha2 - 1.0) + 1.0);
@@ -111,6 +101,31 @@ float PBR_ComputeDirectLight(
     outSpecular = vec3(specular) * fresnel * lightColor;
     return hdotv;
 }
+
+float PBR_ComputeDirectLight(
+                            vec3 normal, vec3 lightDir, vec3 viewDir,
+                            vec3 lightColor, vec3 fZero, float roughness, float ndotv,
+                            out vec3 outDiffuse, out vec3 outSpecular){
+    // Compute halfway vector.
+    vec3 halfVec = normalize(lightDir + viewDir);
+    return Inner_PBR_ComputeDirectLight(normal, halfVec, lightDir, viewDir,
+                                        lightColor, fZero, roughness * roughness, ndotv,
+                                        outDiffuse, outSpecular);
+}
+
+float PBR_ComputeDirectLightWithSpecularAA(
+                            vec3 normal, vec3 lightDir, vec3 viewDir,
+                            vec3 lightColor, vec3 fZero, float roughness, float sigma, float kappa, float ndotv,
+                            out vec3 outDiffuse, out vec3 outSpecular){
+    // Compute halfway vector.
+    vec3 halfVec = normalize(lightDir + viewDir);
+    // Specular-AA
+    float alpha = Specular_Anti_Aliasing(normal, halfVec, roughness * roughness, sigma, kappa);
+    return Inner_PBR_ComputeDirectLight(normal, halfVec, lightDir, viewDir,
+                                        lightColor, fZero, alpha, ndotv,
+                                        outDiffuse, outSpecular);
+}
+// END-@jhonkkk
 
 vec3 integrateBRDFApprox( const in vec3 specular, float roughness, float NoV ){
     const vec4 c0 = vec4( -1, -0.0275, -0.572, 0.022 );

--- a/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
@@ -15,7 +15,6 @@ void Specular_Anti_Aliasing(in vec3 normal, in vec3 half_vector,
 
     float sigma = 0.50f; 							//- screen space variance
     float Kappa = 0.18f;								//- clamping treshold
-    vec2  H = half_vector.xy;
     vec3 dndu = dFdx(normal);
     vec3 dndv = dFdy(normal);
     float  variance = sigma*sigma*(dot(dndu, dndu) + dot(dndv, dndv));

--- a/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/PBR.glsllib
@@ -10,15 +10,13 @@
 // see:http://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA(slides).pdf
 // https://docs.unity3d.com/Packages/com.unity.render-pipelines.high-definition@15.0/manual/Geometric-Specular-Anti-Aliasing.html
 void Specular_Anti_Aliasing(in vec3 normal, in vec3 half_vector,
-                           	inout float alpha_x)
+                           	inout float alpha_x, in float sigma, in float kappa)
 {
 
-    float sigma = 0.50f; 							//- screen space variance
-    float Kappa = 0.18f;								//- clamping treshold
     vec3 dndu = dFdx(normal);
     vec3 dndv = dFdy(normal);
     float  variance = sigma*sigma*(dot(dndu, dndu) + dot(dndv, dndv));
-    float  kernel_roughness = min(Kappa, variance);
+    float  kernel_roughness = min(kappa, variance);
     alpha_x = sqrt(alpha_x*alpha_x + kernel_roughness);
 }
 // END-@jhonkkk
@@ -53,7 +51,11 @@ vec3 sphericalHarmonics( const in vec3 normal, const vec3 sph[9] ){
 }
 
 
-float PBR_ComputeDirectLight(vec3 normal, vec3 lightDir, vec3 viewDir,
+float PBR_ComputeDirectLight(
+#ifdef SPECULAR_AA
+                            in float sigma, in float kappa,
+#endif
+                            vec3 normal, vec3 lightDir, vec3 viewDir,
                             vec3 lightColor, vec3 fZero, float roughness, float ndotv,
                             out vec3 outDiffuse, out vec3 outSpecular){
     // Compute halfway vector.
@@ -73,7 +75,7 @@ float PBR_ComputeDirectLight(vec3 normal, vec3 lightDir, vec3 viewDir,
    
     float alpha = roughness * roughness;
     #ifdef SPECULAR_AA
-        Specular_Anti_Aliasing(normal, halfVec, alpha);
+        Specular_Anti_Aliasing(normal, halfVec, alpha, sigma, kappa);
     #endif
 
     //D, GGX normal Distribution function

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
@@ -17,6 +17,14 @@ varying vec3 lightVec;
 varying vec3 inNormal;
 varying vec3 wNormal;
 
+// Specular-AA
+#ifdef SCREEN_SPACE_VARIANCE
+  uniform float m_Sigma;
+#endif
+#ifdef THRESHOLD
+  uniform float m_Kappa;
+#endif
+
 #ifdef DEBUG_VALUES_MODE
     uniform int m_DebugValuesMode;
 #endif
@@ -485,6 +493,16 @@ void main(){
     
      
     float ndotv = max( dot( normal, viewDir ),0.0);
+    #ifdef SPECULAR_AA
+        float sigma = 0.5f;
+        float kappa = 0.18f;
+        #ifdef SCREEN_SPACE_VARIANCE
+            sigma = m_Sigma;
+        #endif
+        #ifdef THRESHOLD
+            kappa = m_Kappa;
+        #endif
+    #endif
     for( int i = 0;i < NB_LIGHTS; i+=3){
         vec4 lightColor = g_LightData[i];
         vec4 lightData1 = g_LightData[i+1];                
@@ -508,7 +526,11 @@ void main(){
         vec3 directDiffuse;
         vec3 directSpecular;
         
-        float hdotv = PBR_ComputeDirectLight(normal, lightDir.xyz, viewDir,
+        float hdotv = PBR_ComputeDirectLight(
+        #ifdef SPECULAR_AA
+                            sigma, kappa,
+        #endif
+                            normal, lightDir.xyz, viewDir,
                             lightColor.rgb, fZero, Roughness, ndotv,
                             directDiffuse,  directSpecular);
 

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
@@ -19,10 +19,10 @@ varying vec3 wNormal;
 
 // Specular-AA
 #ifdef SCREEN_SPACE_VARIANCE
-  uniform float m_Sigma;
+  uniform float m_SpecularAASigma;
 #endif
 #ifdef THRESHOLD
-  uniform float m_Kappa;
+  uniform float m_SpecularAAKappa;
 #endif
 
 #ifdef DEBUG_VALUES_MODE
@@ -497,10 +497,10 @@ void main(){
         float sigma = 1.0;
         float kappa = 0.18;
         #ifdef SCREEN_SPACE_VARIANCE
-            sigma = m_Sigma;
+            sigma = m_SpecularAASigma;
         #endif
         #ifdef THRESHOLD
-            kappa = m_Kappa;
+            kappa = m_SpecularAAKappa;
         #endif
     #endif
     for( int i = 0;i < NB_LIGHTS; i+=3){

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
@@ -494,8 +494,8 @@ void main(){
      
     float ndotv = max( dot( normal, viewDir ),0.0);
     #ifdef SPECULAR_AA
-        float sigma = 1.0f;
-        float kappa = 0.18f;
+        float sigma = 1.0;
+        float kappa = 0.18;
         #ifdef SCREEN_SPACE_VARIANCE
             sigma = m_Sigma;
         #endif

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
@@ -494,7 +494,7 @@ void main(){
      
     float ndotv = max( dot( normal, viewDir ),0.0);
     #ifdef SPECULAR_AA
-        float sigma = 0.5f;
+        float sigma = 1.0f;
         float kappa = 0.18f;
         #ifdef SCREEN_SPACE_VARIANCE
             sigma = m_Sigma;
@@ -526,13 +526,17 @@ void main(){
         vec3 directDiffuse;
         vec3 directSpecular;
         
-        float hdotv = PBR_ComputeDirectLight(
         #ifdef SPECULAR_AA
-                            sigma, kappa,
+            float hdotv = PBR_ComputeDirectLightWithSpecularAA(
+                                normal, lightDir.xyz, viewDir,
+                                lightColor.rgb, fZero, Roughness, sigma, kappa, ndotv,
+                                directDiffuse,  directSpecular);
+        #else
+            float hdotv = PBR_ComputeDirectLight(
+                                normal, lightDir.xyz, viewDir,
+                                lightColor.rgb, fZero, Roughness, ndotv,
+                                directDiffuse,  directSpecular);
         #endif
-                            normal, lightDir.xyz, viewDir,
-                            lightColor.rgb, fZero, Roughness, ndotv,
-                            directDiffuse,  directSpecular);
 
         vec3 directLighting = diffuseColor.rgb *directDiffuse + directSpecular;
             

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
@@ -18,10 +18,10 @@ varying vec3 inNormal;
 varying vec3 wNormal;
 
 // Specular-AA
-#ifdef SCREEN_SPACE_VARIANCE
+#ifdef SPECULAR_AA_SCREEN_SPACE_VARIANCE
   uniform float m_SpecularAASigma;
 #endif
-#ifdef THRESHOLD
+#ifdef SPECULAR_AA_THRESHOLD
   uniform float m_SpecularAAKappa;
 #endif
 
@@ -496,10 +496,10 @@ void main(){
     #ifdef SPECULAR_AA
         float sigma = 1.0;
         float kappa = 0.18;
-        #ifdef SCREEN_SPACE_VARIANCE
+        #ifdef SPECULAR_AA_SCREEN_SPACE_VARIANCE
             sigma = m_SpecularAASigma;
         #endif
-        #ifdef THRESHOLD
+        #ifdef SPECULAR_AA_THRESHOLD
             kappa = m_SpecularAAKappa;
         #endif
     #endif

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.j3md
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.j3md
@@ -30,9 +30,9 @@ MaterialDef Advanced PBR Terrain {
         // Specular-AA
         Boolean UseSpecularAA : true
         // screen space variance,Use the slider to set the strength of the geometric specular anti-aliasing effect between 0 and 1. Higher values produce a blurrier result with less aliasing.
-        Float Sigma
+        Float SpecularAASigma
         // clamping threshold,Use the slider to set a maximum value for the offset that HDRP subtracts from the smoothness value to reduce artifacts.
-        Float Kappa
+        Float SpecularAAKappa
 
         Texture2D AfflictionAlphaMap
 
@@ -288,8 +288,8 @@ MaterialDef Advanced PBR Terrain {
             USE_SPLAT_NOISE : SplatNoiseVar
 
             SPECULAR_AA : UseSpecularAA
-            SCREEN_SPACE_VARIANCE : Sigma
-            THRESHOLD : Kappa
+            SCREEN_SPACE_VARIANCE : SpecularAASigma
+            THRESHOLD : SpecularAAKappa
 
             TRI_PLANAR_MAPPING : useTriPlanarMapping
 

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.j3md
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.j3md
@@ -30,9 +30,9 @@ MaterialDef Advanced PBR Terrain {
         // Specular-AA
         Boolean UseSpecularAA : true
         // screen space variance,Use the slider to set the strength of the geometric specular anti-aliasing effect between 0 and 1. Higher values produce a blurrier result with less aliasing.
-        Float Sigma : 1.0
+        Float Sigma
         // clamping threshold,Use the slider to set a maximum value for the offset that HDRP subtracts from the smoothness value to reduce artifacts.
-        Float Kappa : 0.18
+        Float Kappa
 
         Texture2D AfflictionAlphaMap
 

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.j3md
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.j3md
@@ -288,8 +288,8 @@ MaterialDef Advanced PBR Terrain {
             USE_SPLAT_NOISE : SplatNoiseVar
 
             SPECULAR_AA : UseSpecularAA
-            SCREEN_SPACE_VARIANCE : SpecularAASigma
-            THRESHOLD : SpecularAAKappa
+            SPECULAR_AA_SCREEN_SPACE_VARIANCE : SpecularAASigma
+            SPECULAR_AA_THRESHOLD : SpecularAAKappa
 
             TRI_PLANAR_MAPPING : useTriPlanarMapping
 

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.j3md
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.j3md
@@ -27,6 +27,13 @@ MaterialDef Advanced PBR Terrain {
      // affliction texture splatting & desaturation functionality
         Boolean UseTriplanarAfflictionMapping
 
+        // Specular-AA
+        Boolean UseSpecularAA : true
+        // screen space variance,Use the slider to set the strength of the geometric specular anti-aliasing effect between 0 and 1. Higher values produce a blurrier result with less aliasing.
+        Float Sigma : 1.0
+        // clamping threshold,Use the slider to set a maximum value for the offset that HDRP subtracts from the smoothness value to reduce artifacts.
+        Float Kappa : 0.18
+
         Texture2D AfflictionAlphaMap
 
         Texture2D SplatAlbedoMap  -LINEAR
@@ -279,6 +286,10 @@ MaterialDef Advanced PBR Terrain {
             AFFLICTIONROUGHNESSMETALLICMAP : SplatRoughnessMetallicMap
             AFFLICTIONEMISSIVEMAP : SplatEmissiveMap
             USE_SPLAT_NOISE : SplatNoiseVar
+
+            SPECULAR_AA : UseSpecularAA
+            SCREEN_SPACE_VARIANCE : Sigma
+            THRESHOLD : Kappa
 
             TRI_PLANAR_MAPPING : useTriPlanarMapping
 

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.frag
@@ -426,7 +426,7 @@ gl_FragColor.rgb = vec3(0.0);
      
     float ndotv = max( dot( normal, viewDir ),0.0);
     #ifdef SPECULAR_AA
-        float sigma = 0.5f;
+        float sigma = 1.0f;
         float kappa = 0.18f;
         #ifdef SCREEN_SPACE_VARIANCE
             sigma = m_Sigma;
@@ -458,13 +458,17 @@ gl_FragColor.rgb = vec3(0.0);
         vec3 directDiffuse;
         vec3 directSpecular;
         
-        float hdotv = PBR_ComputeDirectLight(
         #ifdef SPECULAR_AA
-                            sigma, kappa,
+            float hdotv = PBR_ComputeDirectLightWithSpecularAA(
+                                normal, lightDir.xyz, viewDir,
+                                lightColor.rgb, fZero, Roughness, sigma, kappa, ndotv,
+                                directDiffuse,  directSpecular);
+        #else
+            float hdotv = PBR_ComputeDirectLight(
+                                normal, lightDir.xyz, viewDir,
+                                lightColor.rgb, fZero, Roughness, ndotv,
+                                directDiffuse,  directSpecular);
         #endif
-                            normal, lightDir.xyz, viewDir,
-                            lightColor.rgb, fZero, Roughness, ndotv,
-                            directDiffuse,  directSpecular);
 
         vec3 directLighting = diffuseColor.rgb *directDiffuse + directSpecular;
             

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.frag
@@ -19,10 +19,10 @@ varying vec3 wNormal;
 
 // Specular-AA
 #ifdef SCREEN_SPACE_VARIANCE
-  uniform float m_Sigma;
+  uniform float m_SpecularAASigma;
 #endif
 #ifdef THRESHOLD
-  uniform float m_Kappa;
+  uniform float m_SpecularAAKappa;
 #endif
 
 #ifdef DEBUG_VALUES_MODE
@@ -429,10 +429,10 @@ gl_FragColor.rgb = vec3(0.0);
         float sigma = 1.0;
         float kappa = 0.18;
         #ifdef SCREEN_SPACE_VARIANCE
-            sigma = m_Sigma;
+            sigma = m_SpecularAASigma;
         #endif
         #ifdef THRESHOLD
-            kappa = m_Kappa;
+            kappa = m_SpecularAAKappa;
         #endif
     #endif
     for( int i = 0;i < NB_LIGHTS; i+=3){

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.frag
@@ -18,10 +18,10 @@ varying vec3 inNormal;
 varying vec3 wNormal;
 
 // Specular-AA
-#ifdef SCREEN_SPACE_VARIANCE
+#ifdef SPECULAR_AA_SCREEN_SPACE_VARIANCE
   uniform float m_SpecularAASigma;
 #endif
-#ifdef THRESHOLD
+#ifdef SPECULAR_AA_THRESHOLD
   uniform float m_SpecularAAKappa;
 #endif
 
@@ -428,10 +428,10 @@ gl_FragColor.rgb = vec3(0.0);
     #ifdef SPECULAR_AA
         float sigma = 1.0;
         float kappa = 0.18;
-        #ifdef SCREEN_SPACE_VARIANCE
+        #ifdef SPECULAR_AA_SCREEN_SPACE_VARIANCE
             sigma = m_SpecularAASigma;
         #endif
-        #ifdef THRESHOLD
+        #ifdef SPECULAR_AA_THRESHOLD
             kappa = m_SpecularAAKappa;
         #endif
     #endif

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.frag
@@ -426,8 +426,8 @@ gl_FragColor.rgb = vec3(0.0);
      
     float ndotv = max( dot( normal, viewDir ),0.0);
     #ifdef SPECULAR_AA
-        float sigma = 1.0f;
-        float kappa = 0.18f;
+        float sigma = 1.0;
+        float kappa = 0.18;
         #ifdef SCREEN_SPACE_VARIANCE
             sigma = m_Sigma;
         #endif

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.frag
@@ -17,6 +17,14 @@ varying vec3 lightVec;
 varying vec3 inNormal;
 varying vec3 wNormal;
 
+// Specular-AA
+#ifdef SCREEN_SPACE_VARIANCE
+  uniform float m_Sigma;
+#endif
+#ifdef THRESHOLD
+  uniform float m_Kappa;
+#endif
+
 #ifdef DEBUG_VALUES_MODE
     uniform int m_DebugValuesMode;
 #endif
@@ -417,6 +425,16 @@ gl_FragColor.rgb = vec3(0.0);
     
      
     float ndotv = max( dot( normal, viewDir ),0.0);
+    #ifdef SPECULAR_AA
+        float sigma = 0.5f;
+        float kappa = 0.18f;
+        #ifdef SCREEN_SPACE_VARIANCE
+            sigma = m_Sigma;
+        #endif
+        #ifdef THRESHOLD
+            kappa = m_Kappa;
+        #endif
+    #endif
     for( int i = 0;i < NB_LIGHTS; i+=3){
         vec4 lightColor = g_LightData[i];
         vec4 lightData1 = g_LightData[i+1];                
@@ -440,7 +458,11 @@ gl_FragColor.rgb = vec3(0.0);
         vec3 directDiffuse;
         vec3 directSpecular;
         
-        float hdotv = PBR_ComputeDirectLight(normal, lightDir.xyz, viewDir,
+        float hdotv = PBR_ComputeDirectLight(
+        #ifdef SPECULAR_AA
+                            sigma, kappa,
+        #endif
+                            normal, lightDir.xyz, viewDir,
                             lightColor.rgb, fZero, Roughness, ndotv,
                             directDiffuse,  directSpecular);
 

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.j3md
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.j3md
@@ -24,6 +24,13 @@ MaterialDef PBR Terrain {
         Texture2D SplatRoughnessMetallicMap -LINEAR
         Texture2D SplatEmissiveMap -LINEAR
 
+        // Specular-AA
+        Boolean UseSpecularAA : true
+        // screen space variance,Use the slider to set the strength of the geometric specular anti-aliasing effect between 0 and 1. Higher values produce a blurrier result with less aliasing.
+        Float Sigma : 1.0
+        // clamping threshold,Use the slider to set a maximum value for the offset that HDRP subtracts from the smoothness value to reduce artifacts.
+        Float Kappa : 0.18
+
         Color AfflictionEmissiveColor : 0.0 0.0 0.0 0.0
 
         Float SplatNoiseVar
@@ -255,6 +262,10 @@ MaterialDef PBR Terrain {
             AFFLICTIONEMISSIVEMAP : SplatEmissiveMap
 
             USE_SPLAT_NOISE : SplatNoiseVar
+
+            SPECULAR_AA : UseSpecularAA
+            SCREEN_SPACE_VARIANCE : Sigma
+            THRESHOLD : Kappa
 
 
             USE_VERTEX_COLORS_AS_SUN_INTENSITY : UseVertexColorsAsSunIntensity

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.j3md
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.j3md
@@ -264,8 +264,8 @@ MaterialDef PBR Terrain {
             USE_SPLAT_NOISE : SplatNoiseVar
 
             SPECULAR_AA : UseSpecularAA
-            SCREEN_SPACE_VARIANCE : SpecularAASigma
-            THRESHOLD : SpecularAAKappa
+            SPECULAR_AA_SCREEN_SPACE_VARIANCE : SpecularAASigma
+            SPECULAR_AA_THRESHOLD : SpecularAAKappa
 
 
             USE_VERTEX_COLORS_AS_SUN_INTENSITY : UseVertexColorsAsSunIntensity

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.j3md
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.j3md
@@ -27,9 +27,9 @@ MaterialDef PBR Terrain {
         // Specular-AA
         Boolean UseSpecularAA : true
         // screen space variance,Use the slider to set the strength of the geometric specular anti-aliasing effect between 0 and 1. Higher values produce a blurrier result with less aliasing.
-        Float Sigma
+        Float SpecularAASigma
         // clamping threshold,Use the slider to set a maximum value for the offset that HDRP subtracts from the smoothness value to reduce artifacts.
-        Float Kappa
+        Float SpecularAAKappa
 
         Color AfflictionEmissiveColor : 0.0 0.0 0.0 0.0
 
@@ -264,8 +264,8 @@ MaterialDef PBR Terrain {
             USE_SPLAT_NOISE : SplatNoiseVar
 
             SPECULAR_AA : UseSpecularAA
-            SCREEN_SPACE_VARIANCE : Sigma
-            THRESHOLD : Kappa
+            SCREEN_SPACE_VARIANCE : SpecularAASigma
+            THRESHOLD : SpecularAAKappa
 
 
             USE_VERTEX_COLORS_AS_SUN_INTENSITY : UseVertexColorsAsSunIntensity

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.j3md
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/PBRTerrain.j3md
@@ -27,9 +27,9 @@ MaterialDef PBR Terrain {
         // Specular-AA
         Boolean UseSpecularAA : true
         // screen space variance,Use the slider to set the strength of the geometric specular anti-aliasing effect between 0 and 1. Higher values produce a blurrier result with less aliasing.
-        Float Sigma : 1.0
+        Float Sigma
         // clamping threshold,Use the slider to set a maximum value for the offset that HDRP subtracts from the smoothness value to reduce artifacts.
-        Float Kappa : 0.18
+        Float Kappa
 
         Color AfflictionEmissiveColor : 0.0 0.0 0.0 0.0
 


### PR DESCRIPTION
see:http://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA(slides).pdf
https://docs.unity3d.com/Packages/com.unity.render-pipelines.high-definition@15.0/manual/Geometric-Specular-Anti-Aliasing.html
https://hub.jmonkeyengine.org/t/geometric-specular-anti-aliasing/47246/2
Usage: Simply set Material.setBoolean("SpecularAA", true);