### PR TITLE
Fix for issue #2302 - NativeLibraryLoader fails due to no write permissions

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
@@ -198,14 +198,15 @@ public final class NativeLibraryLoader {
                 setExtractionFolderToUserCache();
             } else {
                 try {
-                    File jmeTempDir = new File(userTempDir, "jme3");
-                    if (!jmeTempDir.exists()) {
-                        jmeTempDir.mkdir();
-                    }
-                    extractionFolder = new File(jmeTempDir, "natives_" + Integer.toHexString(computeNativesHash()));
+                    extractionFolder = new File(userTempDir, "jme3_natives_" + Integer.toHexString(computeNativesHash()));
 
                     if (!extractionFolder.exists()) {
-                        extractionFolder.mkdir();
+                        if(!extractionFolder.mkdir()) {
+                            throw new IOException("Failed to create folder "+extractionFolder);
+                        }
+                    }
+                    if(!extractionFolder.canWrite()) {
+                        setExtractionFolderToUserCache();
                     }
                 } catch (Exception e) {
                     setExtractionFolderToUserCache();
@@ -268,7 +269,7 @@ public final class NativeLibraryLoader {
             extractionFolder.mkdir();
         }
         
-        logger.log(Level.WARNING, "Working directory is not writable. "
+        logger.log(Level.WARNING, "Temp directory is not writable. "
                                 + "Natives will be extracted to:\n{0}", 
                                 extractionFolder);
     }


### PR DESCRIPTION
This fixes an an issue I encountered while running a jmonkey application in Linux. #2302 - NativeLibraryLoader fails due to no write permissions.
The cause of the bug is a bit of an edge case, but it results in the native library not being extracted and the application not starting.

The main change I made is to extract the native library to a folder directly beneath the user temp folder, instead of using an intermediate tmp/jme subfolder. The reason for this is to avoid the scenario where the /tmp/jme folder is owned by one user and another user tries to write to it.
Note that this change is optional and I could modify the PR to not include it. We can still use /tmp/jme and fall back to calling setExtractionFolderToUserCache() if the /tmp/jme folder is not writable.
 
The other changes are to tighten the logic so the code will call setExtractionFolderToUserCache() instead of crashing.
- Check the result of the call to mkdir. If it fails, call call setExtractionFolderToUserCache()
- Check if the extraction folder is actually writable. If not, call setExtractionFolderToUserCache()
- Updated log message: since a previous change we no longer extract to the working directory.

Some general notes about this PR:
I tried to limit the scope to only fix the immediate issue.
There are other issues with NativeLibraryLoader that this PR does not address
- There are other places in NativeLibraryLoader where the result of mkdir is not checked.
- It should potentially use mkdirs() instead of mkdir()


