### PR TITLE
update the "gson" library to v2.10.1

### DIFF
--- a/jme3-plugins-json-gson/build.gradle
+++ b/jme3-plugins-json-gson/build.gradle
@@ -11,6 +11,6 @@ sourceSets {
 dependencies {
 
     api project(':jme3-plugins-json')
-    api 'com.google.code.gson:gson:2.9.1'
+    api 'com.google.code.gson:gson:2.10.1'
 
 }


### PR DESCRIPTION
Currently the jme3-plugins-json-gson subproject depends on v2.9.1 of Google's Gson library, which was released in July 2022.

This PR updates the dependency to v2.10.1, which was released in January 2023.

For a summary of the differences between the 2 releases, see [the Gson release notes](https://github.com/google/gson/releases).