### PR TITLE
solve issue #2096 (error launching examples from the dist jar)

### DIFF
--- a/jme3-examples/build.gradle
+++ b/jme3-examples/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     implementation project(':jme3-networking')
     implementation project(':jme3-niftygui')
     implementation project(':jme3-plugins')
+    implementation project(':jme3-plugins-json')
+    implementation project(':jme3-plugins-json-gson')
     implementation project(':jme3-terrain')
     implementation project(':jme3-awt-dialogs')
     runtimeOnly project(':jme3-testdata')


### PR DESCRIPTION
I reproduced issue #2096 using Java 11 on Mint Linux.  Adding 2 library dependencies solved it, as I suspected it might.

However, I'm not very confident this is the right solution.
I don't understand why issue #2096 doesn't occur when running examples in NetBeans.
I don't understand when/why the jme3-plugins-json and jme3-plugins-json-gson libraries are required. Is this documented anywhere?