### PR TITLE
catch every exception from audio context initialization

### DIFF
--- a/jme3-core/src/main/java/com/jme3/audio/openal/ALAudioRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/audio/openal/ALAudioRenderer.java
@@ -129,7 +129,7 @@ public class ALAudioRenderer implements AudioRenderer, Runnable {
             if (!alc.isCreated()) {
                 alc.createALC();
             }
-        } catch (UnsatisfiedLinkError ex) {
+        } catch (Exception ex) {
             logger.log(Level.SEVERE, "Failed to load audio library (OpenAL). Audio will be disabled.", ex);
             audioDisabled = true;
             return;


### PR DESCRIPTION
Sometimes the audio context can throw different exception if the platform does not have an audio device at all, 
eg.  
```
java.lang.NullPointerException
	at org.lwjgl.system.Checks.check(Checks.java:188)
Checks.java:188
	at org.lwjgl.openal.ALC10.nalcCreateContext(ALC10.java:102)
ALC10.java:102
	at org.lwjgl.openal.ALC10.alcCreateContext(ALC10.java:113)
ALC10.java:113
	at com.jme3.audio.lwjgl.LwjglALC.createALC(LwjglALC.java:58)
LwjglALC.java:58
	at com.jme3.audio.openal.ALAudioRenderer.initOpenAL(ALAudioRenderer.java:130)
ALAudioRenderer.java:130
	at com.jme3.audio.openal.ALAudioRenderer.initialize(ALAudioRenderer.java:303)
ALAudioRenderer.java:303
	at com.jme3.app.LegacyApplication.initAudio(LegacyApplication.java:307)
LegacyApplication.java:307
	at com.jme3.app.LegacyApplication.initialize(LegacyApplication.java:670)
LegacyApplication.java:670
	at com.jme3.app.SimpleApplication.initialize(SimpleApplication.java:253)
SimpleApplication.java:253
	at com.jme3.system.lwjgl.LwjglWindow.initInThread(LwjglWindow.java:710)
LwjglWindow.java:710
	at com.jme3.system.lwjgl.LwjglWindow.run(LwjglWindow.java:813)
LwjglWindow.java:813
	at java.base/java.lang.Thread.run(Thread.java:1583)
```
on software rendered fedora.

This is currently causing the engine to crash unless the audio renderer is disabled manually.
This pr changes the code to catch every exception and disable the audio context,