### PR TITLE
build.gradle:  update Gradle version to match gradle-wrapper.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -283,7 +283,7 @@ if (skipPrebuildLibraries != "true" && buildNativeProjects != "true") {
 //}
 
 wrapper {
-    gradleVersion = '7.6.2'
+    gradleVersion = '7.6.4'
 }
 
 


### PR DESCRIPTION
After PR #2197 (updating the Gradle version in gradle/wrapper/gradle-wrapper.properties) was integrated, @llzen44 pointed out that a Gradle version is also coded in the project's top-level build script.

I'm not 100% certain, but I assume this code is in case someone executes a "gradlew wrapper" command without specifying the desired version.

For the sake of consistency, this PR updates the top-level build script to specify the same version as gradle/wrapper/gradle-wrapper.properties