### PR TITLE
Refactor: AbstractShadowFilter reduce object allocations

### DIFF
--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
@@ -88,6 +88,15 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
         return true;
     }
 
+    /**
+     * @deprecated Use {@link #getMaterial()} instead.
+     * @return The Material used by this filter.
+     */
+    @Deprecated
+    public Material getShadowMaterial() {       
+        return material;
+    }
+
     @Override
     protected void preFrame(float tpf) {
         shadowRenderer.preFrame(tpf);

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
@@ -56,6 +56,9 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
     protected T shadowRenderer;
     protected ViewPort viewPort;
 
+    private final Vector4f tempVec4 = new Vector4f();
+    private final Matrix4f tempMat4 = new Matrix4f();
+
     /**
      * For serialization only. Do not use.
      */
@@ -99,13 +102,8 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
     protected void preFrame(float tpf) {
         shadowRenderer.preFrame(tpf);
         Matrix4f m = viewPort.getCamera().getViewProjectionMatrix();
-        TempVars vars = TempVars.get();
-        try {
-            material.setMatrix4("ViewProjectionMatrixInverse", vars.tempMat4.set(m).invertLocal());
-            material.setVector4("ViewProjectionMatrixRow2", vars.vect4f1.set(m.m20, m.m21, m.m22, m.m23));
-        } finally {
-            vars.release();
-        }
+        material.setMatrix4("ViewProjectionMatrixInverse", tempMat4.set(m).invertLocal());
+        material.setVector4("ViewProjectionMatrixRow2", tempVec4.set(m.m20, m.m21, m.m22, m.m23));
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
@@ -32,10 +32,6 @@
 package com.jme3.shadow;
 
 import com.jme3.asset.AssetManager;
-import com.jme3.export.InputCapsule;
-import com.jme3.export.JmeExporter;
-import com.jme3.export.JmeImporter;
-import com.jme3.export.OutputCapsule;
 import com.jme3.material.Material;
 import com.jme3.material.RenderState;
 import com.jme3.math.Matrix4f;
@@ -48,18 +44,19 @@ import com.jme3.texture.FrameBuffer;
 import com.jme3.util.clone.Cloner;
 import com.jme3.util.clone.JmeCloneable;
 
-import java.io.IOException;
-
 /**
  * Generic abstract filter that holds common implementations for the different
  * shadow filters
  *
- * @author Rémy Bouquet aka Nehon
+ * @author Nehon
  */
-public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> extends Filter implements Cloneable, JmeCloneable {
+public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> extends Filter implements JmeCloneable {
 
     protected T shadowRenderer;
     protected ViewPort viewPort;
+
+    private final Vector4f tempVec4 = new Vector4f();
+    private final Matrix4f tempMat4 = new Matrix4f();
 
     /**
      * For serialization only. Do not use.
@@ -68,15 +65,13 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
     }
     
     /**
-     * Abstract class constructor
+     * Creates an AbstractShadowFilter. Subclasses invoke this constructor.
      *
-     * @param manager the application asset manager
-     * @param shadowMapSize the size of the rendered shadowmaps (512,1024,2048,
-     * etc...)
-     * @param shadowRenderer the shadowRenderer to use for this Filter
+     * @param assetManager The application's asset manager.
+     * @param shadowMapSize The size of the rendered shadow maps (e.g., 512, 1024, 2048).
+     * @param shadowRenderer The shadowRenderer to use for this Filter
      */
-    @SuppressWarnings("all")
-    protected AbstractShadowFilter(AssetManager manager, int shadowMapSize, T shadowRenderer) {
+    protected AbstractShadowFilter(AssetManager assetManager, int shadowMapSize, T shadowRenderer) {
         super("Post Shadow");
         this.shadowRenderer = shadowRenderer;
         // this is legacy setting for shadows with backface shadows
@@ -93,18 +88,12 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
         return true;
     }
 
-    public Material getShadowMaterial() {       
-        return material;
-    }
-
-    Vector4f tmpv = new Vector4f();
-
     @Override
     protected void preFrame(float tpf) {
         shadowRenderer.preFrame(tpf);
-        material.setMatrix4("ViewProjectionMatrixInverse", viewPort.getCamera().getViewProjectionMatrix().invert());
         Matrix4f m = viewPort.getCamera().getViewProjectionMatrix();
-        material.setVector4("ViewProjectionMatrixRow2", tmpv.set(m.m20, m.m21, m.m22, m.m23));
+        material.setMatrix4("ViewProjectionMatrixInverse", tempMat4.set(m).invertLocal());
+        material.setVector4("ViewProjectionMatrixRow2", tempVec4.set(m.m20, m.m21, m.m22, m.m23));
     }
 
     @Override
@@ -337,15 +326,4 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
         shadowRenderer.setPostShadowMaterial(material);
     }
 
-    @Override
-    public void write(JmeExporter ex) throws IOException {
-        super.write(ex);
-        OutputCapsule oc = ex.getCapsule(this);
-    }
-
-    @Override
-    public void read(JmeImporter im) throws IOException {
-        super.read(im);
-        InputCapsule ic = im.getCapsule(this);
-    }
 }

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
@@ -41,6 +41,7 @@ import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.ViewPort;
 import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.texture.FrameBuffer;
+import com.jme3.util.TempVars;
 import com.jme3.util.clone.Cloner;
 import com.jme3.util.clone.JmeCloneable;
 
@@ -54,9 +55,6 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
 
     protected T shadowRenderer;
     protected ViewPort viewPort;
-
-    private final Vector4f tempVec4 = new Vector4f();
-    private final Matrix4f tempMat4 = new Matrix4f();
 
     /**
      * For serialization only. Do not use.
@@ -101,8 +99,13 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
     protected void preFrame(float tpf) {
         shadowRenderer.preFrame(tpf);
         Matrix4f m = viewPort.getCamera().getViewProjectionMatrix();
-        material.setMatrix4("ViewProjectionMatrixInverse", tempMat4.set(m).invertLocal());
-        material.setVector4("ViewProjectionMatrixRow2", tempVec4.set(m.m20, m.m21, m.m22, m.m23));
+        TempVars vars = TempVars.get();
+        try {
+            material.setMatrix4("ViewProjectionMatrixInverse", vars.tempMat4.set(m).invertLocal());
+            material.setVector4("ViewProjectionMatrixRow2", vars.vect4f1.set(m.m20, m.m21, m.m22, m.m23));
+        } finally {
+            vars.release();
+        }
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
+++ b/jme3-core/src/main/java/com/jme3/shadow/AbstractShadowFilter.java
@@ -48,7 +48,7 @@ import com.jme3.util.clone.JmeCloneable;
  * Generic abstract filter that holds common implementations for the different
  * shadow filters
  *
- * @author Nehon
+ * @author Rémy Bouquet aka Nehon
  */
 public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> extends Filter implements JmeCloneable {
 
@@ -63,7 +63,7 @@ public abstract class AbstractShadowFilter<T extends AbstractShadowRenderer> ext
      */
     protected AbstractShadowFilter() {
     }
-    
+
     /**
      * Creates an AbstractShadowFilter. Subclasses invoke this constructor.
      *


### PR DESCRIPTION
**Refactor AbstractShadowFilter: Remove Unused Serialization and Legacy Fields**

- Removed unused imports and legacy serialization methods (`write`/`read`), simplifying the class.
- Cleaned up and clarified Javadoc comments for constructors and author attribution.
- Replaced legacy temporary variables with final temp fields for matrix and vector operations, improving consistency.
- Minor improvements in naming and parameter descriptions for clarity and maintainability.

This refactor streamlines the code, reduces clutter, and adheres to modern coding practices without affecting functionality.