### PR TITLE
don't code the Gradle version in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -282,11 +282,6 @@ if (skipPrebuildLibraries != "true" && buildNativeProjects != "true") {
 //    }
 //}
 
-wrapper {
-    gradleVersion = '7.6.4'
-}
-
-
 retrolambda {
   javaVersion JavaVersion.VERSION_1_7
   incremental true


### PR DESCRIPTION
As discussed at PR #2207, the Engine currently codes the Gradle version in 2 places (build.gradle and gradle/wrapper/gradle-wrapper.properties).

As a result:
+ The Engine's procedure for updating Gradle differs from that described in Gradle release notes, requiring an extra step.
+ It's possible for the coded versions to get out of synch with one another, causing confusion about which version is used to build the Engine.

This PR deletes the "wrapper" block from build.gradle .

As a result:
+ The Engine's Gradle version is coded in a single, central place.
+ The upgrade procedure documented in Gradle release notes will suffice, but a simple "gradlew update" will not.

