### PR TITLE
Add reflectivity/shininess support to TerrainLighting.frag

### DIFF
--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/TerrainLighting.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/TerrainLighting.frag
@@ -646,7 +646,7 @@ void main(){
     #ifdef SPECULARMAP
       vec4 specularMapColor = texture2D(m_SpecularMap, texCoord);
       #ifdef USE_SPECULARMAP_AS_SHININESS
-        finalShininessValue = specularColor.r; //assumes that specularMap is a gray-scale reflectivity/shininess map)
+        finalShininessValue = specularMapColor.r; //assumes that specularMap is a gray-scale reflectivity/shininess map)
       #else
         specularColor = specularMapColor;
       #endif      

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/TerrainLighting.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/TerrainLighting.frag
@@ -3,6 +3,10 @@
 #import "Common/ShaderLib/Lighting.glsllib"
 
 uniform float m_Shininess;
+#ifdef SPECULARMAP
+  uniform sampler2D m_SpecularMap;
+#endif
+
 uniform vec4 g_LightDirection;
 
 varying vec4 AmbientSum;
@@ -634,6 +638,15 @@ void main(){
       vec3 normal = vNormal;
     #endif
 
+    //-----------------------
+    // read shininess from specularMap    (possibly want to create a new texture called ShininessMap insetad, since this isn't really what specular is for. but specularMap isn't used elsewhere in this shader anyways, so this doesn't break anything doing it like this)
+    //-----------------------
+    #ifdef SPECULARMAP
+      vec4 specularColor = texture2D(m_SpecularMap, texCoord);
+      float finalShininessValue = specularColor.r; //assumes that specularMap is a gray-scale reflectivity/shininess map)
+    #else
+      float finalShininessValue = m_Shininess;
+    #endif
 
     //-----------------------
     // lighting calculations
@@ -641,7 +654,7 @@ void main(){
     vec4 lightDir = vLightDir;
     lightDir.xyz = normalize(lightDir.xyz);
 
-    vec2 light = computeLighting(normal, vViewDir.xyz, lightDir.xyz,lightDir.w*spotFallOff,m_Shininess);
+    vec2 light = computeLighting(normal, vViewDir.xyz, lightDir.xyz,lightDir.w*spotFallOff,finalShininessValue);
 
     vec4 specularColor = vec4(1.0);
 

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/TerrainLighting.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/TerrainLighting.frag
@@ -639,13 +639,17 @@ void main(){
     #endif
 
     //-----------------------
-    // read shininess from specularMap    (possibly want to create a new texture called ShininessMap insetad, since this isn't really what specular is for. but specularMap isn't used elsewhere in this shader anyways, so this doesn't break anything doing it like this)
-    //-----------------------
+    // read shininess or specularColor from specularMap    (possibly want to create a new texture called ShininessMap if there is ever a need to have both a specularMap and reflectivityMap)
+    //-----------------------    
+    vec4 specularColor = vec4(1.0);
+    float finalShininessValue = m_Shininess;
     #ifdef SPECULARMAP
-      vec4 specularColor = texture2D(m_SpecularMap, texCoord);
-      float finalShininessValue = specularColor.r; //assumes that specularMap is a gray-scale reflectivity/shininess map)
-    #else
-      float finalShininessValue = m_Shininess;
+      vec4 specularMapColor = texture2D(m_SpecularMap, texCoord);
+      #ifdef USE_SPECULARMAP_AS_SHININESS
+        finalShininessValue = specularColor.r; //assumes that specularMap is a gray-scale reflectivity/shininess map)
+      #else
+        specularColor = specularMapColor;
+      #endif      
     #endif
 
     //-----------------------
@@ -655,8 +659,6 @@ void main(){
     lightDir.xyz = normalize(lightDir.xyz);
 
     vec2 light = computeLighting(normal, vViewDir.xyz, lightDir.xyz,lightDir.w*spotFallOff,finalShininessValue);
-
-    vec4 specularColor = vec4(1.0);
 
     //--------------------------
     // final color calculations

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/TerrainLighting.j3md
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/TerrainLighting.j3md
@@ -103,6 +103,10 @@ MaterialDef Terrain Lighting {
 
         // The glow color of the object
         Color GlowColor
+
+        // Use diffuse alpha when mixing
+        Boolean useSpecularMapAsShininess
+        
     }
 
     Technique {
@@ -167,6 +171,7 @@ MaterialDef Terrain Lighting {
             DIFFUSEMAP_11_SCALE : DiffuseMap_11_scale
             
             USE_ALPHA : useDiffuseAlpha
+            USE_SPECULARMAP_AS_SHININESS : useSpecularMapAsShininess
         }
     }
 


### PR DESCRIPTION
Uses the (previously unused) SpecularMap as a gray-scale texture for painting shininess/reflectivity on the whole terrain.