### PR TITLE
 PBR Fixes: Apply band factor to spherical harmonic coefficients in accelerated baker light and prevent fireflies artifacts

### DIFF
--- a/jme3-core/src/main/java/com/jme3/environment/EnvironmentProbeControl.java
+++ b/jme3-core/src/main/java/com/jme3/environment/EnvironmentProbeControl.java
@@ -287,8 +287,9 @@ public class EnvironmentProbeControl extends LightProbe implements Control {
     }
 
     void rebakeNow(RenderManager renderManager) {
-        IBLHybridEnvBakerLight baker = new IBLGLEnvBakerLight(renderManager, assetManager, Format.RGB16F, Format.Depth,
-                envMapSize, envMapSize);
+        IBLHybridEnvBakerLight baker = new IBLGLEnvBakerLight(renderManager, assetManager, Format.RGB16F,
+                Format.Depth,
+                        envMapSize, envMapSize);
                     
         baker.setTexturePulling(isRequiredSavableResults());
         baker.bakeEnvironment(spatial, getPosition(), frustumNear, frustumFar, filter);

--- a/jme3-core/src/main/java/com/jme3/environment/FastLightProbeFactory.java
+++ b/jme3-core/src/main/java/com/jme3/environment/FastLightProbeFactory.java
@@ -33,6 +33,7 @@ package com.jme3.environment;
 
 import com.jme3.asset.AssetManager;
 import com.jme3.environment.baker.IBLGLEnvBakerLight;
+import com.jme3.environment.baker.IBLHybridEnvBakerLight;
 import com.jme3.environment.util.EnvMapUtils;
 import com.jme3.light.LightProbe;
 import com.jme3.math.Vector3f;
@@ -74,7 +75,8 @@ public class FastLightProbeFactory {
      * @return The baked LightProbe
      */
     public static LightProbe makeProbe(RenderManager rm, AssetManager am, int size, Vector3f pos, float frustumNear, float frustumFar, Spatial scene) {
-        IBLGLEnvBakerLight baker = new IBLGLEnvBakerLight(rm, am, Format.RGB16F, Format.Depth, size, size);
+        IBLHybridEnvBakerLight baker = new IBLGLEnvBakerLight(rm, am, Format.RGB16F, Format.Depth, size,
+                        size);
 
         baker.setTexturePulling(true);
         baker.bakeEnvironment(scene, pos, frustumNear, frustumFar, null);

--- a/jme3-core/src/main/java/com/jme3/environment/baker/IBLGLEnvBakerLight.java
+++ b/jme3-core/src/main/java/com/jme3/environment/baker/IBLGLEnvBakerLight.java
@@ -34,6 +34,7 @@ package com.jme3.environment.baker;
 import java.nio.ByteBuffer;
 import java.util.logging.Logger;
 import com.jme3.asset.AssetManager;
+import com.jme3.environment.util.EnvMapUtils;
 import com.jme3.material.Material;
 import com.jme3.math.ColorRGBA;
 import com.jme3.math.FastMath;
@@ -130,10 +131,11 @@ public class IBLGLEnvBakerLight extends IBLHybridEnvBakerLight {
                 int s = renderOnT;
                 renderOnT = renderOnT == 0 ? 1 : 0;
                 mat.setTexture("ShCoef", shCoefTx[s]);
-                mat.setInt("FaceId", faceId);
             } else {
                 renderOnT = 0;
             }
+
+            mat.setInt("FaceId", faceId);
 
             screen.updateLogicalState(0);
             screen.updateGeometricState();
@@ -169,7 +171,7 @@ public class IBLGLEnvBakerLight extends IBLHybridEnvBakerLight {
             if (remapMaxValue > 0) shCoef[i].divideLocal(remapMaxValue);
             shCoef[i].multLocal(4.0f * FastMath.PI / weightAccum);
         }
-
+        EnvMapUtils.prepareShCoefs(shCoef);
         img.dispose();
 
     }

--- a/jme3-core/src/main/java/com/jme3/environment/baker/IBLHybridEnvBakerLight.java
+++ b/jme3-core/src/main/java/com/jme3/environment/baker/IBLHybridEnvBakerLight.java
@@ -200,6 +200,7 @@ public class IBLHybridEnvBakerLight extends GenericEnvBaker implements IBLEnvBak
     @Override
     public void bakeSphericalHarmonicsCoefficients() {
         shCoef = EnvMapUtils.getSphericalHarmonicsCoefficents(getEnvMap());
+        EnvMapUtils.prepareShCoefs(shCoef);
     }
 
     @Override


### PR DESCRIPTION
Band factors were not applies to spherical harmonic coefficients in the accelerated baker, causing bad lighting on high roughness materials.
This PR fixes that for both IBLHybridEnvBakerLight (gpu+cpu) and IBLGLEnvBaker**Light** (gpu) bakers.

This PR also clamps the luminance in the prefiltered envmap kernel, to avoid fireflies artifacts when sampling over bright areas (that could be due to artistic choice or bad tonemap).

