### PR TITLE
Bug: PBRLightingUtils.glsllib - Typo in GlossinessMap

### DIFF
--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -395,7 +395,7 @@
                         vec4 specularColor = vec4(1.0);
                     #endif
                     #ifdef GLOSSINESSMAP
-                        glossiness *= texture2D(m_GlossinesMap, newTexCoord).r;
+                        glossiness *= texture2D(m_GlossinessMap, newTexCoord).r;
                     #endif
                 #endif
                 specularColor *= m_Specular;
@@ -711,3 +711,4 @@
     }
 
 #endif
+


### PR DESCRIPTION
The uniform is declared as:
`uniform sampler2D m_GlossinessMap;`

But we have:
`texture2D(m_GlossinesMap, newTexCoord)`

This will cause a compile error if GLOSSINESSMAP is enabled.