### PR TITLE
#2174 deprecate key classes in JME3-vr. 

### DIFF
--- a/jme3-vr/src/main/java/com/jme3/app/VRAppState.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VRAppState.java
@@ -72,7 +72,13 @@ import java.util.logging.Logger;
  * </ul>
  * Attaching an instance of this app state to an already started application may cause crashes.
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
+ *
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class VRAppState extends AbstractAppState {
     public static final String ID = "VRAppState";
     private static final Logger logger = Logger.getLogger(VRAppState.class.getName());
@@ -117,7 +123,12 @@ public class VRAppState extends AbstractAppState {
      * Create a new VR app state with given settings. The app state relies on the given {@link VREnvironment VR environment}.
      * @param settings the settings to use.
      * @param environment the {@link VREnvironment VR environment} that this app state is using.
+     * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+     *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+     *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+     *             for more information.
      */
+    @Deprecated
     public VRAppState(AppSettings settings, VREnvironment environment){
         this(environment);
         this.settings = settings;

--- a/jme3-vr/src/main/java/com/jme3/app/VRConstants.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VRConstants.java
@@ -7,7 +7,12 @@ import com.jme3.system.AppSettings;
  * Some constants dedicated to the VR module.
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  * @since 3.1.0
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class VRConstants {
     /**
      * An AppSettings parameter that set if the VR compositor has to be used.

--- a/jme3-vr/src/main/java/com/jme3/app/VREnvironment.java
+++ b/jme3-vr/src/main/java/com/jme3/app/VREnvironment.java
@@ -31,7 +31,12 @@ import com.jme3.util.VRGuiManager;
  *
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  *
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class VREnvironment {
     private static final Logger logger = Logger.getLogger(VREnvironment.class.getName());
 

--- a/jme3-vr/src/main/java/com/jme3/input/vr/AnalogActionState.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/AnalogActionState.java
@@ -1,5 +1,12 @@
 package com.jme3.input.vr;
 
+/**
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
+ */
+@Deprecated
 public class AnalogActionState{
 
     /**

--- a/jme3-vr/src/main/java/com/jme3/input/vr/DigitalActionState.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/DigitalActionState.java
@@ -1,5 +1,12 @@
 package com.jme3.input.vr;
 
+/**
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
+ */
+@Deprecated
 public class DigitalActionState{
 
     /**

--- a/jme3-vr/src/main/java/com/jme3/input/vr/lwjgl_openvr/LWJGLOpenVRInput.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/lwjgl_openvr/LWJGLOpenVRInput.java
@@ -73,7 +73,12 @@ Button press: 2, touch: 2
  * @author reden - phr00t
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  * @author Rickard Edén
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class LWJGLOpenVRInput implements VRInputAPI {
 
     private static final Logger logger = Logger.getLogger(LWJGLOpenVRInput.class.getName());

--- a/jme3-vr/src/main/java/com/jme3/post/CartoonSSAO.java
+++ b/jme3-vr/src/main/java/com/jme3/post/CartoonSSAO.java
@@ -15,7 +15,12 @@ import com.jme3.texture.Image.Format;
  * @author reden - phr00t - https://github.com/phr00t
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  *
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class CartoonSSAO extends Filter{
     private Pass normalPass;
     private Vector3f frustumCorner;

--- a/jme3-vr/src/main/java/com/jme3/post/FilterUtil.java
+++ b/jme3-vr/src/main/java/com/jme3/post/FilterUtil.java
@@ -8,7 +8,12 @@ import com.jme3.shadow.DirectionalLightShadowFilter;
 /**
  *
  * @author Rickard
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class FilterUtil {
     /**
      * A private constructor to inhibit instantiation of this class.

--- a/jme3-vr/src/main/java/com/jme3/post/PreNormalCaching.java
+++ b/jme3-vr/src/main/java/com/jme3/post/PreNormalCaching.java
@@ -11,7 +11,12 @@ import com.jme3.texture.FrameBuffer;
  * Pre normal caching class.
  * @author reden - phr00t - https://github.com/phr00t
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class PreNormalCaching {
     
     private static FrameBuffer cachedPreNormals;

--- a/jme3-vr/src/main/java/com/jme3/shadow/AbstractShadowFilterVR.java
+++ b/jme3-vr/src/main/java/com/jme3/shadow/AbstractShadowFilterVR.java
@@ -55,7 +55,12 @@ import java.io.IOException;
  * @author reden - phr00t - https://github.com/phr00t
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  * @param <T> the type of the underlying renderer (subclass of {@link AbstractShadowRendererVR}).
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public abstract class AbstractShadowFilterVR<T extends AbstractShadowRendererVR> extends Filter {
 
     protected T shadowRenderer;

--- a/jme3-vr/src/main/java/com/jme3/shadow/AbstractShadowRendererVR.java
+++ b/jme3-vr/src/main/java/com/jme3/shadow/AbstractShadowRendererVR.java
@@ -75,7 +75,12 @@ import java.util.List;
  * @author Rémy Bouquet aka Nehon
  * @author reden - phr00t - https://github.com/phr00t
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public abstract class AbstractShadowRendererVR implements SceneProcessor, Savable {
     private static final LightFilter NULL_LIGHT_FILTER = new NullLightFilter();
     protected int nbShadowMaps = 1;

--- a/jme3-vr/src/main/java/com/jme3/shadow/DirectionalLightShadowFilterVR.java
+++ b/jme3-vr/src/main/java/com/jme3/shadow/DirectionalLightShadowFilterVR.java
@@ -56,7 +56,12 @@ import java.io.IOException;
  * @author Rémy Bouquet aka Nehon
  * @author reden - phr00t - https://github.com/phr00t
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class DirectionalLightShadowFilterVR extends AbstractShadowFilterVR<DirectionalLightShadowRendererVR> {
 
     /**

--- a/jme3-vr/src/main/java/com/jme3/shadow/DirectionalLightShadowRendererVR.java
+++ b/jme3-vr/src/main/java/com/jme3/shadow/DirectionalLightShadowRendererVR.java
@@ -62,7 +62,12 @@ import java.io.IOException;
  * @author Rémy Bouquet aka Nehon
  * @author reden - phr00t - https://github.com/phr00t
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class DirectionalLightShadowRendererVR extends AbstractShadowRendererVR {
 
     protected float lambda = 0.65f;    

--- a/jme3-vr/src/main/java/com/jme3/shadow/InstancedDirectionalShadowFilter.java
+++ b/jme3-vr/src/main/java/com/jme3/shadow/InstancedDirectionalShadowFilter.java
@@ -9,7 +9,12 @@ import com.jme3.renderer.Camera;
  * An instanced version of the {@link DirectionalLightShadowFilterVR directional light shadow filter}.
  * @author reden - phr00t - https://github.com/phr00t
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class InstancedDirectionalShadowFilter extends DirectionalLightShadowFilterVR {
     private final Vector4f temp4f = new Vector4f(), temp4f2 = new Vector4f();
 

--- a/jme3-vr/src/main/java/com/jme3/shadow/VRDirectionalLightShadowRenderer.java
+++ b/jme3-vr/src/main/java/com/jme3/shadow/VRDirectionalLightShadowRenderer.java
@@ -44,7 +44,12 @@ import com.jme3.shadow.DirectionalLightShadowRenderer;
  * href="http://http.developer.nvidia.com/GPUGems3/gpugems3_ch10.html">http://http.developer.nvidia.com/GPUGems3/gpugems3_ch10.html</a><br>
  *
  * @author Rémy Bouquet aka Nehon
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class VRDirectionalLightShadowRenderer extends DirectionalLightShadowRenderer {
 
     /**

--- a/jme3-vr/src/main/java/com/jme3/util/VRGUIPositioningMode.java
+++ b/jme3-vr/src/main/java/com/jme3/util/VRGUIPositioningMode.java
@@ -4,7 +4,12 @@ package com.jme3.util;
  * An enumeration that describes the GUI display positioning modes.
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  *
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public enum VRGUIPositioningMode {
     MANUAL,
     AUTO_CAM_ALL,

--- a/jme3-vr/src/main/java/com/jme3/util/VRGuiManager.java
+++ b/jme3-vr/src/main/java/com/jme3/util/VRGuiManager.java
@@ -28,7 +28,12 @@ import java.util.Iterator;
  * @author reden - phr00t - https://github.com/phr00t
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  *
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class VRGuiManager {
     private Camera camLeft, camRight;
     private float guiDistance = 1.5f;

--- a/jme3-vr/src/main/java/com/jme3/util/VRUtil.java
+++ b/jme3-vr/src/main/java/com/jme3/util/VRUtil.java
@@ -11,7 +11,12 @@ import java.util.concurrent.TimeUnit;
  * 
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  *
+ * @deprecated The jme3-vr module is deprecated and will be removed in a future version (as it only supports OpenVR).
+ *             For new Virtual Reality projects, use user libraries that provide OpenXR support.
+ *             See <a href = "https://wiki.jmonkeyengine.org/docs/3.4/core/vr/virtualreality.html">Virtual Reality JME wiki section</a>
+ *             for more information.
  */
+@Deprecated
 public class VRUtil {
 
     private static final long SLEEP_PRECISION = TimeUnit.MILLISECONDS.toNanos(4);


### PR DESCRIPTION
Deprecate key classes in JME3-vr. This functionality is outdated (using OpenVR) and will be deleted in a future version.

User provided libraries supporting OpenXR should be used instead.

As discussed in the [thread for JME V3.7](https://hub.jmonkeyengine.org/t/jme-3-7/47390/5?u=richtea)