### PR TITLE
Fix NPE on AbstractShadowFilter deserialization

### DIFF
--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2024 jMonkeyEngine
+ * Copyright (c) 2009-2025 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -51,7 +51,6 @@ import com.jme3.util.clone.JmeCloneable;
 import java.io.IOException;
 
 /**
- *
  * Generic abstract filter that holds common implementations for the different
  * shadow filters
  *
@@ -63,9 +62,9 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
     protected ViewPort viewPort;
 
     /**
-     * used for serialization
+     * For serialization only. Do not use.
      */
-    protected AbstractShadowFilter(){
+    protected AbstractShadowFilter() {
     }
     
     /**
@@ -79,11 +78,8 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
     @SuppressWarnings("all")
     protected AbstractShadowFilter(AssetManager manager, int shadowMapSize, T shadowRenderer) {
         super("Post Shadow");
-        material = new Material(manager, "Common/MatDefs/Shadow/PostShadowFilter.j3md");       
         this.shadowRenderer = shadowRenderer;
-        this.shadowRenderer.setPostShadowMaterial(material);
-
-        //this is legacy setting for shadows with backface shadows
+        // this is legacy setting for shadows with backface shadows
         this.shadowRenderer.setRenderBackFacesShadows(true);
     }
 
@@ -100,6 +96,7 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
     public Material getShadowMaterial() {       
         return material;
     }
+
     Vector4f tmpv = new Vector4f();
 
     @Override
@@ -113,15 +110,15 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
     @Override
     protected void postQueue(RenderQueue queue) {
         shadowRenderer.postQueue(queue);
-         if(shadowRenderer.skipPostPass){
-             //removing the shadow map so that the post pass is skipped
-             material.setTexture("ShadowMap0", null);
-         }
+        if (shadowRenderer.skipPostPass) {
+            // removing the shadow map so that the post pass is skipped
+            material.setTexture("ShadowMap0", null);
+        }
     }
 
     @Override
     protected void postFrame(RenderManager renderManager, ViewPort viewPort, FrameBuffer prevFilterBuffer, FrameBuffer sceneBuffer) {
-        if(!shadowRenderer.skipPostPass){
+        if (!shadowRenderer.skipPostPass) {
             shadowRenderer.setPostShadowParams();
         }
     }
@@ -129,15 +126,17 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
     @Override
     protected void initFilter(AssetManager manager, RenderManager renderManager, ViewPort vp, int w, int h) {
         shadowRenderer.needsfallBackMaterial = true;
+        material = new Material(manager, "Common/MatDefs/Shadow/PostShadowFilter.j3md");
+        shadowRenderer.setPostShadowMaterial(material);
         shadowRenderer.initialize(renderManager, vp);
         this.viewPort = vp;
     }
-    
-      /**
+
+    /**
      * How far the shadows are rendered in the view
      *
-     * @see #setShadowZExtend(float zFar)
      * @return shadowZExtend
+     * @see #setShadowZExtend(float zFar)
      */
     public float getShadowZExtend() {
         return shadowRenderer.getShadowZExtend();

--- a/jme3-core/src/test/java/com/jme3/shadow/FilterPostProcessingTest.java
+++ b/jme3-core/src/test/java/com/jme3/shadow/FilterPostProcessingTest.java
@@ -1,0 +1,68 @@
+package com.jme3.shadow;
+
+import com.jme3.asset.AssetManager;
+import com.jme3.asset.DesktopAssetManager;
+import com.jme3.export.binary.BinaryExporter;
+import com.jme3.light.DirectionalLight;
+import com.jme3.light.PointLight;
+import com.jme3.light.SpotLight;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.Vector3f;
+import com.jme3.post.Filter;
+import com.jme3.post.FilterPostProcessor;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Automated tests for the {@code FilterPostProcessing} class.
+ *
+ * @author capdevon
+ */
+public class FilterPostProcessingTest {
+
+    /**
+     * Tests serialization and de-serialization of a {@code FilterPostProcessing}.
+     */
+    @Test
+    public void testSaveAndLoad() {
+        AssetManager assetManager = new DesktopAssetManager(true);
+
+        FilterPostProcessor fpp = new FilterPostProcessor(assetManager);
+        fpp.addFilter(createDirectionalLightShadowFilter(assetManager));
+        fpp.addFilter(createSpotLightShadowFilter(assetManager));
+        fpp.addFilter(createPointLightShadowFilter(assetManager));
+
+        BinaryExporter.saveAndLoad(assetManager, fpp);
+    }
+
+    private DirectionalLightShadowFilter createDirectionalLightShadowFilter(AssetManager assetManager) {
+        DirectionalLight light = new DirectionalLight();
+        light.setDirection(new Vector3f(-1, -2, -3).normalizeLocal());
+        light.setColor(new ColorRGBA(0.8f, 0.8f, 0.8f, 1f));
+
+        DirectionalLightShadowFilter dlsf = new DirectionalLightShadowFilter(assetManager, 2048, 1);
+        dlsf.setLight(light);
+
+        return dlsf;
+    }
+
+    private SpotLightShadowFilter createSpotLightShadowFilter(AssetManager assetManager) {
+        SpotLight light = new SpotLight();
+        light.setColor(new ColorRGBA(0.8f, 0.8f, 0.8f, 1f));
+
+        SpotLightShadowFilter slsf = new SpotLightShadowFilter(assetManager, 2048);
+        slsf.setLight(light);
+
+        return slsf;
+    }
+
+    private PointLightShadowFilter createPointLightShadowFilter(AssetManager assetManager) {
+        PointLight light = new PointLight();
+        light.setColor(new ColorRGBA(0.8f, 0.8f, 0.8f, 1f));
+
+        PointLightShadowFilter plsf = new PointLightShadowFilter(assetManager, 2048);
+        plsf.setLight(light);
+
+        return plsf;
+    }
+}


### PR DESCRIPTION
move the initialization of the Post Shadow Material to the `AbstractShadowFilter.init()` method