### PR TITLE
Add defensive copy to EmitterShape's Vector3f

### DIFF
--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterBoxShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterBoxShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2025 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,15 +44,24 @@ public class EmitterBoxShape implements EmitterShape {
 
     private Vector3f min, len;
 
+    /**
+     * For serialization only. Do not use.
+     */
     public EmitterBoxShape() {
     }
 
+    /**
+     * Creates a new {@code EmitterBoxShape} defined by its minimum and maximum corners.
+     *
+     * @param min The minimum corner of the box. (not null, unaffected)
+     * @param max The maximum corner of the box. (not null, unaffected)
+     */
     public EmitterBoxShape(Vector3f min, Vector3f max) {
         if (min == null || max == null) {
             throw new IllegalArgumentException("min or max cannot be null");
         }
 
-        this.min = min;
+        this.min = new Vector3f(min);
         this.len = new Vector3f();
         this.len.set(max).subtractLocal(min);
     }
@@ -113,15 +122,15 @@ public class EmitterBoxShape implements EmitterShape {
     }
 
     public void setMin(Vector3f min) {
-        this.min = min;
+        this.min.set(min);
     }
 
     public Vector3f getLen() {
         return len;
     }
 
-    public void setLen(Vector3f len) {
-        this.len = len;
+    public void setLen(Vector3f length) {
+        this.len.set(length);
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterBoxShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterBoxShape.java
@@ -42,7 +42,8 @@ import java.io.IOException;
 
 public class EmitterBoxShape implements EmitterShape {
 
-    private Vector3f min, len;
+    private Vector3f min = new Vector3f(-1, -1, -1);
+    private Vector3f len = new Vector3f(2, 2, 2);
 
     /**
      * For serialization only. Do not use.
@@ -61,8 +62,7 @@ public class EmitterBoxShape implements EmitterShape {
             throw new IllegalArgumentException("min or max cannot be null");
         }
 
-        this.min = new Vector3f(min);
-        this.len = new Vector3f();
+        this.min.set(min);
         this.len.set(max).subtractLocal(min);
     }
 

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterBoxShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterBoxShape.java
@@ -46,7 +46,7 @@ public class EmitterBoxShape implements EmitterShape {
     private Vector3f len = new Vector3f(2, 2, 2);
 
     /**
-     * For serialization only. Do not use.
+     * Empty constructor. Sets nothing.
      */
     public EmitterBoxShape() {
     }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshConvexHullShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshConvexHullShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2025 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,7 +45,7 @@ import java.util.List;
 public class EmitterMeshConvexHullShape extends EmitterMeshFaceShape {
 
     /**
-     * Empty constructor. Sets nothing.
+     * For serialization only. Do not use.
      */
     public EmitterMeshConvexHullShape() {
     }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshConvexHullShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshConvexHullShape.java
@@ -45,7 +45,7 @@ import java.util.List;
 public class EmitterMeshConvexHullShape extends EmitterMeshFaceShape {
 
     /**
-     * For serialization only. Do not use.
+     * Empty constructor. Sets nothing.
      */
     public EmitterMeshConvexHullShape() {
     }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshFaceShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshFaceShape.java
@@ -46,7 +46,7 @@ import java.util.List;
 public class EmitterMeshFaceShape extends EmitterMeshVertexShape {
 
     /**
-     * For serialization only. Do not use.
+     * Empty constructor. Sets nothing.
      */
     public EmitterMeshFaceShape() {
     }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshFaceShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshFaceShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2025 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,7 +46,7 @@ import java.util.List;
 public class EmitterMeshFaceShape extends EmitterMeshVertexShape {
 
     /**
-     * Empty constructor. Sets nothing.
+     * For serialization only. Do not use.
      */
     public EmitterMeshFaceShape() {
     }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshVertexShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshVertexShape.java
@@ -58,7 +58,7 @@ public class EmitterMeshVertexShape implements EmitterShape {
     protected List<List<Vector3f>> normals;
 
     /**
-     * For serialization only. Do not use.
+     * Empty constructor. Sets nothing.
      */
     public EmitterMeshVertexShape() {
     }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshVertexShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshVertexShape.java
@@ -80,8 +80,8 @@ public class EmitterMeshVertexShape implements EmitterShape {
     public void setMeshes(List<Mesh> meshes) {
         Map<Vector3f, Vector3f> vertToNormalMap = new HashMap<>();
 
-        this.vertices = new ArrayList<List<Vector3f>>(meshes.size());
-        this.normals = new ArrayList<List<Vector3f>>(meshes.size());
+        this.vertices = new ArrayList<>(meshes.size());
+        this.normals = new ArrayList<>(meshes.size());
         for (Mesh mesh : meshes) {
             // fetching the data
             float[] vertexTable = BufferUtils.getFloatArray(mesh.getFloatBuffer(Type.Position));

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshVertexShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterMeshVertexShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2025 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -58,7 +58,7 @@ public class EmitterMeshVertexShape implements EmitterShape {
     protected List<List<Vector3f>> normals;
 
     /**
-     * Empty constructor. Sets nothing.
+     * For serialization only. Do not use.
      */
     public EmitterMeshVertexShape() {
     }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterPointShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterPointShape.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 
 public class EmitterPointShape implements EmitterShape {
 
-    private Vector3f point;
+    private Vector3f point = new Vector3f();
 
     /**
      * For serialization only. Do not use.
@@ -58,7 +58,7 @@ public class EmitterPointShape implements EmitterShape {
         if (point == null) {
             throw new IllegalArgumentException("point cannot be null");
         }
-        this.point = new Vector3f(point);
+        this.point.set(point);
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterPointShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterPointShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2025 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,7 @@
  */
 package com.jme3.effect.shapes;
 
+import com.jme3.export.InputCapsule;
 import com.jme3.export.JmeExporter;
 import com.jme3.export.JmeImporter;
 import com.jme3.export.OutputCapsule;
@@ -42,11 +43,22 @@ public class EmitterPointShape implements EmitterShape {
 
     private Vector3f point;
 
+    /**
+     * For serialization only. Do not use.
+     */
     public EmitterPointShape() {
     }
 
+    /**
+     * Creates a new {@code EmitterPointShape} with the specified emission point.
+     *
+     * @param point The initial emission point. (not null, unaffected)
+     */
     public EmitterPointShape(Vector3f point) {
-        this.point = point;
+        if (point == null) {
+            throw new IllegalArgumentException("point cannot be null");
+        }
+        this.point = new Vector3f(point);
     }
 
     @Override
@@ -101,7 +113,7 @@ public class EmitterPointShape implements EmitterShape {
     }
 
     public void setPoint(Vector3f point) {
-        this.point = point;
+        this.point.set(point);
     }
 
     @Override
@@ -112,6 +124,7 @@ public class EmitterPointShape implements EmitterShape {
 
     @Override
     public void read(JmeImporter im) throws IOException {
-        this.point = (Vector3f) im.getCapsule(this).readSavable("point", null);
+        InputCapsule ic = im.getCapsule(this);
+        this.point = (Vector3f) ic.readSavable("point", null);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterPointShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterPointShape.java
@@ -44,7 +44,7 @@ public class EmitterPointShape implements EmitterShape {
     private Vector3f point = new Vector3f();
 
     /**
-     * For serialization only. Do not use.
+     * Empty constructor. Sets nothing.
      */
     public EmitterPointShape() {
     }

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
@@ -74,7 +74,6 @@ public class EmitterSphereShape implements EmitterShape {
         try {
             EmitterSphereShape clone = (EmitterSphereShape) super.clone();
             clone.center = center.clone();
-            clone.radius = radius;
             return clone;
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
@@ -99,7 +98,6 @@ public class EmitterSphereShape implements EmitterShape {
     @Override
     public void cloneFields(Cloner cloner, Object original) {
         this.center = cloner.clone(center);
-        this.radius = cloner.clone(radius);
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
@@ -42,8 +42,8 @@ import java.io.IOException;
 
 public class EmitterSphereShape implements EmitterShape {
 
-    private Vector3f center;
-    private float radius;
+    private Vector3f center = new Vector3f();
+    private float radius = 1;
 
     /**
      * For serialization only. Do not use.
@@ -65,7 +65,7 @@ public class EmitterSphereShape implements EmitterShape {
             throw new IllegalArgumentException("radius must be greater than 0");
         }
 
-        this.center = new Vector3f(center);
+        this.center.set(center);
         this.radius = radius;
     }
 

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012 jMonkeyEngine
+ * Copyright (c) 2009-2025 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,19 +45,27 @@ public class EmitterSphereShape implements EmitterShape {
     private Vector3f center;
     private float radius;
 
+    /**
+     * For serialization only. Do not use.
+     */
     public EmitterSphereShape() {
     }
 
+    /**
+     * Creates a new {@code EmitterSphereShape} with the specified center and radius.
+     *
+     * @param center The center of the sphere. (not null, unaffected)
+     * @param radius The radius of the sphere. Must be greater than 0.
+     */
     public EmitterSphereShape(Vector3f center, float radius) {
         if (center == null) {
             throw new IllegalArgumentException("center cannot be null");
         }
-
         if (radius <= 0) {
-            throw new IllegalArgumentException("Radius must be greater than 0");
+            throw new IllegalArgumentException("radius must be greater than 0");
         }
 
-        this.center = center;
+        this.center = new Vector3f(center);
         this.radius = radius;
     }
 
@@ -66,6 +74,7 @@ public class EmitterSphereShape implements EmitterShape {
         try {
             EmitterSphereShape clone = (EmitterSphereShape) super.clone();
             clone.center = center.clone();
+            clone.radius = radius;
             return clone;
         } catch (CloneNotSupportedException ex) {
             throw new AssertionError();
@@ -90,6 +99,7 @@ public class EmitterSphereShape implements EmitterShape {
     @Override
     public void cloneFields(Cloner cloner, Object original) {
         this.center = cloner.clone(center);
+        this.radius = cloner.clone(radius);
     }
 
     @Override
@@ -113,7 +123,7 @@ public class EmitterSphereShape implements EmitterShape {
     }
 
     public void setCenter(Vector3f center) {
-        this.center = center;
+        this.center.set(center);
     }
 
     public float getRadius() {

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
@@ -46,7 +46,7 @@ public class EmitterSphereShape implements EmitterShape {
     private float radius = 1;
 
     /**
-     * For serialization only. Do not use.
+     * Empty constructor. Sets nothing.
      */
     public EmitterSphereShape() {
     }


### PR DESCRIPTION
* Update licence year
* Update javadoc
A defensive copy is created to ensure that any external modifications to the original Vector3f objects will not affect the EmitterShape's internal state.