### PR TITLE
buildscripts:  centralize version numbers in a TOML catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,9 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
-        classpath 'me.tatarka:gradle-retrolambda:3.7.1'
-        classpath "com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.18"
+        classpath libs.android.build.gradle
+        classpath libs.gradle.retrolambda
+        classpath libs.spotbugs.gradle.plugin
     }
 }
 

--- a/common.gradle
+++ b/common.gradle
@@ -29,11 +29,6 @@ tasks.withType(JavaCompile) { // compile-time options:
     }
 }
 
-ext {
-    lwjgl3Version = '3.3.3' // used in both the jme3-lwjgl3 and jme3-vr build scripts
-    niftyVersion = '1.4.3' // used in both the jme3-niftygui and jme3-examples build scripts
-}
-
 repositories {
     mavenCentral()
     flatDir {
@@ -43,9 +38,9 @@ repositories {
 
 dependencies {
     // Adding dependencies here will add the dependencies to each subproject.
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:3.12.4'
-    testImplementation 'org.codehaus.groovy:groovy-test:3.0.21'
+    testImplementation libs.junit4
+    testImplementation libs.mokito.core
+    testImplementation libs.groovy.test
 }
 
 // Uncomment if you want to see the status of every test that is run and
@@ -206,7 +201,7 @@ tasks.withType(Sign) {
 }
 
 checkstyle {
-    toolVersion '9.3'
+    toolVersion libs.versions.checkstyle.get()
     configFile file("${gradle.rootProject.rootDir}/config/checkstyle/checkstyle.xml")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,50 @@
+## catalog of libraries and plugins used to build the jmonkeyengine project
+
+[versions]
+
+checkstyle = "9.3"
+lwjgl3 = "3.3.3"
+nifty = "1.4.3"
+
+[libraries]
+
+android-build-gradle = "com.android.tools.build:gradle:4.2.0"
+android-support-appcompat = "com.android.support:appcompat-v7:28.0.0"
+androidx-annotation = "androidx.annotation:annotation:1.3.0"
+androidx-lifecycle-common = "androidx.lifecycle:lifecycle-common:2.4.0"
+gradle-git = "org.ajoberstar:gradle-git:1.2.0"
+gradle-retrolambda = "me.tatarka:gradle-retrolambda:3.7.1"
+groovy-test = "org.codehaus.groovy:groovy-test:3.0.21"
+gson = "com.google.code.gson:gson:2.9.1"
+j-ogg-vorbis = "com.github.stephengold:j-ogg-vorbis:1.0.4"
+jbullet = "com.github.stephengold:jbullet:1.0.3"
+jinput = "net.java.jinput:jinput:2.0.9"
+jna = "net.java.dev.jna:jna:5.10.0"
+jnaerator-runtime = "com.nativelibs4java:jnaerator-runtime:0.12"
+junit4 = "junit:junit:4.13.2"
+lwjgl2 = "org.jmonkeyengine:lwjgl:2.9.5"
+lwjgl3-awt = "org.lwjglx:lwjgl3-awt:0.1.8"
+
+lwjgl3-base     = { module = "org.lwjgl:lwjgl",          version.ref = "lwjgl3" }
+lwjgl3-glfw     = { module = "org.lwjgl:lwjgl-glfw",     version.ref = "lwjgl3" }
+lwjgl3-jawt     = { module = "org.lwjgl:lwjgl-jawt",     version.ref = "lwjgl3" }
+lwjgl3-jemalloc = { module = "org.lwjgl:lwjgl-jemalloc", version.ref = "lwjgl3" }
+lwjgl3-openal   = { module = "org.lwjgl:lwjgl-openal",   version.ref = "lwjgl3" }
+lwjgl3-opencl   = { module = "org.lwjgl:lwjgl-opencl",   version.ref = "lwjgl3" }
+lwjgl3-opengl   = { module = "org.lwjgl:lwjgl-opengl",   version.ref = "lwjgl3" }
+lwjgl3-openvr   = { module = "org.lwjgl:lwjgl-openvr",   version.ref = "lwjgl3" }
+lwjgl3-ovr      = { module = "org.lwjgl:lwjgl-ovr",      version.ref = "lwjgl3" }
+
+mokito-core = "org.mockito:mockito-core:3.12.4"
+
+nifty                  = { module = "com.github.nifty-gui:nifty",                  version.ref = "nifty" }
+nifty-default-controls = { module = "com.github.nifty-gui:nifty-default-controls", version.ref = "nifty" }
+nifty-examples         = { module = "com.github.nifty-gui:nifty-examples",         version.ref = "nifty" }
+nifty-style-black      = { module = "com.github.nifty-gui:nifty-style-black",      version.ref = "nifty" }
+
+spotbugs-gradle-plugin = "com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.18"
+vecmath = "javax.vecmath:vecmath:1.5.2"
+
+[bundles]
+
+[plugins]

--- a/jme3-android-examples/build.gradle
+++ b/jme3-android-examples/build.gradle
@@ -41,8 +41,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    testImplementation 'junit:junit:4.13.2'
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    testImplementation libs.junit4
+    implementation libs.android.support.appcompat
 
     implementation project(':jme3-core')
     implementation project(':jme3-android')

--- a/jme3-android/build.gradle
+++ b/jme3-android/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 
 dependencies {
     //added annotations used by JmeSurfaceView.
-    compileOnly 'androidx.annotation:annotation:1.3.0'
-    compileOnly 'androidx.lifecycle:lifecycle-common:2.4.0'
+    compileOnly libs.androidx.annotation
+    compileOnly libs.androidx.lifecycle.common
     api project(':jme3-core')
     compileOnly 'android:android'
 }

--- a/jme3-examples/build.gradle
+++ b/jme3-examples/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation project(':jme3-terrain')
     implementation project(':jme3-awt-dialogs')
     runtimeOnly project(':jme3-testdata')
-    runtimeOnly "com.github.nifty-gui:nifty-examples:${niftyVersion}" // for the "all/intro.xml" example GUI
+    runtimeOnly libs.nifty.examples // for the "all/intro.xml" example GUI
 }
 
 jar.doFirst{

--- a/jme3-jbullet/build.gradle
+++ b/jme3-jbullet/build.gradle
@@ -14,8 +14,8 @@ sourceSets {
 }
 
 dependencies {
-    api 'com.github.stephengold:jbullet:1.0.3'
-    api 'javax.vecmath:vecmath:1.5.2'
+    api libs.jbullet
+    api libs.vecmath
     api project(':jme3-core')
     api project(':jme3-terrain')
     compileOnly project(':jme3-vr') //is selectively used if on classpath

--- a/jme3-jogg/build.gradle
+++ b/jme3-jogg/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
     api project(':jme3-core')
-    api 'com.github.stephengold:j-ogg-vorbis:1.0.4'
+    api libs.j.ogg.vorbis
 }

--- a/jme3-lwjgl/build.gradle
+++ b/jme3-lwjgl/build.gradle
@@ -2,12 +2,12 @@ dependencies {
     api project(':jme3-core')
     api project(':jme3-desktop')
 
-    api 'org.jmonkeyengine:lwjgl:2.9.5'
+    api libs.lwjgl2
 
     /*
      * Upgrades the default jinput-2.0.5 to jinput-2.0.9 to fix a bug with gamepads on Linux.
      * See https://hub.jmonkeyengine.org/t/linux-gamepad-input-on-jme3-lwjgl-splits-input-between-two-logical-gamepads
      */
-    api 'net.java.jinput:jinput:2.0.9'
-    api 'net.java.jinput:jinput:2.0.9:natives-all'
+    api libs.jinput
+    api(variantOf(libs.jinput){ classifier('natives-all') })
 }

--- a/jme3-lwjgl3/build.gradle
+++ b/jme3-lwjgl3/build.gradle
@@ -1,60 +1,55 @@
 dependencies {
     api project(':jme3-core')
     api project(':jme3-desktop')
-    
-    api "org.lwjglx:lwjgl3-awt:0.1.8"
+    api libs.lwjgl3.awt
 
-    api "org.lwjgl:lwjgl:${lwjgl3Version}"
-    api "org.lwjgl:lwjgl-glfw:${lwjgl3Version}"
-    api "org.lwjgl:lwjgl-jawt:${lwjgl3Version}"
-    api "org.lwjgl:lwjgl-jemalloc:${lwjgl3Version}"
-    api "org.lwjgl:lwjgl-openal:${lwjgl3Version}"
-    api "org.lwjgl:lwjgl-opencl:${lwjgl3Version}"
-    api "org.lwjgl:lwjgl-opengl:${lwjgl3Version}"
+    api libs.lwjgl3.base
+    api libs.lwjgl3.glfw
+    api libs.lwjgl3.jawt
+    api libs.lwjgl3.jemalloc
+    api libs.lwjgl3.openal
+    api libs.lwjgl3.opencl
+    api libs.lwjgl3.opengl
 
-    runtimeOnly "org.lwjgl:lwjgl:${lwjgl3Version}:natives-windows"
-    runtimeOnly "org.lwjgl:lwjgl:${lwjgl3Version}:natives-windows-x86"
-    runtimeOnly "org.lwjgl:lwjgl:${lwjgl3Version}:natives-linux"
-    runtimeOnly "org.lwjgl:lwjgl:${lwjgl3Version}:natives-linux-arm32"
-    runtimeOnly "org.lwjgl:lwjgl:${lwjgl3Version}:natives-linux-arm64"
-    runtimeOnly "org.lwjgl:lwjgl:${lwjgl3Version}:natives-macos"
-    runtimeOnly "org.lwjgl:lwjgl:${lwjgl3Version}:natives-macos-arm64"
+    runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-windows') })
+    runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-windows-x86') })
+    runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-linux') })
+    runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-linux-arm32') })
+    runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-linux-arm64') })
+    runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-macos') })
+    runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-macos-arm64') })
 
-    runtimeOnly "org.lwjgl:lwjgl-glfw:${lwjgl3Version}:natives-windows"
-    runtimeOnly "org.lwjgl:lwjgl-glfw:${lwjgl3Version}:natives-windows-x86"
-    runtimeOnly "org.lwjgl:lwjgl-glfw:${lwjgl3Version}:natives-linux"
-    runtimeOnly "org.lwjgl:lwjgl-glfw:${lwjgl3Version}:natives-linux-arm32"
-    runtimeOnly "org.lwjgl:lwjgl-glfw:${lwjgl3Version}:natives-linux-arm64"
-    runtimeOnly "org.lwjgl:lwjgl-glfw:${lwjgl3Version}:natives-macos"
-    runtimeOnly "org.lwjgl:lwjgl-glfw:${lwjgl3Version}:natives-macos-arm64"
+    runtimeOnly(variantOf(libs.lwjgl3.glfw){ classifier('natives-windows') })
+    runtimeOnly(variantOf(libs.lwjgl3.glfw){ classifier('natives-windows-x86') })
+    runtimeOnly(variantOf(libs.lwjgl3.glfw){ classifier('natives-linux') })
+    runtimeOnly(variantOf(libs.lwjgl3.glfw){ classifier('natives-linux-arm32') })
+    runtimeOnly(variantOf(libs.lwjgl3.glfw){ classifier('natives-linux-arm64') })
+    runtimeOnly(variantOf(libs.lwjgl3.glfw){ classifier('natives-macos') })
+    runtimeOnly(variantOf(libs.lwjgl3.glfw){ classifier('natives-macos-arm64') })
 
+    runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-windows') })
+    runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-windows-x86') })
+    runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-linux') })
+    runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-linux-arm32') })
+    runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-linux-arm64') })
+    runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-macos') })
+    runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-macos-arm64') })
 
-    runtimeOnly "org.lwjgl:lwjgl-jemalloc:${lwjgl3Version}:natives-windows"
-    runtimeOnly "org.lwjgl:lwjgl-jemalloc:${lwjgl3Version}:natives-windows-x86"
-    runtimeOnly "org.lwjgl:lwjgl-jemalloc:${lwjgl3Version}:natives-linux"
-    runtimeOnly "org.lwjgl:lwjgl-jemalloc:${lwjgl3Version}:natives-linux-arm32"
-    runtimeOnly "org.lwjgl:lwjgl-jemalloc:${lwjgl3Version}:natives-linux-arm64"
-    runtimeOnly "org.lwjgl:lwjgl-jemalloc:${lwjgl3Version}:natives-macos"
-    runtimeOnly "org.lwjgl:lwjgl-jemalloc:${lwjgl3Version}:natives-macos-arm64"
+    runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-windows') })
+    runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-windows-x86') })
+    runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-linux') })
+    runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-linux-arm32') })
+    runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-linux-arm64') })
+    runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-macos') })
+    runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-macos-arm64') })
 
-
-    runtimeOnly "org.lwjgl:lwjgl-opengl:${lwjgl3Version}:natives-windows"
-    runtimeOnly "org.lwjgl:lwjgl-opengl:${lwjgl3Version}:natives-windows-x86"
-    runtimeOnly "org.lwjgl:lwjgl-opengl:${lwjgl3Version}:natives-linux"
-    runtimeOnly "org.lwjgl:lwjgl-opengl:${lwjgl3Version}:natives-linux-arm32"
-    runtimeOnly "org.lwjgl:lwjgl-opengl:${lwjgl3Version}:natives-linux-arm64"
-    runtimeOnly "org.lwjgl:lwjgl-opengl:${lwjgl3Version}:natives-macos"
-    runtimeOnly "org.lwjgl:lwjgl-opengl:${lwjgl3Version}:natives-macos-arm64"
-
-
-    runtimeOnly "org.lwjgl:lwjgl-openal:${lwjgl3Version}:natives-windows"
-    runtimeOnly "org.lwjgl:lwjgl-openal:${lwjgl3Version}:natives-windows-x86"
-    runtimeOnly "org.lwjgl:lwjgl-openal:${lwjgl3Version}:natives-linux"
-    runtimeOnly "org.lwjgl:lwjgl-openal:${lwjgl3Version}:natives-linux-arm32"
-    runtimeOnly "org.lwjgl:lwjgl-openal:${lwjgl3Version}:natives-linux-arm64"
-    runtimeOnly "org.lwjgl:lwjgl-openal:${lwjgl3Version}:natives-macos"
-    runtimeOnly "org.lwjgl:lwjgl-openal:${lwjgl3Version}:natives-macos-arm64"
-
+    runtimeOnly(variantOf(libs.lwjgl3.openal){ classifier('natives-windows') })
+    runtimeOnly(variantOf(libs.lwjgl3.openal){ classifier('natives-windows-x86') })
+    runtimeOnly(variantOf(libs.lwjgl3.openal){ classifier('natives-linux') })
+    runtimeOnly(variantOf(libs.lwjgl3.openal){ classifier('natives-linux-arm32') })
+    runtimeOnly(variantOf(libs.lwjgl3.openal){ classifier('natives-linux-arm64') })
+    runtimeOnly(variantOf(libs.lwjgl3.openal){ classifier('natives-macos') })
+    runtimeOnly(variantOf(libs.lwjgl3.openal){ classifier('natives-macos-arm64') })
 }
 
 javadoc {

--- a/jme3-niftygui/build.gradle
+++ b/jme3-niftygui/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     api project(':jme3-core')
-    api "com.github.nifty-gui:nifty:${niftyVersion}"
-    api "com.github.nifty-gui:nifty-default-controls:${niftyVersion}"
-    runtimeOnly "com.github.nifty-gui:nifty-style-black:${niftyVersion}"
+    api libs.nifty
+    api libs.nifty.default.controls
+    runtimeOnly libs.nifty.style.black
 }

--- a/jme3-plugins-json-gson/build.gradle
+++ b/jme3-plugins-json-gson/build.gradle
@@ -11,6 +11,6 @@ sourceSets {
 dependencies {
 
     api project(':jme3-plugins-json')
-    api 'com.google.code.gson:gson:2.9.1'
+    api libs.gson
 
 }

--- a/jme3-vr/build.gradle
+++ b/jme3-vr/build.gradle
@@ -5,20 +5,20 @@ dependencies {
     api project(':jme3-effects')
 	
     // https://mvnrepository.com/artifact/net.java.dev.jna/jna
-    implementation 'net.java.dev.jna:jna:5.10.0'
-    implementation 'com.nativelibs4java:jnaerator-runtime:0.12'
+    implementation libs.jna
+    implementation libs.jnaerator.runtime
 
     // Native LibOVR/Oculus support
-    api "org.lwjgl:lwjgl-ovr:${lwjgl3Version}"
-    runtimeOnly "org.lwjgl:lwjgl-ovr:${lwjgl3Version}:natives-windows"
+    api libs.lwjgl3.ovr
+    runtimeOnly(variantOf(libs.lwjgl3.ovr){ classifier('natives-windows') })
     
     // Native OpenVR/LWJGL support
-    api "org.lwjgl:lwjgl-openvr:${lwjgl3Version}"
-    implementation "org.lwjgl:lwjgl-openvr:${lwjgl3Version}:natives-linux"
-    implementation "org.lwjgl:lwjgl-openvr:${lwjgl3Version}:natives-macos"
-    runtimeOnly "org.lwjgl:lwjgl-openvr:${lwjgl3Version}:natives-windows"
-    runtimeOnly "org.lwjgl:lwjgl-openvr:${lwjgl3Version}:natives-linux"
-    runtimeOnly "org.lwjgl:lwjgl-openvr:${lwjgl3Version}:natives-macos"
+    api libs.lwjgl3.openvr
+    implementation(variantOf(libs.lwjgl3.openvr){ classifier('natives-linux') })
+    implementation(variantOf(libs.lwjgl3.openvr){ classifier('natives-macos') })
+    runtimeOnly(variantOf(libs.lwjgl3.openvr){ classifier('natives-windows') })
+    runtimeOnly(variantOf(libs.lwjgl3.openvr){ classifier('natives-linux') })
+    runtimeOnly(variantOf(libs.lwjgl3.openvr){ classifier('natives-macos') })
 }
 
 javadoc {

--- a/version.gradle
+++ b/version.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.ajoberstar:gradle-git:1.2.0'
+        classpath libs.gradle.git
     }
 }
 


### PR DESCRIPTION
[Starting with Gradle v8](https://gradle.org/whats-new/gradle-8/#version-catalog), the best practice for managing version numbers of external libraries is to centralize them in a TOML catalog.

This PR implements such a catalog for JMonkeyEngine. It supersedes PR #2305.