### PR TITLE
com.jme3.audio.LowPassFilter lacks the required no-argument constructor for jME deserialization

### DIFF
--- a/jme3-core/src/main/java/com/jme3/audio/LowPassFilter.java
+++ b/jme3-core/src/main/java/com/jme3/audio/LowPassFilter.java
@@ -136,16 +136,16 @@ public class LowPassFilter extends Filter {
     public void write(JmeExporter ex) throws IOException {
         super.write(ex);
         OutputCapsule oc = ex.getCapsule(this);
-        oc.write(volume, "volume", 0);
-        oc.write(highFreqVolume, "hf_volume", 0);
+        oc.write(volume, "volume", 1f);
+        oc.write(highFreqVolume, "hf_volume", 1f);
     }
 
     @Override
     public void read(JmeImporter im) throws IOException {
         super.read(im);
         InputCapsule ic = im.getCapsule(this);
-        volume = ic.readFloat("volume", 0);
-        highFreqVolume = ic.readFloat("hf_volume", 0);
+        volume = ic.readFloat("volume", 1f);
+        highFreqVolume = ic.readFloat("hf_volume", 1f);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/audio/LowPassFilter.java
+++ b/jme3-core/src/main/java/com/jme3/audio/LowPassFilter.java
@@ -49,13 +49,21 @@ public class LowPassFilter extends Filter {
     /**
      * The overall volume scaling of the filtered sound
      */
-    protected float volume;
+    protected float volume = 1.0f;
     /**
      * The volume scaling of the high frequencies allowed to pass through. Valid values range
      * from 0.0 to 1.0, where 0.0 completely eliminates high frequencies and 1.0 lets them pass
      * through unchanged.
      */
-    protected float highFreqVolume;
+    protected float highFreqVolume = 1.0f;
+
+    /**
+     * Constructs a low-pass filter with default settings.
+     * Required for jME deserialization.
+     */
+    public LowPassFilter() {
+        super();
+    }
 
     /**
      * Constructs a low-pass filter.

--- a/jme3-core/src/test/java/com/jme3/audio/AudioFilterTest.java
+++ b/jme3-core/src/test/java/com/jme3/audio/AudioFilterTest.java
@@ -1,0 +1,31 @@
+package com.jme3.audio;
+
+import com.jme3.asset.AssetManager;
+import com.jme3.asset.DesktopAssetManager;
+import com.jme3.export.binary.BinaryExporter;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Automated tests for the Filter class.
+ *
+ * @author capdevon
+ */
+public class AudioFilterTest {
+
+    /**
+     * Tests serialization and de-serialization of a {@code LowPassFilter}.
+     */
+    @Test
+    public void testSaveAndLoad() {
+        AssetManager assetManager = new DesktopAssetManager(true);
+
+        LowPassFilter f = new LowPassFilter(.5f, .5f);
+        LowPassFilter copy = BinaryExporter.saveAndLoad(assetManager, f);
+
+        float delta = 0.001f;
+        Assert.assertEquals(f.getVolume(), copy.getVolume(), delta);
+        Assert.assertEquals(f.getHighFreqVolume(), copy.getHighFreqVolume(), delta);
+    }
+
+}


### PR DESCRIPTION
`com.jme3.audio.LowPassFilter` lacks the required no-argument constructor for jME deserialization.

```
java.lang.InstantiationException: Loading requires a no-arg constructor, but class com.jme3.audio.LowPassFilter lacks one.
	at com.jme3.export.SavableClassUtil.findNoArgConstructor(SavableClassUtil.java:248)
	at com.jme3.export.SavableClassUtil.fromName(SavableClassUtil.java:187)
	at com.jme3.export.binary.BinaryImporter.readObject(BinaryImporter.java:332)
	at com.jme3.export.binary.BinaryImporter.load(BinaryImporter.java:245)
	at com.jme3.export.binary.BinaryImporter.load(BinaryImporter.java:128)
	at com.jme3.export.binary.BinaryImporter.load(BinaryImporter.java:282)
	at com.jme3.export.binary.BinaryExporter.saveAndLoad(BinaryExporter.java:168)

> Task :jme3-core:test FAILED
AudioFilterTest > testSaveAndLoad FAILED
    java.lang.NullPointerException: Cannot invoke "com.jme3.audio.LowPassFilter.getVolume()" because "copy" is null
        at com.jme3.audio.AudioFilterTest.testSaveAndLoad(AudioFilterTest.java:27)
1 test completed, 1 failed
```

