### PR TITLE
solve issue #2374 (NoSuchMethodError)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/AnimComposer.java
+++ b/jme3-core/src/main/java/com/jme3/anim/AnimComposer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2024 jMonkeyEngine
+ * Copyright (c) 2009-2025 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -317,10 +317,20 @@ public class AnimComposer extends AbstractControl {
      * @param mask The desired mask for the new layer (alias created)
      * @return a new layer
      */
-    public AnimLayer makeLayer(String name, AnimationMask mask) {
+    public AnimLayer addAnimLayer(String name, AnimationMask mask) {
         AnimLayer l = new AnimLayer(name, mask);
         layers.put(name, l);
         return l;
+    }
+
+    /**
+     * Adds a layer to this composer. (for compatibility with v3.7)
+     *
+     * @param name The desired name for the new layer
+     * @param mask The desired mask for the new layer (alias created)
+     */
+    public void makeLayer(String name, AnimationMask mask) {
+        addAnimLayer(name, mask);
     }
 
     /**
@@ -329,8 +339,18 @@ public class AnimComposer extends AbstractControl {
      * @param name The name of the layer to remove.
      * @return The removed layer.
      */
-    public AnimLayer removeLayer(String name) {
+    public AnimLayer removeAnimLayer(String name) {
         return layers.remove(name);
+    }
+
+    /**
+     * Removes the specified layer and stops the current action on that layer.
+     * (for compatibility with v3.7)
+     *
+     * @param name The name of the layer to remove.
+     */
+    public void removeLayer(String name) {
+        removeAnimLayer(name);
     }
 
     /**


### PR DESCRIPTION
This restores the pre-PR #2231 API of `AnimComposer`, in order to improve compatibility with JME 3.7 .

It then adds the 2 new methods (which return objects) under different names, to provide the functionality desired by @capdevon.