### PR TITLE
Fix deprecated gradle features, prepare for gradle 9

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -15,8 +15,10 @@ eclipse.jdt.file.withProperties { props ->
 group = 'org.jmonkeyengine'
 version = jmeFullVersion
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 tasks.withType(JavaCompile) { // compile-time options:
     //options.compilerArgs << '-Xlint:deprecation' // to show deprecation warnings


### PR DESCRIPTION
With this change, gradle 8.8 no longer complains about using deprecated gradle features that will be removed in 9, so we will have an easier time upgrading next time.