### PR TITLE
in J3MD files, always list GLSL versions in descending order

### DIFF
--- a/jme3-core/src/test/resources/bad-booleans1.j3md
+++ b/jme3-core/src/test/resources/bad-booleans1.j3md
@@ -62,8 +62,8 @@ MaterialDef bad-booleans1 {
     }
 
     Technique {
-        VertexShader GLSL100 GLSL150:   Common/MatDefs/Misc/Unshaded.vert
-        FragmentShader GLSL100 GLSL150: Common/MatDefs/Misc/Unshaded.frag
+        VertexShader GLSL150 GLSL100:   Common/MatDefs/Misc/Unshaded.vert
+        FragmentShader GLSL150 GLSL100: Common/MatDefs/Misc/Unshaded.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -88,8 +88,8 @@ MaterialDef bad-booleans1 {
 
     Technique PreNormalPass {
 
-        VertexShader GLSL100 GLSL150 :   Common/MatDefs/SSAO/normal.vert
-        FragmentShader GLSL100 GLSL150 : Common/MatDefs/SSAO/normal.frag
+        VertexShader GLSL150 GLSL100 :   Common/MatDefs/SSAO/normal.vert
+        FragmentShader GLSL150 GLSL100 : Common/MatDefs/SSAO/normal.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -109,8 +109,8 @@ MaterialDef bad-booleans1 {
 
     Technique PreShadow {
 
-        VertexShader GLSL100 GLSL150 :   Common/MatDefs/Shadow/PreShadow.vert
-        FragmentShader GLSL100 GLSL150 : Common/MatDefs/Shadow/PreShadow.frag
+        VertexShader GLSL150 GLSL100 :   Common/MatDefs/Shadow/PreShadow.vert
+        FragmentShader GLSL150 GLSL100 : Common/MatDefs/Shadow/PreShadow.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -140,8 +140,8 @@ MaterialDef bad-booleans1 {
 
 
     Technique PostShadow {
-        VertexShader GLSL100 GLSL150:   Common/MatDefs/Shadow/PostShadow.vert
-        FragmentShader GLSL100 GLSL150: Common/MatDefs/Shadow/PostShadow.frag
+        VertexShader GLSL150 GLSL100:   Common/MatDefs/Shadow/PostShadow.vert
+        FragmentShader GLSL150 GLSL100: Common/MatDefs/Shadow/PostShadow.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -176,8 +176,8 @@ MaterialDef bad-booleans1 {
 
     Technique Glow {
 
-        VertexShader GLSL100 GLSL150:   Common/MatDefs/Misc/Unshaded.vert
-        FragmentShader GLSL100 GLSL150: Common/MatDefs/Light/Glow.frag
+        VertexShader GLSL150 GLSL100:   Common/MatDefs/Misc/Unshaded.vert
+        FragmentShader GLSL150 GLSL100: Common/MatDefs/Light/Glow.frag
 
         WorldParameters {
             WorldViewProjectionMatrix

--- a/jme3-core/src/test/resources/bad-booleans2.j3md
+++ b/jme3-core/src/test/resources/bad-booleans2.j3md
@@ -62,8 +62,8 @@ MaterialDef bad-booleans2 {
     }
 
     Technique {
-        VertexShader GLSL100 GLSL150:   Common/MatDefs/Misc/Unshaded.vert
-        FragmentShader GLSL100 GLSL150: Common/MatDefs/Misc/Unshaded.frag
+        VertexShader GLSL150 GLSL100:   Common/MatDefs/Misc/Unshaded.vert
+        FragmentShader GLSL150 GLSL100: Common/MatDefs/Misc/Unshaded.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -88,8 +88,8 @@ MaterialDef bad-booleans2 {
 
     Technique PreNormalPass {
 
-        VertexShader GLSL100 GLSL150 :   Common/MatDefs/SSAO/normal.vert
-        FragmentShader GLSL100 GLSL150 : Common/MatDefs/SSAO/normal.frag
+        VertexShader GLSL150 GLSL100 :   Common/MatDefs/SSAO/normal.vert
+        FragmentShader GLSL150 GLSL100 : Common/MatDefs/SSAO/normal.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -109,8 +109,8 @@ MaterialDef bad-booleans2 {
 
     Technique PreShadow {
 
-        VertexShader GLSL100 GLSL150 :   Common/MatDefs/Shadow/PreShadow.vert
-        FragmentShader GLSL100 GLSL150 : Common/MatDefs/Shadow/PreShadow.frag
+        VertexShader GLSL150 GLSL100 :   Common/MatDefs/Shadow/PreShadow.vert
+        FragmentShader GLSL150 GLSL100 : Common/MatDefs/Shadow/PreShadow.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -140,8 +140,8 @@ MaterialDef bad-booleans2 {
 
 
     Technique PostShadow {
-        VertexShader GLSL100 GLSL150:   Common/MatDefs/Shadow/PostShadow.vert
-        FragmentShader GLSL100 GLSL150: Common/MatDefs/Shadow/PostShadow.frag
+        VertexShader GLSL150 GLSL100:   Common/MatDefs/Shadow/PostShadow.vert
+        FragmentShader GLSL150 GLSL100: Common/MatDefs/Shadow/PostShadow.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -176,8 +176,8 @@ MaterialDef bad-booleans2 {
 
     Technique Glow {
 
-        VertexShader GLSL100 GLSL150:   Common/MatDefs/Misc/Unshaded.vert
-        FragmentShader GLSL100 GLSL150: Common/MatDefs/Light/Glow.frag
+        VertexShader GLSL150 GLSL100:   Common/MatDefs/Misc/Unshaded.vert
+        FragmentShader GLSL150 GLSL100: Common/MatDefs/Light/Glow.frag
 
         WorldParameters {
             WorldViewProjectionMatrix

--- a/jme3-core/src/test/resources/bad-booleans3.j3md
+++ b/jme3-core/src/test/resources/bad-booleans3.j3md
@@ -62,8 +62,8 @@ MaterialDef bad-booleans3 {
     }
 
     Technique {
-        VertexShader GLSL100 GLSL150:   Common/MatDefs/Misc/Unshaded.vert
-        FragmentShader GLSL100 GLSL150: Common/MatDefs/Misc/Unshaded.frag
+        VertexShader GLSL150 GLSL100:   Common/MatDefs/Misc/Unshaded.vert
+        FragmentShader GLSL150 GLSL100: Common/MatDefs/Misc/Unshaded.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -88,8 +88,8 @@ MaterialDef bad-booleans3 {
 
     Technique PreNormalPass {
 
-        VertexShader GLSL100 GLSL150 :   Common/MatDefs/SSAO/normal.vert
-        FragmentShader GLSL100 GLSL150 : Common/MatDefs/SSAO/normal.frag
+        VertexShader GLSL150 GLSL100 :   Common/MatDefs/SSAO/normal.vert
+        FragmentShader GLSL150 GLSL100 : Common/MatDefs/SSAO/normal.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -109,8 +109,8 @@ MaterialDef bad-booleans3 {
 
     Technique PreShadow {
 
-        VertexShader GLSL100 GLSL150 :   Common/MatDefs/Shadow/PreShadow.vert
-        FragmentShader GLSL100 GLSL150 : Common/MatDefs/Shadow/PreShadow.frag
+        VertexShader GLSL150 GLSL100 :   Common/MatDefs/Shadow/PreShadow.vert
+        FragmentShader GLSL150 GLSL100 : Common/MatDefs/Shadow/PreShadow.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -141,8 +141,8 @@ MaterialDef bad-booleans3 {
 
 
     Technique PostShadow {
-        VertexShader GLSL100 GLSL150:   Common/MatDefs/Shadow/PostShadow.vert
-        FragmentShader GLSL100 GLSL150: Common/MatDefs/Shadow/PostShadow.frag
+        VertexShader GLSL150 GLSL100:   Common/MatDefs/Shadow/PostShadow.vert
+        FragmentShader GLSL150 GLSL100: Common/MatDefs/Shadow/PostShadow.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -177,8 +177,8 @@ MaterialDef bad-booleans3 {
 
     Technique Glow {
 
-        VertexShader GLSL100 GLSL150:   Common/MatDefs/Misc/Unshaded.vert
-        FragmentShader GLSL100 GLSL150: Common/MatDefs/Light/Glow.frag
+        VertexShader GLSL150 GLSL100:   Common/MatDefs/Misc/Unshaded.vert
+        FragmentShader GLSL150 GLSL100: Common/MatDefs/Light/Glow.frag
 
         WorldParameters {
             WorldViewProjectionMatrix

--- a/jme3-examples/src/main/resources/jme3test/materials/TestIssue37.j3md
+++ b/jme3-examples/src/main/resources/jme3test/materials/TestIssue37.j3md
@@ -24,8 +24,8 @@ MaterialDef TestIssue37 {
     }
 
     Technique {
-        VertexShader GLSL100 GLSL150:   Common/MatDefs/Misc/ShowNormals.vert
-        FragmentShader GLSL100 GLSL150: Common/MatDefs/Misc/ShowNormals.frag
+        VertexShader GLSL150 GLSL100:   Common/MatDefs/Misc/ShowNormals.vert
+        FragmentShader GLSL150 GLSL100: Common/MatDefs/Misc/ShowNormals.frag
 
         WorldParameters {
             WorldViewProjectionMatrix


### PR DESCRIPTION
Improve several material definitions used in tests, based on Riccardo's note at the Discourse Forum/Hub: https://hub.jmonkeyengine.org/t/porting-jmonkeyengine-to-the-browser-with-webgl2-and-teavm-sourcecode-released/47020/65

As far as I know, these material definitions aren't causing any issues. This PR is more about setting a good example.