### PR TITLE
Fix for #2327 Mouse pointer moves to centre of canvas on click in OpenGL3 with Swing

### DIFF
--- a/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
+++ b/jme3-core/src/main/java/com/jme3/input/FlyByCamera.java
@@ -107,6 +107,7 @@ public class FlyByCamera implements AnalogListener, ActionListener {
     protected boolean dragToRotate = false;
     protected boolean canRotate = false;
     protected boolean invertY = false;
+    private boolean hideCursorOnNextRotate = false;
     protected InputManager inputManager;
 
     /**
@@ -200,6 +201,7 @@ public class FlyByCamera implements AnalogListener, ActionListener {
         if (enabled && !enable){
             if (inputManager!= null && (!dragToRotate || (dragToRotate && canRotate))){
                 inputManager.setCursorVisible(true);
+                hideCursorOnNextRotate = false;
             }
         }
         enabled = enable;
@@ -353,6 +355,10 @@ public class FlyByCamera implements AnalogListener, ActionListener {
     protected void rotateCamera(float value, Vector3f axis) {
         if (dragToRotate) {
             if (canRotate) {
+                if(hideCursorOnNextRotate) {
+                    inputManager.setCursorVisible(false);
+                    hideCursorOnNextRotate = false;
+                }
 //                value = -value;
             } else {
                 return;
@@ -499,7 +505,14 @@ public class FlyByCamera implements AnalogListener, ActionListener {
 
         if (name.equals(CameraInput.FLYCAM_ROTATEDRAG) && dragToRotate) {
             canRotate = value;
-            inputManager.setCursorVisible(!value);
+
+            if(value) {
+                hideCursorOnNextRotate = true;
+            }
+            else {
+                inputManager.setCursorVisible(true);
+                hideCursorOnNextRotate = false;
+            }
         } else if (name.equals(CameraInput.FLYCAM_INVERTY)) {
             // Invert the "up" direction.
             if (!value) {


### PR DESCRIPTION
Modify FlyByCamera to only hide the mouse cursor when the user actually rotates the camera, rather than when the user first presses the left mouse button. When the mouse is clicked, instead of immediately hiding the cursor, a flag (hideCursorOnNextRotate) is set. If and when a rotate is detected, the flag is checked and if true the cursor is hidden and the flag is cleared.