### PR TITLE
perform json element autoCast when loading user data in gltf loader

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/UserDataLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/UserDataLoader.java
@@ -112,6 +112,7 @@ public class UserDataLoader implements ExtrasLoader {
         if (el == null) {
             return null;
         }
+        el = el.autoCast();
         if (el instanceof JsonObject) {
             return toAttribute(el.getAsJsonObject(), nested);
         } else if (el instanceof JsonArray) {


### PR DESCRIPTION
This is a non-issue with the default GSON based json parser in jme, since it does it automatically, but if someone were to re-implement the parser (that is the purpose of the abstraction) with a dumber one, it would technically be bugged without  this line.