### PR TITLE
stop building with JDK 8 at GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest,windows-2019,macOS-latest]
-        jdk: [8, 11, 17]
+        jdk: [11, 17]
         include:
           - os: ubuntu-latest
             osName: linux
@@ -101,8 +101,6 @@ jobs:
             deploy: false
           - os: macOS-latest
             osName: mac
-            deploy: false
-          - jdk: 8
             deploy: false
           - jdk: 11
             deploy: false


### PR DESCRIPTION
Recent macOS builds at GitHub Actions have been failing with the following diagnostics:

```log
##[group]Run actions/setup-java@v4
2024-04-24T01:40:44.9411640Z with:
2024-04-24T01:40:44.9411810Z   distribution: temurin
2024-04-24T01:40:44.9412020Z   java-version: 8
2024-04-24T01:40:44.9412220Z   java-package: jdk
2024-04-24T01:40:44.9412420Z   check-latest: false
2024-04-24T01:40:44.9412670Z   server-id: github
2024-04-24T01:40:44.9412880Z   server-username: GITHUB_ACTOR
2024-04-24T01:40:44.9413130Z   server-password: GITHUB_TOKEN
2024-04-24T01:40:44.9413370Z   overwrite-settings: true
2024-04-24T01:40:44.9413590Z   job-status: success
2024-04-24T01:40:44.9413870Z   token: ***
2024-04-24T01:40:44.9414030Z ##[endgroup]
2024-04-24T01:40:45.1018110Z ##[group]Installed distributions
2024-04-24T01:40:45.1059500Z Trying to resolve the latest version from remote
2024-04-24T01:40:45.2091430Z ##[error]Could not find satisfied version for SemVer '8'. 
Available versions: 22.0.1+8, 22.0.0+36, 21.0.3+9.0.LTS, 21.0.2+13.0.LTS, 21.0.1+12.0.LTS, 21.0.0+35.0.LTS, 20.0.2+9, 20.0.1+9, 20.0.0+36, 19.0.2+7, 19.0.1+10, 19.0.0+36, 18.0.2+101, 18.0.2+9, 18.0.1+10, 18.0.0+36, 17.0.11+9, 17.0.10+7, 17.0.9+9, 17.0.8+101, 17.0.8+7, 17.0.7+7, 17.0.6+10, 17.0.5+8, 17.0.4+101, 17.0.4+8, 17.0.3+7, 17.0.2+8, 17.0.1+12, 17.0.0+35, 11.0.23+9, 11.0.22+7.1, 11.0.22+7, 11.0.21+9, 11.0.20+101, 11.0.20+8, 11.0.19+7, 11.0.18+10, 11.0.17+8, 11.0.16+101, 11.0.16+8, 11.0.15+10
```

Apparently Java 8 is no longer available for GitHub's "macOS-latest" platform. It's time to take JDK 8 out of the build matrix.