### PR TITLE
VarType: format code

### DIFF
--- a/jme3-core/src/main/java/com/jme3/shader/VarType.java
+++ b/jme3-core/src/main/java/com/jme3/shader/VarType.java
@@ -46,40 +46,39 @@ import com.jme3.texture.TextureCubeMap;
 
 public enum VarType {
 
-    Float("float", float.class, Float.class), 
-    Vector2("vec2", Vector2f.class), 
+    Float("float", float.class, Float.class),
+    Vector2("vec2", Vector2f.class),
     Vector3("vec3", Vector3f.class),
     Vector4("vec4", Vector4f.class, ColorRGBA.class),
 
     IntArray(true, false, "int", int[].class, Integer[].class),
-    FloatArray(true, false, "float", float[].class, Float[].class), 
+    FloatArray(true, false, "float", float[].class, Float[].class),
     Vector2Array(true, false, "vec2", Vector2f[].class),
-    Vector3Array(true, false, "vec3", Vector3f[].class), 
+    Vector3Array(true, false, "vec3", Vector3f[].class),
     Vector4Array(true, false, "vec4", Vector4f[].class),
 
-    Boolean("bool", boolean.class, Boolean.class),
+    Boolean("bool", Boolean.class, boolean.class),
 
-    Matrix3(true, false, "mat3", Matrix3f.class), 
+    Matrix3(true, false, "mat3", Matrix3f.class),
     Matrix4(true, false, "mat4", Matrix4f.class),
 
-    Matrix3Array(true, false, "mat3", Matrix3f[].class), 
+    Matrix3Array(true, false, "mat3", Matrix3f[].class),
     Matrix4Array(true, false, "mat4", Matrix4f[].class),
-    
+
     TextureBuffer(false, true, "sampler1D|sampler1DShadow"),
     Texture2D(false, true, "sampler2D|sampler2DShadow", Texture2D.class, Texture.class),
     Texture3D(false, true, "sampler3D", Texture3D.class, Texture.class),
     TextureArray(false, true, "sampler2DArray|sampler2DArrayShadow", TextureArray.class, Texture.class),
     TextureCubeMap(false, true, "samplerCube", TextureCubeMap.class, Texture.class),
-    Int("int", int.class, Integer.class), 
-    UniformBufferObject(false, false, "custom", BufferObject.class), 
+    Int("int", int.class, Integer.class),
+    UniformBufferObject(false, false, "custom", BufferObject.class),
     ShaderStorageBufferObject(false, false, "custom", BufferObject.class);
-    
 
     private boolean usesMultiData = false;
     private boolean textureType = false;
     private final String glslType;
     private Class<?>[] javaTypes;
-    
+
     VarType(String glslType, Class<?>... javaTypes) {
         this.glslType = glslType;
         if (javaTypes != null) {
@@ -90,7 +89,7 @@ public enum VarType {
     }
 
     VarType(boolean multiData, boolean textureType, String glslType, Class<?>... javaTypes) {
-        usesMultiData = multiData;
+        this.usesMultiData = multiData;
         this.textureType = textureType;
         this.glslType = glslType;
         if (javaTypes != null) {
@@ -99,9 +98,10 @@ public enum VarType {
             this.javaTypes = new Class<?>[0];
         }
     }
-    
+
     /**
      * Check if the passed object is of a type mapped to this VarType
+     * 
      * @param o Object to check
      * @return true if the object type is mapped to this VarType
      */
@@ -116,6 +116,7 @@ public enum VarType {
 
     /**
      * Get the java types mapped to this VarType
+     * 
      * @return an array of classes mapped to this VarType
      */
     public Class<?>[] getJavaType() {
@@ -132,6 +133,6 @@ public enum VarType {
 
     public String getGlslType() {
         return glslType;
-    }   
+    }
 
 }

--- a/jme3-core/src/main/java/com/jme3/shader/VarType.java
+++ b/jme3-core/src/main/java/com/jme3/shader/VarType.java
@@ -30,54 +30,63 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.jme3.shader;
-import com.jme3.math.*;
-import com.jme3.shader.bufferobject.BufferObject;
-import com.jme3.texture.*;
+
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.Matrix3f;
+import com.jme3.math.Matrix4f;
+import com.jme3.math.Vector2f;
+import com.jme3.math.Vector3f;
+import com.jme3.math.Vector4f;
+import com.jme3.shader.BufferObject;
+import com.jme3.texture.Texture;
+import com.jme3.texture.Texture2D;
+import com.jme3.texture.Texture3D;
+import com.jme3.texture.TextureArray;
+import com.jme3.texture.TextureCubeMap;
+
 public enum VarType {
 
-    Float("float",float.class,Float.class),
-    Vector2("vec2",Vector2f.class),
-    Vector3("vec3",Vector3f.class),
-    Vector4("vec4",Vector4f.class, ColorRGBA.class),
+    Float("float", float.class, Float.class), 
+    Vector2("vec2", Vector2f.class), 
+    Vector3("vec3", Vector3f.class),
+    Vector4("vec4", Vector4f.class, ColorRGBA.class),
 
-    IntArray(true,false,"int",int[].class,Integer[].class),
-    FloatArray(true,false,"float",float[].class,Float[].class),
-    Vector2Array(true,false,"vec2",Vector2f[].class),
-    Vector3Array(true,false,"vec3",Vector3f[].class),
-    Vector4Array(true,false,"vec4",Vector4f[].class),
+    IntArray(true, false, "int", int[].class, Integer[].class),
+    FloatArray(true, false, "float", float[].class, Float[].class), 
+    Vector2Array(true, false, "vec2", Vector2f[].class),
+    Vector3Array(true, false, "vec3", Vector3f[].class), 
+    Vector4Array(true, false, "vec4", Vector4f[].class),
 
-    Boolean("bool",Boolean.class,boolean.class),
+    Boolean("bool", boolean.class, Boolean.class),
 
-    Matrix3(true,false,"mat3",Matrix3f.class),
-    Matrix4(true,false,"mat4",Matrix4f.class),
+    Matrix3(true, false, "mat3", Matrix3f.class), 
+    Matrix4(true, false, "mat4", Matrix4f.class),
 
-    Matrix3Array(true,false,"mat3",Matrix3f[].class),
-    Matrix4Array(true,false,"mat4",Matrix4f[].class),
+    Matrix3Array(true, false, "mat3", Matrix3f[].class), 
+    Matrix4Array(true, false, "mat4", Matrix4f[].class),
     
-    TextureBuffer(false,true,"sampler1D|sampler1DShadow"), 
-    Texture2D(false,true,"sampler2D|sampler2DShadow",Texture2D.class,Texture.class),
-    Texture3D(false,true,"sampler3D",Texture3D.class,Texture.class),
-    TextureArray(false,true,"sampler2DArray|sampler2DArrayShadow",TextureArray.class,Texture.class),
-    TextureCubeMap(false,true,"samplerCube",TextureCubeMap.class,Texture.class),
-    Int("int",int.class,Integer.class),
-    UniformBufferObject(false, false, "custom",BufferObject.class), 
-    ShaderStorageBufferObject(false, false, "custom",BufferObject.class);
+    TextureBuffer(false, true, "sampler1D|sampler1DShadow"),
+    Texture2D(false, true, "sampler2D|sampler2DShadow", Texture2D.class, Texture.class),
+    Texture3D(false, true, "sampler3D", Texture3D.class, Texture.class),
+    TextureArray(false, true, "sampler2DArray|sampler2DArrayShadow", TextureArray.class, Texture.class),
+    TextureCubeMap(false, true, "samplerCube", TextureCubeMap.class, Texture.class),
+    Int("int", int.class, Integer.class), 
+    BufferObject(false, false, "custom", BufferObject.class);
+
 
     private boolean usesMultiData = false;
     private boolean textureType = false;
-    final private String glslType;
-    private Class<?> javaTypes[];
+    private final String glslType;
+    private Class<?>[] javaTypes;
     
-    VarType(String glslType,Class<?> ...javaTypes){
+    VarType(String glslType, Class<?>... javaTypes) {
         this.glslType = glslType;
         if (javaTypes != null) {
             this.javaTypes = javaTypes;
         } else {
             this.javaTypes = new Class<?>[0];
         }
-        
     }
-
 
     VarType(boolean multiData, boolean textureType, String glslType, Class<?>... javaTypes) {
         usesMultiData = multiData;
@@ -95,19 +104,20 @@ public enum VarType {
      * @param o Object to check
      * @return true if the object type is mapped to this VarType
      */
-    public boolean isOfType(Object o){
-        for(Class<?> c : javaTypes){
-            if(c.isAssignableFrom(o.getClass()))return true;
+    public boolean isOfType(Object o) {
+        for (Class<?> c : javaTypes) {
+            if (c.isAssignableFrom(o.getClass())) {
+                return true;
+            }
         }
         return false;
     }
-    
 
     /**
      * Get the java types mapped to this VarType
      * @return an array of classes mapped to this VarType
      */
-    public Class<?>[] getJavaType(){
+    public Class<?>[] getJavaType() {
         return javaTypes;
     }
 
@@ -121,6 +131,6 @@ public enum VarType {
 
     public String getGlslType() {
         return glslType;
-    }    
+    }   
 
 }

--- a/jme3-core/src/main/java/com/jme3/shader/VarType.java
+++ b/jme3-core/src/main/java/com/jme3/shader/VarType.java
@@ -71,8 +71,9 @@ public enum VarType {
     TextureArray(false, true, "sampler2DArray|sampler2DArrayShadow", TextureArray.class, Texture.class),
     TextureCubeMap(false, true, "samplerCube", TextureCubeMap.class, Texture.class),
     Int("int", int.class, Integer.class), 
-    BufferObject(false, false, "custom", BufferObject.class);
-
+    UniformBufferObject(false, false, "custom", BufferObject.class), 
+    ShaderStorageBufferObject(false, false, "custom", BufferObject.class);
+    
 
     private boolean usesMultiData = false;
     private boolean textureType = false;

--- a/jme3-core/src/main/java/com/jme3/shader/VarType.java
+++ b/jme3-core/src/main/java/com/jme3/shader/VarType.java
@@ -37,7 +37,7 @@ import com.jme3.math.Matrix4f;
 import com.jme3.math.Vector2f;
 import com.jme3.math.Vector3f;
 import com.jme3.math.Vector4f;
-import com.jme3.shader.BufferObject;
+import com.jme3.shader.bufferobject.BufferObject;
 import com.jme3.texture.Texture;
 import com.jme3.texture.Texture2D;
 import com.jme3.texture.Texture3D;


### PR DESCRIPTION
`VarType.Boolean`: reorder the list of `javaTypes` in accordance with `Float` and `Int`

- format code
- update License year

```java
// before
Float("float", float.class, Float.class), 
Int("int", int.class, Integer.class), 
Boolean("bool", Boolean.class, boolean.class), //<----
```

```java
// after
Float("float", float.class, Float.class), 
Int("int", int.class, Integer.class), 
Boolean("bool", boolean.class, Boolean.class), //<----
```