### PR TITLE
Fix Android crash from precision qualifiers in GLSLCompat.glsllib

### DIFF
--- a/jme3-core/src/main/resources/Common/ShaderLib/GLSLCompat.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/GLSLCompat.glsllib
@@ -1,17 +1,8 @@
 #ifdef GL_ES
   #ifdef FRAGMENT_SHADER
-    precision highp float;
-    precision highp int;
     #if __VERSION__ >= 130
-      precision highp sampler2DArray;        
-    #endif
-    precision highp sampler2DArray;
-    precision highp sampler2DShadow;
-    precision highp samplerCube;
-    precision highp sampler3D;
-    precision highp sampler2D;
-    #if __VERSION__ >= 310
-      precision highp sampler2DMS;
+      precision highp float;
+      precision highp int;
     #endif
   #endif
 #endif

--- a/jme3-core/src/main/resources/Common/ShaderLib/GLSLCompat.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/GLSLCompat.glsllib
@@ -1,8 +1,19 @@
 #ifdef GL_ES
+
+  #ifndef lowp
+    #define lowp
+  #endif
+  
   #ifdef FRAGMENT_SHADER
-    #if __VERSION__ >= 130
-      precision highp float;
-      precision highp int;
+    precision highp float;
+    precision highp int;
+    precision highp sampler2DArray;
+    precision highp sampler2DShadow;
+    precision highp samplerCube;
+    precision highp sampler3D;
+    precision highp sampler2D;
+    #if __VERSION__ >= 310
+      precision highp sampler2DMS;
     #endif
   #endif
 #endif


### PR DESCRIPTION
Addresses this issue: https://github.com/jMonkeyEngine/jmonkeyengine/issues/2329#issuecomment-2676145431

Feedback and review is appreciated, as I only just delved into learning about these precision qualifiers and I also don't do any jme dev on android to test this myself.