### PR TITLE
Use windows-latest image for windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,13 +90,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest,windows-2019,macOS-latest]
+        os: [ubuntu-latest,windows-latest,macOS-latest]
         jdk: [11, 17]
         include:
           - os: ubuntu-latest
             osName: linux
             deploy: true
-          - os: windows-2019
+          - os: windows-latest
             osName: windows
             deploy: false
           - os: macOS-latest


### PR DESCRIPTION
Use windows-latest image (windows server 2022) instead of windows 2019