### PR TITLE
LwjglWindow:  solve window centering incorrect in JME 3.8.0-alpha3

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -357,8 +357,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         if (!settings.isFullscreen()) {
             if (settings.getCenterWindow()) {
                 // Center the window
-                requestX = videoMode.width() - requestWidth;
-                requestY = videoMode.height() - requestWidth;
+                requestX = (videoMode.width() - requestWidth) / 2;
+                requestY = (videoMode.height() - requestHeight) / 2;
             } else {
                 requestX = settings.getWindowXPosition();
                 requestY = settings.getWindowYPosition();


### PR DESCRIPTION
Due to a logic error, PR #2314 broke window centering with X windows and LWJGL3.
The breakage first appeared in 3.8.0-alpha3 .
The positioning calculations had a couple errors.
This PR corrects the errors.