### PR TITLE
Special material classes

### DIFF
--- a/jme3-core/src/main/java/com/jme3/material/NormalType.java
+++ b/jme3-core/src/main/java/com/jme3/material/NormalType.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.material;
+
+/**
+ * Represents a normal map convention.
+ * 
+ * @author codex
+ */
+public enum NormalType {
+    
+    /**
+     * Conforms to OpenGL normal map convention (green=Y+).
+     */
+    OpenGL("OpenGL", 1),
+    
+    /**
+     * Conforms to DirectX normal map convention (green=Y-).
+     */
+    DirectX("DirectX", -1);
+    
+    private final String name;
+    private final int value;
+    
+    private NormalType(String name, int value) {
+        this.name = name;
+        this.value = value;
+    }
+    
+    /**
+     * Returns the name of the normal type.
+     * 
+     * @return 
+     */
+    public String getName() {
+        return name;
+    }
+    
+    /**
+     * Returns the value of the normal type that can be applied to materials.
+     * 
+     * @return 
+     */
+    public int getValue() {
+        return value;
+    }
+    
+    /**
+     * Applies the value held to the material.
+     * 
+     * @param mat 
+     */
+    public void apply(Material mat) {
+        mat.setFloat("NormalType", value);
+    }
+    
+}

--- a/jme3-core/src/main/java/com/jme3/material/PBRMaterial.java
+++ b/jme3-core/src/main/java/com/jme3/material/PBRMaterial.java
@@ -1,0 +1,539 @@
+/*
+ * Copyright (c) 2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.material;
+
+import com.jme3.asset.AssetManager;
+import com.jme3.math.ColorRGBA;
+import com.jme3.texture.Texture;
+
+/**
+ * Material using PBRLighting.j3md.
+ * 
+ * @author codex
+ */
+public class PBRMaterial extends Material {
+    
+    /**
+     * Creates material with PBRLighting.j3md.
+     * 
+     * @param assetManager 
+     */
+    public PBRMaterial(AssetManager assetManager) {
+        super(assetManager, "Common/MatDefs/Light/PBRLighting.j3md");
+    }
+    
+    /****************
+     *   TEXTURES   *
+     ****************/
+    
+    /**
+     * Sets the base color map.
+     * <p>
+     * Also known as albedo or diffuse. This defines the base color used to shade
+     * the geometry.
+     * <p>
+     * default=null
+     * 
+     * @param baseColorMap 
+     */
+    public void setBaseColorMap(Texture baseColorMap) {
+        setTexture("BaseColorMap", baseColorMap);
+    }
+    
+    /**
+     * Sets the metallic map.
+     * <p>
+     * Defines how metallic the geometry will appear when shaded.
+     * <p>
+     * default=null
+     * 
+     * @param metallicMap 
+     */
+    public void setMetallicMap(Texture metallicMap) {
+        setTexture("MetallicMap", metallicMap);
+    }
+    
+    /**
+     * Sets the roughness map.
+     * <p>
+     * Defines how able the geometry can reflect light. Low values cleanly
+     * reflect light directed at them, while high values greatly diffuse the light.
+     * <p>
+     * default=null
+     * 
+     * @param roughnessMap 
+     */
+    public void setRoughnessMap(Texture roughnessMap) {
+        setTexture("RoughnessMap", roughnessMap);
+    }
+    
+    /**
+     * Sets the metallic-roughness map.
+     * <p>
+     * Defines both the metallic and roughness properties.
+     * <p>
+     * The channels are assigned as follows:
+     * <ul>
+     *  <li>red = ambient occlusion (if {@link #packAOInMetallicRoughnessMap(boolean)} is set to true.
+     *  <li>green = roughness
+     *  <li>blue = metallic
+     * </ul>
+     * Alpha channel is not assigned.
+     * <p>
+     * default=null
+     * 
+     * @param metallicRoughnessMap 
+     * @see #setMetallicMap(com.jme3.texture.Texture)
+     * @see #setRoughnessMap(com.jme3.texture.Texture) 
+     */
+    public void setMetallicRoughnessMap(Texture metallicRoughnessMap) {
+        setTexture("MetallicRoughnessMap", metallicRoughnessMap);
+    }
+    
+    /**
+     * Sets the emissive map.
+     * <p>
+     * Defines where the geometry "emits light". Emission areas are not affected
+     * by light sources (or the lack thereof).
+     * <p>
+     * default=null
+     * 
+     * @param emissiveMap 
+     */
+    public void setEmissiveMap(Texture emissiveMap) {
+        setTexture("EmissiveMap", emissiveMap);
+    }
+    
+    /**
+     * Sets the normal map.
+     * <p>
+     * Simulates fake bumpiness on the geometry by altering normals per-pixel.
+     * <p>
+     * default=null
+     * 
+     * @param normalMap 
+     */
+    public void setNormalMap(Texture normalMap) {
+        setTexture("NormalMap", normalMap);
+    }
+    
+    /**
+     * Sets the normal map and normal map type.
+     * 
+     * @param normalMap
+     * @param normalType 
+     * @see #setNormalMap(com.jme3.texture.Texture)
+     * @see #setNormalMapType(com.jme3.material.NormalType)
+     */
+    public void setNormalMap(Texture normalMap, NormalType normalType) {
+        setNormalMap(normalMap);
+        setNormalMapType(normalType);
+    }
+    
+    /**
+     * Sets the specular map.
+     * <p>
+     * Specular defines the color where light takes exactly one bounce off the geometry
+     * to reach the camera.
+     * <p>
+     * default=null
+     * 
+     * @param specularMap 
+     */
+    public void setSpecularMap(Texture specularMap) {
+        setTexture("SpecularMap", specularMap);
+    }
+    
+    /**
+     * Sets the glossiness map.
+     * <p>
+     * default=null
+     * 
+     * @param glossMap 
+     */
+    public void setGlossinessMap(Texture glossMap) {
+        setTexture("GlossinessMap", glossMap);
+    }
+    
+    /**
+     * Sets the specular-glossiness map.
+     * <p>
+     * Defines both the specular and glossiness properties.
+     * <p>
+     * The channels are assigned as follows:
+     * <ul>
+     *  <li>red, green, and blue = specular
+     *  <li>alpha = glossiness
+     * </ul>
+     * <p>
+     * default=null
+     * 
+     * @param specGlossMap 
+     */
+    public void setSpecularGlossinessMap(Texture specGlossMap) {
+        setTexture("SpecularGlossinessMap", specGlossMap);
+    }
+    
+    /**
+     * Sets the parallax map.
+     * <p>
+     * Parallax attempts to simulate deeper crevices in the geometry than normal maps
+     * by altering texture coordinates and normals per-pixel.
+     * <p>
+     * default=null
+     * 
+     * @param parallaxMap 
+     */
+    public void setParallaxMap(Texture parallaxMap) {
+        setTexture("ParallaxMap", parallaxMap);
+    }
+    
+    /**
+     * Sets the light map.
+     * <p>
+     * Defines where the geometry is exposed to light. This is mainly used with
+     * baked illumination for static scenes.
+     * <p>
+     * default=null
+     * 
+     * @param lightMap 
+     */
+    public void setLightMap(Texture lightMap) {
+        setTexture("LightMap", lightMap);
+    }
+    
+    /**************
+     *   COLORS   *
+     **************/
+    
+    /**
+     * Sets the base color.
+     * <p>
+     * Defines the base color of the geometry before shading.
+     * <p>
+     * default=(1.0, 1.0, 1.0, 1.0)
+     * 
+     * @param baseColor 
+     */
+    public void setBaseColor(ColorRGBA baseColor) {
+        setColor("BaseColor", baseColor);
+    }
+    
+    /**
+     * Sets the emissive color.
+     * <p>
+     * Defines the color of "light" the entire geometry emits. If this parameter is
+     * not null, the geometry is unaffected by light sources (or the lack thereof).
+     * <p>
+     * default=null
+     * 
+     * @param emissiveColor 
+     */
+    public void setEmissiveColor(ColorRGBA emissiveColor) {
+        setColor("Emissive", emissiveColor);
+    }
+    
+    /**
+     * Sets the specular color.
+     * <p>
+     * Defines the color where light takes exactly one bounce off the geometry
+     * to reach the camera.
+     * <p>
+     * default=(1.0, 1.0, 1.0, 1.0)
+     * 
+     * @param specColor 
+     */
+    public void setSpecularColor(ColorRGBA specColor) {
+        setColor("Specular", specColor);
+    }
+    
+    /**************
+     *   FLOATS   *
+     **************/
+    
+    /**
+     * Sets the alpha discard threshold.
+     * <p>
+     * Pixels with an alpha value below this threshold will be discarded.
+     * <p>
+     * default=null
+     * 
+     * @param alphaDiscard 
+     */
+    public void setAlphaDiscardThreshold(Float alphaDiscard) {
+        setFloat("AlphaDiscardThreshold", alphaDiscard);
+    }
+    
+    /**
+     * Sets the metallic value.
+     * <p>
+     * Defines how metallic the geometry will look when shaded.
+     * <p>
+     * default=1.0
+     * 
+     * @param metallic 
+     */
+    public void setMetallic(Float metallic) {
+        setFloat("Metallic", metallic);
+    }
+    
+    /**
+     * Sets the roughness value.
+     * <p>
+     * Defines how able the geometry can reflect light. Low values cleanly
+     * reflect light directed at them, while high values greatly diffuse the light.
+     * <p>
+     * default=1.0
+     * 
+     * @param roughness 
+     */
+    public void setRoughness(Float roughness) {
+        setFloat("Roughness", roughness);
+    }
+    
+    /**
+     * Sets the emissive power value.
+     * <p>
+     * Defines the power of "light" emitted from the geometry. This often puts colors
+     * resulting into HDR, which is important for HDR-dependent filters such as ToneMapFilter.
+     * <p>
+     * default=3.0
+     * 
+     * @param emissivePower 
+     */
+    public void setEmissivePower(Float emissivePower) {
+        setFloat("EmissivePower", emissivePower);
+    }
+    
+    /**
+     * Sets the emissive intensity value.
+     * <p>
+     * Defines the intensity of "light" emitted from the geometry. This often puts resulting
+     * colors into HDR, which is important for HDR-dependent filters such as ToneMapFilter.
+     * <p>
+     * default=2.0
+     * 
+     * @param emissiveIntensity 
+     */
+    public void setEmissiveIntensity(Float emissiveIntensity) {
+        setFloat("EmissiveIntensity", emissiveIntensity);
+    }
+    
+    /**
+     * Sets the glossiness value.
+     * <p>
+     * default=1.0
+     * 
+     * @param gloss 
+     */
+    public void setGlossiness(Float gloss) {
+        setFloat("Glossiness", gloss);
+    }
+    
+    /**
+     * Sets the specular anti-aliasing screen-space variance.
+     * <p>
+     * default=null
+     * 
+     * @param sigma 
+     */
+    public void setSpecAntiAliasingVariance(Float sigma) {
+        setFloat("SpecularAASigma", sigma);
+    }
+    
+    /**
+     * Sets the specular anti-aliasing clamping threshold.
+     * <p>
+     * default=null
+     * 
+     * @param kappa 
+     */
+    public void setSpecAntiAliasingClamp(Float kappa) {
+        setFloat("SpecularAAKappa", kappa);
+    }
+    
+    /**
+     * Sets the parallax height.
+     * <p>
+     * default=0.05
+     * 
+     * @param parallaxHeight 
+     */
+    public void setParallaxHeight(Float parallaxHeight) {
+        setFloat("ParallaxHeight", parallaxHeight);
+    }
+    
+    /**
+     * Sets the ambient occlusion strength.
+     * <p>
+     * Zero results in no occlusion; one results in full occlusion.
+     * <p>
+     * default=null
+     * 
+     * @param aoStrength 
+     */
+    public void setAmbientOcclusionStrength(Float aoStrength) {
+        setFloat("AoStrength", aoStrength);
+    }
+    
+    /****************
+     *   BOOLEANS   *
+     ****************/
+    
+    /**
+     * Enables using the specular-glossiness map over the individual maps.
+     * <p>
+     * default=false
+     * 
+     * @param specGloss 
+     */
+    public void useSpecGlossPipeline(Boolean specGloss) {
+        setBoolean("UseSpecGloss", specGloss);
+    }
+    
+    /**
+     * Enables specular anti-aliasing.
+     * <p>
+     * default=true
+     * 
+     * @param specAA 
+     */
+    public void useSpecularAA(Boolean specAA) {
+        setBoolean("UseSpecularAA", specAA);
+    }
+    
+    /**
+     * If true, parallax values will be read from the alpha channel of the normal map,
+     * if it exists, instead of the dedicated parallax map.
+     * <p>
+     * default=false
+     * 
+     * @param packNormParallax 
+     */
+    public void usePackedNormalParallax(Boolean packNormParallax) {
+        setBoolean("PackedNormalParallax", packNormParallax);
+    }
+    
+    /**
+     * Enables using steep parallax as opposed to classic parallax.
+     * <p>
+     * Steep parallax produces better results, but is slower than classic parallax.
+     * <p>
+     * default=false
+     * 
+     * @param steepParallax 
+     */
+    public void useSteepParallax(Boolean steepParallax) {
+        setBoolean("SteepParallax", steepParallax);
+    }
+    
+    /**
+     * Enables horizon fading.
+     * <p>
+     * default=false
+     * 
+     * @param horizonFade 
+     */
+    public void useHorizonFade(Boolean horizonFade) {
+        setBoolean("HorizonFade", horizonFade);
+    }
+    
+    /**
+     * Enables use of a seperate texture coordinate (TexCoord2 buffer) for the light map.
+     * <p>
+     * default=false
+     * 
+     * @param seperateTexCoord 
+     */
+    public void useSeperateTexCoord(Boolean seperateTexCoord) {
+        setBoolean("SeperateTexCoord", seperateTexCoord);
+    }
+    
+    /**
+     * If true, ambient occlusion will be read from the light map.
+     * <p>
+     * default=false
+     * 
+     * @param lightAsAO 
+     */
+    public void useLightMapForAmbientOcclusion(Boolean lightAsAO) {
+        setBoolean("LightMapAsAOMap", lightAsAO);
+    }
+    
+    /**
+     * If true, ambient occlusion will be read from the red channel of the
+     * metallic-roughness map.
+     * <p>
+     * default=false
+     * 
+     * @param packAOInMR 
+     */
+    public void packAOInMetallicRoughnessMap(Boolean packAOInMR) {
+        setBoolean("AOPackedInMRMap", packAOInMR);
+    }
+    
+    /**
+     * Enables instancing.
+     * <p>
+     * default=false
+     * 
+     * @param instancing 
+     */
+    public void useInstancing(Boolean instancing) {
+        setBoolean("UseInstancing", instancing);
+    }
+    
+    /**
+     * Enables vertex colors (Color buffer).
+     * 
+     * @param vertColors 
+     */
+    public void useVertexColors(Boolean vertColors) {
+        setBoolean("UseVertexColors", vertColors);
+    }
+    
+    /*************
+     *   OTHER   *
+     *************/
+    
+    /**
+     * Sets the normal map convention used to calculate normals from the normal map.
+     * <p>
+     * default={@link NormalType#OpenGL}
+     * 
+     * @param normalType 
+     */
+    public void setNormalMapType(NormalType normalType) {
+        normalType.apply(this);
+    }
+    
+}

