### PR TITLE
Remove material cache, some materials seem not work when cloned

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -619,11 +619,6 @@ public class GltfLoader implements AssetLoader {
     public Material readMaterial(int materialIndex) throws IOException {
         assertNotNull(materials, "There is no material defined yet a mesh references one");
 
-        Material material = fetchFromCache("materials", materialIndex, Material.class);
-        if (material != null) {
-            return material.clone();
-        }
-
         JsonObject matData = materials.get(materialIndex).getAsJsonObject();
         JsonObject pbrMat = matData.getAsJsonObject("pbrMetallicRoughness");
 
@@ -693,10 +688,7 @@ public class GltfLoader implements AssetLoader {
 
         adapter.setParam("emissiveTexture", readTexture(matData.getAsJsonObject("emissiveTexture")));
 
-        material = adapter.getMaterial();
-        addToCache("materials", materialIndex, material, materials.size());
-
-        return material;
+        return adapter.getMaterial();
     }
 
     public void readCameras() throws IOException {


### PR DESCRIPTION
I just could not figure out why the material cloning doesn't work. I mean, AssetManager does it all the time... I don't know. Anyway, this slows down 20% loading the Bistro scene as GLB on my beefy computer. However, the memory problems are still solved with the texture cache.

Partially reverts https://github.com/jMonkeyEngine/jmonkeyengine/pull/2128. But as said, the memory fix is still in and working.

As discussed in https://hub.jmonkeyengine.org/t/jmonkeyengine-v3-7-feature-freeze/47558/35.