### PR TITLE
#2176 Make LWJGLBufferAllocator use nmemCalloc() instead of nmemAlloc()

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/util/LWJGLBufferAllocator.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/util/LWJGLBufferAllocator.java
@@ -210,7 +210,7 @@ public class LWJGLBufferAllocator implements BufferAllocator {
 
     @Override
     public ByteBuffer allocate(final int size) {
-        final Long address = MemoryUtil.nmemAlloc(size);
+        final Long address = MemoryUtil.nmemCalloc(size, 1);
         final ByteBuffer byteBuffer = MemoryUtil.memByteBuffer(address, size);
         DEALLOCATORS.put(address, createDeallocator(address, byteBuffer));
         return byteBuffer;


### PR DESCRIPTION
https://github.com/jMonkeyEngine/jmonkeyengine/issues/2176
LWJGLBufferAllocator.allocate() now always returns zero-initialized buffers.