### PR TITLE
Update tank material pointing to deleted copy of PBRLighting

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -20,7 +20,7 @@ uniform vec4 g_LightData[NB_LIGHTS];
 uniform vec3 g_CameraPosition;
 
 #ifdef USE_FOG
-    #import "MatDefs/ShaderLib/MaterialFog.glsllib"
+    #import "Common/ShaderLib/MaterialFog.glsllib"
 #endif
 
 void main(){

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
@@ -11,9 +11,9 @@
 #define ENABLE_PBRTerrainUtils_readPBRTerrainLayers 1
 
 #import "Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib"
-#import "Common/MatDefs/ShaderLib/PBRTerrainUtils.glsllib"
+#import "Common/MatDefs/Terrain/Modular/PBRTerrainUtils.glsllib"
 #ifdef AFFLICTIONTEXTURE
-    #import "Common/MatDefs/ShaderLib/AfflictionLib.glsllib"
+    #import "Common/MatDefs/Terrain/Modular/AfflictionLib.glsllib"
 #endif
 
 //declare PBR Lighting vars

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/Modular/PBRTerrainUtils.glsllib
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/Modular/PBRTerrainUtils.glsllib
@@ -1,7 +1,7 @@
 #ifndef __PBR_TERRAIN_UTILS_MODULE__
     #define __PBR_TERRAIN_UTILS_MODULE__
 
-    #import "Common/MatDefs/ShaderLib/PBRTerrainTextureLayer.glsl"    
+    #import "Common/MatDefs/Terrain/Modular/PBRTerrainTextureLayer.glsl"    
 
     #import "Common/ShaderLib/TangentUtils.glsllib"
     #import "Common/ShaderLib/TriPlanarUtils.glsllib"

--- a/jme3-testdata/src/main/resources/Models/Tank/tank.j3m
+++ b/jme3-testdata/src/main/resources/Models/Tank/tank.j3m
@@ -1,4 +1,4 @@
-Material Tank : Common/MatDefs/Light/modular/PBRLighting.j3md {
+Material Tank : Common/MatDefs/Light/PBRLighting.j3md {
      MaterialParameters {
         
         MetallicRoughnessMap : Flip Models/Tank/Tank_Occ_Rough_Metal.png         


### PR DESCRIPTION
While preparing to cut the next alpha release, I did a final engine build and ran some important pbr engine tests/examples, and I ran into a crash with the SimplePBRTest example.

I had forgotten that riccardo had changed this tank material to test the new modular pbr shaders when the shaders were in a separate directory for preliminary testing last year.

But now the duplicated modular shaders were deleted (and have replaced the main PBR shader), so this test crashes with an assetNotFoundException, and just needed updated to point back to Common/MatDefs/Light/PBRLighting.j3md.