### PR TITLE
Fix non decimal format floats in TangentUtils.glsllib

### DIFF
--- a/jme3-core/src/main/resources/Common/ShaderLib/TangentUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/TangentUtils.glsllib
@@ -4,7 +4,8 @@
     //used for calculating tangents in-shader for axis-aligned quads/planes/terrains   
     //primarily used for PBR terrains, since jme terrains do not store pre-calculated tangents by default (thus the tbnMat cannot be used for PBR light calculation like it is in jme's stock PBR shader)
     vec3 calculateTangentsAndApplyToNormals(in vec3 normalIn, in vec3 worldNorm){        
-        vec3 baseNorm = worldNorm.rgb + vec3(0, 0, 1);
+        vec3 baseNorm = worldNorm.rgb + vec3(0.0, 0.0, 1.0);
+        normalIn *= vec3(-1.0, 1.0, 1.0);
         normalIn = baseNorm.rgb*dot(baseNorm.rgb, normalIn.rgb)/baseNorm.z - normalIn.rgb;
         normalIn = normalize(normalIn);
 


### PR DESCRIPTION
I also added a line of code that I had previously removed from the tangent calculations that may fix some minor inaccuracies in shading and lighting direction (although it was very minor and barely noticeable).

I previously removed that line of code because it was also flipping the y component of normal map (which is better done by the NORMAL_TYPE param) but then I realized this line of code also flips the x component of the normal map which is likely important for the tangent calculation that follows. So I just updated it to only multiply the x component by -1 and will leave the y component flipping up to NORMAL_TYPE so users can change it as needed.