### PR TITLE
Fix issues in GLES backends

### DIFF
--- a/jme3-android/src/main/java/com/jme3/renderer/android/AndroidGL.java
+++ b/jme3-android/src/main/java/com/jme3/renderer/android/AndroidGL.java
@@ -349,9 +349,9 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
     @Override
     public long glGetQueryObjectui64(int query, int pname) {
         IntBuffer buff = (IntBuffer)tmpBuff.clear();
-        //FIXME This is wrong IMO should be glGetQueryObjectui64v with a LongBuffer but it seems the API doesn't provide it.
+        //FIXME This reads only 32 bits; mask to return the value as unsigned in a long.
         GLES30.glGetQueryObjectuiv(query, pname, buff);
-        return buff.get(0);
+        return buff.get(0) & 0xFFFF_FFFFL;
     }
 
     @Override

--- a/jme3-android/src/main/java/com/jme3/renderer/android/AndroidGL.java
+++ b/jme3-android/src/main/java/com/jme3/renderer/android/AndroidGL.java
@@ -348,7 +348,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public long glGetQueryObjectui64(int query, int pname) {
-        IntBuffer buff = IntBuffer.allocate(1);
+        IntBuffer buff = tmpBuff.clear();
         //FIXME This is wrong IMO should be glGetQueryObjectui64v with a LongBuffer but it seems the API doesn't provide it.
         GLES30.glGetQueryObjectuiv(query, pname, buff);
         return buff.get(0);
@@ -356,8 +356,8 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public int glGetQueryObjectiv(int query, int pname) {
-        IntBuffer buff = IntBuffer.allocate(1);
-        GLES30.glGetQueryiv(query, pname, buff);
+        IntBuffer buff = tmpBuff.clear();
+        GLES30.glGetQueryObjectuiv(query, pname, buff);
         return buff.get(0);
     }
 
@@ -756,6 +756,11 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
     public void glGenVertexArrays(IntBuffer arrays) {
         GLES30.glGenVertexArrays(arrays.limit(),arrays);
 
+    }
+
+    @Override
+    public String glGetString(int name, int index) {
+        return GLES30.glGetStringi(name, index);
     }
 
 }

--- a/jme3-android/src/main/java/com/jme3/renderer/android/AndroidGL.java
+++ b/jme3-android/src/main/java/com/jme3/renderer/android/AndroidGL.java
@@ -348,7 +348,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public long glGetQueryObjectui64(int query, int pname) {
-        IntBuffer buff = tmpBuff.clear();
+        IntBuffer buff = (IntBuffer)tmpBuff.clear();
         //FIXME This is wrong IMO should be glGetQueryObjectui64v with a LongBuffer but it seems the API doesn't provide it.
         GLES30.glGetQueryObjectuiv(query, pname, buff);
         return buff.get(0);
@@ -356,7 +356,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public int glGetQueryObjectiv(int query, int pname) {
-        IntBuffer buff = tmpBuff.clear();
+        IntBuffer buff = (IntBuffer)tmpBuff.clear();
         GLES30.glGetQueryObjectuiv(query, pname, buff);
         return buff.get(0);
     }

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLES_30.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLES_30.java
@@ -42,10 +42,14 @@ public interface GLES_30 extends GL {
 
     public static final int GL_RGB10_A2 = 0x8059;
     public static final int GL_UNSIGNED_INT_2_10_10_10_REV = 0x8368;
- 
+    public static final int GL_NUM_EXTENSIONS = 0x821D;
+
     public void glBindVertexArray(int array);
 
     public void glDeleteVertexArrays(IntBuffer arrays);
    
     public void glGenVertexArrays(IntBuffer arrays);
+
+    public String glGetString(final int name, final int index);
+
 }

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -186,7 +186,15 @@ public final class GLRenderer implements Renderer {
             gl3.glGetInteger(GL3.GL_NUM_EXTENSIONS, intBuf16);
             int extensionCount = intBuf16.get(0);
             for (int i = 0; i < extensionCount; i++) {
-                String extension = gl3.glGetString(GL.GL_EXTENSIONS, i);
+                String extension = gl3.glGetString(GL3.GL_EXTENSIONS, i);
+                extensionSet.add(extension);
+            }
+        } else if (caps.contains(Caps.OpenGLES30)) {
+            GLES_30 gles = (GLES_30) gl;
+            gles.glGetInteger(GLES_30.GL_NUM_EXTENSIONS, intBuf16);
+            int extensionCount = intBuf16.get(0);
+            for (int i = 0; i < extensionCount; i++) {
+                String extension = gles.glGetString(GLES_30.GL_EXTENSIONS, i);
                 extensionSet.add(extension);
             }
         } else {

--- a/jme3-ios/src/main/java/com/jme3/renderer/ios/IosGL.java
+++ b/jme3-ios/src/main/java/com/jme3/renderer/ios/IosGL.java
@@ -809,5 +809,9 @@ public class IosGL implements GL, GL2, GLES_30, GLExt, GLFbo {
         throw new UnsupportedOperationException("Unimplemented method 'glGenVertexArrays'");
     }
 
+    @Override
+    public String glGetString(int name, int index) {
+        return JmeIosGLES.glGetStringi(name, index);
+    }
 
 }

--- a/jme3-ios/src/main/java/com/jme3/renderer/ios/JmeIosGLES.java
+++ b/jme3-ios/src/main/java/com/jme3/renderer/ios/JmeIosGLES.java
@@ -201,6 +201,8 @@ public class JmeIosGLES {
     public static native String glGetShaderInfoLog(int shader);
     public static native void glGetShaderiv(int shader, int pname, int[] params, int offset);
     public static native String glGetString(int name);
+
+    public static native String glGetStringi(int name, int index);
     public static native int glGetUniformLocation(int program, String name);
     public static native boolean glIsEnabled(int cap);
     public static native boolean glIsFramebuffer(int framebuffer);


### PR DESCRIPTION
1. Avoid reallocating 1 length IntBuffers in glGetQueryObject  in android
2. fix misuse of glGetQueryiv instead of glGetQueryObjectuiv in android
3. implement glGetStringi(name, index) on android and ios (?)
4. use non-deprecated way to fetch extensions in GLES (was causing crashes in some implementations)

At this time, this is mostly untested in both android and ios. 
If anyone wants to give it a try, please go ahead.