### PR TITLE
WireFrustum: javadoc + add makeGeometry(Camera) method

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/debug/WireFrustum.java
+++ b/jme3-core/src/main/java/com/jme3/scene/debug/WireFrustum.java
@@ -113,6 +113,7 @@ public class WireFrustum extends Mesh {
         );
         getBuffer(Type.Index).setUsage(Usage.Static);
         setMode(Mode.Lines);
+        updateBound();
     }
 
     /**
@@ -133,7 +134,7 @@ public class WireFrustum extends Mesh {
         if (vb == null) {
             // If for some reason the position buffer is missing, re-create it.
             // This case should ideally not happen if the object is constructed properly.
-            setBuffer(Type.Position, 3, BufferUtils.createFloatBuffer(points));
+            setGeometryData(points);
             return;
         }
 


### PR DESCRIPTION
These changes focus on improving the **readability**, **robustness**, and **maintainability** of the `WireFrustum `class.

1. **Comprehensive Javadoc Documentation**
Extensive Javadoc comments were added to the class, constructors, and all methods. This significantly enhances code understanding and future maintainability.

2. **Robust Input Validation**
Implemented explicit checks in the WireFrustum constructor and the update method to ensure that the points array is never null and always contains exactly 8 `Vector3f` objects. This prevents common runtime errors such as `NullPointerException` and `IndexOutOfBoundsException`, making the class more reliable.

3. **Minor Code Refinements**
Small adjustments were made to the update method to explicitly clear the existing FloatBuffer before writing new data, enhancing clarity in buffer handling.

**New Utility Method**: `makeGeometry(Camera camera)` for Debugging.
A dedicated static method, `makeGeometry`, was added. This method specifically generates a `Geometry` object representing the wireframe viewing frustum of any given camera. This is an invaluable tool for debugging and visualizing the camera's exact viewing volume within the 3D scene, which helps in understanding culling, shadow calculations, and general scene setup.