### PR TITLE
Semgrep Rule Fix

### DIFF
--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
@@ -96,6 +96,9 @@ public class XMLExporter implements JmeExporter {
         try {
             TransformerFactory tfFactory = TransformerFactory.newInstance();
             tfFactory.setAttribute("indent-number", indentSpaces);
+            // Disable external DTD and stylesheet access to prevent XXE attacks
+            tfFactory.setAttribute("accessExternalDTD", "");
+            tfFactory.setAttribute("accessExternalStylesheet", "");
 
             Transformer transformer = tfFactory.newTransformer();
             transformer.setOutputProperty(OutputKeys.STANDALONE, "yes");


### PR DESCRIPTION
We have used our AI-Guardian( https://ai-rem-demo.remediation.opsmx.net) product to identify and remediate a Semgrep rule violation

Pull Request — Semgrep Rule Fix
Rule ID: transformerfactory-dtds-not-disabled
Rule Message: DOCTYPE declarations are enabled for this TransformerFactory. This is vulnerable to XML external entity attacks. Disable this by setting the attributes "accessExternalDTD" and "accessExternalStylesheet" to "".
File Path: /tools/scanResult/unzipped-2878896019/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
Line: 100