### PR TITLE
Fix framebuffer initialization when cap TextureMultisample is missing

### DIFF
--- a/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
@@ -501,7 +501,7 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
             }
         }
 
-        if (numSamples <= 1 || !caps.contains(Caps.OpenGL32)) {
+        if (numSamples <= 1 || !caps.contains(Caps.OpenGL32) || !caps.contains(Caps.FrameBufferMultisample)) {
             renderFrameBuffer = new FrameBuffer(width, height, 1);
             renderFrameBuffer.setDepthTarget(FrameBufferTarget.newTarget(depthFormat));
             filterTexture = new Texture2D(width, height, fbFormat);


### PR DESCRIPTION
 Without this check if the platform doesn't support TextureMultisample, the fpp isn't initialized properly and it then crashes due to `tex` being null here 

https://github.com/jMonkeyEngine/jmonkeyengine/blob/c1106983f1483707586227a7501efe67173833cd/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java#L273