### PR TITLE
#2224 Fix bug where the clipRect would be left in the openGL state 

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
@@ -1246,6 +1246,12 @@ public class RenderManager {
         // clear any remaining spatials that were not rendered.
         clearQueue(vp);
 
+        /*
+         * the call to setCamera will indirectly cause a clipRect to be set, must be cleared to avoid surprising results
+         * if renderer#copyFrameBuffer is used later
+         */
+        renderer.clearClipRect();
+
         if (prof != null) {
             prof.vpStep(VpStep.EndRender, vp, null);
         }
@@ -1344,8 +1350,7 @@ public class RenderManager {
     /**
      * Returns the render filter that the RenderManager is currently using
      * 
-     * @param filter
-     *            the render filter
+     * @return the render filter
      */
     public Predicate<Geometry> getRenderFilter() {
         return renderFilter;


### PR DESCRIPTION
 Fix bug where the clipRect would be left in the openGL state leading to surprising (clipped) results when later using GLRenderer#copyFrameBuffer

closes #2224 