### PR TITLE
Logic code error (LwjglCanvas - LWJGL3)

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
@@ -497,7 +497,6 @@ public class LwjglCanvas extends LwjglWindow implements JmeCanvasContext, Runnab
         // This will activate the "effective data" scrubber.
         showGLDataEffective.set(settings.getBoolean("GLDataEffectiveDebug"));
         
-        glData.depthSize = settings.getBitsPerPixel();
         glData.alphaSize = settings.getAlphaBits();
         glData.sRGB = settings.isGammaCorrection(); // Not compatible with very old devices
         


### PR DESCRIPTION
This PR is to remove a '**redundancy'** in the size depth settings in **LwjglCanvas**

```java
...
[Line 500] glData.depthSize = settings.getBitsPerPixel();
...
[Line 504] glData.depthSize = settings.getDepthBits();
```

It doesn't cause any problems but it is better to clean it.