### PR TITLE
solve issue #2184 (smart quotes in log messages)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/util/MemoryUtils.java
+++ b/jme3-core/src/main/java/com/jme3/util/MemoryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2024 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -70,7 +70,8 @@ public class MemoryUtils {
             Long value = (Long)mbeans.getAttribute(directPool, "MemoryUsed");
             return value == null ? -1 : value;
         } catch (JMException ex) {
-            Logger.getLogger(MemoryUtils.class.getName()).log(Level.SEVERE, "Error retrieving ‘MemoryUsed’", ex);
+            Logger.getLogger(MemoryUtils.class.getName())
+                    .log(Level.SEVERE, "Error retrieving MemoryUsed", ex);
             return -1;
         }
     }
@@ -84,7 +85,7 @@ public class MemoryUtils {
             Long value = (Long)mbeans.getAttribute(directPool, "Count");
             return value == null ? -1 : value;
         } catch (JMException ex) {
-            Logger.getLogger(MemoryUtils.class.getName()).log(Level.SEVERE, "Error retrieving ‘Count’", ex);
+            Logger.getLogger(MemoryUtils.class.getName()).log(Level.SEVERE, "Error retrieving Count", ex);
             return -1;
         }
     }
@@ -99,7 +100,8 @@ public class MemoryUtils {
             Long value = (Long)mbeans.getAttribute(directPool, "TotalCapacity");
             return value == null ? -1 : value;
         } catch (JMException ex) {
-            Logger.getLogger(MemoryUtils.class.getName()).log(Level.SEVERE, "Error retrieving ‘TotalCapacity’", ex);
+            Logger.getLogger(MemoryUtils.class.getName())
+                    .log(Level.SEVERE, "Error retrieving TotalCapacity", ex);
             return -1;
         }
     }


### PR DESCRIPTION
The smart quotes were unnecessary and caused issues in some editors, so I removed them. This resolves issue #2184.
I also updated the copyright dates and split 2 lines that exceeded the 110-character limit.
Ready for review.