### PR TITLE
Setting the resolution to match the old prevents calling reshape

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -298,8 +298,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             requestWidth = videoMode.width();
             requestHeight = videoMode.height();
         }
-        oldFramebufferHeight = requestHeight;
-        oldFramebufferWidth = requestWidth;
         window = glfwCreateWindow(requestWidth, requestHeight, settings.getTitle(), monitor, NULL);
         if (window == NULL) {
             throw new RuntimeException("Failed to create the GLFW window");


### PR DESCRIPTION
Reverted this change from https://github.com/jMonkeyEngine/jmonkeyengine/commit/ec9c8c5efcc08afa5bb7247abe644df68ca425b2.

Also I tested the canvas and it works (mainly because it is not the same implementation as it was on the commit linked).

Setting these variables made jME think that nothing was changed and no reshape was called.