### PR TITLE
update the Gradle wrapper to v7.6.4

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
We can't easily upgrade to Gradle 8, but at least we can use the latest release of Gradle 7.

Upgrading to 7.6.4 addresses some security vulnerabilities. See [the release notes](https://docs.gradle.org/7.6.4/release-notes.html) for details.

Upgrading is a simple matter of changing the properties file:  the upgrade does not involve any changes to the Gradle JAR. (@tonihele I ran the update command twice, just in case.)

Long-term, we should clean up the project so it can migrate to Gradle 8 ... and perhaps Kotlin-based Gradle as well, since that's where the world appears to be headed.