### PR TITLE
Make initial velocity influence newtornian particles

### DIFF
--- a/jme3-core/src/main/java/com/jme3/effect/influencers/NewtonianParticleInfluencer.java
+++ b/jme3-core/src/main/java/com/jme3/effect/influencers/NewtonianParticleInfluencer.java
@@ -80,6 +80,7 @@ public class NewtonianParticleInfluencer extends DefaultParticleInfluencer {
             // adding tangent vector
             particle.velocity.addLocal(temp);
         }
+        particle.velocity.addLocal(initialVelocity);
         if (velocityVariation != 0.0f) {
             this.applyVelocityVariation(particle);
         }


### PR DESCRIPTION
I've changed the newtonian influence to **not** ignore the initial velocity since it is a default property.
I need a second opinion on whether this is a good idea or now, but it might help making it more versatile.