### PR TITLE
Remove unecessary 'new Vector3f()' in com.jme.ui.Picture

### DIFF
--- a/jme3-core/src/main/java/com/jme3/ui/Picture.java
+++ b/jme3-core/src/main/java/com/jme3/ui/Picture.java
@@ -113,7 +113,7 @@ public class Picture extends Geometry {
      */
     public void setWidth(float width){
         this.width = width;
-        setLocalScale(new Vector3f(width, height, 1f));
+        setLocalScale(width, height, 1f);
     }
 
     /**
@@ -125,7 +125,7 @@ public class Picture extends Geometry {
      */
     public void setHeight(float height){
         this.height = height;
-        setLocalScale(new Vector3f(width, height, 1f));
+        setLocalScale(width, height, 1f);
     }
 
     /**


### PR DESCRIPTION
Removed unnecessary instantiation of 'Vector3f' objects on setWidth() and setHeight() methods.