### PR TITLE
Add java 21 to the CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
           name: android-natives
           path: build/native
 
-  # Build the engine, we only deploy from ubuntu-latest jdk17
+  # Build the engine, we only deploy from ubuntu-latest jdk21
   BuildJMonkey:
     needs: [BuildAndroidNatives]
     name: Build on ${{ matrix.osName }} jdk${{ matrix.jdk }}
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest,windows-2019,macOS-latest]
-        jdk: [11, 17]
+        jdk: [11, 17, 21]
         include:
           - os: ubuntu-latest
             osName: linux
@@ -103,6 +103,8 @@ jobs:
             osName: mac
             deploy: false
           - jdk: 11
+            deploy: false
+          - jdk: 17
             deploy: false
 
     steps:
@@ -304,12 +306,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      # Setup jdk 17 used for building Maven-style artifacts
+      # Setup jdk 21 used for building Maven-style artifacts
       - name: Setup the java environment
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Download natives for android
         uses: actions/download-artifact@master
@@ -348,12 +350,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      # Setup jdk 17 used for building Sonatype OSSRH artifacts
+      # Setup jdk 21 used for building Sonatype OSSRH artifacts
       - name: Setup the java environment
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       # Download all the stuff...
       - name: Download maven artifacts


### PR DESCRIPTION
As well, start deploying from java 21, bumped from java 17.

So, now we have all 3 java LTS's building, and deploy from the latest LTS.