### PR TITLE
Use precision qualifiers only in GL ES shaders

### DIFF
--- a/jme3-core/src/main/resources/Common/ShaderLib/GLSLCompat.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/GLSLCompat.glsllib
@@ -1,15 +1,16 @@
-#ifdef FRAGMENT_SHADER
-      precision highp float;
-      precision highp int;
-      precision highp sampler2DArray;
-      precision highp sampler2DShadow;
-      precision highp samplerCube;
-      precision highp sampler3D;
-      precision highp sampler2D;
-      #if __VERSION__ >= 310
-        precision highp sampler2DMS;
-      #endif
-
+#ifdef GL_ES
+  #ifdef FRAGMENT_SHADER
+    precision highp float;
+    precision highp int;
+    precision highp sampler2DArray;
+    precision highp sampler2DShadow;
+    precision highp samplerCube;
+    precision highp sampler3D;
+    precision highp sampler2D;
+    #if __VERSION__ >= 310
+      precision highp sampler2DMS;
+    #endif
+  #endif
 #endif
 
 #if defined GL_ES


### PR DESCRIPTION
Fix issue reported here: https://hub.jmonkeyengine.org/t/jmonkeyengine-v3-7-0-alpha2-release/47534

Some OpenGL drivers do not like precision qualifiers even if they should be supported as nop accordingly to the documentation