### PR TITLE
Fix LightProbe blending

### DIFF
--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -582,54 +582,92 @@
             finalLightingScale = max(finalLightingScale, surface.brightestNonGlobalLightStrength);    
             finalLightingScale = max(finalLightingScale, minVertLighting); //essentially just the vertColors.r (aka indoor light exposure) multiplied by the time of day scale.   
 
+            #if NB_PROBES >= 1
+                vec3 color1 = vec3(0.0);
+                vec3 color2 = vec3(0.0);
+                vec3 color3 = vec3(0.0);
+                float weight1 = 1.0;
+                float weight2 = 0.0;
+                float weight3 = 0.0;
 
-            #if NB_PROBES > 0
-                float probeNdfSum = 0.0;
-                float invProbeNdfSum = 0.0;    
-
-                #for i=1..4 ( #if NB_PROBES >= $i $0 #endif )
-                    vec3 probeColor$i;
-                    float probeNdf$i = renderProbe(
+                float ndf = renderProbe(
                         surface.viewDir, 
                         surface.position, 
                         surface.normal,
                         surface.geometryNormal,
                         surface.roughness,
-                        vec4(surface.diffuseColor,1.0),
-                        vec4(surface.specularColor,1.0), 
+                        vec4(surface.diffuseColor, 1.0),
+                        vec4(surface.specularColor, 1.0), 
                         surface.NdotV, 
                         surface.ao, 
-                        #if $i == 1
-                            g_LightProbeData, 
-                        #else  
-                            g_LightProbeData$i,
-                        #endif
-                        g_ShCoeffs,
-                        g_PrefEnvMap,
-                        probeColor$i
-                    );
-                    float probeInvNdf$i =  max(1.0 - probeNdf$i,0.0);
-                    probeNdfSum += probeNdf$i;
-                    invProbeNdfSum += probeInvNdf$i;
-                    #ifdef USE_AMBIENT_LIGHT
-                        probeColor$i.rgb *= g_AmbientLightColor.rgb;
-                    #endif
-                    probeColor$i.rgb *= finalLightingScale;
-                #endfor
-
-                #if NB_PROBES > 1
-                    float probeWeightSum = 0.0;
-                    #for i=1..4 ( #if NB_PROBES >= $i $0 #endif )
-                        float probeWeight$i = ((1.0 - (probeNdf$i / probeNdfSum)) / (NB_PROBES - 1)) *  ( probeInvNdf$i / invProbeNdfSum);
-                        probeWeightSum += probeWeight$i;    
-                    #endfor 
-
-                    #for i=1..4 ( #if NB_PROBES >= $i $0 #endif )       
-                        surface.envLightContribution.rgb += probeColor$i * clamp( probeWeight$i / probeWeightSum, 0., 1.);
-                    #endfor 
-                #else
-                    surface.envLightContribution.rgb += probeColor1;
+                        g_LightProbeData, g_ShCoeffs, g_PrefEnvMap, color1);
+                #if NB_PROBES >= 2
+                    float ndf2 = renderProbe(
+                        surface.viewDir, 
+                        surface.position, 
+                        surface.normal,
+                        surface.geometryNormal,
+                        surface.roughness,
+                        vec4(surface.diffuseColor, 1.0),
+                        vec4(surface.specularColor, 1.0), 
+                        surface.NdotV, 
+                        surface.ao, 
+                        g_LightProbeData2, 
+                        g_ShCoeffs2, 
+                        g_PrefEnvMap2, 
+                        color2);
                 #endif
+                #if NB_PROBES == 3
+                    float ndf3 = renderProbe(
+                        surface.viewDir, 
+                        surface.position, 
+                        surface.normal,
+                        surface.geometryNormal,
+                        surface.roughness,
+                        vec4(surface.diffuseColor, 1.0),
+                        vec4(surface.specularColor, 1.0), 
+                        surface.NdotV, 
+                        surface.ao,  
+                        g_LightProbeData3, 
+                        g_ShCoeffs3, 
+                        g_PrefEnvMap3, 
+                        color3);
+                #endif
+
+                #if NB_PROBES >= 2
+                    float invNdf =  max(1.0 - ndf,0.0);
+                    float invNdf2 =  max(1.0 - ndf2,0.0);
+                    float sumNdf = ndf + ndf2;
+                    float sumInvNdf = invNdf + invNdf2;
+                    #if NB_PROBES == 3
+                        float invNdf3 = max(1.0 - ndf3,0.0);
+                        sumNdf += ndf3;
+                        sumInvNdf += invNdf3;
+                        weight3 =  ((1.0 - (ndf3 / sumNdf)) / (NB_PROBES - 1)) *  (invNdf3 / sumInvNdf);
+                    #endif
+
+                    weight1 = ((1.0 - (ndf / sumNdf)) / (NB_PROBES - 1)) *  (invNdf / sumInvNdf);
+                    weight2 = ((1.0 - (ndf2 / sumNdf)) / (NB_PROBES - 1)) *  (invNdf2 / sumInvNdf);
+
+                    float weightSum = weight1 + weight2 + weight3;
+
+                    weight1 /= weightSum;
+                    weight2 /= weightSum;
+                    weight3 /= weightSum;
+                #endif
+                
+                #ifdef USE_AMBIENT_LIGHT
+                    color1.rgb *= g_AmbientLightColor.rgb;
+                    color2.rgb *= g_AmbientLightColor.rgb;
+                    color3.rgb *= g_AmbientLightColor.rgb;
+                #endif
+                
+                color1.rgb *= finalLightingScale;
+                color2.rgb *= finalLightingScale;
+                color3.rgb *= finalLightingScale;
+
+                surface.envLightContribution.rgb += color1 * clamp(weight1,0.0,1.0) + color2 * clamp(weight2,0.0,1.0) + color3 * clamp(weight3,0.0,1.0);
+                
             #endif
         }
     #endif


### PR DESCRIPTION
Fixes this issue: https://github.com/jMonkeyEngine/jmonkeyengine/issues/2399 by reverting this block of code to its pre-for-loop state before the regression occurred. I tried fixing it without removing the for loops, but I'm not super comfortable with this light probe code so reverting this section of code seemed like the safest option.

I tested the changes and can confirm now that smooth blending between LightProbes is working again in my scenes with more than 1 LightProbe.

