### PR TITLE
Improved performance in the lwjgx backend (AWT and OpenGL)

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
@@ -645,11 +645,18 @@ public class LwjglCanvas extends LwjglWindow implements JmeCanvasContext, Runnab
                                                 getPrintContextInitInfo(canvas.getGLDataEffective())));
         }
 
-        try {
-            if (signalTerminate.tryAcquire(5, TimeUnit.MILLISECONDS)) {
-                canvas.doDisposeCanvas();
-            }
-        } catch (InterruptedException ignored) { }
+        // On platforms other than Windows, an ideal amount of time is needed
+        // for the CPU to breathe and avoid interrupting the AWT and OpenGL
+        // context. This ensures a smooth experience between AWT and OpenGL.
+        Platform platform = Platform.get();
+        if (platform != Platform.WINDOWS) {
+            try {
+                // Ideal time: 5 milliseconds
+                if (signalTerminate.tryAcquire(5, TimeUnit.MILLISECONDS)) {
+                    canvas.doDisposeCanvas();
+                }
+            } catch (InterruptedException ignored) { }
+        }
     }
     
     /**

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjglx/LwjglxDefaultGLPlatform.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjglx/LwjglxDefaultGLPlatform.java
@@ -39,7 +39,7 @@ import static org.lwjgl.system.Platform.*;
  * @author wil
  */
 public final class LwjglxDefaultGLPlatform {
-    
+
     /**
      * Returns a drawing platform based on the platform it is running on.
      * @return LwjglxGLPlatform
@@ -49,7 +49,7 @@ public final class LwjglxDefaultGLPlatform {
         switch (Platform.get()) {
             case WINDOWS:
                 return new Win32GLPlatform();
-            case FREEBSD:
+            //case FREEBSD:  -> In future versions of lwjgl3 (possibly)
             case LINUX:
                 return new X11GLPlatform();
             case MACOSX:
@@ -58,7 +58,7 @@ public final class LwjglxDefaultGLPlatform {
                 throw new UnsupportedOperationException("Platform " + Platform.get() + " not yet supported");
         }
     }
-    
+
     /**
      * private constructor.
      */


### PR DESCRIPTION
Hello everyone, after a long time, I finally have some free time so I started working on the performance problem that lwjglx has when supporting OpenGL with AWT.

- In Linux, if the CPU doesn't have time to breathe, the context starts to fail. If this time is too long, it creates a bottleneck by causing a drop in FPS, which severely impacts performance.
- In Windows, if there is a pause to allow the CPU to breathe, the same synchronization problem arises because there are drastic drops in FPS; by removing that pause, things return to normal and the context problem is no longer present.
- Regarding macOS, I cannot comment since I do not have the equipment to perform performance tests, so it should continue to work the same way (_works fine_).

[ **Screenshots** ]

## Linux

### Before

With a maximum of **85 pfs**, in theory it should reach the 144 pfs that this machine supports.

<img width="1920" height="1049" alt="Captura desde 2025-12-13 14-35-03" src="https://github.com/user-attachments/assets/e7bd1c21-66c8-4c07-8e85-d960f32dcbff" />

### After

Then with the applied changes it can reach 145, (which is the maximum that this machine offers, so a high-end model should work as in a normal context without AWT)

<img width="1920" height="1043" alt="Captura desde 2025-12-13 14-33-03" src="https://github.com/user-attachments/assets/6d9ce4a4-a668-4ca4-b3a5-32280747467b" />

## Windows
### Before
~ 60 fps

<img width="644" height="559" alt="Captura de pantalla 2025-12-13 160112" src="https://github.com/user-attachments/assets/3896472d-5ac7-4241-9783-d8c6292f2364" />

### After

~140 fps
<img width="1919" height="1030" alt="Captura de pantalla 2025-12-13 160648" src="https://github.com/user-attachments/assets/2d93fa49-5941-48dd-aeb2-46844b43e993" />

