### PR TITLE
break the sp lighting loop early in modern gl(es)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/material/logic/SinglePassAndImageBasedLightingLogic.java
+++ b/jme3-core/src/main/java/com/jme3/material/logic/SinglePassAndImageBasedLightingLogic.java
@@ -123,6 +123,7 @@ public final class SinglePassAndImageBasedLightingLogic extends DefaultTechnique
 
         Uniform lightData = shader.getUniform("g_LightData");
         lightData.setVector4Length(numLights * 3);//8 lights * max 3
+        Uniform lightCount = shader.getUniform("g_LightCount");
         Uniform ambientColor = shader.getUniform("g_AmbientLightColor");
 
         // Matrix4f
@@ -231,6 +232,7 @@ public final class SinglePassAndImageBasedLightingLogic extends DefaultTechnique
             }
         }
         vars.release();
+        lightCount.setValue(VarType.Int, lightDataIndex / 3);
 
         // pad unused buffer space
         while (lightDataIndex < numLights * 3) {

--- a/jme3-core/src/main/java/com/jme3/material/logic/SinglePassLightingLogic.java
+++ b/jme3-core/src/main/java/com/jme3/material/logic/SinglePassLightingLogic.java
@@ -113,6 +113,7 @@ public final class SinglePassLightingLogic extends DefaultTechniqueDefLogic {
 
         Uniform lightData = shader.getUniform("g_LightData");
         lightData.setVector4Length(numLights * 3);//8 lights * max 3
+        Uniform lightCount = shader.getUniform("g_LightCount");
         Uniform ambientColor = shader.getUniform("g_AmbientLightColor");
 
         if (startIndex != 0) {
@@ -198,6 +199,7 @@ public final class SinglePassLightingLogic extends DefaultTechniqueDefLogic {
             }
         }
         vars.release();
+        lightCount.setValue(VarType.Int, lightDataIndex / 3);
         // pad unused buffer space
         while (lightDataIndex < numLights * 3) {
             lightData.setVector4InArray(0f, 0f, 0f, 0f, lightDataIndex);

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/PBRLighting.frag
@@ -17,6 +17,7 @@
 #endif
 
 uniform vec4 g_LightData[NB_LIGHTS];
+uniform int g_LightCount;
 uniform vec3 g_CameraPosition;
 
 #ifdef USE_FOG
@@ -38,6 +39,11 @@ void main(){
     
     // Calculate direct lights
     for(int i = 0;i < NB_LIGHTS; i+=3){
+        #if (defined(GL_ES) && __VERSION__ >= 300) || (!defined(GL_ES) && __VERSION__ >= 150)
+        if(i >= g_LightCount * 3){
+            break;
+        }
+        #endif
         vec4 lightData0 = g_LightData[i];
         vec4 lightData1 = g_LightData[i+1];
         vec4 lightData2 = g_LightData[i+2];    

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/SPLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/SPLighting.frag
@@ -38,6 +38,7 @@ varying vec3 SpecularSum;
 #ifndef VERTEX_LIGHTING
     uniform mat4 g_ViewMatrix;
     uniform vec4 g_LightData[NB_LIGHTS];
+    uniform int g_LightCount;
     varying vec3 vPos; 
 #endif
 
@@ -197,6 +198,11 @@ void main(){
         #endif
 
         for( int i = 0;i < NB_LIGHTS; i+=3){
+            #if (defined(GL_ES) && __VERSION__ >= 300) || (!defined(GL_ES) && __VERSION__ >= 150)
+            if(i >= g_LightCount * 3){
+                break;
+            }
+            #endif
             vec4 lightColor = g_LightData[i];
             vec4 lightData1 = g_LightData[i+1];                
             vec4 lightDir;

--- a/jme3-core/src/main/resources/Common/MatDefs/Light/SPLighting.vert
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/SPLighting.vert
@@ -21,6 +21,7 @@ uniform float m_Shininess;
 
 #if defined(VERTEX_LIGHTING)
     uniform vec4 g_LightData[NB_LIGHTS];
+    uniform int g_LightCount;
 #endif
 uniform vec4 g_AmbientLightColor;
 varying vec2 texCoord;
@@ -148,6 +149,11 @@ void main(){
         vec4 diffuseColor;
         vec3 specularColor;
         for (int i =0;i < NB_LIGHTS; i+=3){
+            #if (defined(GL_ES) && __VERSION__ >= 300) || (!defined(GL_ES) && __VERSION__ >= 150)
+            if(i >= g_LightCount * 3){
+                break;
+            }
+            #endif
             vec4 lightColor = g_LightData[i];            
             vec4 lightData1 = g_LightData[i+1];            
             #ifdef MATERIAL_COLORS

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/AdvancedPBRTerrain.frag
@@ -18,6 +18,7 @@
 
 //declare PBR Lighting vars
 uniform vec4 g_LightData[NB_LIGHTS];
+uniform int g_LightCount;
 uniform vec3 g_CameraPosition;
 
 #ifdef DEBUG_VALUES_MODE
@@ -133,6 +134,11 @@ void main(){
     
     // Calculate direct lights
     for(int i = 0;i < NB_LIGHTS; i+=3){
+        #if (defined(GL_ES) && __VERSION__ >= 300) || (!defined(GL_ES) && __VERSION__ >= 150)
+        if(i >= g_LightCount * 3){
+            break;
+        }
+        #endif
         vec4 lightData0 = g_LightData[i];
         vec4 lightData1 = g_LightData[i+1];
         vec4 lightData2 = g_LightData[i+2];    

--- a/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/SPTerrainLighting.frag
+++ b/jme3-terrain/src/main/resources/Common/MatDefs/Terrain/SPTerrainLighting.frag
@@ -10,6 +10,7 @@ varying vec4 SpecularSum;
 
 uniform mat4 g_ViewMatrix;
 uniform vec4 g_LightData[NB_LIGHTS];
+uniform int g_LightCount;
 varying vec3 vTangent;
 varying vec3 vBinormal;
 varying vec3 vPos;    
@@ -620,6 +621,11 @@ void main(){
     //-----------------------
     gl_FragColor = AmbientSum * diffuseColor;
     for( int i = 0;i < NB_LIGHTS; i+=3){
+        #if (defined(GL_ES) && __VERSION__ >= 300) || (!defined(GL_ES) && __VERSION__ >= 150)
+        if(i >= g_LightCount * 3){
+            break;
+        }
+        #endif
         vec4 lightColor = g_LightData[i];
         vec4 lightData1 = g_LightData[i+1];                
         vec4 lightDir;


### PR DESCRIPTION
In modern GL(es) there is no point in wasting gpu power processing the whole light batch, this PR stops it as soon as all the active lights are processed, when the shader is compiled in GLES3+ or GL 3.2+.
To integrate this cleanly while also keeping backward compatibility, a new g_LightCount uniform is added.