### PR TITLE
Fix mistake in JoystickButton from PR 2474

### DIFF
--- a/jme3-core/src/main/java/com/jme3/input/JoystickButton.java
+++ b/jme3-core/src/main/java/com/jme3/input/JoystickButton.java
@@ -38,22 +38,22 @@ package com.jme3.input;
  */
 public interface JoystickButton {
 
-    public final String BUTTON_0 = "0";
-    public final String BUTTON_1 = "1";
-    public final String BUTTON_2 = "2";
-    public final String BUTTON_3 = "3";
-    public final String BUTTON_4 = "4";
-    public final String BUTTON_5 = "5";
-    public final String BUTTON_6 = "6";
-    public final String BUTTON_7 = "7";
-    public final String BUTTON_8 = "8";
-    public final String BUTTON_9 = "9";
-    public final String BUTTON_10 = "10";
-    public final String BUTTON_11 = "11";
-    public final String BUTTON_12 = "12";
-    public final String BUTTON_13 = "13";
-    public final String BUTTON_14 = "14";
-    public final String BUTTON_15 = "15";
+    public static final String BUTTON_0 = "0";
+    public static final String BUTTON_1 = "1";
+    public static final String BUTTON_2 = "2";
+    public static final String BUTTON_3 = "3";
+    public static final String BUTTON_4 = "4";
+    public static final String BUTTON_5 = "5";
+    public static final String BUTTON_6 = "6";
+    public static final String BUTTON_7 = "7";
+    public static final String BUTTON_8 = "8";
+    public static final String BUTTON_9 = "9";
+    public static final String BUTTON_10 = "10";
+    public static final String BUTTON_11 = "11";
+    public static final String BUTTON_12 = "12";
+    public static final String BUTTON_13 = "13";
+    public static final String BUTTON_14 = "14";
+    public static final String BUTTON_15 = "15";
 
     /**
      * Assign the mapping name to receive events from the given button index


### PR DESCRIPTION
I accidentally approved and merged this PR  (https://github.com/jMonkeyEngine/jmonkeyengine/pull/2474) without realizing that the static keyword had been removed from a set of String vars, and this mistake breaks any apps that are using JoyStickButton for controller input. Despite reviewing this fairly small PR twice, I unfortunately still didn't see this.

So this PR re-adds the static keyword back. I will merge this in a few hours to ensure that the master branch isn't broken for too long. 

My apologies for the overlooking this mistake in my review, I should also be more hesitant to merge PRs in cases like that where I was the only reviewer, but unfortunately there is a lack of other active reviewers currently, so I just have to do my best I suppose. 

Thankfully there shouldn't have been any any harm done since this was only broken master for a day and I managed to catch it almost immediately after merging.