### PR TITLE
Fix typo serialization key in AbstractCinematicEven (Issue #2449)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/cinematic/events/AbstractCinematicEvent.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/events/AbstractCinematicEvent.java
@@ -306,15 +306,8 @@ public abstract class AbstractCinematicEvent implements CinematicEvent {
         InputCapsule ic = im.getCapsule(this);
         playState = ic.readEnum("playState", PlayState.class, PlayState.Stopped);
         speed = ic.readFloat("speed", 1);
-        // Originally, "initialDuration" was serialized with the name "initalDuration".
-        // The next code ensure backward compatibility.
-        initialDuration = ic.readFloat("initialDuration", -1);
-        if (initialDuration < 0) {
-            initialDuration = ic.readFloat("initalDuration", -1);
-            if (initialDuration < 0) {
-                initialDuration = 10;
-            }
-        }
+        // Maintain backward compatibility for a typo in the serialization key "initalDuration".
+        initialDuration = ic.readFloat("initialDuration", ic.readFloat("initalDuration", 10));
         loopMode = ic.readEnum("loopMode", LoopMode.class, LoopMode.DontLoop);
     }
 


### PR DESCRIPTION
As the issue #2449 stated. The serialization key, for the class's field `initialDuration`, should has been `initialDuration` but `initalDuration` was written. To fix it and, at the same time, avoid the backward incompatibility:

- In the `write` function: The key is always correctly setted as initialDuration.
- In the `read` function: First, it checks for `initialDuration` key, if not found, it uses the default value to indicate that it was not found. Then, the same it does with `initalDuration`. If none is found the class field `initialDuration` is set with the original default value, which is 10. I thought about using the value -1 as indicator of not finding the key since it shouldn't make sense negative temporal units for this field. Also added a commentary to indicate why a double check was occurring for future readers.


close #2449 