### PR TITLE
solution for issue #2250 (exceptions from Image.setMultiSamples(1))

### DIFF
--- a/jme3-core/src/main/java/com/jme3/texture/Image.java
+++ b/jme3-core/src/main/java/com/jme3/texture/Image.java
@@ -942,14 +942,19 @@ public class Image extends NativeObject implements Savable /*, Cloneable*/ {
      * into a multisample texture (on OpenGL3.1 and higher).
      */
     public void setMultiSamples(int multiSamples) {
-        if (multiSamples <= 0)
+        if (multiSamples <= 0) {
             throw new IllegalArgumentException("multiSamples must be > 0");
+        }
 
-        if (getData(0) != null)
-            throw new IllegalArgumentException("Cannot upload data as multisample texture");
+        if (multiSamples > 1) {
+            if (getData(0) != null) {
+                throw new IllegalArgumentException("Cannot upload data as multisample texture");
+            }
 
-        if (hasMipmaps())
-            throw new IllegalArgumentException("Multisample textures do not support mipmaps");
+            if (hasMipmaps()) {
+                throw new IllegalArgumentException("Multisample textures do not support mipmaps");
+            }
+        }
 
         this.multiSamples = multiSamples;
     }

--- a/jme3-core/src/main/java/com/jme3/texture/Image.java
+++ b/jme3-core/src/main/java/com/jme3/texture/Image.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023 jMonkeyEngine
+ * Copyright (c) 2009-2024 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-core/src/test/java/com/jme3/texture/TestIssue2250.java
+++ b/jme3-core/src/test/java/com/jme3/texture/TestIssue2250.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.texture;
+
+import com.jme3.texture.image.ColorSpace;
+import com.jme3.util.BufferUtils;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import org.junit.Test;
+
+/**
+ * Verify that setMultiSamples(1) can be applied to any Image. This was issue
+ * #2250 at GitHub.
+ *
+ * @author Stephen Gold
+ */
+public class TestIssue2250 {
+
+    /**
+     * Test setMultiSamples() on an Image with a data buffer.
+     */
+    @Test
+    public void testIssue2250WithData() {
+        int width = 8;
+        int height = 8;
+        int numBytes = 4 * width * height;
+        ByteBuffer data = BufferUtils.createByteBuffer(numBytes);
+        Image image1 = new Image(
+                Image.Format.RGBA8, width, height, data, ColorSpace.Linear);
+
+        image1.setMultiSamples(1);
+    }
+
+    /**
+     * Test setMultiSamples() on an Image with mip maps.
+     */
+    @Test
+    public void testIssue2250WithMips() {
+        int width = 8;
+        int height = 8;
+        int depth = 1;
+        int[] mipMapSizes = {256, 64, 16, 4};
+
+        ArrayList<ByteBuffer> data = new ArrayList<>();
+        Image image2 = new Image(Image.Format.RGBA8, width, height, depth, data,
+                mipMapSizes, ColorSpace.Linear);
+
+        image2.setMultiSamples(1);
+    }
+}


### PR DESCRIPTION
This pull request adds automated tests for issue #2250.
It then solves the issue by skipping (if `multiSamples==1`) the checks that throw exceptions related to multisampling.