### PR TITLE
Add tbnMat variable to PBRSurface.glsl

### DIFF
--- a/jme3-core/src/main/resources/Common/ShaderLib/module/PBRSurface.glsl
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/PBRSurface.glsl
@@ -10,6 +10,7 @@
         vec3 normal; // normals w/ normalmap
         bool frontFacing; //gl_FrontFacing
         float depth;
+        mat3 tbnMat;
 
         // from texture
         vec3 albedo;

--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -338,6 +338,8 @@
                 vec3 normal = normalize((normalHeight.xyz * vec3(2.0, NORMAL_TYPE * 2.0, 2.0) - vec3(1.0, NORMAL_TYPE * 1.0, 1.0)));
             #endif
             surface.normal = normalize(tbnMat * normal);
+        #else 
+            surface.normal = normal;
         #endif
         
         //spec gloss tex reads:

--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -339,7 +339,7 @@
             #endif
             surface.normal = normalize(tbnMat * normal);
         #else 
-            surface.normal = normal;
+            surface.normal = surface.geometryNormal;
         #endif
         
         //spec gloss tex reads:

--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -266,6 +266,7 @@
         #if defined(NORMALMAP) || defined(PARALLAXMAP)
             vec3 tan = normalize(wTangent.xyz);
             mat3 tbnMat = mat3(tan, wTangent.w * cross( surface.geometryNormal, tan), surface.geometryNormal);
+            surface.tbnMat = tbnMat;
         #endif
         
         vec2 newTexCoord;

--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -338,8 +338,6 @@
                 vec3 normal = normalize((normalHeight.xyz * vec3(2.0, NORMAL_TYPE * 2.0, 2.0) - vec3(1.0, NORMAL_TYPE * 1.0, 1.0)));
             #endif
             surface.normal = normalize(tbnMat * normal);
-        #else 
-            surface.normal = normal;
         #endif
         
         //spec gloss tex reads:


### PR DESCRIPTION
Updated to store tbnMat as a publicly accessible variable in the PBRSurface.glsl struct, that way tbnMat won't need recalculated anywhere else it is needed in the same shader.