### PR TITLE
WIP/Fix: correct parallel projection frustum plane normals for left/right

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/Camera.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/Camera.java
@@ -1344,10 +1344,14 @@ public class Camera implements Savable, Cloneable {
             coeffTop[0] = -frustumNear * inverseLength;
             coeffTop[1] = frustumTop * inverseLength;
         } else {
-            coeffLeft[0] = 1;
+            // getLeft() returns up×direction, but the view matrix (fromFrame)
+            // uses direction×up = -getLeft() as its X axis. Negate the left/right
+            // coefficients so the frustum plane normals match the view matrix,
+            // giving correct culling for any camera orientation.
+            coeffLeft[0] = -1;
             coeffLeft[1] = 0;
 
-            coeffRight[0] = -1;
+            coeffRight[0] = 1;
             coeffRight[1] = 0;
 
             coeffBottom[0] = 1;


### PR DESCRIPTION
getLeft() returns up×direction but fromFrame() uses direction×up as the view matrix X axis. These are negatives of each other. The hardcoded parallel projection coefficients (1 for left, -1 for right) built plane normals from getLeft(), causing them to point opposite to the view matrix.

This made frustum culling reject visible geometry for any camera with a non-standard orientation (e.g. looking along +Z) or asymmetric frustum values in parallel projection mode.

Fix: negate the left/right coefficients so plane normals align with the view matrix's X axis.

Note: this bug was found and fixed by claude. all jme tests pass, my local project passes too, but i am not sure of the consequences. I create this PR now to run all the remote testing. 