### PR TITLE
Fix logic errors and exception in SpecGloss pipeline

### DIFF
--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -384,7 +384,7 @@
             //spec gloss tex reads:
 
             #ifdef SPECGLOSSPIPELINE
-                flota glossiness = m_Glossiness;
+                float glossiness = m_Glossiness;
                 #ifdef USE_PACKED_SG
                     vec4 specularColor = texture2D(m_SpecularGlossinessMap, newTexCoord);
                     glossiness *= specularColor.a;

--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -388,8 +388,6 @@
                 #ifdef USE_PACKED_SG
                     vec4 specularColor = texture2D(m_SpecularGlossinessMap, newTexCoord);
                     glossiness *= specularColor.a;
-                    specularColor *= m_Specular;
-                    surface.specularColor = specularColor.rgb;
                 #else
                     #ifdef SPECULARMAP
                         vec4 specularColor = texture2D(m_SpecularMap, newTexCoord);
@@ -399,10 +397,10 @@
                     #ifdef GLOSSINESSMAP
                         glossiness *= texture2D(m_GlossinesMap, newTexCoord).r;
                     #endif
-                    specularColor *= m_Specular;
-                    surface.specularColor = specularColor.rgb;
-                    surface.roughness = 1.0 - glossiness;
                 #endif
+                specularColor *= m_Specular;
+                surface.specularColor = specularColor.rgb;
+                surface.roughness = 1.0 - glossiness;
             #endif
 
             vec3 ao = vec3(1.0);

--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -384,10 +384,12 @@
             //spec gloss tex reads:
 
             #ifdef SPECGLOSSPIPELINE
+                flota glossiness = m_Glossiness;
                 #ifdef USE_PACKED_SG
                     vec4 specularColor = texture2D(m_SpecularGlossinessMap, newTexCoord);
-                    float glossiness = specularColor.a * m_Glossiness;
+                    glossiness *= specularColor.a;
                     specularColor *= m_Specular;
+                    surface.specularColor = specularColor.rgb;
                 #else
                     #ifdef SPECULARMAP
                         vec4 specularColor = texture2D(m_SpecularMap, newTexCoord);
@@ -395,16 +397,13 @@
                         vec4 specularColor = vec4(1.0);
                     #endif
                     #ifdef GLOSSINESSMAP
-                        float glossiness = texture2D(m_GlossinesMap, newTexCoord).r * m_Glossiness;
-                    #else
-                        float glossiness = m_Glossiness;
+                        glossiness *= texture2D(m_GlossinesMap, newTexCoord).r;
                     #endif
                     specularColor *= m_Specular;
-                    surface.specularColor = specularColor;
+                    surface.specularColor = specularColor.rgb;
+                    surface.roughness = 1.0 - glossiness;
                 #endif
             #endif
-
-
 
             vec3 ao = vec3(1.0);
             #ifdef LIGHTMAP
@@ -475,7 +474,6 @@
 
             #ifdef SPECGLOSSPIPELINE      
                 surface.diffuseColor = surface.albedo;// * (1.0 - max(max(specularColor.r, specularColor.g), specularColor.b));
-                surface.roughness = 1.0 - m_Glossiness;
                 surface.fZero = surface.specularColor.xyz;
             #else
                 surface.specularColor = (0.04 - 0.04 * surface.metallic) + surface.albedo * surface.metallic;  // 0.04 is the standard base specular reflectance for non-metallic surfaces in PBR. While values like 0.08 can be used for different implementations, 0.04 aligns with Khronos' PBR specification.


### PR DESCRIPTION
This PR addresses this issue: 
#2386 
And then I also found another critical logic error in the spec gloss pipeline that was likely there even before riccardo adapted the shader to use structs:

It looks like the specular and glossiness value taken from specularMaps was being totally ignored and the glossiness value was not being accounted for in the final roughness calculation. The code further down in the shader was calculating the roughness solely based on m_Glossiness with no regard for the glossiness scalar read from texture maps, which is incorrect.

The logic error and exception should all be fixed in this PR now, but it will need testing from a spec gloss model with packed specularGlossinesMap as well as a model with seperate specular and glossiness maps in order to ensure everything works properly now.