### PR TITLE
Matrix3f: making mXX fields public 

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Matrix3f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Matrix3f.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 jMonkeyEngine
+ * Copyright (c) 2009-2025 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,39 +63,39 @@ public final class Matrix3f implements Savable, Cloneable, java.io.Serializable 
     /**
      * The element in row 0, column 0.
      */
-    protected float m00;
+    public float m00;
     /**
      * The element in row 0, column 1.
      */
-    protected float m01;
+    public float m01;
     /**
      * The element in row 0, column 2.
      */
-    protected float m02;
+    public float m02;
     /**
      * The element in row 1, column 0.
      */
-    protected float m10;
+    public float m10;
     /**
      * The element in row 1, column 1.
      */
-    protected float m11;
+    public float m11;
     /**
      * The element in row 1, column 2.
      */
-    protected float m12;
+    public float m12;
     /**
      * The element in row 2, column 0.
      */
-    protected float m20;
+    public float m20;
     /**
      * The element in row 2, column 1.
      */
-    protected float m21;
+    public float m21;
     /**
      * The element in row 2, column 2.
      */
-    protected float m22;
+    public float m22;
     /**
      * Shared instance of the all-zero matrix. Do not modify!
      */


### PR DESCRIPTION
**Description:**  
This PR updates the `Matrix3f` class by changing the visibility of its matrix element fields (`m00` to `m22`) from `protected` to `public`. This modification allows direct access to these fields from outside the class, making it easier for users to manipulate matrix values without relying on getter or setter methods. 
The copyright notice has also been updated to 2025.

In this way we unify the Matrix3f class with the [Matrix4f](https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-core/src/main/java/com/jme3/math/Matrix4f.java#L63) class whose matrix elements have public access modifiers.