### PR TITLE
update Groovy to v3.0.21

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -43,7 +43,7 @@ dependencies {
     // Adding dependencies here will add the dependencies to each subproject.
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.12.4'
-    testImplementation 'org.codehaus.groovy:groovy-test:3.0.19'
+    testImplementation 'org.codehaus.groovy:groovy-test:3.0.21'
 }
 
 // Uncomment if you want to see the status of every test that is run and


### PR DESCRIPTION
The Engine uses Groovy solely for automated testing during builds.
This PR updates the buildscripts to use the latest release (dated 1 March 2024).