### PR TITLE
Use Java 17 for mobile native CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/setup-java@v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '11.0.26+4'
+          java-version: '17'
 
       - name: Setup the XCode version to 15.1.0 
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
@@ -148,11 +148,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
 
       - name: Check java version
         run: java -version

--- a/jme3-ios-native/jme3-ios-native.xcodeproj/project.pbxproj
+++ b/jme3-ios-native/jme3-ios-native.xcodeproj/project.pbxproj
@@ -324,8 +324,8 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				HEADER_SEARCH_PATHS = (
 					/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/JavaVM.framework/Headers/,
-					"/Library/Java/JavaVirtualMachines/jdk-11.0.6.jdk/Contents/Home/include/**",
-					"/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.26-4/arm64/Contents/Home/include/**",
+					"$(JAVA_HOME)/include",
+					"$(JAVA_HOME)/include/darwin",
 				);
 				INFOPLIST_FILE = src/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -345,8 +345,8 @@
 				SUPPORTS_MACCATALYST = YES;
 				USER_HEADER_SEARCH_PATHS = (
 					/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/JavaVM.framework/Headers/,
-					"/Library/Java/JavaVirtualMachines/jdk-11.0.6.jdk/Contents/Home/include/**",
-					"/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.26-4/arm64/Contents/Home/include/**",
+					"$(JAVA_HOME)/include",
+					"$(JAVA_HOME)/include/darwin",
 				);
 			};
 			name = Debug;
@@ -362,8 +362,8 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				HEADER_SEARCH_PATHS = (
 					/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/JavaVM.framework/Headers/,
-					"/Library/Java/JavaVirtualMachines/jdk-11.0.6.jdk/Contents/Home/include/**",
-					"/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.26-4/arm64/Contents/Home/include/**",
+					"$(JAVA_HOME)/include",
+					"$(JAVA_HOME)/include/darwin",
 				);
 				INFOPLIST_FILE = src/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -383,8 +383,8 @@
 				SUPPORTS_MACCATALYST = YES;
 				USER_HEADER_SEARCH_PATHS = (
 					/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/JavaVM.framework/Headers/,
-					"/Library/Java/JavaVirtualMachines/jdk-11.0.6.jdk/Contents/Home/include/**",
-					"/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.26-4/arm64/Contents/Home/include/**",
+					"$(JAVA_HOME)/include",
+					"$(JAVA_HOME)/include/darwin",
 				);
 			};
 			name = Release;


### PR DESCRIPTION
Needed to unblock https://github.com/jMonkeyEngine/jmonkeyengine/pull/2696

This only affects the java version for the gradle build of the native libs. We still keep sourceCompatibility=11 in android java builds.