### PR TITLE
Cleaning at the code level (format - jme3-core)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/util/AnimMigrationUtils.java
+++ b/jme3-core/src/main/java/com/jme3/anim/util/AnimMigrationUtils.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.anim.util;
 
 import com.jme3.anim.*;
@@ -10,8 +41,8 @@ import java.util.*;
 
 public class AnimMigrationUtils {
 
-    final private static AnimControlVisitor animControlVisitor = new AnimControlVisitor();
-    final private static SkeletonControlVisitor skeletonControlVisitor = new SkeletonControlVisitor();
+    private static final AnimControlVisitor animControlVisitor = new AnimControlVisitor();
+    private static final SkeletonControlVisitor skeletonControlVisitor = new SkeletonControlVisitor();
 
     /**
      * A private constructor to inhibit instantiation of this class.

--- a/jme3-core/src/main/java/com/jme3/anim/util/HasLocalTransform.java
+++ b/jme3-core/src/main/java/com/jme3/anim/util/HasLocalTransform.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.anim.util;
 
 import com.jme3.export.Savable;

--- a/jme3-core/src/main/java/com/jme3/anim/util/JointModelTransform.java
+++ b/jme3-core/src/main/java/com/jme3/anim/util/JointModelTransform.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.anim.util;
 
 import com.jme3.anim.Joint;

--- a/jme3-core/src/main/java/com/jme3/anim/util/Primitives.java
+++ b/jme3-core/src/main/java/com/jme3/anim/util/Primitives.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.anim.util;
 
 import java.util.Collections;

--- a/jme3-core/src/main/java/com/jme3/anim/util/Weighted.java
+++ b/jme3-core/src/main/java/com/jme3/anim/util/Weighted.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2009-2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.anim.util;
 
 import com.jme3.anim.tween.action.Action;

--- a/jme3-core/src/main/java/com/jme3/app/state/CompositeAppState.java
+++ b/jme3-core/src/main/java/com/jme3/app/state/CompositeAppState.java
@@ -63,41 +63,41 @@ public class CompositeAppState extends BaseAppState {
     private AppStateManager stateManager;
     private boolean attached;  
     
-    public CompositeAppState( AppState... states ) {
-        for( AppState a : states ) {
+    public CompositeAppState(AppState... states) {
+        for (AppState a : states) {
             this.states.add(new AppStateEntry(a, false));
         }
     }
 
-    private int indexOf( AppState state ) {
-        for( int i = 0; i < states.size(); i++ ) {
+    private int indexOf(AppState state) {
+        for (int i = 0; i < states.size(); i++) {
             AppStateEntry e = states.get(i);
-            if( e.state == state ) {
+            if (e.state == state) {
                 return i;
             }
         }
         return -1;
     }
 
-    private AppStateEntry entry( AppState state ) {
-        for( AppStateEntry e : states.getArray() ) {
-            if( e.state == state ) {
+    private AppStateEntry entry(AppState state) {
+        for (AppStateEntry e : states.getArray()) {
+            if (e.state == state) {
                 return e;
             }
         }
         return null;
     }
 
-    protected <T extends AppState> T addChild( T state ) {
+    protected <T extends AppState> T addChild(T state) {
         return addChild(state, false);
     }
     
-    protected <T extends AppState> T addChild( T state, boolean overrideEnable ) {
-        if( indexOf(state) >= 0 ) {
+    protected <T extends AppState> T addChild(T state, boolean overrideEnable) {
+        if (indexOf(state) >= 0) {
             return state;
         }
         states.add(new AppStateEntry(state, overrideEnable));
-        if( attached ) {
+        if (attached) {
             stateManager.attach(state);
         }
         return state;   
@@ -130,30 +130,30 @@ public class CompositeAppState extends BaseAppState {
     }
     
     @Override 
-    public void stateAttached( AppStateManager stateManager ) {
+    public void stateAttached(AppStateManager stateManager) {
         this.stateManager = stateManager;
-        for( AppStateEntry e : states.getArray() ) {
+        for (AppStateEntry e : states.getArray()) {
             stateManager.attach(e.state);
         }
         this.attached = true;
     }
     
     @Override
-    public void stateDetached( AppStateManager stateManager ) {
+    public void stateDetached(AppStateManager stateManager) {
         // Reverse order
-        for( int i = states.size() - 1; i >= 0; i-- ) {
+        for (int i = states.size() - 1; i >= 0; i--) {
             stateManager.detach(states.get(i).state);
         }
         this.attached = false;
         this.stateManager = null;
     }
 
-    protected void setChildrenEnabled( boolean b ) {
-        if( childrenEnabled == b ) {
+    protected void setChildrenEnabled(boolean b) {
+        if(childrenEnabled == b) {
             return;
         }
         childrenEnabled = b;
-        for( AppStateEntry e : states.getArray() ) {
+        for (AppStateEntry e : states.getArray()) {
             e.setEnabled(b);
         }
     }
@@ -170,12 +170,12 @@ public class CompositeAppState extends BaseAppState {
      *  too.  Override is about remembering the child's state before that
      *  happened and restoring it when the 'family' is enabled again as a whole.
      */
-    public void setOverrideEnabled( AppState state, boolean override ) {
+    public void setOverrideEnabled(AppState state, boolean override) {
         AppStateEntry e = entry(state);
-        if( e == null ) {
+        if (e == null) {
             throw new IllegalArgumentException("State not managed:" + state);
         }
-        if( override ) {
+        if (override) {
             e.override = true;
         } else {
             e.override = false;
@@ -206,16 +206,16 @@ public class CompositeAppState extends BaseAppState {
         boolean enabled;
         boolean override;
         
-        public AppStateEntry( AppState state, boolean overrideEnable ) {
+        public AppStateEntry(AppState state, boolean overrideEnable) {
             this.state = state;
             this.override = overrideEnable;
             this.enabled = state.isEnabled();
         }
         
-        public void setEnabled( boolean b ) {
+        public void setEnabled(boolean b) {
  
-            if( override ) {
-                if( b ) {
+            if (override) {
+                if (b) {
                     // Set it to whatever its enabled state
                     // was before going disabled last time.
                     state.setEnabled(enabled);

--- a/jme3-core/src/main/java/com/jme3/asset/cache/WeakRefCloneAssetCache.java
+++ b/jme3-core/src/main/java/com/jme3/asset/cache/WeakRefCloneAssetCache.java
@@ -60,8 +60,7 @@ public class WeakRefCloneAssetCache implements AssetCache {
      * Maps cloned key to AssetRef which has a weak ref to the original
      * key and a strong ref to the original asset.
      */
-    private final ConcurrentHashMap<AssetKey, AssetRef> smartCache
-            = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<AssetKey, AssetRef> smartCache = new ConcurrentHashMap<>();
 
     /**
      * Stored in the ReferenceQueue to find out when originalKey is collected

--- a/jme3-core/src/main/java/com/jme3/audio/openal/ALAudioRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/audio/openal/ALAudioRenderer.java
@@ -55,7 +55,7 @@ public class ALAudioRenderer implements AudioRenderer, Runnable {
     // which is exactly 1 second of audio.
     private static final int BUFFER_SIZE = 35280;
     private static final int STREAMING_BUFFER_COUNT = 5;
-    private final static int MAX_NUM_CHANNELS = 64;
+    private static final int MAX_NUM_CHANNELS = 64;
     private IntBuffer ib = BufferUtils.createIntBuffer(1);
     private final FloatBuffer fb = BufferUtils.createVector3Buffer(2);
     private final ByteBuffer nativeBuf = BufferUtils.createByteBuffer(BUFFER_SIZE);

--- a/jme3-core/src/main/java/com/jme3/cinematic/Cinematic.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/Cinematic.java
@@ -93,7 +93,7 @@ public class Cinematic extends AbstractCinematicEvent implements AppState {
     private Node scene;
     protected TimeLine timeLine = new TimeLine();
     private int lastFetchedKeyFrame = -1;
-    final private List<CinematicEvent> cinematicEvents = new ArrayList<>();
+    private final List<CinematicEvent> cinematicEvents = new ArrayList<>();
     private Map<String, CameraNode> cameras = new HashMap<>();
     private CameraNode currentCam;
     private boolean initialized = false;

--- a/jme3-core/src/main/java/com/jme3/cinematic/events/AnimEvent.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/events/AnimEvent.java
@@ -53,7 +53,7 @@ import java.util.logging.Logger;
  */
 public class AnimEvent extends AbstractCinematicEvent {
 
-    final public static Logger logger
+    public static final Logger logger
             = Logger.getLogger(AnimEvent.class.getName());
 
     /*

--- a/jme3-core/src/main/java/com/jme3/environment/baker/IBLGLEnvBaker.java
+++ b/jme3-core/src/main/java/com/jme3/environment/baker/IBLGLEnvBaker.java
@@ -109,10 +109,12 @@ public class IBLGLEnvBaker extends GenericEnvBaker implements IBLEnvBaker {
         brtf.getImage().setColorSpace(ColorSpace.Linear);
     }
 
+    @Override
     public TextureCubeMap getSpecularIBL() {
         return specular;
     }
 
+    @Override
     public TextureCubeMap getIrradiance() {
         return irradiance;
     }

--- a/jme3-core/src/main/java/com/jme3/export/SavableClassUtil.java
+++ b/jme3-core/src/main/java/com/jme3/export/SavableClassUtil.java
@@ -57,7 +57,7 @@ import java.util.logging.Logger;
  */
 public class SavableClassUtil {
 
-    private final static HashMap<String, String> CLASS_REMAPPINGS = new HashMap<>();
+    private static final HashMap<String, String> CLASS_REMAPPINGS = new HashMap<>();
 
     private static void addRemapping(String oldClass, Class<? extends Savable> newClass) {
         CLASS_REMAPPINGS.put(oldClass, newClass.getName());

--- a/jme3-core/src/main/java/com/jme3/font/BitmapCharacterSet.java
+++ b/jme3-core/src/main/java/com/jme3/font/BitmapCharacterSet.java
@@ -43,7 +43,7 @@ public class BitmapCharacterSet implements Savable {
     private int renderedSize;
     private int width;
     private int height;
-    final private IntMap<IntMap<BitmapCharacter>> characters;
+    private final IntMap<IntMap<BitmapCharacter>> characters;
     private int pageSize;
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/font/ColorTags.java
+++ b/jme3-core/src/main/java/com/jme3/font/ColorTags.java
@@ -47,7 +47,7 @@ import java.util.regex.Pattern;
 class ColorTags {
     private static final Pattern colorPattern = Pattern.compile("\\\\#([0-9a-fA-F]{8})#|\\\\#([0-9a-fA-F]{6})#|" +
                                                                 "\\\\#([0-9a-fA-F]{4})#|\\\\#([0-9a-fA-F]{3})#");
-    final private LinkedList<Range> colors = new LinkedList<>();
+    private final LinkedList<Range> colors = new LinkedList<>();
     private String text;
     private String original;
     private float baseAlpha = -1;

--- a/jme3-core/src/main/java/com/jme3/font/LetterQuad.java
+++ b/jme3-core/src/main/java/com/jme3/font/LetterQuad.java
@@ -66,7 +66,7 @@ class LetterQuad {
     private LetterQuad next;
     private int colorInt = 0xFFFFFFFF;
 
-    final private boolean rightToLeft;
+    private final boolean rightToLeft;
     private float alignX;
     private float alignY;
     private float sizeScale = 1;

--- a/jme3-core/src/main/java/com/jme3/font/Letters.java
+++ b/jme3-core/src/main/java/com/jme3/font/Letters.java
@@ -47,10 +47,10 @@ class Letters {
     private final LetterQuad tail;
     private final BitmapFont font;
     private LetterQuad current;
-    final private StringBlock block;
+    private final StringBlock block;
     private float totalWidth;
     private float totalHeight;
-    final private ColorTags colorTags = new ColorTags();
+    private final ColorTags colorTags = new ColorTags();
     private ColorRGBA baseColor = null;
     private float baseAlpha = -1;
     private String plainText;

--- a/jme3-core/src/main/java/com/jme3/input/AbstractJoystick.java
+++ b/jme3-core/src/main/java/com/jme3/input/AbstractJoystick.java
@@ -42,13 +42,13 @@ import java.util.*;
  */
 public abstract class AbstractJoystick implements Joystick {
 
-    final private InputManager inputManager;
-    final private JoyInput joyInput;
-    final private int joyId;
-    final private String name;
+    private final InputManager inputManager;
+    private final JoyInput joyInput;
+    private final int joyId;
+    private final String name;
 
-    final private List<JoystickAxis> axes = new ArrayList<>();
-    final private List<JoystickButton> buttons = new ArrayList<>();
+    private final List<JoystickAxis> axes = new ArrayList<>();
+    private final List<JoystickButton> buttons = new ArrayList<>();
 
     /**
      * Creates a new joystick instance. Only used internally.

--- a/jme3-core/src/main/java/com/jme3/input/CameraInput.java
+++ b/jme3-core/src/main/java/com/jme3/input/CameraInput.java
@@ -44,37 +44,37 @@ public class CameraInput {
      * Chase camera mapping for moving down. Default assigned to
      * MouseInput.AXIS_Y direction depending on the invertYaxis configuration
      */
-    public final static String CHASECAM_DOWN = "ChaseCamDown";
+    public static final String CHASECAM_DOWN = "ChaseCamDown";
     /**
      * Chase camera mapping for moving up. Default assigned to MouseInput.AXIS_Y
      * direction depending on the invertYaxis configuration
      */
-    public final static String CHASECAM_UP = "ChaseCamUp";
+    public static final String CHASECAM_UP = "ChaseCamUp";
     /**
      * Chase camera mapping for zooming in. Default assigned to
      * MouseInput.AXIS_WHEEL direction positive
      */
-    public final static String CHASECAM_ZOOMIN = "ChaseCamZoomIn";
+    public static final String CHASECAM_ZOOMIN = "ChaseCamZoomIn";
     /**
      * Chase camera mapping for zooming out. Default assigned to
      * MouseInput.AXIS_WHEEL direction negative
      */
-    public final static String CHASECAM_ZOOMOUT = "ChaseCamZoomOut";
+    public static final String CHASECAM_ZOOMOUT = "ChaseCamZoomOut";
     /**
      * Chase camera mapping for moving left. Default assigned to
      * MouseInput.AXIS_X direction depending on the invertXaxis configuration
      */
-    public final static String CHASECAM_MOVELEFT = "ChaseCamMoveLeft";
+    public static final String CHASECAM_MOVELEFT = "ChaseCamMoveLeft";
     /**
      * Chase camera mapping for moving right. Default assigned to
      * MouseInput.AXIS_X direction depending on the invertXaxis configuration
      */
-    public final static String CHASECAM_MOVERIGHT = "ChaseCamMoveRight";
+    public static final String CHASECAM_MOVERIGHT = "ChaseCamMoveRight";
     /**
      * Chase camera mapping to initiate the rotation of the cam. Default assigned
      * to MouseInput.BUTTON_LEFT and MouseInput.BUTTON_RIGHT
      */
-    public final static String CHASECAM_TOGGLEROTATE = "ChaseCamToggleRotate";
+    public static final String CHASECAM_TOGGLEROTATE = "ChaseCamToggleRotate";
     
         
     
@@ -83,63 +83,63 @@ public class CameraInput {
      * Fly camera mapping to look left. Default assigned to MouseInput.AXIS_X,
      * direction negative
      */
-    public final static String FLYCAM_LEFT = "FLYCAM_Left";
+    public static final String FLYCAM_LEFT = "FLYCAM_Left";
     /**
      * Fly camera mapping to look right. Default assigned to MouseInput.AXIS_X,
      * direction positive
      */
-    public final static String FLYCAM_RIGHT = "FLYCAM_Right";
+    public static final String FLYCAM_RIGHT = "FLYCAM_Right";
     /**
      * Fly camera mapping to look up. Default assigned to MouseInput.AXIS_Y,
      * direction positive
      */
-    public final static String FLYCAM_UP = "FLYCAM_Up";
+    public static final String FLYCAM_UP = "FLYCAM_Up";
     /**
      * Fly camera mapping to look down. Default assigned to MouseInput.AXIS_Y,
      * direction negative
      */
-    public final static String FLYCAM_DOWN = "FLYCAM_Down";
+    public static final String FLYCAM_DOWN = "FLYCAM_Down";
     /**
      * Fly camera mapping to move left. Default assigned to KeyInput.KEY_A   
      */
-    public final static String FLYCAM_STRAFELEFT = "FLYCAM_StrafeLeft";
+    public static final String FLYCAM_STRAFELEFT = "FLYCAM_StrafeLeft";
     /**
      * Fly camera mapping to move right. Default assigned to KeyInput.KEY_D  
      */
-    public final static String FLYCAM_STRAFERIGHT = "FLYCAM_StrafeRight";
+    public static final String FLYCAM_STRAFERIGHT = "FLYCAM_StrafeRight";
     /**
      * Fly camera mapping to move forward. Default assigned to KeyInput.KEY_W   
      */
-    public final static String FLYCAM_FORWARD = "FLYCAM_Forward";
+    public static final String FLYCAM_FORWARD = "FLYCAM_Forward";
     /**
      * Fly camera mapping to move backward. Default assigned to KeyInput.KEY_S   
      */
-    public final static String FLYCAM_BACKWARD = "FLYCAM_Backward";
+    public static final String FLYCAM_BACKWARD = "FLYCAM_Backward";
     /**
      * Fly camera mapping to zoom in. Default assigned to MouseInput.AXIS_WHEEL,
      * direction positive
      */
-    public final static String FLYCAM_ZOOMIN = "FLYCAM_ZoomIn";
+    public static final String FLYCAM_ZOOMIN = "FLYCAM_ZoomIn";
     /**
      * Fly camera mapping to zoom in. Default assigned to MouseInput.AXIS_WHEEL,
      * direction negative
      */
-    public final static String FLYCAM_ZOOMOUT = "FLYCAM_ZoomOut";
+    public static final String FLYCAM_ZOOMOUT = "FLYCAM_ZoomOut";
     /**
      * Fly camera mapping to toggle rotation. Default assigned to 
      * MouseInput.BUTTON_LEFT   
      */
-    public final static String FLYCAM_ROTATEDRAG = "FLYCAM_RotateDrag";
+    public static final String FLYCAM_ROTATEDRAG = "FLYCAM_RotateDrag";
     /**
      * Fly camera mapping to move up. Default assigned to KeyInput.KEY_Q   
      */
-    public final static String FLYCAM_RISE = "FLYCAM_Rise";
+    public static final String FLYCAM_RISE = "FLYCAM_Rise";
     /**
      * Fly camera mapping to move down. Default assigned to KeyInput.KEY_W   
      */
-    public final static String FLYCAM_LOWER = "FLYCAM_Lower";
+    public static final String FLYCAM_LOWER = "FLYCAM_Lower";
     
-    public final static String FLYCAM_INVERTY = "FLYCAM_InvertY";
+    public static final String FLYCAM_INVERTY = "FLYCAM_InvertY";
     
     /**
      * A private constructor to inhibit instantiation of this class.

--- a/jme3-core/src/main/java/com/jme3/input/ChaseCamera.java
+++ b/jme3-core/src/main/java/com/jme3/input/ChaseCamera.java
@@ -105,37 +105,37 @@ public class ChaseCamera implements ActionListener, AnalogListener, Control, Jme
      * @deprecated use {@link CameraInput#CHASECAM_DOWN}
      */
     @Deprecated
-    public final static String ChaseCamDown = "ChaseCamDown";
+    public static final String ChaseCamDown = "ChaseCamDown";
     /**
      * @deprecated use {@link CameraInput#CHASECAM_UP}
      */
     @Deprecated
-    public final static String ChaseCamUp = "ChaseCamUp";
+    public static final String ChaseCamUp = "ChaseCamUp";
     /**
      * @deprecated use {@link CameraInput#CHASECAM_ZOOMIN}
      */
     @Deprecated
-    public final static String ChaseCamZoomIn = "ChaseCamZoomIn";
+    public static final String ChaseCamZoomIn = "ChaseCamZoomIn";
     /**
      * @deprecated use {@link CameraInput#CHASECAM_ZOOMOUT}
      */
     @Deprecated
-    public final static String ChaseCamZoomOut = "ChaseCamZoomOut";
+    public static final String ChaseCamZoomOut = "ChaseCamZoomOut";
     /**
      * @deprecated use {@link CameraInput#CHASECAM_MOVELEFT}
      */
     @Deprecated
-    public final static String ChaseCamMoveLeft = "ChaseCamMoveLeft";
+    public static final String ChaseCamMoveLeft = "ChaseCamMoveLeft";
     /**
      * @deprecated use {@link CameraInput#CHASECAM_MOVERIGHT}
      */
     @Deprecated
-    public final static String ChaseCamMoveRight = "ChaseCamMoveRight";
+    public static final String ChaseCamMoveRight = "ChaseCamMoveRight";
     /**
      * @deprecated use {@link CameraInput#CHASECAM_TOGGLEROTATE}
      */
     @Deprecated
-    public final static String ChaseCamToggleRotate = "ChaseCamToggleRotate";
+    public static final String ChaseCamToggleRotate = "ChaseCamToggleRotate";
 
     protected boolean zoomin;
     protected boolean hideCursorOnRotate = true;

--- a/jme3-core/src/main/java/com/jme3/input/DefaultJoystickAxis.java
+++ b/jme3-core/src/main/java/com/jme3/input/DefaultJoystickAxis.java
@@ -40,13 +40,13 @@ import com.jme3.input.controls.JoyAxisTrigger;
  */
 public class DefaultJoystickAxis implements JoystickAxis {
 
-    final private InputManager inputManager;
-    final private Joystick parent;
-    final private int axisIndex;
-    final private String name;
-    final private String logicalId;
-    final private boolean isAnalog;
-    final private boolean isRelative;
+    private final InputManager inputManager;
+    private final Joystick parent;
+    private final int axisIndex;
+    private final String name;
+    private final String logicalId;
+    private final boolean isAnalog;
+    private final boolean isRelative;
     private float deadZone;
 
     /**

--- a/jme3-core/src/main/java/com/jme3/input/DefaultJoystickButton.java
+++ b/jme3-core/src/main/java/com/jme3/input/DefaultJoystickButton.java
@@ -40,11 +40,11 @@ import com.jme3.input.controls.JoyButtonTrigger;
  */
 public class DefaultJoystickButton implements JoystickButton {
 
-    final private InputManager inputManager;
-    final private Joystick parent;
-    final private int buttonIndex;
-    final private String name;
-    final private String logicalId;
+    private final InputManager inputManager;
+    private final Joystick parent;
+    private final int buttonIndex;
+    private final String name;
+    private final String logicalId;
 
     public DefaultJoystickButton(InputManager inputManager, Joystick parent, int buttonIndex,
             String name, String logicalId) {

--- a/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
+++ b/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
@@ -56,7 +56,7 @@ import com.jme3.renderer.Camera;
  */
 public class FlyByCamera implements AnalogListener, ActionListener {
 
-    final private static String[] mappings = new String[]{
+    private static final String[] mappings = new String[]{
         CameraInput.FLYCAM_LEFT,
         CameraInput.FLYCAM_RIGHT,
         CameraInput.FLYCAM_UP,

--- a/jme3-core/src/main/java/com/jme3/input/JoystickCompatibilityMappings.java
+++ b/jme3-core/src/main/java/com/jme3/input/JoystickCompatibilityMappings.java
@@ -72,8 +72,8 @@ public class JoystickCompatibilityMappings {
     private static Map<String, Map<String, String>> buttonMappings = new HashMap<String, Map<String, String>>();
 
     // Remaps names by regex.
-    final private static Map<Pattern, String> nameRemappings = new HashMap<>();
-    final private static Map<String, String> nameCache = new HashMap<>();
+    private static final Map<Pattern, String> nameRemappings = new HashMap<>();
+    private static final Map<String, String> nameCache = new HashMap<>();
 
     static {
         loadDefaultMappings();

--- a/jme3-core/src/main/java/com/jme3/input/event/JoyButtonEvent.java
+++ b/jme3-core/src/main/java/com/jme3/input/event/JoyButtonEvent.java
@@ -41,8 +41,8 @@ import com.jme3.input.JoystickButton;
  */
 public class JoyButtonEvent extends InputEvent {
 
-    final private JoystickButton button;
-    final private boolean pressed;
+    private final JoystickButton button;
+    private final boolean pressed;
 
     public JoyButtonEvent(JoystickButton button, boolean pressed) {
         this.button = button;

--- a/jme3-core/src/main/java/com/jme3/input/event/KeyInputEvent.java
+++ b/jme3-core/src/main/java/com/jme3/input/event/KeyInputEvent.java
@@ -40,10 +40,10 @@ import com.jme3.input.KeyInput;
  */
 public class KeyInputEvent extends InputEvent {
 
-    final private int keyCode;
-    final private char keyChar;
-    final private boolean pressed;
-    final private boolean repeating;
+    private final int keyCode;
+    private final char keyChar;
+    private final boolean pressed;
+    private final boolean repeating;
 
     public KeyInputEvent(int keyCode, char keyChar, boolean pressed, boolean repeating) {
         this.keyCode = keyCode;

--- a/jme3-core/src/main/java/com/jme3/input/event/MouseButtonEvent.java
+++ b/jme3-core/src/main/java/com/jme3/input/event/MouseButtonEvent.java
@@ -40,10 +40,10 @@ import com.jme3.input.MouseInput;
  */
 public class MouseButtonEvent extends InputEvent {
 
-    final private int x;
-    final private int y;
-    final private int btnIndex;
-    final private boolean pressed;
+    private final int x;
+    private final int y;
+    private final int btnIndex;
+    private final boolean pressed;
 
     public MouseButtonEvent(int btnIndex, boolean pressed, int x, int y) {
         this.btnIndex = btnIndex;

--- a/jme3-core/src/main/java/com/jme3/input/event/MouseMotionEvent.java
+++ b/jme3-core/src/main/java/com/jme3/input/event/MouseMotionEvent.java
@@ -40,7 +40,7 @@ package com.jme3.input.event;
  */
 public class MouseMotionEvent extends InputEvent {
 
-    final private int x, y, dx, dy, wheel, deltaWheel;
+    private final int x, y, dx, dy, wheel, deltaWheel;
 
     public MouseMotionEvent(int x, int y, int dx, int dy, int wheel, int deltaWheel) {
         this.x = x;

--- a/jme3-core/src/main/java/com/jme3/light/Light.java
+++ b/jme3-core/src/main/java/com/jme3/light/Light.java
@@ -87,7 +87,7 @@ public abstract class Light implements Savable, Cloneable {
         Probe(4);
                 
 
-        final private int typeId;
+        private final int typeId;
 
         Type(int type){
             this.typeId = type;

--- a/jme3-core/src/main/java/com/jme3/light/SphereProbeArea.java
+++ b/jme3-core/src/main/java/com/jme3/light/SphereProbeArea.java
@@ -13,7 +13,7 @@ public class SphereProbeArea implements ProbeArea {
 
     private Vector3f center = new Vector3f();
     private float radius = 1;
-    final private Matrix4f uniformMatrix = new Matrix4f();
+    private final Matrix4f uniformMatrix = new Matrix4f();
 
     public SphereProbeArea() {
     }

--- a/jme3-core/src/main/java/com/jme3/light/WeightedProbeBlendingStrategy.java
+++ b/jme3-core/src/main/java/com/jme3/light/WeightedProbeBlendingStrategy.java
@@ -45,7 +45,7 @@ import java.util.List;
  */
 public class WeightedProbeBlendingStrategy implements LightProbeBlendingStrategy {
 
-    private final static int MAX_PROBES = 3;
+    private static final int MAX_PROBES = 3;
     List<LightProbe> lightProbes = new ArrayList<>();
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/material/Material.java
+++ b/jme3-core/src/main/java/com/jme3/material/Material.java
@@ -83,7 +83,7 @@ public class Material implements CloneableSmartAsset, Cloneable, Savable {
     private Technique technique;
     private HashMap<String, Technique> techniques = new HashMap<>();
     private RenderState additionalState = null;
-    final private RenderState mergedRenderState = new RenderState();
+    private final RenderState mergedRenderState = new RenderState();
     private boolean transparent = false;
     private boolean receivesShadows = false;
     private int sortingId = -1;

--- a/jme3-core/src/main/java/com/jme3/material/logic/SinglePassAndImageBasedLightingLogic.java
+++ b/jme3-core/src/main/java/com/jme3/material/logic/SinglePassAndImageBasedLightingLogic.java
@@ -55,7 +55,7 @@ public final class SinglePassAndImageBasedLightingLogic extends DefaultTechnique
 
     private boolean useAmbientLight;
     private final ColorRGBA ambientLightColor = new ColorRGBA(0, 0, 0, 1);
-    final private List<LightProbe> lightProbes = new ArrayList<>(3);
+    private final List<LightProbe> lightProbes = new ArrayList<>(3);
 
     static {
         ADDITIVE_LIGHT.setBlendMode(BlendMode.AlphaAdditive);
@@ -278,7 +278,6 @@ public final class SinglePassAndImageBasedLightingLogic extends DefaultTechnique
                 renderMeshFromGeometry(renderer, geometry);
             }
         }
-        return;
     }
 
     protected void extractIndirectLights(LightList lightList, boolean removeLights) {

--- a/jme3-core/src/main/java/com/jme3/math/Ring.java
+++ b/jme3-core/src/main/java/com/jme3/math/Ring.java
@@ -47,7 +47,7 @@ public final class Ring implements Savable, Cloneable, java.io.Serializable {
 
     private Vector3f center, up;
     private float innerRadius, outerRadius;
-    private transient static Vector3f b1 = new Vector3f(), b2 = new Vector3f();
+    private static transient Vector3f b1 = new Vector3f(), b2 = new Vector3f();
 
     /**
      * Constructor creates a new <code>Ring</code> lying on the XZ plane,

--- a/jme3-core/src/main/java/com/jme3/math/Vector3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector3f.java
@@ -52,32 +52,32 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * Shared instance of the all-zero vector (0,0,0). Do not modify!
      */
-    public final static Vector3f ZERO = new Vector3f(0, 0, 0);
+    public static final Vector3f ZERO = new Vector3f(0, 0, 0);
     /**
      * Shared instance of the all-NaN vector (NaN,NaN,NaN). Do not modify!
      */
-    public final static Vector3f NAN = new Vector3f(Float.NaN, Float.NaN, Float.NaN);
+    public static final Vector3f NAN = new Vector3f(Float.NaN, Float.NaN, Float.NaN);
     /**
      * Shared instance of the +X direction (1,0,0). Do not modify!
      */
-    public final static Vector3f UNIT_X = new Vector3f(1, 0, 0);
+    public static final Vector3f UNIT_X = new Vector3f(1, 0, 0);
     /**
      * Shared instance of the +Y direction (0,1,0). Do not modify!
      */
-    public final static Vector3f UNIT_Y = new Vector3f(0, 1, 0);
+    public static final Vector3f UNIT_Y = new Vector3f(0, 1, 0);
     /**
      * Shared instance of the +Z direction (0,0,1). Do not modify!
      */
-    public final static Vector3f UNIT_Z = new Vector3f(0, 0, 1);
+    public static final Vector3f UNIT_Z = new Vector3f(0, 0, 1);
     /**
      * Shared instance of the all-ones vector (1,1,1). Do not modify!
      */
-    public final static Vector3f UNIT_XYZ = new Vector3f(1, 1, 1);
+    public static final Vector3f UNIT_XYZ = new Vector3f(1, 1, 1);
     /**
      * Shared instance of the all-plus-infinity vector (+Inf,+Inf,+Inf). Do not
      * modify!
      */
-    public final static Vector3f POSITIVE_INFINITY = new Vector3f(
+    public static final Vector3f POSITIVE_INFINITY = new Vector3f(
             Float.POSITIVE_INFINITY,
             Float.POSITIVE_INFINITY,
             Float.POSITIVE_INFINITY);
@@ -85,7 +85,7 @@ public final class Vector3f implements Savable, Cloneable, java.io.Serializable 
      * Shared instance of the all-negative-infinity vector (-Inf,-Inf,-Inf). Do
      * not modify!
      */
-    public final static Vector3f NEGATIVE_INFINITY = new Vector3f(
+    public static final Vector3f NEGATIVE_INFINITY = new Vector3f(
             Float.NEGATIVE_INFINITY,
             Float.NEGATIVE_INFINITY,
             Float.NEGATIVE_INFINITY);

--- a/jme3-core/src/main/java/com/jme3/math/Vector4f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Vector4f.java
@@ -51,36 +51,36 @@ public final class Vector4f implements Savable, Cloneable, java.io.Serializable 
     /**
      * shared instance of the all-zero vector (0,0,0,0) - Do not modify!
      */
-    public final static Vector4f ZERO = new Vector4f(0, 0, 0, 0);
+    public static final Vector4f ZERO = new Vector4f(0, 0, 0, 0);
     /**
      * shared instance of the all-NaN vector (NaN,NaN,NaN,NaN) - Do not modify!
      */
-    public final static Vector4f NAN = new Vector4f(Float.NaN, Float.NaN, Float.NaN, Float.NaN);
+    public static final Vector4f NAN = new Vector4f(Float.NaN, Float.NaN, Float.NaN, Float.NaN);
     /**
      * shared instance of the +X direction (1,0,0,0) - Do not modify!
      */
-    public final static Vector4f UNIT_X = new Vector4f(1, 0, 0, 0);
+    public static final Vector4f UNIT_X = new Vector4f(1, 0, 0, 0);
     /**
      * shared instance of the +Y direction (0,1,0,0) - Do not modify!
      */
-    public final static Vector4f UNIT_Y = new Vector4f(0, 1, 0, 0);
+    public static final Vector4f UNIT_Y = new Vector4f(0, 1, 0, 0);
     /**
      * shared instance of the +Z direction (0,0,1,0) - Do not modify!
      */
-    public final static Vector4f UNIT_Z = new Vector4f(0, 0, 1, 0);
+    public static final Vector4f UNIT_Z = new Vector4f(0, 0, 1, 0);
     /**
      * shared instance of the +W direction (0,0,0,1) - Do not modify!
      */
-    public final static Vector4f UNIT_W = new Vector4f(0, 0, 0, 1);
+    public static final Vector4f UNIT_W = new Vector4f(0, 0, 0, 1);
     /**
      * shared instance of the all-ones vector (1,1,1,1) - Do not modify!
      */
-    public final static Vector4f UNIT_XYZW = new Vector4f(1, 1, 1, 1);
+    public static final Vector4f UNIT_XYZW = new Vector4f(1, 1, 1, 1);
     /**
      * shared instance of the all-plus-infinity vector (+Inf,+Inf,+Inf,+Inf)
      * - Do not modify!
      */
-    public final static Vector4f POSITIVE_INFINITY = new Vector4f(
+    public static final Vector4f POSITIVE_INFINITY = new Vector4f(
             Float.POSITIVE_INFINITY,
             Float.POSITIVE_INFINITY,
             Float.POSITIVE_INFINITY,
@@ -89,7 +89,7 @@ public final class Vector4f implements Savable, Cloneable, java.io.Serializable 
      * shared instance of the all-negative-infinity vector (-Inf,-Inf,-Inf,-Inf)
      * - Do not modify!
      */
-    public final static Vector4f NEGATIVE_INFINITY = new Vector4f(
+    public static final Vector4f NEGATIVE_INFINITY = new Vector4f(
             Float.NEGATIVE_INFINITY,
             Float.NEGATIVE_INFINITY,
             Float.NEGATIVE_INFINITY,

--- a/jme3-core/src/main/java/com/jme3/opencl/OpenCLObjectManager.java
+++ b/jme3-core/src/main/java/com/jme3/opencl/OpenCLObjectManager.java
@@ -53,8 +53,8 @@ public class OpenCLObjectManager {
         return INSTANCE;
     }
     
-    final private ReferenceQueue<Object> refQueue = new ReferenceQueue<>();
-    final private HashSet<OpenCLObjectRef> activeObjects = new HashSet<>();
+    private final ReferenceQueue<Object> refQueue = new ReferenceQueue<>();
+    private final HashSet<OpenCLObjectRef> activeObjects = new HashSet<>();
     
     private static class OpenCLObjectRef extends PhantomReference<Object> {
         

--- a/jme3-core/src/main/java/com/jme3/post/HDRRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/post/HDRRenderer.java
@@ -95,7 +95,7 @@ public class HDRRenderer implements SceneProcessor {
 
     private MinFilter fbMinFilter = MinFilter.BilinearNoMipMaps;
     private MagFilter fbMagFilter = MagFilter.Bilinear;
-    final private AssetManager manager;
+    private final AssetManager manager;
 
     private boolean enabled = true;
 

--- a/jme3-core/src/main/java/com/jme3/post/PreDepthProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/PreDepthProcessor.java
@@ -49,8 +49,8 @@ public class PreDepthProcessor implements SceneProcessor {
 
     private RenderManager rm;
     private ViewPort vp;
-    final private Material preDepth;
-    final private RenderState forcedRS;
+    private final Material preDepth;
+    private final RenderState forcedRS;
 
     public PreDepthProcessor(AssetManager assetManager){
         preDepth = new Material(assetManager, "Common/MatDefs/Shadow/PreShadow.j3md");

--- a/jme3-core/src/main/java/com/jme3/renderer/queue/GeometryList.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/queue/GeometryList.java
@@ -51,7 +51,7 @@ public class GeometryList implements Iterable<Geometry>{
     private static final int DEFAULT_SIZE = 32;
 
     private Geometry[] geometries;
-    final private ListSort listSort;
+    private final ListSort listSort;
     private int size;
     private GeometryComparator comparator;
 

--- a/jme3-core/src/main/java/com/jme3/scene/SimpleBatchNode.java
+++ b/jme3-core/src/main/java/com/jme3/scene/SimpleBatchNode.java
@@ -39,7 +39,9 @@ import com.jme3.util.TempVars;
  * SimpleBatchNode  comes with some restrictions, but can yield better performances.
  * Geometries to be batched has to be attached directly to the BatchNode
  * You can't attach a Node to a SimpleBatchNode
- * SimpleBatchNode is recommended when you have a large number of geometries using the same material that does not require a complex scene graph structure.
+ * SimpleBatchNode is recommended when you have a large number of geometries using the 
+ * same material that does not require a complex scene graph structure.
+ * 
  * @see BatchNode
  * @author Nehon
  */
@@ -55,9 +57,9 @@ public class SimpleBatchNode extends BatchNode {
 
     @Override
     public int attachChild(Spatial child) {
-
         if (!(child instanceof Geometry)) {
-            throw new UnsupportedOperationException("BatchNode is BatchMode.Simple only support child of type Geometry, use BatchMode.Complex to use a complex structure");
+            throw new UnsupportedOperationException("BatchNode is BatchMode.Simple only support child "
+                                    + "of type Geometry, use BatchMode.Complex to use a complex structure");
         }
 
         return super.attachChild(child);
@@ -71,7 +73,8 @@ public class SimpleBatchNode extends BatchNode {
             batch.geometry.setTransformRefresh();
         }
     }
-    final private Matrix4f cachedLocalMat = new Matrix4f();
+    
+    private final Matrix4f cachedLocalMat = new Matrix4f();
 
     @Override
     protected Matrix4f getTransformMatrix(Geometry g){
@@ -89,7 +92,6 @@ public class SimpleBatchNode extends BatchNode {
         return cachedLocalMat;
     }
     
-
     @Override
     public void batch() {
         doBatch();

--- a/jme3-core/src/main/java/com/jme3/scene/control/AreaUtils.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/AreaUtils.java
@@ -31,10 +31,7 @@
  */
 package com.jme3.scene.control;
 
-import com.jme3.bounding.BoundingBox;
-import com.jme3.bounding.BoundingSphere;
 import com.jme3.bounding.BoundingVolume;
-import com.jme3.math.FastMath;
 
 /**
  * <code>AreaUtils</code> is used to calculate the area of various objects, such as bounding volumes.  These

--- a/jme3-core/src/main/java/com/jme3/scene/debug/Arrow.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/Arrow.java
@@ -47,8 +47,8 @@ import java.nio.FloatBuffer;
  */
 public class Arrow extends Mesh {
     
-    final private Quaternion tempQuat = new Quaternion();
-    final private Vector3f tempVec = new Vector3f();
+    private final Quaternion tempQuat = new Quaternion();
+    private final Vector3f tempVec = new Vector3f();
 
     private static final float[] positions = new float[]{
         0, 0, 0,

--- a/jme3-core/src/main/java/com/jme3/scene/debug/SkeletonDebugger.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/SkeletonDebugger.java
@@ -150,6 +150,7 @@ public class SkeletonDebugger extends Node {
         interBoneWires = getMesh("_interwires");
     }
 
+    @SuppressWarnings("unchecked")
     private <T extends Mesh> T getMesh(String suffix) {
         Geometry child = (Geometry)getChild(getGeometryName(suffix));
         if(child != null) {

--- a/jme3-core/src/main/java/com/jme3/scene/debug/custom/ArmatureInterJointsWire.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/custom/ArmatureInterJointsWire.java
@@ -46,7 +46,7 @@ import java.nio.FloatBuffer;
  * @author Marcin Roguski (Kaelthas)
  */
 public class ArmatureInterJointsWire extends Mesh {
-    final private Vector3f tmp = new Vector3f();
+    private final Vector3f tmp = new Vector3f();
 
 
     public ArmatureInterJointsWire(Vector3f start, Vector3f[] ends) {

--- a/jme3-core/src/main/java/com/jme3/scene/debug/custom/ArmatureNode.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/custom/ArmatureNode.java
@@ -54,19 +54,19 @@ public class ArmatureNode extends Node {
     /**
      * The armature to be displayed.
      */
-    final private Armature armature;
+    private final Armature armature;
     /**
      * The map between the bone index and its length.
      */
-    final private Map<Joint, Geometry[]> jointToGeoms = new HashMap<>();
-    final private Map<Geometry, Joint> geomToJoint = new HashMap<>();
+    private final Map<Joint, Geometry[]> jointToGeoms = new HashMap<>();
+    private final Map<Geometry, Joint> geomToJoint = new HashMap<>();
     private Joint selectedJoint = null;
-    final private Vector3f tmp = new Vector3f();
-    final private Vector2f tmpv2 = new Vector2f();
-    private final static ColorRGBA selectedColor = ColorRGBA.Orange;
-    private final static ColorRGBA selectedColorJ = ColorRGBA.Yellow;
-    private final static ColorRGBA outlineColor = ColorRGBA.LightGray;
-    private final static ColorRGBA baseColor = new ColorRGBA(0.05f, 0.05f, 0.05f, 1f);
+    private final Vector3f tmp = new Vector3f();
+    private final Vector2f tmpv2 = new Vector2f();
+    private static final ColorRGBA selectedColor = ColorRGBA.Orange;
+    private static final ColorRGBA selectedColorJ = ColorRGBA.Yellow;
+    private static final ColorRGBA outlineColor = ColorRGBA.LightGray;
+    private static final ColorRGBA baseColor = new ColorRGBA(0.05f, 0.05f, 0.05f, 1f);
 
     private Camera camera;
 

--- a/jme3-core/src/main/java/com/jme3/scene/debug/custom/JointShape.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/custom/JointShape.java
@@ -35,9 +35,7 @@ package com.jme3.scene.debug.custom;
 import com.jme3.scene.Mesh;
 import com.jme3.scene.VertexBuffer.Type;
 
-
 public class JointShape extends Mesh {
-
 
     /**
      * Serialization only. Do not use.
@@ -74,6 +72,4 @@ public class JointShape extends Mesh {
         updateBound();
         setStatic();
     }
-
-
 }

--- a/jme3-core/src/main/java/com/jme3/scene/mesh/IndexByteBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/mesh/IndexByteBuffer.java
@@ -43,7 +43,7 @@ import com.jme3.scene.VertexBuffer.Format;
  */
 public class IndexByteBuffer extends IndexBuffer {
 
-    final private ByteBuffer buf;
+    private final ByteBuffer buf;
     /**
      * the largest index value that can be put to the buffer
      */

--- a/jme3-core/src/main/java/com/jme3/scene/mesh/IndexIntBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/mesh/IndexIntBuffer.java
@@ -43,7 +43,7 @@ import com.jme3.scene.VertexBuffer.Format;
  */
 public class IndexIntBuffer extends IndexBuffer {
 
-    final private IntBuffer buf;
+    private final IntBuffer buf;
 
     public IndexIntBuffer(IntBuffer buffer) {
         buf = buffer;

--- a/jme3-core/src/main/java/com/jme3/scene/mesh/IndexShortBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/scene/mesh/IndexShortBuffer.java
@@ -43,7 +43,7 @@ import com.jme3.scene.VertexBuffer.Format;
  */
 public class IndexShortBuffer extends IndexBuffer {
 
-    final private ShortBuffer buf;
+    private final ShortBuffer buf;
     /**
      * the largest index value that can be put to the buffer
      */

--- a/jme3-core/src/main/java/com/jme3/scene/mesh/MorphTarget.java
+++ b/jme3-core/src/main/java/com/jme3/scene/mesh/MorphTarget.java
@@ -10,7 +10,7 @@ import java.util.EnumMap;
 import java.util.Map;
 
 public class MorphTarget implements Savable {
-    final private EnumMap<VertexBuffer.Type, FloatBuffer> buffers = new EnumMap<>(VertexBuffer.Type.class);
+    private final EnumMap<VertexBuffer.Type, FloatBuffer> buffers = new EnumMap<>(VertexBuffer.Type.class);
     private String name = null;
     
     public MorphTarget() {

--- a/jme3-core/src/main/java/com/jme3/shader/Glsl100ShaderGenerator.java
+++ b/jme3-core/src/main/java/com/jme3/shader/Glsl100ShaderGenerator.java
@@ -50,7 +50,7 @@ public class Glsl100ShaderGenerator extends ShaderGenerator {
     /**
      * the indentation characters 1à tabulation characters
      */
-    private final static String INDENTCHAR = "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t";
+    private static final String INDENTCHAR = "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t";
 
     protected ShaderNodeVariable inPosTmp;
 

--- a/jme3-core/src/main/java/com/jme3/shader/UniformBindingManager.java
+++ b/jme3-core/src/main/java/com/jme3/shader/UniformBindingManager.java
@@ -55,31 +55,31 @@ public class UniformBindingManager {
     private float near, far;
     private Float time, tpf;
     private int viewX, viewY, viewWidth, viewHeight;
-    final private Vector3f camUp = new Vector3f(),
+    private final Vector3f camUp = new Vector3f(),
             camLeft = new Vector3f(),
             camDir = new Vector3f(),
             camLoc = new Vector3f();
-    final private Matrix4f tempMatrix = new Matrix4f();
-    final private Matrix4f viewMatrix = new Matrix4f();
-    final private Matrix4f projMatrix = new Matrix4f();
-    final private Matrix4f viewProjMatrix = new Matrix4f();
-    final private Matrix4f worldMatrix = new Matrix4f();
-    final private Matrix4f worldViewMatrix = new Matrix4f();
-    final private Matrix4f worldViewProjMatrix = new Matrix4f();
-    final private Matrix3f normalMatrix = new Matrix3f();
-    final private Matrix3f worldNormalMatrix = new Matrix3f();
-    final private Matrix4f worldMatrixInv = new Matrix4f();
-    final private Matrix3f worldMatrixInvTrsp = new Matrix3f();
-    final private Matrix4f viewMatrixInv = new Matrix4f();
-    final private Matrix4f projMatrixInv = new Matrix4f();
-    final private Matrix4f viewProjMatrixInv = new Matrix4f();
-    final private Matrix4f worldViewMatrixInv = new Matrix4f();
-    final private Matrix3f normalMatrixInv = new Matrix3f();
-    final private Matrix4f worldViewProjMatrixInv = new Matrix4f();
-    final private Vector4f viewPort = new Vector4f();
-    final private Vector2f resolution = new Vector2f();
-    final private Vector2f resolutionInv = new Vector2f();
-    final private Vector2f nearFar = new Vector2f();
+    private final Matrix4f tempMatrix = new Matrix4f();
+    private final Matrix4f viewMatrix = new Matrix4f();
+    private final Matrix4f projMatrix = new Matrix4f();
+    private final Matrix4f viewProjMatrix = new Matrix4f();
+    private final Matrix4f worldMatrix = new Matrix4f();
+    private final Matrix4f worldViewMatrix = new Matrix4f();
+    private final Matrix4f worldViewProjMatrix = new Matrix4f();
+    private final Matrix3f normalMatrix = new Matrix3f();
+    private final Matrix3f worldNormalMatrix = new Matrix3f();
+    private final Matrix4f worldMatrixInv = new Matrix4f();
+    private final Matrix3f worldMatrixInvTrsp = new Matrix3f();
+    private final Matrix4f viewMatrixInv = new Matrix4f();
+    private final Matrix4f projMatrixInv = new Matrix4f();
+    private final Matrix4f viewProjMatrixInv = new Matrix4f();
+    private final Matrix4f worldViewMatrixInv = new Matrix4f();
+    private final Matrix3f normalMatrixInv = new Matrix3f();
+    private final Matrix4f worldViewProjMatrixInv = new Matrix4f();
+    private final Vector4f viewPort = new Vector4f();
+    private final Vector2f resolution = new Vector2f();
+    private final Vector2f resolutionInv = new Vector2f();
+    private final Vector2f nearFar = new Vector2f();
 
     /**
      * Internal use only.

--- a/jme3-core/src/main/java/com/jme3/shader/bufferobject/layout/BufferLayout.java
+++ b/jme3-core/src/main/java/com/jme3/shader/bufferobject/layout/BufferLayout.java
@@ -84,8 +84,7 @@ public abstract class  BufferLayout {
 
     /**
      * Register a serializer
-     * 
-     * @param type
+     * @param serializer An object of type {@link ObjectSerializer}
      */
     protected void registerSerializer(ObjectSerializer<?> serializer) {
         serializers.add(serializer);
@@ -98,6 +97,7 @@ public abstract class  BufferLayout {
      *            the object to serialize
      * @return the size
      */
+    @SuppressWarnings("unchecked")
     public int estimateSize(Object o) {
         ObjectSerializer s = getSerializer(o);
         return s.length(this, o);
@@ -109,7 +109,7 @@ public abstract class  BufferLayout {
      *            the object to serialize
      * @return the basic alignment
      */
-
+    @SuppressWarnings("unchecked")
     public int getBasicAlignment(Object o) {
         ObjectSerializer s = getSerializer(o);
         return s.basicAlignment(this, o);
@@ -137,6 +137,7 @@ public abstract class  BufferLayout {
      * @param o
      *            the Object to serialize
      */
+    @SuppressWarnings("unchecked")
     public void write(ByteBuffer out, Object o) {
         ObjectSerializer s = getSerializer(o);        
         s.write(this, out, o);

--- a/jme3-core/src/main/java/com/jme3/shadow/BasicShadowRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/BasicShadowRenderer.java
@@ -64,17 +64,17 @@ public class BasicShadowRenderer implements SceneProcessor {
     private static final LightFilter NULL_LIGHT_FILTER = new NullLightFilter();
     private RenderManager renderManager;
     private ViewPort viewPort;
-    final private FrameBuffer shadowFB;
-    final private Texture2D shadowMap;
-    final private Camera shadowCam;
-    final private Material preshadowMat;
-    final private Material postshadowMat;
-    final private Picture dispPic = new Picture("Picture");
+    private final FrameBuffer shadowFB;
+    private final Texture2D shadowMap;
+    private final Camera shadowCam;
+    private final Material preshadowMat;
+    private final Material postshadowMat;
+    private final Picture dispPic = new Picture("Picture");
     private boolean noOccluders = false;
-    final private Vector3f[] points = new Vector3f[8];
-    final private Vector3f direction = new Vector3f();
+    private final Vector3f[] points = new Vector3f[8];
+    private final Vector3f direction = new Vector3f();
     protected Texture2D dummyTex;
-    final private float shadowMapSize;
+    private final float shadowMapSize;
 
     protected GeometryList lightReceivers = new GeometryList(new OpaqueComparator());
     protected GeometryList shadowOccluders = new GeometryList(new OpaqueComparator());

--- a/jme3-core/src/main/java/com/jme3/texture/FrameBuffer.java
+++ b/jme3-core/src/main/java/com/jme3/texture/FrameBuffer.java
@@ -80,7 +80,7 @@ public class FrameBuffer extends NativeObject {
     private int width = 0;
     private int height = 0;
     private int samples = 1;
-    final private ArrayList<RenderBuffer> colorBufs = new ArrayList<>();
+    private final ArrayList<RenderBuffer> colorBufs = new ArrayList<>();
     private RenderBuffer depthBuf = null;
     private int colorBufIndex = 0;
     private boolean srgb;

--- a/jme3-core/src/main/java/com/jme3/util/BufferUtils.java
+++ b/jme3-core/src/main/java/com/jme3/util/BufferUtils.java
@@ -65,8 +65,8 @@ public final class BufferUtils {
     private static final BufferAllocator allocator = BufferAllocatorFactory.create();
 
     private static boolean trackDirectMemory = false;
-    final private static ReferenceQueue<Buffer> removeCollected = new ReferenceQueue<Buffer>();
-    final private static ConcurrentHashMap<BufferInfo, BufferInfo> trackedBuffers = new ConcurrentHashMap<BufferInfo, BufferInfo>();
+    private static final ReferenceQueue<Buffer> removeCollected = new ReferenceQueue<Buffer>();
+    private static final ConcurrentHashMap<BufferInfo, BufferInfo> trackedBuffers = new ConcurrentHashMap<BufferInfo, BufferInfo>();
     static ClearReferences cleanupthread;
 
     /**

--- a/jme3-core/src/main/java/com/jme3/util/JmeFormatter.java
+++ b/jme3-core/src/main/java/com/jme3/util/JmeFormatter.java
@@ -45,11 +45,11 @@ import java.util.logging.LogRecord;
  */
 public class JmeFormatter extends Formatter {
 
-    final private Date calendar = new Date();
-    final private String lineSeparator;
-    final private MessageFormat format;
-    final private Object args[] = new Object[1];
-    final private StringBuffer store = new StringBuffer();
+    private final Date calendar = new Date();
+    private final String lineSeparator;
+    private final MessageFormat format;
+    private final Object args[] = new Object[1];
+    private final StringBuffer store = new StringBuffer();
 
     public JmeFormatter(){
         lineSeparator = System.getProperty("line.separator");
@@ -80,7 +80,7 @@ public class JmeFormatter extends Formatter {
             try {
                 StringWriter sw = new StringWriter();
                 PrintWriter pw = new PrintWriter(sw);
-                record.getThrown().printStackTrace(pw);
+                    record.getThrown().printStackTrace(pw);
                 pw.close();
                 sb.append(sw.toString());
             } catch (Exception ex) {

--- a/jme3-core/src/main/java/com/jme3/util/ListMap.java
+++ b/jme3-core/src/main/java/com/jme3/util/ListMap.java
@@ -43,7 +43,7 @@ import java.util.Map.Entry;
  */
 public final class ListMap<K, V> extends AbstractMap<K, V> implements Cloneable, Serializable {
 
-    private final static class ListMapEntry<K, V> implements Map.Entry<K, V>, Cloneable {
+    private static final class ListMapEntry<K, V> implements Map.Entry<K, V>, Cloneable {
 
         private final K key;
         private V value;

--- a/jme3-core/src/main/java/com/jme3/util/NativeObjectManager.java
+++ b/jme3-core/src/main/java/com/jme3/util/NativeObjectManager.java
@@ -74,12 +74,12 @@ public class NativeObjectManager {
     /**
      * List of currently active GLObjects.
      */
-    final private HashMap<Long, NativeObjectRef> refMap = new HashMap<>();
+    private final HashMap<Long, NativeObjectRef> refMap = new HashMap<>();
     
     /**
      * List of real objects requested by user for deletion.
      */
-    final private ArrayDeque<NativeObject> userDeletionQueue = new ArrayDeque<>();
+    private final ArrayDeque<NativeObject> userDeletionQueue = new ArrayDeque<>();
 
     private static class NativeObjectRef extends PhantomReference<Object> {
         

--- a/jme3-core/src/main/java/com/jme3/util/SafeArrayList.java
+++ b/jme3-core/src/main/java/com/jme3/util/SafeArrayList.java
@@ -83,7 +83,7 @@ public class SafeArrayList<E> implements List<E>, Cloneable {
     //       the list.  This was because the callers couldn't remove a child
     //       without it being detached properly, for example.
 
-    final private Class<E> elementType;
+    private final Class<E> elementType;
     private List<E> buffer;
     private E[] backingArray;
     private int size = 0;

--- a/jme3-core/src/main/java/com/jme3/util/blockparser/BlockLanguageParser.java
+++ b/jme3-core/src/main/java/com/jme3/util/blockparser/BlockLanguageParser.java
@@ -41,7 +41,7 @@ import java.util.List;
 public class BlockLanguageParser {
 
     private Reader reader;
-    final private ArrayList<Statement> statementStack = new ArrayList<>();
+    private final ArrayList<Statement> statementStack = new ArrayList<>();
     private Statement lastStatement;
     private int lineNumber = 1;
 

--- a/jme3-core/src/main/java/com/jme3/util/clone/Cloner.java
+++ b/jme3-core/src/main/java/com/jme3/util/clone/Cloner.java
@@ -104,12 +104,12 @@ public class Cloner {
     /**
      *  Keeps track of the objects that have been cloned so far.
      */
-    final private IdentityHashMap<Object, Object> index = new IdentityHashMap<>();
+    private final IdentityHashMap<Object, Object> index = new IdentityHashMap<>();
 
     /**
      *  Custom functions for cloning objects.
      */
-    final private Map<Class, CloneFunction> functions = new HashMap<>();
+    private final Map<Class, CloneFunction> functions = new HashMap<>();
 
     /**
      *  Cache the clone methods once for all cloners.

--- a/jme3-core/src/main/java/com/jme3/util/functional/Function.java
+++ b/jme3-core/src/main/java/com/jme3/util/functional/Function.java
@@ -1,5 +1,35 @@
+/*
+ * Copyright (c) 2009-2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.util.functional;
-
 
 public interface Function<R,T> {
     R eval(T t);

--- a/jme3-core/src/main/java/com/jme3/util/functional/NoArgFunction.java
+++ b/jme3-core/src/main/java/com/jme3/util/functional/NoArgFunction.java
@@ -1,4 +1,34 @@
-
+/*
+ * Copyright (c) 2009-2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.util.functional;
 
 public interface NoArgFunction<R> {

--- a/jme3-core/src/main/java/com/jme3/util/functional/NoArgVoidFunction.java
+++ b/jme3-core/src/main/java/com/jme3/util/functional/NoArgVoidFunction.java
@@ -1,4 +1,34 @@
-
+/*
+ * Copyright (c) 2009-2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.util.functional;
 
 public interface NoArgVoidFunction {

--- a/jme3-core/src/main/java/com/jme3/util/functional/VoidFunction.java
+++ b/jme3-core/src/main/java/com/jme3/util/functional/VoidFunction.java
@@ -1,4 +1,34 @@
-
+/*
+ * Copyright (c) 2009-2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jme3.util.functional;
 
 public interface VoidFunction<T> {

--- a/jme3-core/src/main/java/com/jme3/util/mikktspace/MikktspaceTangentGenerator.java
+++ b/jme3-core/src/main/java/com/jme3/util/mikktspace/MikktspaceTangentGenerator.java
@@ -61,11 +61,11 @@ import java.util.logging.Logger;
  */
 public class MikktspaceTangentGenerator {
 
-    private final static int MARK_DEGENERATE = 1;
-    private final static int QUAD_ONE_DEGEN_TRI = 2;
-    private final static int GROUP_WITH_ANY = 4;
-    private final static int ORIENT_PRESERVING = 8;
-    private final static long INTERNAL_RND_SORT_SEED = 39871946 & 0xffffffffL;
+    private static final int MARK_DEGENERATE = 1;
+    private static final int QUAD_ONE_DEGEN_TRI = 2;
+    private static final int GROUP_WITH_ANY = 4;
+    private static final int ORIENT_PRESERVING = 8;
+    private static final long INTERNAL_RND_SORT_SEED = 39871946 & 0xffffffffL;
     static final int CELLS = 2048;
     
     private final static Logger logger = Logger.getLogger(MikktspaceTangentGenerator.class.getName());

--- a/jme3-core/src/main/java/com/jme3/util/struct/fields/SubStructArrayField.java
+++ b/jme3-core/src/main/java/com/jme3/util/struct/fields/SubStructArrayField.java
@@ -39,11 +39,13 @@ import com.jme3.util.struct.StructField;
 
 public class SubStructArrayField<T extends Struct> extends StructField<T[]> {
 
+    @SuppressWarnings("unchecked")
     public SubStructArrayField(int position, String name, T[] value) {
         super(position, name, value);
         initializeToZero((Class<? extends T>) value[0].getClass());
     }
 
+    @SuppressWarnings("unchecked")
     public SubStructArrayField(int position, String name, int length, Class<? extends T> structClass) {
         super(position, name, (T[]) Array.newInstance(structClass, length));
         initializeToZero(structClass);

--- a/jme3-core/src/plugins/java/com/jme3/asset/plugins/UrlAssetInfo.java
+++ b/jme3-core/src/plugins/java/com/jme3/asset/plugins/UrlAssetInfo.java
@@ -47,7 +47,7 @@ import java.net.URLConnection;
  */
 public class UrlAssetInfo extends AssetInfo {
     
-    final private URL url;
+    private final URL url;
     private InputStream in;
     
     public static UrlAssetInfo create(AssetManager assetManager, AssetKey key, URL url) throws IOException {

--- a/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryExporter.java
+++ b/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryExporter.java
@@ -124,17 +124,17 @@ public class BinaryExporter implements JmeExporter {
     protected int aliasCount = 1;
     protected int idCount = 1;
 
-    final private IdentityHashMap<Savable, BinaryIdContentPair> contentTable
+    private final IdentityHashMap<Savable, BinaryIdContentPair> contentTable
              = new IdentityHashMap<>();
 
     protected HashMap<Integer, Integer> locationTable
              = new HashMap<>();
 
     // key - class name, value = bco
-    final private HashMap<String, BinaryClassObject> classes
+    private final HashMap<String, BinaryClassObject> classes
              = new HashMap<>();
 
-    final private ArrayList<Savable> contentKeys = new ArrayList<>();
+    private final ArrayList<Savable> contentKeys = new ArrayList<>();
 
     public static boolean debug = false;
     public static boolean useFastBufs = true;

--- a/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryImporter.java
+++ b/jme3-core/src/plugins/java/com/jme3/export/binary/BinaryImporter.java
@@ -54,16 +54,16 @@ public final class BinaryImporter implements JmeImporter {
     private AssetManager assetManager;
 
     //Key - alias, object - bco
-    final private HashMap<String, BinaryClassObject> classes
+    private final HashMap<String, BinaryClassObject> classes
              = new HashMap<>();
     //Key - id, object - the savable
-    final private HashMap<Integer, Savable> contentTable
+    private final HashMap<Integer, Savable> contentTable
             = new HashMap<>();
     //Key - savable, object - capsule
-    final private IdentityHashMap<Savable, BinaryInputCapsule> capsuleTable
+    private final IdentityHashMap<Savable, BinaryInputCapsule> capsuleTable
              = new IdentityHashMap<>();
     //Key - id, object - location in the file
-    final private HashMap<Integer, Integer> locationTable
+    private final HashMap<Integer, Integer> locationTable
              = new HashMap<>();
 
     public static boolean debug = false;

--- a/jme3-core/src/plugins/java/com/jme3/material/plugins/J3MLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/material/plugins/J3MLoader.java
@@ -51,8 +51,6 @@ import com.jme3.util.blockparser.BlockLanguageParser;
 import com.jme3.util.blockparser.Statement;
 import com.jme3.util.clone.Cloner;
 import jme3tools.shader.Preprocessor;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
@@ -76,10 +74,10 @@ public class J3MLoader implements AssetLoader {
     private Material material;
     private TechniqueDef technique;
     private RenderState renderState;
-    final private ArrayList<String> presetDefines = new ArrayList<>();
+    private final ArrayList<String> presetDefines = new ArrayList<>();
 
-    final private List<EnumMap<Shader.ShaderType, String>> shaderLanguages;
-    final private EnumMap<Shader.ShaderType, String> shaderNames;
+    private final List<EnumMap<Shader.ShaderType, String>> shaderLanguages;
+    private final EnumMap<Shader.ShaderType, String> shaderNames;
 
     private static final String whitespacePattern = "\\p{javaWhitespace}+";
 

--- a/jme3-core/src/plugins/java/com/jme3/shader/plugins/GLSLLoader.java
+++ b/jme3-core/src/plugins/java/com/jme3/shader/plugins/GLSLLoader.java
@@ -43,7 +43,7 @@ import java.util.*;
 public class GLSLLoader implements AssetLoader {
 
     private AssetManager assetManager;
-    final private Map<String, ShaderDependencyNode> dependCache = new HashMap<>();
+    private final Map<String, ShaderDependencyNode> dependCache = new HashMap<>();
 
     /**
      * Used to load {@link ShaderDependencyNode}s.

--- a/jme3-core/src/tools/java/jme3tools/optimize/LodGenerator.java
+++ b/jme3-core/src/tools/java/jme3tools/optimize/LodGenerator.java
@@ -108,7 +108,7 @@ public class LodGenerator {
     private List<Triangle> triangleList;
     private List<Vertex> vertexList = new ArrayList<>();
     private float meshBoundingSphereRadius;
-    final private Mesh mesh;
+    private final Mesh mesh;
 
     /**
      * Enumerate criteria for removing triangles.
@@ -235,7 +235,7 @@ public class LodGenerator {
     /**
      * Comparator used to sort vertices according to their collapse cost
      */
-    final private Comparator<Vertex> collapseComparator = new Comparator<Vertex>() {
+    private final Comparator<Vertex> collapseComparator = new Comparator<Vertex>() {
         @Override
         public int compare(Vertex o1, Vertex o2) {
             if (Float.compare(o1.collapseCost, o2.collapseCost) == 0) {

--- a/jme3-core/src/tools/java/jme3tools/optimize/TextureAtlas.java
+++ b/jme3-core/src/tools/java/jme3tools/optimize/TextureAtlas.java
@@ -121,11 +121,11 @@ public class TextureAtlas {
 
     private static final Logger logger = Logger.getLogger(TextureAtlas.class.getName());
     private Map<String, byte[]> images;
-    final private int atlasWidth, atlasHeight;
-    final private Format format = Format.ABGR8;
-    final private Node root;
-    final private Map<String, TextureAtlasTile> locationMap;
-    final private Map<String, String> mapNameMap;
+    private final int atlasWidth, atlasHeight;
+    private final Format format = Format.ABGR8;
+    private final Node root;
+    private final Map<String, TextureAtlasTile> locationMap;
+    private final Map<String, String> mapNameMap;
     private String rootMapName;
 
     public TextureAtlas(int width, int height) {


### PR DESCRIPTION
Hello everyone, this PR mainly changes the way `static` and `final `variables are declared. These changes only applied to the **jme3-core** module (generally)

**Before**
```java
final private...
private final static...
```

**After**
```java
private final...
private static final...
```

In some classes no headers (license) were set. This is now corrected. Also add some annotations to suppress warnings when a method is generic.

What do you think of these changes?
