### PR TITLE
[ Fix ] Minor refactoring to DisplayInfo.class #2345

### DIFF
--- a/jme3-core/src/main/java/com/jme3/system/DisplayInfo.java
+++ b/jme3-core/src/main/java/com/jme3/system/DisplayInfo.java
@@ -25,41 +25,225 @@
  */
 package com.jme3.system;
 
+import java.util.Objects;
+
 /**
  * This class holds information about the display that was returned by glfwGetMonitors() calls in
  * the context class
  *
  * @author Kevin Bales
+ * @author wil
  */
-public class DisplayInfo {
+public final class DisplayInfo {
 
-    /**
-     * displayID - display id that was return from Lwjgl3.
-     */
-    public long displayID = 0;
+    /** displayID - display id that was return from Lwjgl3. */
+    private long display;
+    
+    /** width - width that was return from Lwjgl3.  */
+    private int width;
 
-    /**
-     * width - width that was return from Lwjgl3.
-     */
-    public int width = 1080;
+    /**  height - height that was return from Lwjgl3. */
+    private int height;
 
-    /**
-     * height - height that was return from Lwjgl3.
-     */
-    public int height = 1920;
+    /** rate - refresh rate that was return from Lwjgl3. */
+    private int rate;
 
-    /**
-     * rate - refresh rate that was return from Lwjgl3.
-     */
-    public int rate = 60;
-
-    /**
-     * primary - indicates if the display is the primary monitor.
-     */
-    public boolean primary = false;
+    /** primary - indicates if the display is the primary monitor. */
+    private boolean primary;
 
     /**
      * name - display name that was return from Lwjgl3.
      */
-    public String name = "Generic Monitor";
+    private String name;
+
+    /**
+     * Create a new display mode object with the default values
+     */
+    DisplayInfo() {
+        this(0L /*NULL*/, 1080, 1920, 60, false, "Generic Monitor");
+    }
+    
+    /**
+     * Create a new display mode object with the supplied parameters.
+     * @param display the monitor pointer (native), the virtual memory 
+     *                  address used by lwjgl.
+     * @param width the width of the display, provided by lwjgl.
+     * @param height the height of the display, provided by lwjgl.
+     * @param rate the refresh rate of the display, in hertz.
+     * @param primary a logical value that determines whether this display is 
+     *                  primary or not; {@code true | false}
+     * @param name display name
+     */
+    DisplayInfo(long display, int width, int height, int rate, boolean primary, String name) {
+        this.display  = display;
+        this.width      = width;
+        this.height     = height;
+        this.rate       = rate;
+        this.primary    = primary;
+        this.name       = name;
+    }
+
+    // === ----------------------------------------------------------------- ===
+    // ===                            SETTERS                                ===
+    // === ----------------------------------------------------------------- ===
+    
+    /**
+     * Sets the monitor pointer (native), the virtual memory address used by lwjgl.
+     * 
+     * @param display the monitor pointer (native), the virtual memory 
+     *                  address used by lwjgl
+     */
+    void setDisplay(long display) {
+        this.display = display;
+    }
+
+    /**
+     * Sets the width of the display.
+     * @param width the width of the display
+     */
+    void setWidth(int width) {
+        this.width = width;
+    }
+
+    /**
+     * Sets the height of the display.
+     * @param height the height of the display
+     */
+    void setHeight(int height) {
+        this.height = height;
+    }
+
+    /**
+     * Sets the refresh rate of the display, in hertz.
+     * @param rate the refresh rate of the display, in hertz
+     */
+    void setRate(int rate) {
+        this.rate = rate;
+    }
+
+    /**
+     * Set this display as primary or not.
+     * @param primary {@code true} if the display is primary, {@code false} otherwise.
+     */
+    void setPrimary(boolean primary) {
+        this.primary = primary;
+    }
+
+    /**
+     * Set the screen (display) name
+     * @param name display name
+     */
+    void setName(String name) {
+        this.name = name;
+    }
+
+    // === ----------------------------------------------------------------- ===
+    // ===                              GETTERS                              ===
+    // === ----------------------------------------------------------------- ===
+    
+    /**
+     * Returns the monitor pointer (native), the virtual memory address used by lwjgl.
+     * @return the monitor pointer (native), the virtual memory address used by lwjgl
+     */
+    public long getDisplay() {
+        return display;
+    }
+
+    /**
+     * Returns the width of the display.
+     * @return the width of the display.
+     */
+    public int getWidth() {
+        return width;
+    }
+
+    /**
+     * Returns the height of the display.
+     * @return the height of the display
+     */
+    public int getHeight() {
+        return height;
+    }
+
+    /**
+     * Returns the refresh rate of the display, in hertz.
+     * @return the refresh rate of the display, in hertz
+     */
+    public int getRate() {
+        return rate;
+    }
+
+    /**
+     * Determines if this display belongs to the main monitor.
+     * @return {@code true} if the display is primary, {@code false} otherwise.
+     */
+    public boolean isPrimary() {
+        return primary;
+    }
+
+    /**
+     * Returns the display name.
+     * @return display name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * {@inheritDoc }
+     */
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 97 * hash + (int) (this.display ^ (this.display >>> 32));
+        hash = 97 * hash + this.width;
+        hash = 97 * hash + this.height;
+        hash = 97 * hash + this.rate;
+        hash = 97 * hash + (this.primary ? 1 : 0);
+        hash = 97 * hash + Objects.hashCode(this.name);
+        return hash;
+    }
+
+    /**
+     * {@inheritDoc }
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final DisplayInfo other = (DisplayInfo) obj;
+        if (this.display != other.display) {
+            return false;
+        }
+        if (this.width != other.width) {
+            return false;
+        }
+        if (this.height != other.height) {
+            return false;
+        }
+        if (this.rate != other.rate) {
+            return false;
+        }
+        if (this.primary != other.primary) {
+            return false;
+        }
+        return Objects.equals(this.name, other.name);
+    }
+
+    /**
+     * {@inheritDoc }
+     */
+    @Override
+    public String toString() {
+        return getDisplay() == 0L ? "NULL" : ("(" + getName() + "|" 
+                + getDisplay() + ")" + getWidth() + "x" + getHeight() + "@" 
+                + (getRate() > 0 ? getRate()  + "Hz" : "[Unknown refresh rate]"));
+    }
 }

