### PR TITLE
Support for switching platforms (from Wayland EGL to X11 GLX)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -1518,7 +1518,7 @@ public final class AppSettings extends HashMap<String, Object> {
      * @param preferred true to prefer GLX (native X11) for the GL context, false to prefer EGL (native Wayland).
      */
     public void setX11PlatformPreferred(boolean preferred) {
-        put("X11PlatformPreferred", preferred);
+        putBoolean("X11PlatformPreferred", preferred);
     }
     
     /**

--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -1510,32 +1510,24 @@ public final class AppSettings extends HashMap<String, Object> {
     }
 
     /**
-     * Sets the native platform to be used to create the GL context.
-     * 
+     * Sets the preferred native platform for creating the GL context on Linux distributions.
      * <p>
-     * This only affects Linux distributions or derivatives that use a Wayland session in conjunction 
-     * with X11 via the XWayland bridge, which enables or disables GLX for window positioning and/or 
-     * icon configuration.
-     * </p>
+     * This setting is relevant for Linux distributions or derivatives that utilize a Wayland session alongside an X11 via the XWayland bridge.
+     * Enabling this option allows the use of GLX for window positioning and/or icon configuration.
      *
-     * <p>
-     * <strong>NOTE:</strong> Note that disabling this option uses GLX (native X11) instead of EGL (native WL).
-     * </p>
-     * 
-     * @param nplaf true if you want to enable GLX, otherwise false when using EGL (native)
+     * @param preferred true to prefer GLX (native X11) for the GL context, false to prefer EGL (native Wayland).
      */
-    public void setX11PlatformPreferred(boolean nplaf) {
-        put("X11PlatformPreferred", nplaf);
+    public void setX11PlatformPreferred(boolean preferred) {
+        put("X11PlatformPreferred", preferred);
     }
     
     /**
-     * Gets what type of platform is being used.
-     * 
+     * Determines which native platform is preferred for GL context creation on Linux distributions.
      * <p>
-     * Only valid on Linux distributions or derivatives that support Wayland, where it indicates whether GLX or EGL is enabled.
-     * </p>
-     * 
-     * @return returns true if GLX is enabled, otherwise false if used in EGL (native)
+     * This setting is only valid on Linux distributions or derivatives that support Wayland,
+     * and it indicates whether GLX (native X11) or EGL (native Wayland) is enabled for the GL context.
+     *
+     * @return true if GLX is preferred, otherwise false if EGL is preferred (native Wayland).
      */
     public boolean isX11PlatformPreferred() {
         return getBoolean("X11PlatformPreferred");

--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -214,7 +214,7 @@ public final class AppSettings extends HashMap<String, Object> {
      * @see AppSettings#setAudioRenderer(java.lang.String)
      */
     public static final String LWJGL_OPENAL = "LWJGL";
-    
+
     /**
      * Use the Android MediaPlayer / SoundPool based renderer for Android audio capabilities.
      * <p>
@@ -295,7 +295,7 @@ public final class AppSettings extends HashMap<String, Object> {
         defaults.put("UseRetinaFrameBuffer", false);
         defaults.put("WindowYPosition", 0);
         defaults.put("WindowXPosition", 0);
-        defaults.put("NativePlatform", true);
+        defaults.put("X11PlatformPreferred", false);
         //  defaults.put("Icons", null);
     }
 
@@ -1522,10 +1522,10 @@ public final class AppSettings extends HashMap<String, Object> {
      * <strong>NOTE:</strong> Note that disabling this option uses GLX (native X11) instead of EGL (native WL).
      * </p>
      * 
-     * @param nplaf true when using EGL (native), otherwise false if you want to enable GLX
+     * @param nplaf true if you want to enable GLX, otherwise false when using EGL (native)
      */
-    public void setNativePlatform(boolean nplaf) {
-        put("NativePlatform", nplaf);
+    public void setX11PlatformPreferred(boolean nplaf) {
+        put("X11PlatformPreferred", nplaf);
     }
     
     /**
@@ -1535,9 +1535,9 @@ public final class AppSettings extends HashMap<String, Object> {
      * Only valid on Linux distributions or derivatives that support Wayland, where it indicates whether GLX or EGL is enabled.
      * </p>
      * 
-     * @return returns true if used in EGL (native), otherwise false if GLX is enabled
+     * @return returns true if GLX is enabled, otherwise false if used in EGL (native)
      */
-    public boolean isNativePlatform() {
-        return getBoolean("NativePlatform");
+    public boolean isX11PlatformPreferred() {
+        return getBoolean("X11PlatformPreferred");
     }
 }

--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -214,7 +214,7 @@ public final class AppSettings extends HashMap<String, Object> {
      * @see AppSettings#setAudioRenderer(java.lang.String)
      */
     public static final String LWJGL_OPENAL = "LWJGL";
-
+    
     /**
      * Use the Android MediaPlayer / SoundPool based renderer for Android audio capabilities.
      * <p>
@@ -295,6 +295,7 @@ public final class AppSettings extends HashMap<String, Object> {
         defaults.put("UseRetinaFrameBuffer", false);
         defaults.put("WindowYPosition", 0);
         defaults.put("WindowXPosition", 0);
+        defaults.put("NativePlatform", true);
         //  defaults.put("Icons", null);
     }
 
@@ -1506,5 +1507,37 @@ public final class AppSettings extends HashMap<String, Object> {
      */
     public void setDisplay(int mon) {
         putInteger("Display", mon);
+    }
+
+    /**
+     * Sets the native platform to be used to create the GL context.
+     * 
+     * <p>
+     * This only affects Linux distributions or derivatives that use a Wayland session in conjunction 
+     * with X11 via the XWayland bridge, which enables or disables GLX for window positioning and/or 
+     * icon configuration.
+     * </p>
+     *
+     * <p>
+     * <strong>NOTE:</strong> Note that disabling this option uses GLX (native X11) instead of EGL (native WL).
+     * </p>
+     * 
+     * @param nplaf true when using EGL (native), otherwise false if you want to enable GLX
+     */
+    public void setNativePlatform(boolean nplaf) {
+        put("NativePlatform", nplaf);
+    }
+    
+    /**
+     * Gets what type of platform is being used.
+     * 
+     * <p>
+     * Only valid on Linux distributions or derivatives that support Wayland, where it indicates whether GLX or EGL is enabled.
+     * </p>
+     * 
+     * @return returns true if used in EGL (native), otherwise false if GLX is enabled
+     */
+    public boolean isNativePlatform() {
+        return getBoolean("NativePlatform");
     }
 }

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -412,6 +412,14 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         );
 
         int platformId = glfwGetPlatform();
+        if (settings.isX11PlatformPreferred()) {
+            if (platformId == GLFW_PLATFORM_X11) {
+                LOGGER.log(Level.INFO, "Active X11 server for GLX management:\n * Platform: GLFW_PLATFORM_X11|XWayland ({0})", platformId);
+            } else {
+                LOGGER.log(Level.WARNING, "Can't change platform to X11 (GLX), check if you have XWayland enabled");
+            }
+        }
+        
         if (platformId != GLFW_PLATFORM_WAYLAND && !settings.isFullscreen()) {
             /*
              * in case the window positioning hints above were ignored, but not

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -273,7 +273,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
                     }
                 }
         );
-                
+
         if (glfwPlatformSupported(GLFW_PLATFORM_WAYLAND)) {
 
             /*

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -273,7 +273,19 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
                     }
                 }
         );
-
+                
+        if (glfwPlatformSupported(GLFW_PLATFORM_WAYLAND)) {
+            
+            /*
+             * Change the platform GLFW uses to enable GLX on Wayland as long as you 
+             * have XWayland (X11 compatibility)
+             */
+            if (!settings.isNativePlatform() && glfwPlatformSupported(GLFW_PLATFORM_X11)) {
+                glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_X11);
+            }
+            
+        }
+        
         if (!glfwInit()) {
             throw new IllegalStateException("Unable to initialize GLFW");
         }

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -280,7 +280,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
              * Change the platform GLFW uses to enable GLX on Wayland as long as you 
              * have XWayland (X11 compatibility)
              */
-            if (!settings.isNativePlatform() && glfwPlatformSupported(GLFW_PLATFORM_X11)) {
+            if (settings.isX11PlatformPreferred() && glfwPlatformSupported(GLFW_PLATFORM_X11)) {
                 glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_X11);
             }
             


### PR DESCRIPTION
PR where support is implemented to change the default [GLFW](https://www.glfw.org/docs/latest/intro_guide.html#platform) platform on Linux distributions or derivatives that support Wayland to use X11 (enable GLX).

This will open the ability to reposition windows and set icons for them, as Wayland currently does not have support for this, this works if you have XWayland enabled to have a bridge.

Wayland uses EGL by default to create GL contexts, which is great, but sometimes we need to use GLX for our applications, which is very useful. XWaylanda for GLX context.