### PR TITLE
Fix bbox validation check in particle emitter

### DIFF
--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -1124,7 +1124,7 @@ public class ParticleEmitter extends Geometry {
         lastPos.set(getWorldTranslation());
 
         //This check avoids a NaN bounds when all the particles are dead during the first update.
-        if (!min.equals(Vector3f.POSITIVE_INFINITY) && !max.equals(Vector3f.NEGATIVE_INFINITY)) {
+        if (Vector3f.isValidVector(min) && Vector3f.isValidVector(max)) {
             BoundingBox bbox = (BoundingBox) this.getMesh().getBound();
             bbox.setMinMax(min, max);
             this.setBoundRefresh();


### PR DESCRIPTION
The current code checks if all the components are either positive or negative infinity.
This patch changes it to check component per component using the `Vector3f.isValidVector()` method, without this, some (misconfigured?) particle emitters could cause the engine to crash when assertions are enabled due to the `com.jme3.bounding.Intersection` class using the  `isValidVector()` check internally.

I've encountered this issue in my code using  the newtonian particle influencer, but i don't have the step-by-step to reproduce.