### PR TITLE
jme3-core:  add 2 getters for frame interpolators

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/MorphTrack.java
@@ -229,6 +229,15 @@ public class MorphTrack implements AnimTrack<float[]> {
     }
 
     /**
+     * Access the FrameInterpolator.
+     *
+     * @return the pre-existing instance or null
+     */
+    public FrameInterpolator getFrameInterpolator() {
+        return interpolator;
+    }
+
+    /**
      * Replace the FrameInterpolator.
      *
      * @param interpolator the interpolator to use (alias created)

--- a/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
+++ b/jme3-core/src/main/java/com/jme3/anim/TransformTrack.java
@@ -302,6 +302,15 @@ public class TransformTrack implements AnimTrack<Transform> {
     }
 
     /**
+     * Access the FrameInterpolator.
+     *
+     * @return the pre-existing instance or null
+     */
+    public FrameInterpolator getFrameInterpolator() {
+        return interpolator;
+    }
+
+    /**
      * Replaces the frame interpolator.
      *
      * @param interpolator the interpolator to use (alias created)


### PR DESCRIPTION
This PR adds getters for the `FrameInterpolator` of a `MorphTrack` or `TransformTrack`.

The corresponding setters date back to MonkAnim, but Nehon didn't provide getters. I don't know why.

The use case is when I want to deep-clone an `AnimTrack`.  Since these classes don't implement deep cloning using `cloneFields()`, I need access to the private `interpolator` field. Currently such access is possible only by using reflection.
