### PR TITLE
main.yml:  upgrade the wrapper validation action to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Validate the Gradle wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v3
       - name: Build
         run: |
           ./gradlew -PuseCommitHashAsVersionName=true --no-daemon -PbuildNativeProjects=true \
@@ -124,7 +124,7 @@ jobs:
           path: build/native
 
       - name: Validate the Gradle wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v3
       - name: Build Engine
         shell: bash
         run: |


### PR DESCRIPTION
The wrapper validation actions in the GitHub Actions CI/CD script (".github/workflows/main.yml") verify the signature of the project's Gradle wrapper JAR file ("gradle-wrapper.jar"). This helps protect the project against malware.

Currently the script specifies version 2 of the action. However, version 3 has been out since 12 April 2024. Furthermore, [the README](https://github.com/gradle/wrapper-validation-action?tab=readme-ov-file#readme) indicates that the "gradle/wrapper-validation-action" action has been superseded by "gradle/actions/wrapper-validation".

This pull request brings the jMonkeyEngine repo up-to-date in this respect.