### PR TITLE
Fix NullPointer in MikktspaceTangentGenerator

### DIFF
--- a/jme3-core/src/main/java/com/jme3/util/mikktspace/MikktspaceTangentGenerator.java
+++ b/jme3-core/src/main/java/com/jme3/util/mikktspace/MikktspaceTangentGenerator.java
@@ -117,33 +117,35 @@ public class MikktspaceTangentGenerator {
             Geometry g = (Geometry) s;
             Mesh mesh = g.getMesh();
 
-            Mesh.Mode mode = mesh.getMode();
-            boolean hasTriangles;
-            switch (mode) {
-                case Points:
-                case Lines:
-                case LineStrip:
-                case LineLoop:
-                    hasTriangles = false; // skip this mesh
-                    break;
+            if (mesh.getBuffer(Type.TexCoord) != null && mesh.getBuffer(Type.Normal) != null) {
+                Mesh.Mode mode = mesh.getMode();
+                boolean hasTriangles;
+                switch (mode) {
+                    case Points:
+                    case Lines:
+                    case LineStrip:
+                    case LineLoop:
+                        hasTriangles = false; // skip this mesh
+                        break;
 
-                case Triangles:
-                case TriangleFan:
-                case TriangleStrip:
-                    hasTriangles = true;
-                    break;
+                    case Triangles:
+                    case TriangleFan:
+                    case TriangleStrip:
+                        hasTriangles = true;
+                        break;
 
-                default:
-                    String message = "Tangent generation isn't implemented for mode=" + mode;
-                    throw new UnsupportedOperationException(message);
-            }
-
-            if (hasTriangles) {
-                MikkTSpaceImpl context = new MikkTSpaceImpl(mesh);
-                if (!genTangSpaceDefault(context)) {
-                    logger.log(Level.SEVERE, "Failed to generate tangents for geometry {0}", g.getName());
+                    default:
+                        String message = "Tangent generation isn't implemented for mode=" + mode;
+                        throw new UnsupportedOperationException(message);
                 }
-                TangentUtils.generateBindPoseTangentsIfNecessary(mesh);
+
+                if (hasTriangles) {
+                    MikkTSpaceImpl context = new MikkTSpaceImpl(mesh);
+                    if (!genTangSpaceDefault(context)) {
+                        logger.log(Level.SEVERE, "Failed to generate tangents for geometry {0}", g.getName());
+                    }
+                    TangentUtils.generateBindPoseTangentsIfNecessary(mesh);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes a null pointer exception that occurred when trying to generate tangents on a model without a normal buffer: https://hub.jmonkeyengine.org/t/mikktspacetangentgenerator-fails-with-npe/48114/4

This PR makes it so that MikktspaceTangentGenerator handles a non existant normal (or texCoord) buffer in the same way that the old TangentBinormalGenerator handled it.