--- a/jme3-core/src/main/java/com/jme3/system/DisplayInfo.java
+++ b/jme3-core/src/main/java/com/jme3/system/DisplayInfo.java
@@ -1,27 +1,33 @@
 /*
- * Copyright (c) 2009-2023 jMonkeyEngine All rights reserved.
+ * Copyright (c) 2009-2025 jMonkeyEngine
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification, are permitted
- * provided that the following conditions are met:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
  *
- * * Redistributions of source code must retain the above copyright notice, this list of conditions
- * and the following disclaimer.
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
  *
- * * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials provided with
- * the distribution.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
  *
- * * Neither the name of 'jMonkeyEngine' nor the names of its contributors may be used to endorse or
- * promote products derived from this software without specific prior written permission.
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
- * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.jme3.system;
 

--- a/jme3-core/src/main/java/com/jme3/system/DisplayInfo.java
+++ b/jme3-core/src/main/java/com/jme3/system/DisplayInfo.java
@@ -42,7 +42,7 @@ import java.util.Objects;
  */
 public final class DisplayInfo {
 
-    /** displayID - display id that was return from Lwjgl3. */
+    /** display - display id that was return from Lwjgl3. */
     private long display;
     
     /** width - width that was return from Lwjgl3.  */

--- a/jme3-core/src/main/java/com/jme3/system/Displays.java
+++ b/jme3-core/src/main/java/com/jme3/system/Displays.java
@@ -35,11 +35,18 @@ import java.util.ArrayList;
  */
 public class Displays {
 
-    private ArrayList<DisplayInfo> displays = new ArrayList<DisplayInfo>();
+    /** List of monitors. */
+    private ArrayList<DisplayInfo> displays = new ArrayList<>();
 
+    /**
+     * Add a new monitor to the list
+     * 
+     * @param displaysID the (native) pointer of the new monitor
+     * @return the position of the monitor (represents the index)
+     */
     public int addNewMonitor(long displaysID) {
         DisplayInfo info = new DisplayInfo();
-        info.displayID = displaysID;
+        info.setDisplay(displaysID);
         displays.add(info);
         return displays.size() - 1;
     }
@@ -47,7 +54,7 @@ public class Displays {
     /**
      * This function returns the size of the display ArrayList
      *
-     * @return the
+     * @return the number of monitors available.
      */
     public int size() {
         return displays.size();
@@ -78,10 +85,10 @@ public class Displays {
         if (displayPos < displays.size()) {
             DisplayInfo info = displays.get(displayPos);
             if (info != null) {
-                info.width = width;
-                info.height = height;
-                info.rate = rate;
-                info.name = name;
+                info.setWidth(width);
+                info.setHeight(height);
+                info.setRate(rate);
+                info.setName(name);
             }
         }
     }
@@ -94,7 +101,7 @@ public class Displays {
     public void setPrimaryDisplay(int displayPos) {
         if (displayPos < displays.size()) {
             DisplayInfo info = displays.get(displayPos);
-            if (info != null) info.primary = true;
+            if (info != null) info.setPrimary(true);
         }
     }
 }

--- a/jme3-examples/src/main/java/jme3test/app/TestMonitorApp.java
+++ b/jme3-examples/src/main/java/jme3test/app/TestMonitorApp.java
@@ -140,15 +140,15 @@ public class TestMonitorApp extends SimpleApplication implements ActionListener 
             String label =
                 "Selected Monitor " +
                 "Name: " +
-                monitors.get(settings.getDisplay()).name +
+                monitors.get(settings.getDisplay()).getName() +
                 " " +
                 monitorSelected +
                 " Res: " +
-                monitors.get(settings.getDisplay()).width +
+                monitors.get(settings.getDisplay()).getWidth() +
                 "," +
-                monitors.get(settings.getDisplay()).height +
+                monitors.get(settings.getDisplay()).getHeight() +
                 " refresh: " +
-                monitors.get(settings.getDisplay()).rate;
+                monitors.get(settings.getDisplay()).getRate();
             selectedMonitorTxt.setText(label);
             selectedMonitorTxt.setLocalTranslation(0, settings.getHeight() - 80, 0);
             guiNode.attachChild(selectedMonitorTxt);
@@ -160,13 +160,13 @@ public class TestMonitorApp extends SimpleApplication implements ActionListener 
                     "Mon : " +
                     i +
                     " " +
-                    monitor.name +
+                    monitor.getName() +
                     " " +
-                    monitor.width +
+                    monitor.getWidth() +
                     "," +
-                    monitor.height +
+                    monitor.getHeight() +
                     " refresh: " +
-                    monitor.rate;
+                    monitor.getRate();
                 txt = new BitmapText(loadGuiFont());
                 txt.setText(labelValue);
                 txt.setLocalTranslation(0, settings.getHeight() - 160 - (40 * i), 0);
@@ -222,13 +222,13 @@ public class TestMonitorApp extends SimpleApplication implements ActionListener 
                 "Selected Monitor " +
                 monitorSelected +
                 " " +
-                monitors.get(monitorSelected).name +
+                monitors.get(monitorSelected).getName() +
                 " Res: " +
-                monitors.get(monitorSelected).width +
+                monitors.get(monitorSelected).getWidth() +
                 "," +
-                monitors.get(monitorSelected).height +
+                monitors.get(monitorSelected).getHeight() +
                 "refresh: " +
-                monitors.get(monitorSelected).rate;
+                monitors.get(monitorSelected).getRate();
             selectedMonitorTxt.setText(label);
             if (!settings.isFullscreen()) fullScreenTxt.setText(
                 "(f) Window Screen"

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -947,7 +947,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         long prim = glfwGetPrimaryMonitor();
         Displays monitors = getDisplays();
         for (int i = 0; i < monitors.size(); i++) {
-            long monitorI = monitors.get(i).displayID;
+            long monitorI = monitors.get(i).getDisplay();
             if (monitorI == prim) return i;
         }
 
@@ -964,7 +964,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
      */
     private long getDisplay(int pos) {
         Displays displays = getDisplays();
-        if (pos < displays.size()) return displays.get(pos).displayID;
+        if (pos < displays.size()) return displays.get(pos).getDisplay();
 
         LOGGER.log(
             Level.SEVERE,

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -29,7 +29,6 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package com.jme3.system.lwjgl;
 
 import static org.lwjgl.glfw.GLFW.*;


### PR DESCRIPTION
This PR fixes issue #2345 by refactoring class `DisplayInfo` to have better encapsulation. The new changes are intended to make the class as immutable as possible for end users, except for internal JME processes.

I'd like to point out that I've renamed the variable `displayID` to `display` since that variable (`long`) is actually a pointer that lwjgl3 returns and not an identifier itself (the old name might be a bit confusing).