### PR TITLE
Multi scenario screenshot test

### DIFF
--- a/jme3-screenshot-tests/src/main/java/org/jmonkeyengine/screenshottests/testframework/Scenario.java
+++ b/jme3-screenshot-tests/src/main/java/org/jmonkeyengine/screenshottests/testframework/Scenario.java
@@ -1,0 +1,13 @@
+package org.jmonkeyengine.screenshottests.testframework;
+
+import com.jme3.app.state.AppState;
+
+public class Scenario {
+    String scenarioName;
+    AppState[] states;
+
+    public Scenario(String scenarioName, AppState... states) {
+        this.scenarioName = scenarioName;
+        this.states = states;
+    }
+}

--- a/jme3-screenshot-tests/src/main/java/org/jmonkeyengine/screenshottests/testframework/ScreenshotTest.java
+++ b/jme3-screenshot-tests/src/main/java/org/jmonkeyengine/screenshottests/testframework/ScreenshotTest.java
@@ -47,7 +47,11 @@ public class ScreenshotTest{
 
     TestType testType = TestType.MUST_PASS;
 
-    AppState[] states;
+    /**
+     * Usually there will be a single scenario but sometimes it will be desirable to test that two ways
+     * of doing something produce the same result. In that case there will be multiple scenarios.
+     */
+    List<Scenario> scenarios = new ArrayList<>();
 
     List<Integer> framesToTakeScreenshotsOn = new ArrayList<>();
 
@@ -56,7 +60,11 @@ public class ScreenshotTest{
     String baseImageFileName = null;
 
     public ScreenshotTest(AppState... initialStates){
-        states = initialStates;
+        scenarios.add(new Scenario("SimpleSingleScenario", initialStates));
+        framesToTakeScreenshotsOn.add(1); //default behaviour is to take a screenshot on the first frame
+    }
+    public ScreenshotTest(Scenario... scenarios){
+        this.scenarios.addAll(Arrays.asList(scenarios));
         framesToTakeScreenshotsOn.add(1); //default behaviour is to take a screenshot on the first frame
     }
 
@@ -100,7 +108,7 @@ public class ScreenshotTest{
 
         String imageFilePrefix = baseImageFileName == null ? calculateImageFilePrefix() : baseImageFileName;
 
-        TestDriver.bootAppForTest(testType,settings,imageFilePrefix, framesToTakeScreenshotsOn, states);
+        TestDriver.bootAppForTest(testType,settings,imageFilePrefix, framesToTakeScreenshotsOn, scenarios);
     }
 
 

--- a/jme3-screenshot-tests/src/main/java/org/jmonkeyengine/screenshottests/testframework/ScreenshotTestBase.java
+++ b/jme3-screenshot-tests/src/main/java/org/jmonkeyengine/screenshottests/testframework/ScreenshotTestBase.java
@@ -47,10 +47,22 @@ public abstract class ScreenshotTestBase{
     /**
      * Initialises a screenshot test. The resulting object should be configured (if neccessary) and then started
      * by calling {@link ScreenshotTest#run()}.
-     * @param initialStates
+     * @param initialStates the states that will create the JME environment
      * @return
      */
     public ScreenshotTest screenshotTest(AppState... initialStates){
         return new ScreenshotTest(initialStates);
+    }
+
+    /**
+     * Permits multiple scenarios to be tested in a single test. Each scenario should give identical results and
+     * will have a screenshot taken on the same frame.
+     *
+     * <p>
+     *     This is intended for testing migrations where the old and new approach should both give identical results.
+     * </p>
+     */
+    public ScreenshotTest screenshotMultiScenarioTest(Scenario... scenarios){
+        return new ScreenshotTest(scenarios);
     }
 }


### PR DESCRIPTION
As discussed at https://hub.jmonkeyengine.org/t/screenshottests-use-a-image-from-a-different-test-as-reference/49395/4 adds a mechanism to test multiple (theoretically identical) scenarios against a single set of reference images. Example usage:

```
public class MultiTest extends ScreenshotTestBase {

    @Test
    public void multiTest() {
        
        screenshotMultiScenarioTest(
                new Scenario(
                        "setByParts",
                        new BaseAppState() {
                            @Override
                            protected void initialize(Application app) {
                                Box box = new Box(1, 1, 1);
                                Geometry geom = new Geometry("Box", box);
                                Material mat = new Material(app.getAssetManager(), "Common/MatDefs/Misc/Unshaded.j3md");
                                mat.setColor("Color", ColorRGBA.Blue);
                                geom.setMaterial(mat);

                                geom.setLocalTranslation(1, 0, 0);

                                ((SimpleApplication) app).getRootNode().attachChild(geom);
                            }

                            @Override
                            protected void cleanup(Application app) {}

                            @Override
                            protected void onEnable() {}

                            @Override
                            protected void onDisable() {}
                        }),
                new Scenario(
                        "setByVector",
                        new BaseAppState() {
                            @Override
                            protected void initialize(Application app) {
                                Box box = new Box(1, 1, 1);
                                Geometry geom = new Geometry("Box", box);
                                Material mat = new Material(app.getAssetManager(), "Common/MatDefs/Misc/Unshaded.j3md");
                                mat.setColor("Color", ColorRGBA.Blue);
                                geom.setMaterial(mat);

                                geom.setLocalTranslation(new Vector3f(1f, 0, 0));

                                ((SimpleApplication) app).getRootNode().attachChild(geom);
                            }

                            @Override
                            protected void cleanup(Application app) {}

                            @Override
                            protected void onEnable() {}

                            @Override
                            protected void onDisable() {}
                        })
        ).run();
    }
}
```

It will test that:

- Every scenario generates the same screenshot(s)
- The first scenario has the same screenshot(s) as the reference image(s)