### PR TITLE
MatParamTexture: duplicate variables, missing javadoc, exceptions

### DIFF
--- a/jme3-core/src/main/java/com/jme3/material/MatParamTexture.java
+++ b/jme3-core/src/main/java/com/jme3/material/MatParamTexture.java
@@ -81,7 +81,7 @@ public class MatParamTexture extends MatParam {
      * Sets the texture associated with this material parameter.
      *
      * @param value the texture object to set
-     * @throws IllegalArgumentException if the provided value is not a {@link Texture}
+     * @throws RuntimeException if the provided value is not a {@link Texture}
      */
     public void setTextureValue(Texture value) {
         setValue(value);

--- a/jme3-core/src/main/java/com/jme3/material/MatParamTexture.java
+++ b/jme3-core/src/main/java/com/jme3/material/MatParamTexture.java
@@ -86,22 +86,6 @@ public class MatParamTexture extends MatParam {
     public void setTextureValue(Texture value) {
         setValue(value);
     }
-    
-    /**
-     * Overrides the base class {@link MatParam#setValue(Object)} to allow null
-     * values.
-     *
-     * @param value the object to set as the value (must be a {@link Texture} or null)
-     * @throws IllegalArgumentException if the provided value is not a {@link Texture} and not null
-     */
-    @Override
-    public void setValue(Object value) {
-        if ((value == null) || value instanceof Texture) {
-            this.value = value;
-        } else {
-            throw new IllegalArgumentException("Value must be a Texture object");
-        }
-    }
 
     /**
      * Gets the required color space for this texture parameter.

--- a/jme3-core/src/main/java/com/jme3/material/MatParamTexture.java
+++ b/jme3-core/src/main/java/com/jme3/material/MatParamTexture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2024 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,51 +40,83 @@ import com.jme3.texture.Texture;
 import com.jme3.texture.image.ColorSpace;
 import java.io.IOException;
 
+/**
+ * A material parameter that holds a reference to a texture and its required color space.
+ * This class extends {@link MatParam} to provide texture specific functionalities.
+ */
 public class MatParamTexture extends MatParam {
 
-    private Texture texture;
     private ColorSpace colorSpace;
 
+    /**
+     * Constructs a new MatParamTexture instance with the specified type, name,
+     * texture, and color space.
+     *
+     * @param type       the type of the material parameter
+     * @param name       the name of the parameter
+     * @param texture    the texture associated with this parameter
+     * @param colorSpace the required color space for the texture
+     */
     public MatParamTexture(VarType type, String name, Texture texture, ColorSpace colorSpace) {
         super(type, name, texture);
-        this.texture = texture;
         this.colorSpace = colorSpace;
     }
 
+    /**
+     * Serialization only. Do not use.
+     */
     public MatParamTexture() {
     }
 
+    /**
+     * Retrieves the texture associated with this material parameter.
+     *
+     * @return the texture object
+     */
     public Texture getTextureValue() {
-        return texture;
-    }
-
-    public void setTextureValue(Texture value) {
-        this.value = value;
-        this.texture = value;
-    }
-    
-    @Override
-    public void setValue(Object value) {
-        if (!(value instanceof Texture)) {
-            throw new IllegalArgumentException("value must be a texture object");
-        }
-        this.value = value;
-        this.texture = (Texture) value;
+        return (Texture) getValue();
     }
 
     /**
+     * Sets the texture associated with this material parameter.
+     *
+     * @param value the texture object to set
+     * @throws IllegalArgumentException if the provided value is not a {@link Texture}
+     */
+    public void setTextureValue(Texture value) {
+        setValue(value);
+    }
+    
+    /**
+     * Overrides the base class {@link MatParam#setValue(Object)} to allow null
+     * values.
+     *
+     * @param value the object to set as the value (must be a {@link Texture} or null)
+     * @throws IllegalArgumentException if the provided value is not a {@link Texture} and not null
+     */
+    @Override
+    public void setValue(Object value) {
+        if ((value == null) || value instanceof Texture) {
+            this.value = value;
+        } else {
+            throw new IllegalArgumentException("Value must be a Texture object");
+        }
+    }
+
+    /**
+     * Gets the required color space for this texture parameter.
      * 
-     * @return the color space required by this texture param
+     * @return the required color space ({@link ColorSpace})
      */
     public ColorSpace getColorSpace() {
         return colorSpace;
     }
 
     /**
-     * Set to {@link ColorSpace#Linear} if the texture color space has to be forced to linear 
-     * instead of sRGB
+     * Set to {@link ColorSpace#Linear} if the texture color space has to be forced
+     * to linear instead of sRGB.
+     * 
      * @param colorSpace the desired color space
-     * @see ColorSpace
      */
     public void setColorSpace(ColorSpace colorSpace) {
         this.colorSpace = colorSpace;
@@ -94,17 +126,17 @@ public class MatParamTexture extends MatParam {
     public void write(JmeExporter ex) throws IOException {
         super.write(ex);
         OutputCapsule oc = ex.getCapsule(this);
-        oc.write(0, "texture_unit", -1);
-        oc.write(texture, "texture", null); // For backwards compatibility
-
         oc.write(colorSpace, "colorSpace", null);
+        // For backwards compatibility
+        oc.write(0, "texture_unit", -1);
+        oc.write((Texture) value, "texture", null);
     }
 
     @Override
     public void read(JmeImporter im) throws IOException {
         super.read(im);
         InputCapsule ic = im.getCapsule(this);
-        texture = (Texture) value;
         colorSpace = ic.readEnum("colorSpace", ColorSpace.class, null);
     }
+    
 }


### PR DESCRIPTION
This pull request addresses several issues with the `MatParamTexture` class:

* **Duplicate variable**: The `texture` variable is redundant as it's already stored in the inherited `value` variable. This PR removes the unnecessary texture field.
* **Missing Javadoc**: The class and its methods lacked proper documentation. This PR adds comprehensive Javadoc comments to improve code readability and maintainability.
* **Inconsistent null handling**: The behavior of `setValue` methods regarding null values differed. This PR modifies `setValue` to allow null values, aligning it with the behavior of `setTextureValue` and the superclass's `setValue`.

Key improvements:
* **Code simplification**: By removing the duplicate variable, the code becomes cleaner and easier to understand.
* **Improved documentation**: Clear Javadoc comments explain the class, its purpose, and how to use its methods.
* **Consistent null handling**: All setValue methods now allow null values, preventing unnecessary exceptions.

Overall, this PR enhances the MatParamTexture class by streamlining the code, providing proper documentation, and ensuring consistent behavior.

--Edit:
Instead of overriding `setValue` in `MatParamTexture`, we can leverage the existing behavior in the superclass. The superclass method likely performs type and value checking, making an override unnecessary in this case (see https://github.com/jMonkeyEngine/jmonkeyengine/pull/1797).