### PR TITLE
LICENSE.md:  add 2025 to the copyright years

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2024 jMonkeyEngine.
+Copyright (c) 2009-2025 jMonkeyEngine.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions


### PR DESCRIPTION
This updates the copyright notice (in the project's overall license) to include the current calendar year.