### PR TITLE
Fixes Gltf Emissive Intensity Default

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/MaterialAdapter.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/MaterialAdapter.java
@@ -62,6 +62,13 @@ public abstract class MaterialAdapter {
     protected abstract String getMaterialDefPath();
 
     protected abstract MatParam adaptMatParam(MatParam param);
+    
+    /**
+     * Initializes material parameters to their default settings.
+     * 
+     * @param material 
+     */
+    protected abstract void initDefaultMatParams(Material material);
 
     protected void init(AssetManager assetManager) {
         this.assetManager = assetManager;
@@ -75,6 +82,7 @@ public abstract class MaterialAdapter {
     protected Material getMaterial() {
         if (mat == null) {
             mat = new Material(assetManager, getMaterialDefPath());
+            initDefaultMatParams(mat);
         }
         return mat;
     }

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/PBRMaterialAdapter.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/PBRMaterialAdapter.java
@@ -61,6 +61,11 @@ public abstract class PBRMaterialAdapter extends MaterialAdapter {
     protected String getMaterialDefPath() {
         return "Common/MatDefs/Light/PBRLighting.j3md";
     }
+    
+    @Override
+    protected void initDefaultMatParams(Material material) {
+        material.setFloat("EmissiveIntensity", 1);
+    }
 
     @Override
     protected MatParam adaptMatParam(MatParam param) {

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/UnlitExtensionLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/UnlitExtensionLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/UnlitExtensionLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/UnlitExtensionLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 jMonkeyEngine
+ * Copyright (c) 2009-2021 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/UnlitMaterialAdapter.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/UnlitMaterialAdapter.java
@@ -32,6 +32,7 @@
 package com.jme3.scene.plugins.gltf;
 
 import com.jme3.material.MatParam;
+import com.jme3.material.Material;
 import com.jme3.material.RenderState;
 
 /**
@@ -77,5 +78,9 @@ public class UnlitMaterialAdapter extends MaterialAdapter {
             return null;
         }
         return param;
-    }
+    }    
+    
+    @Override
+    protected void initDefaultMatParams(Material material) {}
+    
 }

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/UnlitMaterialAdapter.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/UnlitMaterialAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Additional patch to #2085 that makes gltf pbr materials default EmissiveIntensity to 1.0.