### PR TITLE
fix crash when default framebuffer sizes are too small

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -482,8 +482,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         // framebuffer size (resolution) may differ from window size (e.g. HiDPI)
 
         glfwGetWindowSize(window, width, height);
-        int windowWidth = width[0] < 2 ? 2 : width[0];
-        int windowHeight = height[0] < 2 ? 2 : height[0];
+        int windowWidth = width[0] < 16 ? 16 : width[0];
+        int windowHeight = height[0] < 16 ? 16 : height[0];
         if (settings.getWindowWidth() != windowWidth || settings.getWindowHeight() != windowHeight) {
             settings.setWindowSize(windowWidth, windowHeight);
             for (WindowSizeListener wsListener : windowSizeListeners.getArray()) {
@@ -492,8 +492,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         }
 
         glfwGetFramebufferSize(window, width, height);
-        int framebufferWidth = width[0] < 2 ? 2 : width[0];
-        int framebufferHeight = height[0] < 2 ? 2 : height[0];
+        int framebufferWidth = width[0] < 16 ? 16 : width[0];
+        int framebufferHeight = height[0] < 16 ? 16 : height[0];
         if (framebufferWidth != oldFramebufferWidth || framebufferHeight != oldFramebufferHeight) {
             settings.setResolution(framebufferWidth, framebufferHeight);
             listener.reshape(framebufferWidth, framebufferHeight);


### PR DESCRIPTION
Should fix https://github.com/jMonkeyEngine/jmonkeyengine/issues/2618

Ensure the engine never sees a framebuffer size smaller than 2. Also clamp the window size to a minimum of 2 (instead of 1) for extra safety.