### PR TITLE
Fix incorrect metallic calculations in PBRLighting.frag

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -217,11 +217,9 @@ void main(){
         Roughness = 1.0 - glossiness;
         vec3 fZero = specularColor.xyz;
     #else
-        float nonMetalSpec = 0.08; //nonMetalSpec is always constant value of 0.8 in metallic workflow
-        vec4 specularColor = (nonMetalSpec - nonMetalSpec * Metallic) + albedo * Metallic;
+        vec4 specularColor = (0.08 - 0.08 * Metallic) + albedo * Metallic;  // 0.08 represents the base specular reflectance for non-metallic surfaces. This can be slightly adjusted to values like 0.04, however 0.08 is considered the standard for PBR.
         vec4 diffuseColor = albedo - albedo * Metallic;
-        vec3 fZero = vec3(0.04); 
-        fZero = mix(fZero, albedo.rgb, Metallic);          
+        vec3 fZero = mix(vec3(0.04), albedo.rgb, Metallic);
     #endif
 
     gl_FragColor.rgb = vec3(0.0);

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -217,7 +217,7 @@ void main(){
         Roughness = 1.0 - glossiness;
         vec3 fZero = specularColor.xyz;
     #else
-        vec4 specularColor = (0.08 - 0.08 * Metallic) + albedo * Metallic;  // 0.08 represents the base specular reflectance for non-metallic surfaces. This can be slightly adjusted to values like 0.04, however 0.08 is considered the standard for PBR.
+        vec4 specularColor = (0.04 - 0.04 * Metallic) + albedo * Metallic;  // 0.04 is the standard base specular reflectance for non-metallic surfaces in PBR. While values like 0.08 can be used for different implementations, 0.04 aligns with Khronos' PBR specification.
         vec4 diffuseColor = albedo - albedo * Metallic;
         vec3 fZero = mix(vec3(0.04), albedo.rgb, Metallic);
     #endif

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -218,7 +218,7 @@ void main(){
         vec3 fZero = specularColor.xyz;
     #else
         float nonMetalSpec = 0.08; //nonMetalSpec is always constant value of 0.8 in metallic workflow
-        specularColor = (nonMetalSpec - nonMetalSpec * Metallic) + albedo * Metallic;
+        vec4 specularColor = (nonMetalSpec - nonMetalSpec * Metallic) + albedo * Metallic;
         vec4 diffuseColor = albedo - albedo * Metallic;
         vec3 fZero = vec3(0.04); 
         fZero = mix(fZero, albedo.rgb, Metallic);          

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -217,11 +217,11 @@ void main(){
         Roughness = 1.0 - glossiness;
         vec3 fZero = specularColor.xyz;
     #else
-        float specular = 0.5;
-        float nonMetalSpec = 0.08 * specular;
-        vec4 specularColor = (nonMetalSpec - nonMetalSpec * Metallic) + albedo * Metallic;
+        float nonMetalSpec = 0.08; //nonMetalSpec is always constant value of 0.8 in metallic workflow
+        specularColor = (nonMetalSpec - nonMetalSpec * Metallic) + albedo * Metallic;
         vec4 diffuseColor = albedo - albedo * Metallic;
-        vec3 fZero = vec3(specular);
+        vec3 fZero = vec3(0.04); 
+        fZero = mix(fZero, albedo.rgb, Metallic);          
     #endif
 
     gl_FragColor.rgb = vec3(0.0);


### PR DESCRIPTION
addresses this issue: https://github.com/jMonkeyEngine/jmonkeyengine/issues/2330

There were 2 apparent issues with our metallic calculation that were causing our PBR implementation to render different visual results compared to the khronos PBR standards:

1) fZero was being calculated incorrectly, as mentioned in the linked issue 
2) the nonMetalSpec float constant was being set incorrectly. According to what I've read, it should always be 0.08

I also checked tested changes in my own app and it appears the rendering difference is more accurate now. But I'm not an expert in lighting math like this, so let me know if anyone sees anything else that looks incorrect with the PBR shader's code.