### PR TITLE
update GitHub actions: setup-java to v4, wrapper-validation-action to v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Validate the Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Build
         run: |
           ./gradlew -PuseCommitHashAsVersionName=true --no-daemon -PbuildNativeProjects=true \
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup the java environment
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.jdk }}
@@ -125,7 +125,7 @@ jobs:
           path: build/native
 
       - name: Validate the Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Build Engine
         shell: bash
         run: |
@@ -307,7 +307,7 @@ jobs:
 
       # Setup jdk 17 used for building Maven-style artifacts
       - name: Setup the java environment
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -351,7 +351,7 @@ jobs:
 
       # Setup jdk 17 used for building Sonatype OSSRH artifacts
       - name: Setup the java environment
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'


### PR DESCRIPTION
The continuous integration at GitHub needs a few updates to address the recent deprecation of Node.js 16.

Recent CI summaries contain annotations of the following sort:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-java@v3, gradle/wrapper-validation-action@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

For example, see: https://github.com/jMonkeyEngine/jmonkeyengine/actions/runs/7747717155

If left unresolved, these issues might someday cause our continuous integration to fail.
This PR should resolve all or most of those annotations.