### PR TITLE
Add MipMaps to PBRTerrainAdvancedTest.java

### DIFF
--- a/jme3-examples/src/main/java/jme3test/terrain/PBRTerrainAdvancedTest.java
+++ b/jme3-examples/src/main/java/jme3test/terrain/PBRTerrainAdvancedTest.java
@@ -52,6 +52,8 @@ import com.jme3.terrain.heightmap.ImageBasedHeightMap;
 import com.jme3.texture.Image;
 import com.jme3.texture.Texture;
 import com.jme3.texture.Texture.WrapMode;
+import com.jme3.texture.Texture.MagFilter;
+import com.jme3.texture.Texture.MinFilter;
 import com.jme3.texture.TextureArray;
 import java.util.ArrayList;
 import java.util.List;
@@ -279,10 +281,10 @@ public class PBRTerrainAdvancedTest extends SimpleApplication {
         TextureArray metallicRoughnessAoEiTextureArray = new TextureArray(metallicRoughnessAoEiMapImages);
 
         //apply wrapMode to the whole texture array, rather than each individual texture in the array
-        albedoTextureArray.setWrap(WrapMode.Repeat);
-        normalParallaxTextureArray.setWrap(WrapMode.Repeat);
-        metallicRoughnessAoEiTextureArray.setWrap(WrapMode.Repeat);
-
+        setWrapAndMipMaps(albedoTextureArray);
+        setWrapAndMipMaps(normalParallaxTextureArray);
+        setWrapAndMipMaps(metallicRoughnessAoEiTextureArray);
+        
         //assign texture array to materials
         matTerrain.setParam("AlbedoTextureArray", VarType.TextureArray, albedoTextureArray);
         matTerrain.setParam("NormalParallaxTextureArray", VarType.TextureArray, normalParallaxTextureArray);
@@ -428,6 +430,12 @@ public class PBRTerrainAdvancedTest extends SimpleApplication {
         terrain.setLocalTranslation(0, -100, 0);
         terrain.setLocalScale(1f, 1f, 1f);
         rootNode.attachChild(terrain);
+    }
+
+    private void setWrapAndMipMaps(Texture texture){
+        texture.setWrap(WrapMode.Repeat);
+        texture.setMinFilter(MinFilter.Trilinear);
+        texture.setMagFilter(MagFilter.Bilinear);
     }
 
     private void setUpLights() {


### PR DESCRIPTION
This test case has some noisey rendering due to not setting MipMaps on the terrain material's TextureArrays.

So I added MinFilter.Trilinear to fix this issue, and also added MagFilter.Bilinear.

I don't know much about the different MipMap settings, but MinFilter.Trilinear appeared to create the smoothest results for the terrain in this test case (and my own projects), so I went with that. 