### PR TITLE
Add support for global lights

### DIFF
--- a/jme3-core/src/main/java/com/jme3/light/DirectionalLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/DirectionalLight.java
@@ -59,6 +59,17 @@ public class DirectionalLight extends Light {
      * Creates a DirectionalLight
      */
     public DirectionalLight() {
+        super();
+    }
+
+    /**
+     * Creates a DirectionalLight
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.     
+     */
+    public DirectionalLight(boolean global) {
+        this();
+        this.global = global;
     }
 
     /**
@@ -66,7 +77,19 @@ public class DirectionalLight extends Light {
      * @param direction the light's direction
      */
     public DirectionalLight(Vector3f direction) {
+        super();
         setDirection(direction);
+    }
+
+    /**
+     * Creates a DirectionalLight with the given direction
+     * @param direction the light's direction
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.
+     */
+    public DirectionalLight(Vector3f direction, boolean global) {
+        this(direction);
+        this.global = global;
     }
 
     /**
@@ -78,6 +101,19 @@ public class DirectionalLight extends Light {
         super(color);
         setDirection(direction);
     }
+
+    /**
+     * Creates a DirectionalLight with the given direction and the given color
+     * @param direction the light's direction
+     * @param color the light's color
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.
+     */
+    public DirectionalLight(Vector3f direction, ColorRGBA color, boolean global) {
+        this(direction, color);
+        this.global = global;
+    }
+
 
     @Override
     public void computeLastDistance(Spatial owner) {

--- a/jme3-core/src/main/java/com/jme3/light/Light.java
+++ b/jme3-core/src/main/java/com/jme3/light/Light.java
@@ -116,6 +116,7 @@ public abstract class Light implements Savable, Cloneable {
      * The light name. 
      */
     protected String name;
+    protected boolean global = false;
     
     boolean frustumCheckNeeded = true;
     boolean intersectsFrustum  = false;
@@ -123,8 +124,28 @@ public abstract class Light implements Savable, Cloneable {
     protected Light() {
     }
 
+
+    protected Light(boolean global) {
+        this.global = global;
+    }
+    
+    protected Light(ColorRGBA color, boolean global) {
+        setColor(color);
+    }
+
     protected Light(ColorRGBA color) {
         setColor(color);
+    }
+
+
+    /**
+     * Returns true if this light affects the entire tree from the root node,
+     * otherwise returns false, meaning it only affects the children of the node
+     * in which it is attached.
+     * @return true if the light is global, otherwise false.
+     */
+    public boolean isGlobal() {
+        return global;
     }
 
     /**
@@ -265,6 +286,7 @@ public abstract class Light implements Savable, Cloneable {
         oc.write(color, "color", null);
         oc.write(enabled, "enabled", true);
         oc.write(name, "name", null);
+        oc.write(global, "global", false);
     }
 
     @Override
@@ -273,6 +295,7 @@ public abstract class Light implements Savable, Cloneable {
         color = (ColorRGBA) ic.readSavable("color", null);
         enabled = ic.readBoolean("enabled", true);
         name = ic.readString("name", null);
+        global = ic.readBoolean("global", false);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/light/PointLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/PointLight.java
@@ -66,6 +66,17 @@ public class PointLight extends Light {
      * Creates a PointLight
      */
     public PointLight() {
+        super();
+    }
+
+    /**
+     * Creates a PointLight
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.
+     */
+    public PointLight(boolean global) {
+        this();
+        this.global = global;
     }
 
     /**
@@ -73,7 +84,19 @@ public class PointLight extends Light {
      * @param position the position in world space
      */
     public PointLight(Vector3f position) {
+        super();
         setPosition(position);
+    }
+    
+    /**
+     * Creates a PointLight at the given position
+     * @param position the position in world space
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.
+     */
+    public PointLight(Vector3f position, boolean global) {
+        this(position);
+        this.global = global;
     }
 
     /**
@@ -87,6 +110,18 @@ public class PointLight extends Light {
     }
 
     /**
+     * Creates a PointLight at the given position and with the given color
+     * @param position the position in world space
+     * @param color the light color
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.
+     */
+    public PointLight(Vector3f position, ColorRGBA color, boolean global) {
+        this(position, color);
+        this.global = global;
+    }
+
+    /**
      * Creates a PointLight at the given position, with the given color and the
      * given radius
      * @param position the position in world space
@@ -97,6 +132,20 @@ public class PointLight extends Light {
         this(position, color);
         setRadius(radius);
     }
+    
+    /**
+     * Creates a PointLight at the given position, with the given color and the
+     * given radius
+     * @param position the position in world space
+     * @param color the light color
+     * @param radius the light radius
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.
+     */
+    public PointLight(Vector3f position, ColorRGBA color, float radius, boolean global) {
+        this(position, color, radius);
+        this.global = global;
+    }
 
     /**
      * Creates a PointLight at the given position, with the given radius
@@ -106,6 +155,18 @@ public class PointLight extends Light {
     public PointLight(Vector3f position, float radius) {
         this(position);
         setRadius(radius);
+    }
+    
+    /**
+     * Creates a PointLight at the given position, with the given radius
+     * @param position the position in world space
+     * @param radius the light radius
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.
+     */
+    public PointLight(Vector3f position, float radius, boolean global) {
+        this(position, radius);
+        this.global = global;
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/light/SpotLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/SpotLight.java
@@ -80,6 +80,17 @@ public class SpotLight extends Light {
         computeAngleParameters();
     }
 
+        
+    /**
+     * Creates a SpotLight.
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.
+     */
+    public SpotLight(boolean global) {
+        this();
+        this.global = global;
+    }
+
     /**
      * Creates a SpotLight at the given position and with the given direction.
      * @param position the position in world space.
@@ -89,6 +100,18 @@ public class SpotLight extends Light {
         this();
         setPosition(position);
         setDirection(direction);
+    }
+
+     /**
+     * Creates a SpotLight at the given position and with the given direction.
+     * @param position the position in world space.
+     * @param direction the direction of the light.
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.
+     */
+    public SpotLight(Vector3f position, Vector3f direction, boolean global) {
+        this(position, direction);
+        this.global = global;
     }
     
     /**
@@ -105,6 +128,20 @@ public class SpotLight extends Light {
         setSpotRange(range);
     }
 
+     /**
+     * Creates a SpotLight at the given position, with the given direction, and the
+     * given range.
+     * @param position the position in world space.
+     * @param direction the direction of the light.
+     * @param range the spotlight range
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.
+     */
+    public SpotLight(Vector3f position, Vector3f direction, float range, boolean global) {
+        this(position, direction, range);
+        this.global = global;
+    }
+
     /**
      * Creates a SpotLight at the given position, with the given direction and
      * the given color.
@@ -117,6 +154,21 @@ public class SpotLight extends Light {
         computeAngleParameters();
         setPosition(position);
         setDirection(direction);
+    }
+
+
+    /**
+     * Creates a SpotLight at the given position, with the given direction and
+     * the given color.
+     * @param position the position in world space.
+     * @param direction the direction of the light.
+     * @param color the light's color.
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.
+     */
+    public SpotLight(Vector3f position, Vector3f direction, ColorRGBA color, boolean global) {
+        this(position, direction, color);
+        this.global = global;
     }
 
     /**
@@ -134,6 +186,22 @@ public class SpotLight extends Light {
         setDirection(direction);
         setSpotRange(range);
     }
+
+    /**
+     * Creates a SpotLight at the given position, with the given direction,
+     * the given range and the given color.
+     * @param position the position in world space.
+     * @param direction the direction of the light.
+     * @param range the spotlight range
+     * @param color the light's color.
+     */
+    public SpotLight(Vector3f position, Vector3f direction, float range, ColorRGBA color, boolean global) {
+        this(position, direction, range, color);
+        this.global = global;
+    }
+    
+    
+    
     
     /**
      * Creates a SpotLight at the given position, with the given direction,
@@ -159,6 +227,29 @@ public class SpotLight extends Light {
         setDirection(direction);
         setSpotRange(range);
     }  
+
+    /**
+     * Creates a SpotLight at the given position, with the given direction,
+     * the given color and the given inner and outer angles 
+     * (controls the falloff of the light)
+     * 
+     * @param position the position in world space.
+     * @param direction the direction of the light.
+     * @param range the spotlight range
+     * @param color the light's color.
+     * @param innerAngle the inner angle of the spotlight.
+     * @param outerAngle the outer angle of the spotlight.
+     * @param global if true, the light affects the entire tree from the root node,
+     * otherwise it only affects the children of the node in which it is attached.
+     * 
+     * @see SpotLight#setSpotInnerAngle(float) 
+     * @see SpotLight#setSpotOuterAngle(float) 
+     */
+    public SpotLight(Vector3f position, Vector3f direction, float range, ColorRGBA color, float innerAngle, float outerAngle, boolean global) {
+        this(position, direction, range, color, innerAngle, outerAngle);
+        this.global = global;
+    }  
+
 
     private void computeAngleParameters() {
         float innerCos = FastMath.cos(spotInnerAngle);

--- a/jme3-core/src/main/java/com/jme3/scene/Node.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Node.java
@@ -37,6 +37,8 @@ import com.jme3.collision.Collidable;
 import com.jme3.collision.CollisionResults;
 import com.jme3.export.JmeExporter;
 import com.jme3.export.JmeImporter;
+import com.jme3.light.Light;
+import com.jme3.light.LightList;
 import com.jme3.material.Material;
 import com.jme3.util.SafeArrayList;
 import com.jme3.util.clone.Cloner;
@@ -249,6 +251,23 @@ public class Node extends Spatial {
         if ((refreshFlags & RF_LIGHTLIST) != 0) {
             updateWorldLightList();
         }
+
+        boolean updateGlobalLights = (refreshFlags & RF_GLOBAL_LIGHTS) != 0;
+        if (updateGlobalLights){
+            refreshFlags &= ~RF_GLOBAL_LIGHTS;
+            // if root node, we collect the global lights
+            if (getParent() == null){ 
+                depthFirstTraversal(sx->{
+                    LightList childLights = sx.getLocalLightList();
+                    for (Light l : childLights) {
+                        if (l.isGlobal()) {
+                            worldLights.add(l);
+                        }
+                    }
+                });
+            }
+        }
+
         if ((refreshFlags & RF_TRANSFORM) != 0) {
             // combine with parent transforms- same for all spatial
             // subclasses.

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/LightsPunctualExtensionLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/LightsPunctualExtensionLoader.java
@@ -143,7 +143,7 @@ public class LightsPunctualExtensionLoader implements ExtensionLoader {
             outerConeAngle = FastMath.HALF_PI - 0.000001f;
         }
 
-        SpotLight spotLight = new SpotLight();
+        SpotLight spotLight = new SpotLight(true);
         spotLight.setName(name);
         spotLight.setColor(color);
         spotLight.setSpotRange(range);
@@ -167,7 +167,7 @@ public class LightsPunctualExtensionLoader implements ExtensionLoader {
         ColorRGBA color = obj.has("color") ? GltfUtils.getAsColor(obj, "color") : new ColorRGBA(ColorRGBA.White);
         color = lumensToColor(color, intensity);
 
-        DirectionalLight directionalLight = new DirectionalLight();
+        DirectionalLight directionalLight = new DirectionalLight(true);
         directionalLight.setName(name);
         directionalLight.setColor(color);
         directionalLight.setDirection(Vector3f.UNIT_Z.negate());
@@ -189,7 +189,7 @@ public class LightsPunctualExtensionLoader implements ExtensionLoader {
         color = lumensToColor(color, intensity);
         float range = obj.has("range") ? obj.get("range").getAsFloat() : Float.POSITIVE_INFINITY;
 
-        PointLight pointLight = new PointLight();
+        PointLight pointLight = new PointLight(true);
         pointLight.setName(name);
         pointLight.setColor(color);
         pointLight.setRadius(range);


### PR DESCRIPTION
JME lights only affect children of the nodes to which they are attached.
This makes sense from a performance/optimization standpoint, but it does not reflect the behavior of blender and other renderers.

This PR adds support for global lights ie. lights that affect all the spatials up to the rootNode.

Lights can be marked as global by setting to true the  "global" boolean flag on the lights' constructors . The flag is false by by default, so existing scene won't be affected.

This implementation exploits the jme scenegraph update logic to make global lights possible without any change to the renderer, this is an overview of how it works:

- A new refresh flag `RF_GLOBAL_LIGHTS`  is added.
- This flag is always propagated upstream up to the rootNode
- The rootNode seeing this flag will do a deep traversal of its children to find all the global lights to add to its own world light list.
- As a side effect, when the children are be updated, immediately after, they will pull the world lights list of their parent (first one being the rootNode with the global lights) propagating the global lights down the scene graph.