### PR TITLE
Fix PBR Support for Glow

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRGlow.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRGlow.frag
@@ -1,0 +1,38 @@
+#import "Common/ShaderLib/GLSLCompat.glsllib"
+#if defined(NEED_TEXCOORD1) 
+    varying vec2 texCoord1;
+#else 
+    varying vec2 texCoord;
+#endif
+
+
+#ifdef HAS_EMISSIVEMAP
+  uniform sampler2D m_EmissiveMap;
+#endif
+
+#ifdef HAS_EMISSIVECOLOR
+  uniform vec4 m_Emissive;
+#endif
+
+
+void main(){
+    #ifdef HAS_EMISSIVEMAP
+        #ifdef HAS_EMISSIVECOLOR
+           vec4 color = m_Emissive;
+        #else
+           vec4 color = vec4(1.0);
+        #endif
+
+        #if defined(NEED_TEXCOORD1) 
+           gl_FragColor = texture2D(m_EmissiveMap, texCoord1) * color;
+        #else 
+           gl_FragColor = texture2D(m_EmissiveMap, texCoord) * color;
+        #endif
+    #else
+        #ifdef HAS_EMISSIVECOLOR
+            gl_FragColor =  m_Emissive;
+        #else
+            gl_FragColor = vec4(0.0);
+        #endif
+    #endif
+}

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.j3md
@@ -280,7 +280,7 @@ MaterialDef PBR Lighting {
     Technique Glow {
 
         VertexShader   GLSL300 GLSL150 GLSL100:   Common/MatDefs/Misc/Unshaded.vert
-        FragmentShader GLSL300 GLSL150 GLSL100: Common/MatDefs/Light/Glow.frag
+        FragmentShader GLSL300 GLSL150 GLSL100: Common/MatDefs/Light/PBRGlow.frag
 
         WorldParameters {
             WorldViewProjectionMatrix
@@ -289,6 +289,8 @@ MaterialDef PBR Lighting {
         }
 
         Defines {
+            HAS_EMISSIVEMAP : EmissiveMap
+            HAS_EMISSIVECOLOR : Emissive
             BOUND_DRAW_BUFFER: BoundDrawBuffer
             NEED_TEXCOORD1
             NUM_BONES : NumberOfBones


### PR DESCRIPTION
Fixes #2161 by making PBRLighting use PBRGlow.frag, which uses Emissive and EmissiveMap material parameters for calculating glow.