### PR TITLE
Return normal of sphere shaped emitter

### DIFF
--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
@@ -137,6 +137,7 @@ public class EmitterSphereShape implements EmitterShape {
     @Override
     public void getRandomPointAndNormal(Vector3f store, Vector3f normal) {
         this.getRandomPoint(store);
+        normal.set(store).subtractLocal(center).normalizeLocal();
     }
 
     /**


### PR DESCRIPTION
Looks like this line was omitted when writing this class, even though all the necessary data to calculate the normal was already available.