### PR TITLE
Cleans up warnings in jme3-desktop

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/app/AppletHarness.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/AppletHarness.java
@@ -68,7 +68,7 @@ public class AppletHarness extends Applet {
         return appToApplet.get(app);
     }
 
-    @SuppressWarnings("unchecked")
+    
     private void createCanvas(){
         AppSettings settings = new AppSettings(true);
 
@@ -107,7 +107,7 @@ public class AppletHarness extends Applet {
         JmeSystem.setLowPermissions(true);
 
         try{
-            Class clazz = Class.forName(appClass);
+            Class<?> clazz = Class.forName(appClass);
             app = (LegacyApplication) clazz.getDeclaredConstructor().newInstance();
         } catch (ClassNotFoundException
                 | InstantiationException

--- a/jme3-desktop/src/main/java/com/jme3/app/state/AWTComponentAppState.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/AWTComponentAppState.java
@@ -34,8 +34,6 @@ package com.jme3.app.state;
 import java.awt.Component;
 
 import com.jme3.app.Application;
-import com.jme3.app.state.AbstractAppState;
-import com.jme3.app.state.AppStateManager;
 import com.jme3.system.AWTFrameProcessor;
 import com.jme3.system.AWTTaskExecutor;
 

--- a/jme3-desktop/src/main/java/com/jme3/cursors/plugins/CursorLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/cursors/plugins/CursorLoader.java
@@ -95,6 +95,8 @@ public class CursorLoader implements AssetLoader {
         }
     }
 
+
+    // @SuppressWarnings("resource")
     private JmeCursor loadCursor(InputStream inStream) throws IOException {
 
         byte[] icoimages = new byte[0]; // new byte [0] facilitates read()
@@ -107,7 +109,7 @@ public class CursorLoader implements AssetLoader {
             int steps = 0;
             int width = 0;
             int height = 0;
-            int flag = 0; // we don't use that.
+            //int flag = 0; // we don't use that.
             int[] rate = null;
             int[] animSeq = null;
             ArrayList<byte[]> icons;
@@ -135,7 +137,7 @@ public class CursorLoader implements AssetLoader {
                             height = leIn.readInt();
                             leIn.skipBytes(8);
                             jiffy = leIn.readInt();
-                            flag = leIn.readInt();
+                            leIn.readInt(); // flag 
                             nextInt = leIn.readInt();
                         } else if (nextInt == 0x65746172) { // found a 'rate' of animation
 //                            System.out.println("we have 'rate'.");
@@ -207,8 +209,10 @@ public class CursorLoader implements AssetLoader {
                 return setJmeCursor(ciDat);
 
             } else if (riff == 0x58464952) {
+                ((LittleEndien) leIn).close();
                 throw new IllegalArgumentException("Big-Endian RIFX is not supported. Sorry.");
             } else {
+                ((LittleEndien) leIn).close();
                 throw new IllegalArgumentException("Unknown format.");
             }
         } else if (isCur || isIco) {

--- a/jme3-desktop/src/main/java/com/jme3/input/AWTInput.java
+++ b/jme3-desktop/src/main/java/com/jme3/input/AWTInput.java
@@ -35,8 +35,6 @@ import java.awt.Component;
 import java.util.Objects;
 
 import com.jme3.app.Application;
-import com.jme3.input.Input;
-import com.jme3.input.RawInputListener;
 import com.jme3.system.AWTContext;
 import com.jme3.system.AWTTaskExecutor;
 

--- a/jme3-desktop/src/main/java/com/jme3/system/AWTComponentRenderer.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/AWTComponentRenderer.java
@@ -185,10 +185,7 @@ public class AWTComponentRenderer {
     if (frameBuffer != null) {
       this.frameBuffer = frameBuffer;
     } else {
-      this.frameBuffer = new FrameBuffer(width, height, 1);
-      this.frameBuffer.setDepthBuffer(Image.Format.Depth);
-      this.frameBuffer.setColorBuffer(Image.Format.RGBA8);
-      this.frameBuffer.setSrgb(true);
+      this.frameBuffer = AWTUtils.getFrameBuffer(width, height, 1);
     }
 
     colorModel = ColorModel.getRGBdefault();
@@ -202,6 +199,7 @@ public class AWTComponentRenderer {
     this.component = destination;
     
   }
+
 
   /**
    * Initialize the component renderer.

--- a/jme3-desktop/src/main/java/com/jme3/system/AWTFrameProcessor.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/AWTFrameProcessor.java
@@ -49,13 +49,15 @@ import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.ViewPort;
 import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.texture.FrameBuffer;
-import com.jme3.texture.Image;
 
 /**
  * A frame processor that enables to render JMonkey frame buffer onto an AWT component.
  * <p>
- * This class is based on the <a href="http://www.oracle.com/technetwork/java/javase/overview/javafx-overview-2158620.html">JavaFX</a> original code provided by Alexander Brui (see <a href="https://github.com/JavaSaBr/JME3-JFX">JME3-FX</a>)
+ * This class is based on the
+ * <a href="http://www.oracle.com/technetwork/java/javase/overview/javafx-overview-2158620.html">JavaFX</a>
+ * original code provided by Alexander Brui (see <a href="https://github.com/JavaSaBr/JME3-JFX">JME3-FX</a>)
  * </p>
+ * 
  * @author Julien Seinturier - COMEX SA - <a href="http://www.seinturier.fr">http://www.seinturier.fr</a>
  * @author Alexander Brui (JavaSaBr)
  *
@@ -63,8 +65,7 @@ import com.jme3.texture.Image;
 public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener {
 
     public enum TransferMode {
-        ALWAYS,
-        ON_CHANGES
+        ALWAYS, ON_CHANGES
     }
 
     private Application application = null;
@@ -186,12 +187,13 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
 
     @Override
     public void setProfiler(AppProfiler profiler) {
-            // not implemented
+        // not implemented
     }
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        System.out.println("Property changed: "+evt.getPropertyName()+" "+evt.getOldValue()+" -> "+evt.getNewValue());
+        System.out.println("Property changed: " + evt.getPropertyName() + " " + evt.getOldValue() + " -> "
+                + evt.getNewValue());
     }
 
     public AWTFrameProcessor() {
@@ -199,13 +201,14 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
         askWidth = 1;
         askHeight = 1;
         main = true;
-        reshapeNeeded = new AtomicInteger(2);    
+        reshapeNeeded = new AtomicInteger(2);
     }
 
     /**
      * Notify about that the ratio was changed.
      *
-     * @param newValue the new value of the ratio.
+     * @param newValue
+     *            the new value of the ratio.
      */
     protected void notifyChangedRatio(Boolean newValue) {
         notifyComponentResized(destination.getWidth(), destination.getHeight(), newValue);
@@ -214,7 +217,8 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
     /**
      * Notify about that the height was changed.
      *
-     * @param newValue the new value of the height.
+     * @param newValue
+     *            the new value of the height.
      */
     protected void notifyChangedHeight(Number newValue) {
         notifyComponentResized(destination.getWidth(), newValue.intValue(), isPreserveRatio());
@@ -223,7 +227,8 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
     /**
      * Notify about that the width was changed.
      *
-     * @param newValue the new value of the width.
+     * @param newValue
+     *            the new value of the width.
      */
     protected void notifyChangedWidth(Number newValue) {
         notifyComponentResized(newValue.intValue(), destination.getHeight(), isPreserveRatio());
@@ -241,7 +246,8 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
     /**
      * Sets the application.
      *
-     * @param application the application.
+     * @param application
+     *            the application.
      */
     protected void setApplication(Application application) {
         this.application = application;
@@ -259,7 +265,8 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
     /**
      * Sets the destination.
      *
-     * @param destination the destination.
+     * @param destination
+     *            the destination.
      */
     protected void setDestination(Component destination) {
         this.destination = destination;
@@ -267,6 +274,7 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
 
     /**
      * Checks of existing destination.
+     * 
      * @return true if destination is exists.
      */
     protected boolean hasDestination() {
@@ -275,15 +283,16 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
 
     /**
      * Checks of existing application.
+     * 
      * @return true if destination is exists.
      */
     protected boolean hasApplication() {
         return application != null;
     }
 
-
     /**
      * Gets the frame transfer.
+     * 
      * @return the file transfer.
      */
     protected AWTComponentRenderer getFrameTransfer() {
@@ -293,7 +302,8 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
     /**
      * Sets the frame transfer.
      *
-     * @param frameTransfer the file transfer.
+     * @param frameTransfer
+     *            the file transfer.
      */
     protected void setFrameTransfer(AWTComponentRenderer frameTransfer) {
         this.frameTransfer = frameTransfer;
@@ -332,9 +342,12 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
     /**
      * Handle resizing.
      *
-     * @param newWidth  the new width.
-     * @param newHeight the new height.
-     * @param fixAspect true to fix the aspect ratio.
+     * @param newWidth
+     *            the new width.
+     * @param newHeight
+     *            the new height.
+     * @param fixAspect
+     *            true to fix the aspect ratio.
      */
     protected void notifyComponentResized(int newWidth, int newHeight, boolean fixAspect) {
 
@@ -385,8 +398,10 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
     /**
      * Bind this processor.
      *
-     * @param destination the destination.
-     * @param application the application.
+     * @param destination
+     *            the destination.
+     * @param application
+     *            the application.
      */
     public void bind(Component destination, Application application) {
         final RenderManager renderManager = application.getRenderManager();
@@ -406,9 +421,12 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
     /**
      * Bind this processor.
      *
-     * @param destination the destination.
-     * @param application the application.
-     * @param viewPort    the view port.
+     * @param destination
+     *            the destination.
+     * @param application
+     *            the application.
+     * @param viewPort
+     *            the view port.
      */
     public void bind(Component destination, Application application, ViewPort viewPort) {
         bind(destination, application, viewPort, true);
@@ -417,12 +435,17 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
     /**
      * Bind this processor.
      *
-     * @param destination the destination.
-     * @param application the application.
-     * @param viewPort    the view port.
-     * @param main        true if this processor is main.
+     * @param destination
+     *            the destination.
+     * @param application
+     *            the application.
+     * @param viewPort
+     *            the view port.
+     * @param main
+     *            true if this processor is main.
      */
-    public void bind(final Component destination, final Application application, ViewPort viewPort, boolean main) {
+    public void bind(final Component destination, final Application application, ViewPort viewPort,
+            boolean main) {
 
         if (hasApplication()) {
             throw new RuntimeException("This process is already bonded.");
@@ -443,7 +466,8 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
                 @Override
                 public void run() {
                     bindDestination(application, destination);
-                }});
+                }
+            });
         }
     }
 
@@ -465,7 +489,8 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
                 @Override
                 public void run() {
                     unbindDestination();
-                }});
+                }
+            });
         }
 
     }
@@ -473,8 +498,10 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
     /**
      * Bind this processor.
      *
-     * @param application the application.
-     * @param destination the destination.
+     * @param application
+     *            the application.
+     * @param destination
+     *            the destination.
      */
     protected void bindDestination(Application application, Component destination) {
 
@@ -498,10 +525,13 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
                     notifyComponentResized(getDestinationWidth(), getDestinationHeight(), isPreserveRatio());
 
                 } else {
-                    throw new IllegalArgumentException("Underlying application has to use AWTContext (actually using "+application.getContext().getClass().getSimpleName()+")");
+                    throw new IllegalArgumentException(
+                            "Underlying application has to use AWTContext (actually using "
+                                    + application.getContext().getClass().getSimpleName() + ")");
                 }
             } else {
-                throw new IllegalArgumentException("Underlying application has to use a valid AWTContext (context is null)");
+                throw new IllegalArgumentException(
+                        "Underlying application has to use a valid AWTContext (context is null)");
             }
         }
     }
@@ -531,13 +561,11 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
         }
     }
 
-
     protected void bindListeners() {
         Component destination = getDestination();
         destination.addPropertyChangeListener(this);
         destination.addPropertyChangeListener(this);
     }
-
 
     protected void unbindListeners() {
         Component destination = getDestination();
@@ -548,12 +576,16 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
     /**
      * Reshape the current frame transfer for the new size.
      *
-     * @param width     the width.
-     * @param height    the height.
-     * @param fixAspect true to fix the aspect ratio.
+     * @param width
+     *            the width.
+     * @param height
+     *            the height.
+     * @param fixAspect
+     *            true to fix the aspect ratio.
      * @return the new frame transfer.
      */
-    protected AWTComponentRenderer reshapeInThread(final int width, final int height, final boolean fixAspect) {
+    protected AWTComponentRenderer reshapeInThread(final int width, final int height,
+            final boolean fixAspect) {
 
         reshapeCurrentViewPort(width, height);
 
@@ -576,20 +608,26 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
     /**
      * Create a new frame transfer.
      *
-     * @param frameBuffer the frame buffer.
-     * @param width       the width.
-     * @param height      the height.
+     * @param frameBuffer
+     *            the frame buffer.
+     * @param width
+     *            the width.
+     * @param height
+     *            the height.
      * @return the new frame transfer.
      */
     protected AWTComponentRenderer createFrameTransfer(FrameBuffer frameBuffer, int width, int height) {
-        return new AWTComponentRenderer(getDestination(), getTransferMode(), isMain() ? null : frameBuffer, width, height);
+        return new AWTComponentRenderer(getDestination(), getTransferMode(), isMain() ? null : frameBuffer,
+                width, height);
     }
 
     /**
      * Reshape the current view port.
      *
-     * @param width  the width.
-     * @param height the height.
+     * @param width
+     *            the width.
+     * @param height
+     *            the height.
      */
     protected void reshapeCurrentViewPort(int width, int height) {
 
@@ -611,7 +649,7 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
 
         boolean found = false;
         Iterator<SceneProcessor> iter = processors.iterator();
-        while(!found && iter.hasNext()) {
+        while (!found && iter.hasNext()) {
             if (!(iter.next() instanceof AWTFrameProcessor)) {
                 found = true;
             }
@@ -619,11 +657,7 @@ public class AWTFrameProcessor implements SceneProcessor, PropertyChangeListener
 
         if (found) {
 
-            FrameBuffer frameBuffer = new FrameBuffer(width, height, 1);
-            frameBuffer.setDepthBuffer(Image.Format.Depth);
-            frameBuffer.setColorBuffer(Image.Format.RGBA8);
-            frameBuffer.setSrgb(true);
-
+            FrameBuffer frameBuffer = AWTUtils.getFrameBuffer(width, height, 1);
             viewPort.setOutputFrameBuffer(frameBuffer);
         }
 

--- a/jme3-desktop/src/main/java/com/jme3/system/AWTUtils.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/AWTUtils.java
@@ -1,0 +1,25 @@
+package com.jme3.system;
+
+import com.jme3.texture.FrameBuffer;
+import com.jme3.texture.Image;
+
+public class AWTUtils {
+    /**
+     * This should be a Temporary solution. FrameBuffer functions and Image-Formats are deprecated.
+     * 
+     * @param width
+     * @param height
+     * @param samples
+     * @return
+     */
+    @SuppressWarnings("deprecation")
+    public static FrameBuffer getFrameBuffer(int width, int height, int samples) {
+        FrameBuffer frameBuffer = new FrameBuffer(width, height, samples);
+        frameBuffer.setDepthBuffer(Image.Format.Depth);
+        frameBuffer.setColorBuffer(Image.Format.RGBA8);
+        frameBuffer.setSrgb(true);
+
+        return frameBuffer;
+    }
+
+}

--- a/jme3-desktop/src/main/java/com/jme3/system/JmeDesktopSystem.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/JmeDesktopSystem.java
@@ -127,10 +127,10 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
         }
     }
 
-    @SuppressWarnings("unchecked")
+    //@SuppressWarnings("unchecked")
     private JmeContext newContextLwjgl(AppSettings settings, JmeContext.Type type) {
         try {
-            Class ctxClazz = null;
+            Class<?> ctxClazz = null;
             switch (type) {
                 case Canvas:
                     ctxClazz = Class.forName("com.jme3.system.lwjgl.LwjglCanvas");
@@ -158,10 +158,10 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
         return null;
     }
 
-    @SuppressWarnings("unchecked")
+    //@SuppressWarnings("unchecked")
     private JmeContext newContextJogl(AppSettings settings, JmeContext.Type type) {
         try {
-            Class ctxClazz = null;
+            Class<?> ctxClazz = null;
             switch (type) {
                 case Display:
                     ctxClazz = Class.forName("com.jme3.system.jogl.JoglNewtDisplay");
@@ -194,8 +194,8 @@ public class JmeDesktopSystem extends JmeSystemDelegate {
         try {
             String className = settings.getRenderer().substring("CUSTOM".length());
 
-            Class ctxClazz = Class.forName(className);
-            return (JmeContext) ctxClazz.getDeclaredConstructor().newInstance();
+            Class<JmeContext> ctxClazz = (Class<JmeContext>) Class.forName(className);
+            return ctxClazz.getDeclaredConstructor().newInstance();
         } catch (InstantiationException | IllegalAccessException
                 | IllegalArgumentException | InvocationTargetException
                 | NoSuchMethodException | SecurityException ex) {

--- a/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
@@ -150,7 +150,7 @@ public final class NativeLibraryLoader {
      */
     public static boolean isUsingNativeBullet() {
         try {
-            Class clazz = Class.forName("com.jme3.bullet.util.NativeMeshUtil");
+            Class<?> clazz = Class.forName("com.jme3.bullet.util.NativeMeshUtil");
             return clazz != null;
         } catch (ClassNotFoundException ex) {
             return false;
@@ -245,6 +245,8 @@ public final class NativeLibraryLoader {
             case Windows:
                 userCacheFolder = new File(new File(userHomeFolder, "AppData"), "Local");
                 break;
+            default:
+                break;
         }
         
         if (userCacheFolder == null || !userCacheFolder.exists()) {
@@ -329,31 +331,6 @@ public final class NativeLibraryLoader {
         }
     }
     
-    /**
-     * Removes platform-specific portions of a library file name so
-     * that it can be accepted by {@link System#loadLibrary(java.lang.String) }.
-     * <p>
-     * E.g.<br>
-     * <ul>
-     * <li>jinput-dx8_64.dll => jinput-dx8_64</li>
-     * <li>liblwjgl64.so => lwjgl64</li>
-     * <li>libopenal.so => openal</li>
-     * </ul>
-     * 
-     * @param filename The filename to strip platform-specific parts
-     * @return The stripped library name
-     */
-    private static String unmapLibraryName(String filename) {
-        StringBuilder sb = new StringBuilder(filename);
-        if (sb.indexOf("lib") == 0 && !filename.toLowerCase().endsWith(".dll")) {
-            sb.delete(0, 3);
-        }
-        int dot = sb.lastIndexOf(".");
-        if (dot > 0) {
-            sb.delete(dot, sb.length());
-        }
-        return sb.toString();
-    }
     
     public static File getJarForNativeLibrary(Platform platform, String name) {
         NativeLibrary library = nativeLibraryMap.get(new NativeLibrary.Key(name, platform));

--- a/jme3-desktop/src/main/java/com/jme3/texture/plugins/AWTLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/texture/plugins/AWTLoader.java
@@ -87,19 +87,6 @@ public class AWTLoader implements AssetLoader {
             System.arraycopy(sln, 0,         img, y2 * scSz, scSz);
         }
     }
-    
-    private void flipImage(short[] img, int width, int height, int bpp){
-        int scSz = (width * bpp) / 8;
-        scSz /= 2; // Because shorts are 2 bytes
-        short[] sln = new short[scSz];
-        int y2 = 0;
-        for (int y1 = 0; y1 < height / 2; y1++){
-            y2 = height - y1 - 1;
-            System.arraycopy(img, y1 * scSz, sln, 0,         scSz);
-            System.arraycopy(img, y2 * scSz, img, y1 * scSz, scSz);
-            System.arraycopy(sln, 0,         img, y2 * scSz, scSz);
-        }
-    }
 
     public Image load(BufferedImage img, boolean flipY){
         int width = img.getWidth();

--- a/jme3-desktop/src/main/java/jme3tools/converters/ImageToAwt.java
+++ b/jme3-desktop/src/main/java/jme3tools/converters/ImageToAwt.java
@@ -87,9 +87,9 @@ public class ImageToAwt {
             this.is = is;
         }
 
-        public DecodeParams(int bpp, int rm, int rs, int im, int is){
-            this(bpp, rm, rs, im, is, false);
-        }
+        /*
+         * public DecodeParams(int bpp, int rm, int rs, int im, int is){ this(bpp, rm, rs, im, is, false); }
+         */
     }
 
     static {
@@ -104,13 +104,21 @@ public class ImageToAwt {
         final int mxxxx = 0xffffffff;
         final int sxxxx = 0;
 
+        @SuppressWarnings("unused")
         final int m4x___ = 0xf000;
+        @SuppressWarnings("unused")
         final int m4_x__ = 0x0f00;
+        @SuppressWarnings("unused")
         final int m4__x_ = 0x00f0;
+        @SuppressWarnings("unused")
         final int m4___x = 0x000f;
+        @SuppressWarnings("unused")
         final int s4x___ = 12;
+        @SuppressWarnings("unused")
         final int s4_x__ = 8;
+        @SuppressWarnings("unused")
         final int s4__x_ = 4;
+        @SuppressWarnings("unused")
         final int s4___x = 0;
 
         final int m5___  = 0xf800;
@@ -326,15 +334,12 @@ public class ImageToAwt {
 
         boolean inAlpha = false;
         boolean inLum = false;
-        boolean inRGB = false;
         if (inParams.am != 0) {
             inAlpha = true;
         }
 
         if (inParams.rm != 0 && inParams.gm == 0 && inParams.bm == 0) {
             inLum = true;
-        } else if (inParams.rm != 0 && inParams.gm != 0 && inParams.bm != 0) {
-            inRGB = true;
         }
 
         int expansionA = 8 - Integer.bitCount(inParams.am);
@@ -377,7 +382,7 @@ public class ImageToAwt {
 
     public static BufferedImage convert(Image image, boolean do16bit, boolean fullAlpha, int mipLevel){
         Format format = image.getFormat();
-        DecodeParams p = params.get(image.getFormat());
+        DecodeParams p = params.get(format);
         if (p == null)
             throw new UnsupportedOperationException();
 

--- a/jme3-desktop/src/main/java/jme3tools/converters/MipMapGenerator.java
+++ b/jme3-desktop/src/main/java/jme3tools/converters/MipMapGenerator.java
@@ -87,7 +87,7 @@ public class MipMapGenerator {
         BufferedImage original = ImageToAwt.convert(image, false, true, 0);
         int width = original.getWidth();
         int height = original.getHeight();
-        int level = 0;
+        // int level = 0;
 
         BufferedImage current = original;
         AWTLoader loader = new AWTLoader();
@@ -105,7 +105,7 @@ public class MipMapGenerator {
               break;
             }
 
-            level++;
+            // level++;
 
             height /= 2;
             width /= 2;


### PR DESCRIPTION
As written in https://hub.jmonkeyengine.org/t/2079-warnings/47608/3 I tried to remove some warnings. 

For the **raw type** warnings, I replaced it with a simple wildcard; maybe I should change some of them to a lower-bound wildcard. Any thoughts on that?

 ```
Class<JmeContext> ctxClazz = (Class<JmeContext>) Class.forName(className);
            return ctxClazz.getDeclaredConstructor().newInstance();
``` 
I think this doesn't work while I am writing this.


Ressource Warning in **/cursors/plugins/CursorLoader.java** was fixed by closing DataInput
the _int flag_ wasn't and what the comment implies shoundn't be used so I removed it and nextInt into "nirvana".

**/system/AWTComponentRenderer.java** and **system/AWTFrameProcessor.java** had a deprecated FrameBuffer creation. I added **AWTUtils** with the function _getFrameBuffer(...)_ and suppressed the warning. Is there a better way to create the buffer?

**jme3tools/converters/ImageToAwt.java** had some unused "constants" I suppressed the warning. I also removed an unused constructor.