### PR TITLE
update LWJGL from v3.3.4 to v3.3.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 [versions]
 
 checkstyle = "9.3"
-lwjgl3 = "3.3.4"
+lwjgl3 = "3.3.6"
 nifty = "1.4.3"
 
 [libraries]

--- a/jme3-vr/src/main/java/com/jme3/input/vr/osvr/OSVR.java
+++ b/jme3-vr/src/main/java/com/jme3/input/vr/osvr/OSVR.java
@@ -33,6 +33,7 @@ import com.ochafik.lang.jnaerator.runtime.NativeSizeByReference;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.PointerByReference;
 import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
 import java.util.logging.Logger;
 
 /**
@@ -78,6 +79,7 @@ public class OSVR implements VRAPI {
      */
     public static byte[] OpenGLString = { 'O', 'p', 'e', 'n', 'G', 'L', (byte)0 };
 
+    private final IntBuffer lastError = IntBuffer.allocate(2);
     private final Matrix4f[] eyeMatrix = new Matrix4f[2];
 
     private PointerByReference grabRM;
@@ -180,7 +182,7 @@ public class OSVR implements VRAPI {
      */
     public void grabGLFWContext() {
         // get current context
-        wglGLFW = org.lwjgl.opengl.WGL.wglGetCurrentContext();
+        wglGLFW = org.lwjgl.opengl.WGL.wglGetCurrentContext(lastError);
         glfwContext = org.lwjgl.glfw.GLFW.glfwGetCurrentContext();
     }
 
@@ -189,7 +191,7 @@ public class OSVR implements VRAPI {
      * @return <code>true</code> if the context is successfully shared and <code>false</code> otherwise.
      */
     public boolean shareContext() {
-        if( org.lwjgl.opengl.WGL.wglShareLists(wglRM, wglGLFW)) {
+        if (org.lwjgl.opengl.WGL.wglShareLists(lastError, wglRM, wglGLFW)) {
             System.out.println("Context sharing success!");
             return true;
         } else {
@@ -216,7 +218,7 @@ public class OSVR implements VRAPI {
             openResults.setAutoSynch(false);
             retval = OsvrRenderManagerOpenGLLibrary.osvrRenderManagerOpenDisplayOpenGL(renderManager, openResults);
             if( retval == 0 ) {
-                wglRM = org.lwjgl.opengl.WGL.wglGetCurrentContext();
+                wglRM = org.lwjgl.opengl.WGL.wglGetCurrentContext(lastError);
                 renderManagerContext = org.lwjgl.glfw.GLFW.glfwGetCurrentContext();
                 shareContext();
                 OsvrClientKitLibrary.osvrClientUpdate(context);
@@ -298,7 +300,6 @@ public class OSVR implements VRAPI {
         // may need to take current position and negate it from future values
     }
 
-    @Override
     public void getRenderSize(Vector2f store) {
         if( eyeLeftInfo == null || eyeLeftInfo.viewport.width == 0.0 ) {
             store.x = 1280f; store.y = 720f;
@@ -345,7 +346,6 @@ public class OSVR implements VRAPI {
         return storePos;
     }
 
-    @Override
     public void getPositionAndOrientation(Vector3f storePos, Quaternion storeRot) {
         storePos.x = (float)-hmdPose.translation.data[0];
         storePos.y = (float)hmdPose.translation.data[1];


### PR DESCRIPTION
Last week, in [jMonkeyEngine 3.8.0-alpha3](https://github.com/jMonkeyEngine/jmonkeyengine/releases/tag/v3.8.0-alpha3), we finally upgraded jme3-lwjgl3 and jme3-vr to use [LWJGL v3.3.4](https://github.com/LWJGL/lwjgl3/releases/tag/3.3.4).

V3.3.4 is over 6 months old. Already there are 2 newer releases out: v3.3.5 and v3.3.6. The differences between them are so slight that I propose we upgrade directly from v3.3.4 to v3.3.6. This pull request implements that upgrade.

I'm unsure whether this change should go public in JME v3.8.0-stable or in a later release. I'll leave that decision to the release manager .

Either way, we'll need someone to test on VR hardware. Currently, I don't have access to such hardware. @jseinturier and @phr00t can you help?