### PR TITLE
Bright and dark (ColorRGBA - Functions)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
+++ b/jme3-core/src/main/java/com/jme3/math/ColorRGBA.java
@@ -42,9 +42,19 @@ import java.io.IOException;
  * @version $Id: ColorRGBA.java,v 1.29 2007/09/09 18:25:14 irrisor Exp $
  */
 public final class ColorRGBA implements Savable, Cloneable, java.io.Serializable {
+    /** Saturation-gamma.*/
     static final float GAMMA = 2.2f;
-
+    /** UID for serialization.*/
     static final long serialVersionUID = 1;
+    
+    /** 
+     * Factor to make colors brighter or darker.
+     * 
+     * @see ColorRGBA#brighter(com.jme3.math.ColorRGBA) 
+     * @see ColorRGBA#darker(com.jme3.math.ColorRGBA) 
+     */
+    private static final float FACTOR = 0.7F;
+    
     /**
      * The color black (0,0,0).
      */
@@ -751,6 +761,44 @@ public final class ColorRGBA implements Savable, Cloneable, java.io.Serializable
         return new ColorRGBA(r / 255.0F, g / 255.0F, b / 255.0F, a / 255.0F);
     }
 
+    /**
+     * Returns a darker color than the current color.
+     * 
+     * @param color color.
+     * @return dark {@link com.jme3.math.ColorRGBA}.
+     */
+    public static final ColorRGBA darker(ColorRGBA color) {
+        return new ColorRGBA(Math.max(color.r * FACTOR, 0),
+                             Math.max(color.g * FACTOR, 0),
+                             Math.max(color.b * FACTOR, 0),
+                             color.a);
+    }
+    
+    /**
+     * Returns one more color with more brightness than the current color.
+     * 
+     * @param color color.
+     * @return A new {@link com.jme3.math.ColorRGBA} with a more intense shine.
+     */
+    public static final ColorRGBA brighter(ColorRGBA color) {
+        float r = color.r, g = color.g, b = color.b;        
+        float alpha = color.getAlpha();
+        
+        float i = ((1.0f/3.0f) * (1.0f-FACTOR));
+        if ( r == 0 && g == 0 && b == 0) {
+            return new ColorRGBA(i, i, i, alpha);
+        }
+        
+        if ( r > 0 && r < i ) r = i;
+        if ( g > 0 && g < i ) g = i;
+        if ( b > 0 && b < i ) b = i;
+        
+        return new ColorRGBA(Math.min(r/FACTOR, 1.0F),
+                             Math.min(g/FACTOR, 1.0F),
+                             Math.min(b/FACTOR, 1.0F),
+                             alpha);
+    }
+    
     /**
      * Transform this <code>ColorRGBA</code> to a <code>Vector3f</code> using
      * x = r, y = g, z = b. The Alpha value is not used.

--- a/jme3-examples/src/main/java/jme3test/math/ColorBrighterTest.java
+++ b/jme3-examples/src/main/java/jme3test/math/ColorBrighterTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2009-2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package jme3test.math;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.Quaternion;
+import com.jme3.math.Vector3f;
+import com.jme3.renderer.RenderManager;
+import com.jme3.renderer.ViewPort;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.control.AbstractControl;
+import com.jme3.scene.shape.Box;
+import com.jme3.system.AppSettings;
+
+/**
+ * Class where both the brightness and darkness of colors are tested.
+ * @author wil
+ */
+public class ColorBrighterTest extends SimpleApplication {
+    
+    public static void main(String[] args) {
+        ColorBrighterTest app = new ColorBrighterTest();
+        
+        AppSettings settings = new AppSettings(true);
+        settings.setResolution(1204, 756);
+        settings.setGammaCorrection(false);
+        
+        app.setShowSettings(false);
+        app.setSettings(settings);
+        app.start();
+    }
+    
+    @Override
+    public void simpleInitApp() {
+        ColorRGBA color = ColorRGBA.randomColor();
+
+        Geometry normal = getInstanceBox(color);
+        normal.addControl(new ColorControl(Vector3f.UNIT_X));
+        rootNode.attachChild(normal);
+
+        Geometry darker = getInstanceBox(ColorRGBA.darker(color));
+        darker.move(4, 0, 0);
+        darker.addControl(new ColorControl(Vector3f.UNIT_Y));
+        rootNode.attachChild(darker);
+
+        Geometry brighter = getInstanceBox(ColorRGBA.brighter(color));
+        brighter.move(-4, 0, 0);
+        brighter.addControl(new ColorControl(Vector3f.UNIT_Z));
+        rootNode.attachChild(brighter);
+    }
+
+    private Geometry getInstanceBox(ColorRGBA color) {
+        Box b = new Box(1, 1, 1);
+        Geometry geom = new Geometry("Box", b);
+
+        Material mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+        mat.setColor("Color", color);
+        geom.setMaterial(mat);
+        return geom;
+    }
+
+    class ColorControl extends AbstractControl {
+
+        Vector3f dir;
+        float angle = 0;
+
+        public ColorControl(Vector3f dir) {
+            this.dir = dir;
+        }
+        
+        @Override
+        protected void controlUpdate(float tpf) {
+            spatial.setLocalRotation(new Quaternion().fromAngleAxis(angle, dir));
+            angle += 5f * tpf;
+        }
+
+        @Override
+        protected void controlRender(RenderManager rm, ViewPort vp) { }        
+    }
+}


### PR DESCRIPTION
Hello everyone, this PR is about adding two new methods to the **ColorRGBA** class where you can make colors brighter or darker.

The difference between method `brighter()` and `get|setAsSrgb() `is the following:

- It is static (which makes it easier to call)
-  It doesn't saturate the color, just a brighter ("lighter") tone.

Also add an example class (**ColorBrighterTest**) so you can try it out.

[ **Some screenshots** ]

![Captura desde 2024-04-06 19-18-57](https://github.com/jMonkeyEngine/jmonkeyengine/assets/97632588/158afef9-30c3-4c08-bdb3-ed5a9135d08e)
![Captura desde 2024-04-06 19-19-10](https://github.com/jMonkeyEngine/jmonkeyengine/assets/97632588/7ac7c30d-ff98-449b-b4ed-726943b16bf6)

What do you think of this idea?


