### PR TITLE
fix regression that disabled custom fpp color format in some platforms

### DIFF
--- a/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
@@ -206,14 +206,16 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
         }
 
         // Determine optimal framebuffer format based on renderer capabilities
-        if (fbFormat == null) fbFormat = Format.RGB111110F;
-        if (!renderer.getCaps().contains(Caps.PackedFloatTexture)) {
-            if (renderer.getCaps().contains(Caps.FloatColorBufferRGB)) {
-                fbFormat = Format.RGB16F;
-            } else if (renderer.getCaps().contains(Caps.FloatColorBufferRGBA)) {
-                fbFormat = Format.RGBA16F;
-            } else {
-                fbFormat = Format.RGB8;
+        if (fbFormat == null) {
+            fbFormat = Format.RGB111110F;
+            if (!renderer.getCaps().contains(Caps.PackedFloatTexture)) {
+                if (renderer.getCaps().contains(Caps.FloatColorBufferRGB)) {
+                    fbFormat = Format.RGB16F;
+                } else if (renderer.getCaps().contains(Caps.FloatColorBufferRGBA)) {
+                    fbFormat = Format.RGBA16F;
+                } else {
+                    fbFormat = Format.RGB8;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes the issue reported [here](https://hub.jmonkeyengine.org/t/cartoonedgefilter-makes-the-entire-background-black/49419/9)