### PR TITLE
Add makeGeometry() method to WireSphere for consistency with WireBox

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/debug/WireSphere.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/WireSphere.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 jMonkeyEngine
+ * Copyright (c) 2009-2025 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,13 +33,15 @@ package com.jme3.scene.debug;
 
 import com.jme3.bounding.BoundingSphere;
 import com.jme3.math.FastMath;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
 import com.jme3.scene.Mesh;
-import com.jme3.scene.Mesh.Mode;
 import com.jme3.scene.VertexBuffer;
 import com.jme3.scene.VertexBuffer.Format;
 import com.jme3.scene.VertexBuffer.Type;
 import com.jme3.scene.VertexBuffer.Usage;
 import com.jme3.util.BufferUtils;
+
 import java.nio.FloatBuffer;
 import java.nio.ShortBuffer;
 
@@ -151,11 +153,25 @@ public class WireSphere extends Mesh {
     /**
      * Create a WireSphere from a BoundingSphere
      *
-     * @param bsph
-     *     BoundingSphere used to create the WireSphere
-     *
+     * @param bsph BoundingSphere used to create the WireSphere
      */
     public void fromBoundingSphere(BoundingSphere bsph) {
         updatePositions(bsph.getRadius());
+    }
+
+    /**
+     * Create a geometry suitable for visualizing the specified bounding sphere.
+     *
+     * @param bsph the bounding sphere (not null)
+     * @return a new Geometry instance in world space
+     */
+    public static Geometry makeGeometry(BoundingSphere bsph) {
+        WireSphere mesh = new WireSphere(bsph.getRadius());
+        Geometry result = new Geometry("bounding sphere", mesh);
+
+        Vector3f center = bsph.getCenter();
+        result.setLocalTranslation(center);
+
+        return result;
     }
 }


### PR DESCRIPTION
This PR introduces a static `makeGeometry(BoundingSphere bsph)` method to the `WireSphere` class. This new method mirrors the existing `WireBox.makeGeometry(BoundingBox bbox)` method, providing a consistent API for creating `Geometry` instances suitable for visualizing bounding volumes. This improves usability and uniformity across the debug scene classes.