### PR TITLE
#2460: Fix getBoolean(GLExt.GL_FRAMEBUFFER_SRGB_CAPABLE_EXT) causes error 1280 (invalid enum)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2025 jMonkeyEngine
+ * Copyright (c) 2009-2026 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -129,7 +129,7 @@ public final class GLRenderer implements Renderer {
         this.glext = glext;
         this.texUtil = new TextureUtil(gl, gl2, glext);
     }
-
+    
     /**
      * Enable/Disable default automatic generation of mipmaps for framebuffers
      * @param v  Default is true
@@ -159,14 +159,14 @@ public final class GLRenderer implements Renderer {
         }
     }
 
-
+    
 
     @Override
     public Statistics getStatistics() {
         return statistics;
     }
 
-    @Override
+    @Override 
     public EnumSet<Caps> getCaps() {
         return caps;
     }
@@ -223,7 +223,7 @@ public final class GLRenderer implements Renderer {
         String version = gl.glGetString(GL.GL_VERSION);
         int oglVer = extractVersion(version);
         if (isWebGL(version)) {
-            caps.add(Caps.WebGL);
+            caps.add(Caps.WebGL);       
         }
         caps.add(Caps.GLSL100);
         caps.add(Caps.OpenGLES20);
@@ -711,7 +711,7 @@ public final class GLRenderer implements Renderer {
             }else if(gl instanceof GLES_30){
                 ((GLES_30)gl).glGenVertexArrays(intBuf16);
                 int vaoId = intBuf16.get(0);
-                ((GLES_30)gl).glBindVertexArray(vaoId);
+                ((GLES_30)gl).glBindVertexArray(vaoId);                
             }   else{
                 throw new UnsupportedOperationException("Core profile not supported");
             }
@@ -1290,7 +1290,7 @@ public final class GLRenderer implements Renderer {
         }
         return true;
     }
-
+    
     private boolean isValidNumber(Vector2f v) {
         return isValidNumber(v.x) && isValidNumber(v.y);
     }
@@ -1455,7 +1455,7 @@ public final class GLRenderer implements Renderer {
 
         final BufferObject bufferObject = bufferBlock.getBufferObject();
         final BufferType bufferType = bufferBlock.getType();
-
+        
 
         if (bufferObject.isUpdateNeeded()) {
             if (bufferType == BufferType.ShaderStorageBufferObject) {
@@ -1485,7 +1485,7 @@ public final class GLRenderer implements Renderer {
                     }
                     if (bufferBlock.getLocation() != NativeObject.INVALID_ID) {
                         gl3.glUniformBlockBinding(shaderId, bufferBlock.getLocation(), bindingPoint);
-                    }
+                    } 
                 }
                 break;
             }
@@ -1615,7 +1615,7 @@ public final class GLRenderer implements Renderer {
             }
 
         }
-
+        
         if (linearizeSrgbImages) {
             stringBuf.append("#define SRGB 1\n");
         }
@@ -1748,7 +1748,7 @@ public final class GLRenderer implements Renderer {
     public void setShader(Shader shader) {
         if (shader == null) {
             throw new IllegalArgumentException("Shader cannot be null");
-        } else {
+        } else {            
             if (shader.isUpdateNeeded()) {
                 updateShaderData(shader);
             }
@@ -2128,12 +2128,12 @@ public final class GLRenderer implements Renderer {
         final int MRT_OFF = 100;
 
         if (fb != null) {
-
+          
             if (fb.getNumColorBuffers() == 0) {
                 // make sure to select NONE as draw buf
                 // no color buffer attached.                
-                gl2.glDrawBuffer(GL.GL_NONE);
-                gl2.glReadBuffer(GL.GL_NONE);
+                gl2.glDrawBuffer(GL.GL_NONE);             
+                gl2.glReadBuffer(GL.GL_NONE);                 
             } else {
                 if (fb.getNumColorBuffers() > limits.get(Limits.FrameBufferAttachments)) {
                     throw new RendererException("Framebuffer has more color "
@@ -2245,7 +2245,7 @@ public final class GLRenderer implements Renderer {
             }
 
             setFrameBuffer(fb);
-
+         
 
         } else {
             setFrameBuffer(null);
@@ -2724,7 +2724,7 @@ public final class GLRenderer implements Renderer {
         if (unit < 0 || unit >= RenderContext.maxTextureUnits) {
             throw new TextureUnitException();
         }
-
+        
         Image image = tex.getImage();
         if (image.isUpdateNeeded() || (image.isGeneratedMipmapsRequired() && !image.isMipmapsGenerated())) {
             // Check NPOT requirements
@@ -2755,7 +2755,7 @@ public final class GLRenderer implements Renderer {
             if (tex.getName() != null) glext.glObjectLabel(GL.GL_TEXTURE, tex.getImage().getId(), tex.getName());
         }
     }
-
+    
     @Override
     public void setTextureImage(int unit, TextureImage tex) throws TextureUnitException {
         if (unit < 0 || unit >= RenderContext.maxTextureUnits) {
@@ -2768,7 +2768,7 @@ public final class GLRenderer implements Renderer {
             tex.bindImage(gl4, texUtil, unit);
         }
     }
-
+    
     @Override
     public void setUniformBufferObject(int bindingPoint, BufferObject bufferObject) {
         if (bufferObject.isUpdateNeeded()) {
@@ -3493,10 +3493,10 @@ public final class GLRenderer implements Renderer {
 
         if (enableSrgb) {
             gl.glEnable(GLExt.GL_FRAMEBUFFER_SRGB_EXT);
-            logger.log(Level.FINER, "SRGB FrameBuffer enabled (Gamma Correction)");
+            logger.log(Level.FINER, "sRGB FrameBuffer enabled (Gamma Correction)");
         } else {
             gl.glDisable(GLExt.GL_FRAMEBUFFER_SRGB_EXT);
-            logger.log(Level.FINER, "SRGB FrameBuffer disabled (Gamma Correction)");
+			logger.log(Level.FINER, "sRGB FrameBuffer disabled (Gamma Correction)");
         }
     }
 


### PR DESCRIPTION
`GL_FRAMEBUFFER_SRGB_CAPABLE_EXT` is likely not a queryable state via `glGetBooleanv`. It's a capability flag for *configuring* framebuffers, not for *querying* the global sRGB state. It's good that it's commented out.

This PR should fix https://github.com/jMonkeyEngine/jmonkeyengine/issues/1996