### PR TITLE
fix: Issue 89 resolved #2602 - upgrade lwjglx (jme3)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ jna = "net.java.dev.jna:jna:5.10.0"
 jnaerator-runtime = "com.nativelibs4java:jnaerator-runtime:0.12"
 junit4 = "junit:junit:4.13.2"
 lwjgl2 = "org.jmonkeyengine:lwjgl:2.9.5"
-lwjgl3-awt = "org.lwjglx:lwjgl3-awt:0.2.3"
+lwjgl3-awt = "org.jmonkeyengine:lwjgl3-awt:0.2.4"
 
 lwjgl3-base     = { module = "org.lwjgl:lwjgl",          version.ref = "lwjgl3" }
 lwjgl3-glfw     = { module = "org.lwjgl:lwjgl-glfw",     version.ref = "lwjgl3" }


### PR DESCRIPTION
This pull request updates the lwjgx version to match the version released by jme3 ([v0.2.4](https://central.sonatype.com/artifact/org.jmonkeyengine/lwjgl3-awt)), as mentioned in issue #2602. The lwjgx team released the patch for this issue (https://github.com/LWJGLX/lwjgl3-awt/commit/b7270e94dff620afddb68018a75af4a95c1eb526), but there were some issues with its release, so jme3 is now handling it. 

LwjglCanvas should now work on Windows...