### PR TITLE
#2582 Correct thread warden so it can cope with multiple threaded JME apps

### DIFF
--- a/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java
+++ b/jme3-core/src/main/java/com/jme3/app/SimpleApplication.java
@@ -308,13 +308,6 @@ public abstract class SimpleApplication extends LegacyApplication {
     }
 
     @Override
-    public void stop(boolean waitFor) {
-        //noinspection AssertWithSideEffects
-        assert SceneGraphThreadWarden.reset();
-        super.stop(waitFor);
-    }
-
-    @Override
     public void update() {
         if (prof != null) {
             prof.appStep(AppStep.BeginFrame);


### PR DESCRIPTION
This allows the thread warden to permit multiple threads each with their own root node (on different threads). Those restrictions are then separately tracked such that each scene graph is modifiable only on its own thread 

closes https://github.com/jMonkeyEngine/jmonkeyengine/issues/2582