### PR TITLE
build.gradle:  use get() to convert Jar-task properties to strings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,17 +130,15 @@ jobs:
       - name: Build Engine
         shell: bash
         run: |
-          # Build
-          ./gradlew -PuseCommitHashAsVersionName=true -PskipPrebuildLibraries=true build
+          # Normal build plus ZIP distribution and merged javadoc
+          ./gradlew -PuseCommitHashAsVersionName=true -PskipPrebuildLibraries=true \
+          build createZipDistribution mergedJavadoc
 
           if [ "${{ matrix.deploy }}" = "true" ];
           then
             # We are going to need "zip"
             sudo apt-get update
             sudo apt-get install -y zip
-
-            # Create the zip release and the javadoc
-            ./gradlew -PuseCommitHashAsVersionName=true -PskipPrebuildLibraries=true mergedJavadoc createZipDistribution
 
             # We prepare the release for deploy
             mkdir -p ./dist/release/

--- a/build.gradle
+++ b/build.gradle
@@ -75,23 +75,25 @@ task libDist(dependsOn: subprojects.build, description: 'Builds and copies the e
         subprojects.each {project ->
             if(!project.hasProperty('mainClassName')){
                 project.tasks.withType(Jar).each {archiveTask ->
-                    if(archiveTask.archiveClassifier == "sources"){
+                    String classifier = archiveTask.archiveClassifier.get()
+                    String ext = archiveTask.archiveExtension.get()
+                    if (classifier == "sources") {
                         copy {
                             from archiveTask.archivePath
                                 into sourceFolder
-                                rename {project.name + '-' + archiveTask.archiveClassifier +'.'+ archiveTask.archiveExtension}
+                                rename {project.name + '-' + classifier + '.' + ext}
                         }
-                    } else if(archiveTask.archiveClassifier == "javadoc"){
+                    } else if (classifier == "javadoc") {
                         copy {
                             from archiveTask.archivePath
                                 into javadocFolder
-                                rename {project.name + '-' + archiveTask.archiveClassifier +'.'+ archiveTask.archiveExtension}
+                                rename {project.name + '-' + classifier + '.' + ext}
                         }
                     } else{
                         copy {
                             from archiveTask.archivePath
                                 into libFolder
-                                rename {project.name + '.' + archiveTask.archiveExtension}
+                                rename {project.name + '.' + ext}
                         }
                     }
                 }


### PR DESCRIPTION
These changes are meant to resolve issue #2335.

The `archiveClassifer` and `archiveExtension` properties of `archiveTask` are converted to strings using `get()`.

This enables the correct JAR files to be copied to the correct "build/libDist" folders under the correct names.

Tested on both Linux and Windows. Holding 24 hours for review. If there's no substantial discussion, I will self-integrate this PR.