### PR TITLE
Ignore file extension of external glTF buffers

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/BinDataKey.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/BinDataKey.java
@@ -40,6 +40,12 @@ import com.jme3.asset.cache.AssetCache;
 class BinDataKey extends AssetKey<Object> {
     public BinDataKey(String name) {
         super(name);
+
+        // References to external data in glTF are not required to have a
+        // specific file extension. But the 'General.cfg' contains
+        // LOADER com.jme3.scene.plugins.gltf.BinLoader : bin
+        // So always set the extension to be "bin" to find the loader.
+        this.extension = "bin";
     }
 
     @Override


### PR DESCRIPTION
Already mentioned in https://github.com/jMonkeyEngine/jmonkeyengine/issues/2118#issuecomment-3817245510 : 

A `.gltf` file may refer to arbitrary external (binary) data, using a URI. The specification recommends to give these files a `.bin` or `.glbin` extension, but this is **not** required. 

Right now, trying to load a file where such an external buffer does not have a `.bin` file extension will cause a crash.

This PR changes the behavior: It causes the actual file extension to be ignored.

I'm not entirely sure whether the approach here is the "right" one (or what the "best" approach is). What I gathered so far:

- The actual data resolution happens based on an `AssetKey`
- By default, this extracts the extension of a given file name, and stores it as its `extension`
- Based on that `AssetKey`, there is a lookup mechanism for loaders, based on the file extension
- The [`General.cfg`](https://github.com/jMonkeyEngine/jmonkeyengine/blob/e319e2f34a707b013c5cbc9baa5f3854ac5e5396/jme3-core/src/main/resources/com/jme3/asset/General.cfg#L26) establishes the mapping of 
  `LOADER com.jme3.scene.plugins.gltf.BinLoader : bin`
  to use that `BinLoader` for assets with the `bin` extension

The main change here now is that the existing `BinDataKey` that was used for external glTF buffer references sets its `extension` to `bin`, regardless of the actual extension. 

I've tested it with these files:

[TriangleWithDifferentExternalExtensions-2026-02-15.zip](https://github.com/user-attachments/files/25325366/TriangleWithDifferentExternalExtensions-2026-02-15.zip)

They can be loaded from the `TestGltfLoading` class, by putting them into the example data, and loading them with either of
```java
loadModelFromPath("Models/gltf/TriangleWithBin/TriangleWithBin.gltf");
loadModelFromPath("Models/gltf/TriangleWithGlbin/TriangleWithGlbin.gltf");
loadModelFromPath("Models/gltf/TriangleWithNoExtension/TriangleWithNoExtension.gltf");
```` 

---

More generally: Trying to determine a file type based on a file extension is usually brittle and not sufficient in many cases. But... I know that everything that is going beyond that can be tricky. Many files have "magic bytes" that can be used for identifying the file type. But eventually, loaders may have to differentiate between different JSON files, and at this point, there is no way around _parsing_ the whole thing and making guesses (!) based on the presence of absence of certain properties. I think that for the case of the glTF `.bin` files, the current approach should be OK. One could consider changing the registration and extension to
`LOADER com.jme3.scene.plugins.gltf.BinLoader : glbin`,
because `glbin` is ait more specific than `bin`, but that can be done at any point in time now.
