### PR TITLE
Fix render states merging when additionalState is not set

### DIFF
--- a/jme3-core/src/main/java/com/jme3/material/Material.java
+++ b/jme3-core/src/main/java/com/jme3/material/Material.java
@@ -907,22 +907,23 @@ public class Material implements CloneableSmartAsset, Cloneable, Savable {
 
 
     private void updateRenderState(Geometry geometry, RenderManager renderManager, Renderer renderer, TechniqueDef techniqueDef) {
+        RenderState finalRenderState;
         if (renderManager.getForcedRenderState() != null) {
-            mergedRenderState.copyFrom(renderManager.getForcedRenderState());
+            finalRenderState = mergedRenderState.copyFrom(renderManager.getForcedRenderState());
         } else if (techniqueDef.getRenderState() != null) {
-            mergedRenderState.copyFrom(RenderState.DEFAULT);
-            techniqueDef.getRenderState().copyMergedTo(additionalState, mergedRenderState);
+            finalRenderState = mergedRenderState.copyFrom(RenderState.DEFAULT);
+            finalRenderState = techniqueDef.getRenderState().copyMergedTo(additionalState, finalRenderState);
         } else {
-            mergedRenderState.copyFrom(RenderState.DEFAULT);
-            RenderState.DEFAULT.copyMergedTo(additionalState, mergedRenderState);
+            finalRenderState = mergedRenderState.copyFrom(RenderState.DEFAULT);
+            finalRenderState = RenderState.DEFAULT.copyMergedTo(additionalState, finalRenderState);
         }
         // test if the face cull mode should be flipped before render
-        if (mergedRenderState.isFaceCullFlippable() && isNormalsBackward(geometry.getWorldScale())) {
-            mergedRenderState.flipFaceCull();
+        if (finalRenderState.isFaceCullFlippable() && isNormalsBackward(geometry.getWorldScale())) {
+            finalRenderState.flipFaceCull();
         }
-        renderer.applyRenderState(mergedRenderState);
+        renderer.applyRenderState(finalRenderState);
     }
-    
+
     /**
      * Returns true if the geometry world scale indicates that normals will be backward.
      * @param scalar geometry world scale

--- a/jme3-core/src/main/java/com/jme3/material/RenderState.java
+++ b/jme3-core/src/main/java/com/jme3/material/RenderState.java
@@ -1692,7 +1692,7 @@ public class RenderState implements Cloneable, Savable {
      * This method is more precise than {@link #set(com.jme3.material.RenderState)}.
      * @param state state to copy from
      */
-    public void copyFrom(RenderState state) {
+    public RenderState copyFrom(RenderState state) {
         this.applyBlendMode = state.applyBlendMode;
         this.applyColorWrite = state.applyColorWrite;
         this.applyCullMode = state.applyCullMode;
@@ -1734,6 +1734,7 @@ public class RenderState implements Cloneable, Savable {
         this.sfactorRGB = state.sfactorRGB;
         this.stencilTest = state.stencilTest;
         this.wireframe = state.wireframe;
+        return this;
     }
 
     @Override


### PR DESCRIPTION
While testing some pbr code, i've noticed that something was off with lighting, after some convoluted debugging i've found that pr https://github.com/jMonkeyEngine/jmonkeyengine/commit/5975b3f791d18fae311a10e209b3ed40b5e5c60f introduced a bug.

The tl;dr is that copyMergedTo changes the passed state when additionalState is set, but returns `this` when it isn't, causing mergedRenderState to not be updated at all.

This PR restores the original behavior of passing the returned state to applyRenderState instead of mergedRenderState.