### PR TITLE
Fix fog in SPLighting.frag

### DIFF
--- a/jme3-core/src/main/resources/Common/MatDefs/Light/SPLighting.frag
+++ b/jme3-core/src/main/resources/Common/MatDefs/Light/SPLighting.frag
@@ -8,23 +8,8 @@
 
 // fog - jayfella
 #ifdef USE_FOG
-#import "Common/ShaderLib/MaterialFog.glsllib"
-varying float fog_distance;
-uniform vec4 m_FogColor;
-
-#ifdef FOG_LINEAR
-uniform vec2 m_LinearFog;
-#endif
-
-#ifdef FOG_EXP
-uniform float m_ExpFog;
-#endif
-
-#ifdef FOG_EXPSQ
-uniform float m_ExpSqFog;
-#endif
-
-#endif // end fog
+    #import "Common/ShaderLib/MaterialFog.glsllib"
+#endif 
 
 varying vec2 texCoord;
 #ifdef SEPARATE_TEXCOORD
@@ -259,16 +244,8 @@ void main(){
     // add fog after the lighting because shadows will cause the fog to darken
     // which just results in the geometry looking like it's changed color
     #ifdef USE_FOG
-        #ifdef FOG_LINEAR
-            gl_FragColor = getFogLinear(gl_FragColor, m_FogColor, m_LinearFog.x, m_LinearFog.y, fog_distance);
-        #endif
-        #ifdef FOG_EXP
-            gl_FragColor = getFogExp(gl_FragColor, m_FogColor, m_ExpFog, fog_distance);
-        #endif
-        #ifdef FOG_EXPSQ
-            gl_FragColor = getFogExpSquare(gl_FragColor, m_FogColor, m_ExpSqFog, fog_distance);
-        #endif
-    #endif // end fog
+        gl_FragColor = MaterialFog_calculateFogColor(vec4(gl_FragColor));
+    #endif
 
     gl_FragColor.a = alpha;
 }


### PR DESCRIPTION
Fixes an exception caused by duplicate declaration of the same variables when using fog. 

The fog uniforms are already declared in the imported fog glsllib, so the declaration in the .frag shader causes an exception trying to re-declare them a second time.