--- a/jme3-core/src/main/java/com/jme3/material/PBRMaterial.java
+++ b/jme3-core/src/main/java/com/jme3/material/PBRMaterial.java
@@ -48,7 +48,7 @@ public class PBRMaterial extends Material {
      * @param assetManager 
      */
     public PBRMaterial(AssetManager assetManager) {
-        super(assetManager, "Common/MatDefs/Light/PBRLighting.j3md");
+        super(assetManager, Materials.PBR);
     }
     
     /****************

--- a/jme3-core/src/main/java/com/jme3/material/PhongMaterial.java
+++ b/jme3-core/src/main/java/com/jme3/material/PhongMaterial.java
@@ -51,7 +51,7 @@ public class PhongMaterial extends Material {
      * @param assetManager 
      */
     public PhongMaterial(AssetManager assetManager) {
-        super(assetManager, "Common/MatDefs/Light/Lighting.j3md");
+        super(assetManager, Materials.LIGHTING);
     }
     
     /**

--- a/jme3-core/src/main/java/com/jme3/material/PhongMaterial.java
+++ b/jme3-core/src/main/java/com/jme3/material/PhongMaterial.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.material;
+
+import com.jme3.asset.AssetManager;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.Vector3f;
+import com.jme3.shader.VarType;
+import com.jme3.texture.Texture;
+import com.jme3.texture.TextureCubeMap;
+
+/**
+ * Material using Lighting.j3md.
+ * 
+ * @author codex
+ */
+public class PhongMaterial extends Material {
+    
+    /**
+     * Creates material with Lighting.j3md.
+     * 
+     * @param assetManager 
+     */
+    public PhongMaterial(AssetManager assetManager) {
+        super(assetManager, "Common/MatDefs/Light/Lighting.j3md");
+    }
+    
+    /**
+     * Sets the diffuse map.
+     * <p>
+     * Also known as albedo or base color. This defines the basic color of the geometry.
+     * <p>
+     * default=null
+     * 
+     * @param diffuseMap 
+     */
+    public void setDiffuseMap(Texture diffuseMap) {
+        setTexture("DiffuseMap", diffuseMap);
+    }
+    
+    /**
+     * Sets the normal map.
+     * <p>
+     * Simulates fake bumpiness on the geometry by altering normals per-pixel.
+     * <p>
+     * default=null
+     * 
+     * @param normalMap 
+     */
+    public void setNormalMap(Texture normalMap) {
+        setTexture("NormalMap", normalMap);
+    }
+    
+    /**
+     * Sets the normal map and normal map type.
+     * 
+     * @param normalMap
+     * @param normalType 
+     * @see #setNormalMap(com.jme3.texture.Texture)
+     * @see #setNormalMapType(com.jme3.material.NormalType)
+     */
+    public void setNormalMap(Texture normalMap, NormalType normalType) {
+        setNormalMap(normalMap);
+        setNormalMapType(normalType);
+    }
+    
+    /**
+     * Sets the specular map.
+     * <p>
+     * Specular defines the color where light takes exactly one bounce off the geometry
+     * to reach the camera.
+     * <p>
+     * default=null
+     * 
+     * @param specMap 
+     */
+    public void setSpecularMap(Texture specMap) {
+        setTexture("SpecularMap", specMap);
+    }
+    
+    /**
+     * Sets the parallax map.
+     * <p>
+     * Parallax attempts to simulate deeper crevices in the geometry than normal maps
+     * by altering texture coordinates and normals per-pixel.
+     * <p>
+     * default=null
+     * 
+     * @param parallaxMap 
+     */
+    public void setParallaxMap(Texture parallaxMap) {
+        setTexture("ParallaxMap", parallaxMap);
+    }
+    
+    /**
+     * Sets the alpha map.
+     * <p>
+     * Alters the alpha output by multiplying the alpha by this map's red channel.
+     * <p>
+     * default=null
+     * 
+     * @param alphaMap 
+     */
+    public void setAlphaMap(Texture alphaMap) {
+        setTexture("AlphaMap", alphaMap);
+    }
+    
+    /**
+     * Sets the color ramp texture.
+     * <p>
+     * The diffuse and specular colors in the shader are multiplied by this texture.
+     * This is useful for producing toon-style effects.
+     * <p>
+     * default=null
+     * 
+     * @param colorRamp 
+     */
+    public void setColorRamp(Texture colorRamp) {
+        setTexture("ColorRamp", colorRamp);
+    }
+    
+    /**
+     * Sets the glow map.
+     * <p>
+     * Defines which sections of the geometry glow with BloomFilter.
+     * <p>
+     * default=null
+     * 
+     * @param glowMap 
+     */
+    public void setGlowMap(Texture glowMap) {
+        setTexture("GlowMap", glowMap);
+    }
+    
+    /**
+     * Sets the light map.
+     * <p>
+     * Defines which areas of the geometry are under light. Used mainly for baked
+     * illumination on static scenes.
+     * <p>
+     * default=null
+     * 
+     * @param lightMap 
+     */
+    public void setLightMap(Texture lightMap) {
+        setTexture("LightMap", lightMap);
+    }
+    
+    /**
+     * Sets the environment map used to simulate reflections.
+     * <p>
+     * default=null
+     * 
+     * @param envMap 
+     */
+    public void setEnvironmentMap(TextureCubeMap envMap) {
+        setParam("EnvMap", VarType.TextureCubeMap, envMap);
+    }
+    
+    /**
+     * Sets the ambient light color.
+     * <p>
+     * Faces not under direct light will be influenced by this color.
+     * <p>
+     * default=null
+     * 
+     * @param ambient 
+     */
+    public void setAmbientColor(ColorRGBA ambient) {
+        setColor("Ambient", ambient);
+    }
+    
+    /**
+     * Sets the diffuse color.
+     * <p>
+     * Defines the base color used to shade the geometry.
+     * <p>
+     * default=null
+     * 
+     * @param diffuse 
+     */
+    public void setDiffuseColor(ColorRGBA diffuse) {
+        setColor("Diffuse", diffuse);
+    }
+    
+    /**
+     * Sets the specular color.
+     * <p>
+     * Defines the color where light takes exactly one bounce off the geometry
+     * to reach the camera.
+     * <p>
+     * default=null
+     * 
+     * @param specular 
+     */
+    public void setSpecularColor(ColorRGBA specular) {
+        setColor("Specular", specular);
+    }
+    
+    /**
+     * Sets the color the whole geometry will glow with BloomFilter.
+     * <p>
+     * default=null
+     * 
+     * @param glow 
+     */
+    public void setGlowColor(ColorRGBA glow) {
+        setColor("GlowColor", glow);
+    }
+    
+    /**
+     * Sets the alpha discard threshold.
+     * <p>
+     * Pixels with alpha below the threshold will be discarded.
+     * <p>
+     * default=null
+     * 
+     * @param threshold 
+     */
+    public void setAlphaDiscardThreshold(Float threshold) {
+        setFloat("AlphaDiscardThreshold", threshold);
+    }
+    
+    /**
+     * Sets the shininess, or how easily the geometry reflects light.
+     * <p>
+     * default=1.0
+     * 
+     * @param shininess 
+     */
+    public void setShininess(Float shininess) {
+        setFloat("Shininess", shininess);
+    }
+    
+    /**
+     * Sets the height of the parallax effect.
+     * <p>
+     * default=0.05
+     * 
+     * @param parallaxHeight 
+     */
+    public void setParallaxHeight(Float parallaxHeight) {
+        setFloat("ParallaxHeight", parallaxHeight);
+    }
+    
+    /**
+     * Enables lighting by vertex.
+     * <p>
+     * default=false
+     * 
+     * @param vertLighting 
+     */
+    public void useVertexLighting(boolean vertLighting) {
+        setBoolean("VertexLighting", vertLighting);
+    }
+    
+    /**
+     * If true, {@link ColorRGBA} parameters are favored over map parameters,
+     * and vise versa for false.
+     * <p>
+     * In order to use {@link #setDiffuseColor(com.jme3.math.ColorRGBA)},
+     * {@link #setSpecularColor(com.jme3.math.ColorRGBA)}, etc., this value must
+     * be true. Otherwise maps will be used.
+     * <p>
+     * default=false
+     * 
+     * @param matColors 
+     */
+    public void useMaterialColors(boolean matColors) {
+        setBoolean("UseMaterialColors", matColors);
+    }
+    
+    /**
+     * Enables coloring by vertex attributes (Color buffer).
+     * <p>
+     * default=false
+     * 
+     * @param vertColors 
+     */
+    public void useVertexColors(boolean vertColors) {
+        setBoolean("UseVertexColors", vertColors);
+    }
+    
+    /**
+     * Enables steep parallax algorithm.
+     * <p>
+     * Produces better results at the cost of performance.
+     * <p>
+     * default=false
+     * 
+     * @param steepParallax 
+     */
+    public void useSteepParallax(boolean steepParallax) {
+        setBoolean("SteepParallax", steepParallax);
+    }
+    
+    /**
+     * Sets the environment map to be treated as a sphere.
+     * <p>
+     * default=false
+     * 
+     * @param sphere 
+     */
+    public void useEnvironmentMapAsSphere(boolean sphere) {
+        setBoolean("EnvMapAsSphereMap", sphere);
+    }
+    
+    /**
+     * Enables instancing.
+     * <p>
+     * default=false
+     * 
+     * @param instancing 
+     */
+    public void useInstancing(boolean instancing) {
+        setBoolean("UseInstancing", instancing);
+    }
+    
+    /**
+     * Sets the fresnel parameters.
+     * <p>
+     * The arguments are combined into a {@link Vector3f}.
+     * <p>
+     * default=null (Vector3f)
+     * 
+     * @param bias
+     * @param scale
+     * @param power
+     * @return combined Vector3f
+     */
+    public Vector3f setFresnel(float bias, float scale, float power) {
+        Vector3f params = new Vector3f(bias, scale, power);
+        setVector3("FresnelParams", params);
+        return params;
+    }
+    
+    /**
+     * Sets the fresnel parameters
+     * <p>
+     * default=null
+     * 
+     * @param params 
+     */
+    public void setFresnel(Vector3f params) {
+        setVector3("FresnelParams", params);
+    }
+    
+    /**
+     * Sets the normal map type.
+     * <p>
+     * default={@link NormalType#OpenGL}
+     * 
+     * @param normalType 
+     */
+    public void setNormalMapType(NormalType normalType) {
+        normalType.apply(this);
+    }
+    
+}

--- a/jme3-core/src/main/java/com/jme3/material/UnshadedMaterial.java
+++ b/jme3-core/src/main/java/com/jme3/material/UnshadedMaterial.java
@@ -1,0 +1,134 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package com.jme3.material;
+
+import com.jme3.asset.AssetManager;
+import com.jme3.math.ColorRGBA;
+import com.jme3.texture.Texture;
+
+/**
+ * Material using Unshaded.j3md.
+ * 
+ * @author codex
+ */
+public class UnshadedMaterial extends Material {
+    
+    /**
+     * Creates a material with Unshaded.j3md.
+     * 
+     * @param assetManager 
+     */
+    public UnshadedMaterial(AssetManager assetManager) {
+        super(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+    }
+    
+    /**
+     * Sets the color map.
+     * <p>
+     * Defines the base color of the geometry.
+     * <p>
+     * default=null
+     * 
+     * @param colorMap 
+     */
+    public void setColorMap(Texture colorMap) {
+        setTexture("ColorMap", colorMap);
+    }
+    
+    /**
+     * Sets the light map.
+     * <p>
+     * Defines which areas of the geometry are under light. Used mainly for baked
+     * illumination on static scenes.
+     * <p>
+     * default=null
+     * 
+     * @param lightMap 
+     */
+    public void setLightMap(Texture lightMap) {
+        setTexture("LightMap", lightMap);
+    }
+    
+    /**
+     * Sets the glow map.
+     * <p>
+     * Defines which sections of the geometry glow with BloomFilter.
+     * <p>
+     * default=null
+     * 
+     * @param glowMap 
+     */
+    public void setGlowMap(Texture glowMap) {
+        setTexture("GlowMap", glowMap);
+    }
+    
+    /**
+     * Sets the main color of the geometry.
+     * 
+     * @param color 
+     */
+    public void setColor(ColorRGBA color) {
+        setColor("Color", color);
+    }
+    
+    /**
+     * Sets the color the whole geometry will glow with BloomFilter.
+     * <p>
+     * default=null
+     * 
+     * @param glow 
+     */
+    public void setGlowColor(ColorRGBA glow) {
+        setColor("GlowColor", glow);
+    }
+    
+    /**
+     * Sets the size each individual vertex is render as with
+     * {@link com.jme3.scene.Mesh.Mode#Points}.
+     * 
+     * @param pointSize 
+     */
+    public void setPointSize(float pointSize) {
+        setFloat("PointSize", pointSize);
+    }
+    
+    /**
+     * Sets the color desaturation value.
+     * 
+     * @param value 
+     */
+    public void setDesaturationValue(float value) {
+        setFloat("DesaturationValue", value);
+    }
+    
+    /**
+     * Enables coloring by vertex attributes (Color mesh buffer).
+     * 
+     * @param vertColors 
+     */
+    public void useVertexColors(boolean vertColors) {
+        setBoolean("VertexColor", vertColors);
+    }
+    
+    /**
+     * If true, a seperate set of texture coordinates (TexCoord2 mesh buffer)
+     * will be used for the light map.
+     * 
+     * @param seperateTexCoord 
+     */
+    public void useSeperateTexCoord(boolean seperateTexCoord) {
+        setBoolean("SeperateTexCoord", seperateTexCoord);
+    }
+    
+    /**
+     * Enables instancing.
+     * 
+     * @param instancing 
+     */
+    public void useInstancing(boolean instancing) {
+        setBoolean("UseInstancing", instancing);
+    }
+    
+}

--- a/jme3-core/src/main/java/com/jme3/material/UnshadedMaterial.java
+++ b/jme3-core/src/main/java/com/jme3/material/UnshadedMaterial.java
@@ -21,7 +21,7 @@ public class UnshadedMaterial extends Material {
      * @param assetManager 
      */
     public UnshadedMaterial(AssetManager assetManager) {
-        super(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+        super(assetManager, Materials.UNSHADED);
     }
     
     /**


### PR DESCRIPTION
This PR adds 3 classes extending Material for PBRLighting, Lighting, and Unshaded matdefs. The goal is to make these matdefs as easy to use as possible, since they are used so often.