### PR TITLE
update LWJGLX (AWT) from 0.1.8 to 0.2.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 [versions]
 
 checkstyle = "9.3"
-lwjgl3 = "3.3.4"
+lwjgl3 = "3.3.6"
 nifty = "1.4.3"
 
 [libraries]
@@ -23,7 +23,7 @@ jna = "net.java.dev.jna:jna:5.10.0"
 jnaerator-runtime = "com.nativelibs4java:jnaerator-runtime:0.12"
 junit4 = "junit:junit:4.13.2"
 lwjgl2 = "org.jmonkeyengine:lwjgl:2.9.5"
-lwjgl3-awt = "org.lwjglx:lwjgl3-awt:0.1.8"
+lwjgl3-awt = "org.lwjglx:lwjgl3-awt:0.2.3"
 
 lwjgl3-base     = { module = "org.lwjgl:lwjgl",          version.ref = "lwjgl3" }
 lwjgl3-glfw     = { module = "org.lwjgl:lwjgl-glfw",     version.ref = "lwjgl3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 [versions]
 
 checkstyle = "9.3"
-lwjgl3 = "3.3.6"
+lwjgl3 = "3.3.4"
 nifty = "1.4.3"
 
 [libraries]

--- a/jme3-lwjgl3/build.gradle
+++ b/jme3-lwjgl3/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
     api project(':jme3-core')
     api project(':jme3-desktop')
-    api libs.lwjgl3.awt
+    api (libs.lwjgl3.awt) {
+        exclude group: 'org.lwjgl', module: 'lwjgl'
+    }
 
     api libs.lwjgl3.base
     api libs.lwjgl3.glfw

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjglx/Win32GLPlatform.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjglx/Win32GLPlatform.java
@@ -52,8 +52,7 @@ final class Win32GLPlatform extends PlatformWin32GLCanvas implements LwjglxGLPla
         }
     }
 
-    /*
-     * (non-Javadoc)
+    /* (non-Javadoc)
      * @see com.jme3.system.lwjglx.LwjglxGLPlatform#destroy() 
      */
     @Override

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjglx/Win32GLPlatform.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjglx/Win32GLPlatform.java
@@ -42,7 +42,17 @@ import org.lwjgl.opengl.awt.PlatformWin32GLCanvas;
  */
 final class Win32GLPlatform extends PlatformWin32GLCanvas implements LwjglxGLPlatform {
 
-    /**
+    /* (non-Javadoc)
+     * @see com.jme3.system.lwjglx.LwjglxGLPlatform#dispose()
+     */
+    @Override
+    public void dispose() {
+        if (ds != null) {
+            super.dispose();
+        }
+    }
+
+    /*
      * (non-Javadoc)
      * @see com.jme3.system.lwjglx.LwjglxGLPlatform#destroy() 
      */


### PR DESCRIPTION
This PR updates the lwjglx-awt library to the latest version ([V0.2.3](https://central.sonatype.com/artifact/org.lwjglx/lwjgl3-awt)). In this new version, an error that was reported in the [forum](https://hub.jmonkeyengine.org/t/failed-to-pass-test-case-jme3test-awt-testcanvas-on-jme-3-7-0-with-lwjgl3/47990?u=swiftwolf)  has been solved (correction in [lwjgl-awt](https://github.com/LWJGLX/lwjgl3-awt/pull/81))

I would like to inform you that these changes are related to PR #2371, that is; that this PR depends on PR #2371 so that AWT does not break when updating LWJGL3.