### PR TITLE
Add RawInputListenerAdapter for easier listener creation

### DIFF
--- a/jme3-core/src/main/java/com/jme3/input/RawInputListenerAdapter.java
+++ b/jme3-core/src/main/java/com/jme3/input/RawInputListenerAdapter.java
@@ -39,58 +39,59 @@ import com.jme3.input.event.MouseMotionEvent;
 import com.jme3.input.event.TouchEvent;
 
 /**
- * An abstract adapter class for {@link RawInputListener}. 
- * 
- * This class provides empty implementations for all methods in the 
- * {@link RawInputListener} interface, making it easier to create 
- * custom listeners by extending this class and overriding only the 
- * methods of interest.
+ * An abstract adapter class for {@link RawInputListener}.
+ *
+ * This class provides empty implementations for all methods in the
+ * {@link RawInputListener} interface, making it easier to create custom
+ * listeners by extending this class and overriding only the methods of
+ * interest.
  */
 public abstract class RawInputListenerAdapter implements RawInputListener {
-	
+
     /**
      * Constructs a {@code RawInputListenerAdapter}.
      */
-    protected RawInputListenerAdapter() {}
+    protected RawInputListenerAdapter() {
+    }
 
-	@Override
-	public void beginInput() {
-		// No-op implementation
-	}
+    @Override
+    public void beginInput() {
+        // No-op implementation
+    }
 
-	@Override
-	public void endInput() {
-		// No-op implementation
-	}
+    @Override
+    public void endInput() {
+        // No-op implementation
+    }
 
-	@Override
-	public void onJoyAxisEvent(JoyAxisEvent evt) {
-		// No-op implementation
-	}
+    @Override
+    public void onJoyAxisEvent(JoyAxisEvent evt) {
+        // No-op implementation
+    }
 
-	@Override
-	public void onJoyButtonEvent(JoyButtonEvent evt) {
-		// No-op implementation
-	}
+    @Override
+    public void onJoyButtonEvent(JoyButtonEvent evt) {
+        // No-op implementation
+    }
 
-	@Override
-	public void onMouseMotionEvent(MouseMotionEvent evt) {
-		// No-op implementation
-	}
+    @Override
+    public void onMouseMotionEvent(MouseMotionEvent evt) {
+        // No-op implementation
+    }
 
-	@Override
-	public void onMouseButtonEvent(MouseButtonEvent evt) {
-		// No-op implementation
-	}
+    @Override
+    public void onMouseButtonEvent(MouseButtonEvent evt) {
+        // No-op implementation
+    }
 
-	@Override
-	public void onKeyEvent(KeyInputEvent evt) {
-		// No-op implementation
-	}
+    @Override
+    public void onKeyEvent(KeyInputEvent evt) {
+        // No-op implementation
+    }
 
-	@Override
-	public void onTouchEvent(TouchEvent evt) {
-		// No-op implementation
-	}
+    @Override
+    public void onTouchEvent(TouchEvent evt) {
+        // No-op implementation
+    }
 
 }

--- a/jme3-core/src/main/java/com/jme3/input/RawInputListenerAdapter.java
+++ b/jme3-core/src/main/java/com/jme3/input/RawInputListenerAdapter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2009-2024 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.input;
+
+import com.jme3.input.event.JoyAxisEvent;
+import com.jme3.input.event.JoyButtonEvent;
+import com.jme3.input.event.KeyInputEvent;
+import com.jme3.input.event.MouseButtonEvent;
+import com.jme3.input.event.MouseMotionEvent;
+import com.jme3.input.event.TouchEvent;
+
+/**
+ * An abstract adapter class for {@link RawInputListener}. 
+ * 
+ * This class provides empty implementations for all methods in the 
+ * {@link RawInputListener} interface, making it easier to create 
+ * custom listeners by extending this class and overriding only the 
+ * methods of interest.
+ */
+public abstract class RawInputListenerAdapter implements RawInputListener {
+	
+    /**
+     * Constructs a {@code RawInputListenerAdapter}.
+     */
+    protected RawInputListenerAdapter() {}
+
+	@Override
+	public void beginInput() {
+		// No-op implementation
+	}
+
+	@Override
+	public void endInput() {
+		// No-op implementation
+	}
+
+	@Override
+	public void onJoyAxisEvent(JoyAxisEvent evt) {
+		// No-op implementation
+	}
+
+	@Override
+	public void onJoyButtonEvent(JoyButtonEvent evt) {
+		// No-op implementation
+	}
+
+	@Override
+	public void onMouseMotionEvent(MouseMotionEvent evt) {
+		// No-op implementation
+	}
+
+	@Override
+	public void onMouseButtonEvent(MouseButtonEvent evt) {
+		// No-op implementation
+	}
+
+	@Override
+	public void onKeyEvent(KeyInputEvent evt) {
+		// No-op implementation
+	}
+
+	@Override
+	public void onTouchEvent(TouchEvent evt) {
+		// No-op implementation
+	}
+
+}

--- a/jme3-core/src/main/java/com/jme3/input/RawInputListenerAdapter.java
+++ b/jme3-core/src/main/java/com/jme3/input/RawInputListenerAdapter.java
@@ -48,12 +48,6 @@ import com.jme3.input.event.TouchEvent;
  */
 public abstract class RawInputListenerAdapter implements RawInputListener {
 
-    /**
-     * Constructs a {@code RawInputListenerAdapter}.
-     */
-    protected RawInputListenerAdapter() {
-    }
-
     @Override
     public void beginInput() {
         // No-op implementation


### PR DESCRIPTION
Implement `RawInputListenerAdapter` to provide default empty implementations for all listener methods.