### PR TITLE
PBR Fixes: Use correct accelerated baker  and prevent artifacts in kernel 

### DIFF
--- a/jme3-core/src/main/java/com/jme3/environment/EnvironmentProbeControl.java
+++ b/jme3-core/src/main/java/com/jme3/environment/EnvironmentProbeControl.java
@@ -287,8 +287,9 @@ public class EnvironmentProbeControl extends LightProbe implements Control {
     }
 
     void rebakeNow(RenderManager renderManager) {
-        IBLHybridEnvBakerLight baker = new IBLGLEnvBakerLight(renderManager, assetManager, Format.RGB16F, Format.Depth,
-                envMapSize, envMapSize);
+        IBLHybridEnvBakerLight baker = new IBLHybridEnvBakerLight(renderManager, assetManager, Format.RGB16F,
+                Format.Depth,
+                        envMapSize, envMapSize);
                     
         baker.setTexturePulling(isRequiredSavableResults());
         baker.bakeEnvironment(spatial, getPosition(), frustumNear, frustumFar, filter);

--- a/jme3-core/src/main/java/com/jme3/environment/FastLightProbeFactory.java
+++ b/jme3-core/src/main/java/com/jme3/environment/FastLightProbeFactory.java
@@ -32,7 +32,7 @@
 package com.jme3.environment;
 
 import com.jme3.asset.AssetManager;
-import com.jme3.environment.baker.IBLGLEnvBakerLight;
+import com.jme3.environment.baker.IBLHybridEnvBakerLight;
 import com.jme3.environment.util.EnvMapUtils;
 import com.jme3.light.LightProbe;
 import com.jme3.math.Vector3f;
@@ -74,7 +74,8 @@ public class FastLightProbeFactory {
      * @return The baked LightProbe
      */
     public static LightProbe makeProbe(RenderManager rm, AssetManager am, int size, Vector3f pos, float frustumNear, float frustumFar, Spatial scene) {
-        IBLGLEnvBakerLight baker = new IBLGLEnvBakerLight(rm, am, Format.RGB16F, Format.Depth, size, size);
+        IBLHybridEnvBakerLight baker = new IBLHybridEnvBakerLight(rm, am, Format.RGB16F, Format.Depth, size,
+                size);
 
         baker.setTexturePulling(true);
         baker.bakeEnvironment(scene, pos, frustumNear, frustumFar, null);

--- a/jme3-core/src/main/java/com/jme3/environment/baker/IBLHybridEnvBakerLight.java
+++ b/jme3-core/src/main/java/com/jme3/environment/baker/IBLHybridEnvBakerLight.java
@@ -200,6 +200,7 @@ public class IBLHybridEnvBakerLight extends GenericEnvBaker implements IBLEnvBak
     @Override
     public void bakeSphericalHarmonicsCoefficients() {
         shCoef = EnvMapUtils.getSphericalHarmonicsCoefficents(getEnvMap());
+        EnvMapUtils.prepareShCoefs(shCoef);
     }
 
     @Override

--- a/jme3-core/src/main/resources/Common/IBL/IBLKernels.frag
+++ b/jme3-core/src/main/resources/Common/IBL/IBLKernels.frag
@@ -34,7 +34,7 @@ void brdfKernel(){
         float NdotH = max(H.z, 0.0);
         float VdotH = max(dot(V, H), 0.0);
         if(NdotL > 0.0){
-            float G = GeometrySmith(N, V, L, m_Roughness);
+            float G = GeometrySmith(N, V, L, m_Roughness*m_Roughness);
             float G_Vis = (G * VdotH) / (NdotH * NdotV);
             float Fc = pow(1.0 - VdotH, 5.0);
             A += (1.0 - Fc) * G_Vis;
@@ -75,9 +75,7 @@ void prefilteredEnvKernel(){
     vec3 R = N;
     vec3 V = R;
 
-    // float a2 = m_Roughness;
-    float a2 = m_Roughness * m_Roughness; // jme impl, why?
-    a2 *= a2;
+    float a2 = m_Roughness * m_Roughness; 
 
     const uint SAMPLE_COUNT = 1024u;
     float totalWeight = 0.0;   
@@ -85,16 +83,28 @@ void prefilteredEnvKernel(){
     for(uint i = 0u; i < SAMPLE_COUNT; ++i) {
         vec4 Xi = Hammersley(i, SAMPLE_COUNT);
         vec3 H  = ImportanceSampleGGX(Xi, a2, N);
-        float VoH = dot(V,H);
+        float VoH = max(dot(V, H), 0.0);
         vec3 L  = normalize(2.0 * VoH * H - V);
         float NdotL = max(dot(N, L), 0.0);
         if(NdotL > 0.0) {
+            vec3 sampleColor = texture(m_EnvMap, L).rgb;
+            
+            float luminance = dot(sampleColor, vec3(0.2126, 0.7152, 0.0722));
+            if (luminance > 64.0) { // TODO use average?
+                sampleColor *= 64.0/luminance;
+            }
+            
             // TODO: use mipmap
-            prefilteredColor += texture(m_EnvMap, L).rgb * NdotL;
+            prefilteredColor += sampleColor * NdotL;
             totalWeight      += NdotL;
         }
+
     }
-    prefilteredColor = prefilteredColor / totalWeight;
+
+    if(totalWeight > 0.001){
+         prefilteredColor /= totalWeight;    
+    }
+
     outFragColor = vec4(prefilteredColor, 1.0);
 }  
 


### PR DESCRIPTION
The accelerated baker doesn't use `IBLHybridEnvBakerLight`  by default, as it should. 
Looks like i forgot to change it when i ported the code to jme's pbr a while back.
Basically `IBLGLEnvBakerLight` bakes irradiance to a texture, while `IBLHybridEnvBakerLight`  generates the spherical harmonic coefficients needed by the jme shader, so this was causing the shCoeff array to not be initialized properly, resulting in bad lighting on materials with high roughness.

This PR fixes that and also fixes some issues in the IBL kernels that were causing fireflies artifacts to appear in the prefiltered map when sampling overbright skies.


