### PR TITLE
fix: Native platform - LwjglCanvas (example)

### DIFF
--- a/jme3-examples/src/main/java/jme3test/awt/TestCanvas.java
+++ b/jme3-examples/src/main/java/jme3test/awt/TestCanvas.java
@@ -206,6 +206,9 @@ public class TestCanvas {
     @SuppressWarnings("unchecked")
     public static void createCanvas(String appClass){
         AppSettings settings = new AppSettings(true);
+
+        // Note: Only for Linux and Wayland platforms, forces you to
+        // use XWayland (x11) with awt.
         settings.setX11PlatformPreferred(true);
         settings.setWidth(640);
         settings.setHeight(480);


### PR DESCRIPTION
Since lwjgl3 is the default module in the jme3 [examples](https://github.com/jMonkeyEngine/jmonkeyengine/blob/f02c4e671690d2a456bed5ade9b62971af13cdbe/jme3-examples/build.gradle#L23), enabling (forcing) it to use x11 for the awt canvas is already part of this example to make it work on Wayland (and not appear to have a bug)... since awt/swing still relies on x11 to manage its graphical components (this does not affect functionality on other platforms except Linux with Wayland).