### PR TITLE
GSON global version (Gradle)

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -31,7 +31,8 @@ tasks.withType(JavaCompile) { // compile-time options:
 
 ext {
     lwjgl3Version = '3.3.3' // used in both the jme3-lwjgl3 and jme3-vr build scripts
-    niftyVersion = '1.4.3' // used in both the jme3-niftygui and jme3-examples build scripts
+    niftyVersion = '1.4.3'  // used in both the jme3-niftygui and jme3-examples build scripts
+    gsonVersion = '2.9.1'   // used in both the jme3-plugins and jme3-plugins-json-gson build scripts
 }
 
 repositories {

--- a/jme3-plugins-json-gson/build.gradle
+++ b/jme3-plugins-json-gson/build.gradle
@@ -1,16 +1,12 @@
 sourceSets {
     main {
         java {
-           
             srcDir 'src/main/java'
-
         }
     }
 }
 
 dependencies {
-
     api project(':jme3-plugins-json')
-    api 'com.google.code.gson:gson:2.9.1'
-
+    api "com.google.code.gson:gson:${gsonVersion}"
 }

--- a/jme3-plugins/build.gradle
+++ b/jme3-plugins/build.gradle
@@ -11,6 +11,6 @@ sourceSets {
 
 dependencies {
     api project(':jme3-core')
-    api 'com.google.code.gson:gson:2.9.1'
+    api "com.google.code.gson:gson:${gsonVersion}"
     testRuntimeOnly project(':jme3-desktop')
 }


### PR DESCRIPTION
It seems that the gson library is used by 2 modules: `jme3-plugins and jme3-plugins-json-gson`, this can be tedious when gson has a new version and needs to be updated, it would have to be changed in 2 places (modules)

This PR mainly changes the way the dependency is implemented, the version has been defined globally the same as with lwjgl3 (version)