### PR TITLE
solve issue #2164 (setCausticsTexture() sets non-existent parameter)

### DIFF
--- a/jme3-effects/src/main/java/com/jme3/water/WaterFilter.java
+++ b/jme3-effects/src/main/java/com/jme3/water/WaterFilter.java
@@ -1045,7 +1045,7 @@ public class WaterFilter extends Filter implements JmeCloneable, Cloneable {
     public void setCausticsTexture(Texture2D causticsTexture) {
         this.causticsTexture = causticsTexture;
         if (material != null) {
-            material.setTexture("causticsMap", causticsTexture);
+            material.setTexture("CausticsMap", causticsTexture);
         }
     }
 


### PR DESCRIPTION
Material-parameter names are case-sensitive, and the actual name of the parameter is "CausticsMap".
This resolves issue #2164.