### PR TITLE
Upgrade checkstyle and spotbugs tooling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,60 @@ on:
     types: [published]
 
 jobs:
+  Checkstyle:
+    name: Run Checkstyle
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Setup the java environment
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Validate the Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v5.0.2
+      - name: Run Checkstyle
+        run: |
+          ./gradlew checkstyleMain checkstyleTest --console=plain --stacktrace
+      - name: Upload Checkstyle Reports
+        uses: actions/upload-artifact@v7.0.0
+        if: always()
+        with:
+          name: checkstyle-report
+          retention-days: 30
+          path: |
+            **/build/reports/checkstyle/**
+
+  SpotBugs:
+    name: Run SpotBugs
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Setup the java environment
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Validate the Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v5.0.2
+      - name: Run SpotBugs
+        run: |
+          ./gradlew -PenableSpotBugs=true spotbugsMain spotbugsTest --console=plain --stacktrace
+      - name: Upload SpotBugs Reports
+        uses: actions/upload-artifact@v7.0.0
+        if: always()
+        with:
+          name: spotbugs-report
+          retention-days: 30
+          path: |
+            **/build/reports/spotbugs/**
+
   ScreenshotTests:
     name: Run Screenshot Tests
     runs-on: ubuntu-latest
@@ -234,6 +288,7 @@ jobs:
         run: |
           # Normal build plus ZIP distribution and merged javadoc
           ./gradlew -PuseCommitHashAsVersionName=true -PskipPrebuildLibraries=true \
+          -x checkstyleMain -x checkstyleTest \
           build createZipDistribution mergedJavadoc
 
           if [ "${{ matrix.deploy }}" = "true" ];

--- a/build.gradle
+++ b/build.gradle
@@ -46,13 +46,13 @@ subprojects {
         // Currently we only warn about issues and try to fix them as we go, but those aren't mission critical.
         spotbugs {
             ignoreFailures = true
-            toolVersion = '4.8.6'
+            toolVersion = libs.versions.spotbugs.get()
         }
 
         tasks.withType(com.github.spotbugs.snom.SpotBugsTask ) {
             reports {
-                html.enabled = !project.hasProperty("xml-reports")
-                xml.enabled = project.hasProperty("xml-reports")
+                html.required = !project.hasProperty("xml-reports")
+                xml.required = project.hasProperty("xml-reports")
             }
         }
     }

--- a/common.gradle
+++ b/common.gradle
@@ -208,6 +208,8 @@ tasks.withType(Sign) {
     onlyIf { gradle.rootProject.hasProperty('signingKey') }
 }
 
+def checkstyleSupported = JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)
+
 checkstyle {
     toolVersion libs.versions.checkstyle.get()
     configFile file("${gradle.rootProject.rootDir}/config/checkstyle/checkstyle.xml")
@@ -222,6 +224,7 @@ checkstyleTest {
 }
 
 tasks.withType(Checkstyle) {
+    enabled = checkstyleSupported
     reports {
         xml.required.set(false)
         html.required.set(true)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,10 @@
 
 [versions]
 
-checkstyle = "9.3"
+checkstyle = "13.3.0"
 lwjgl3 = "3.4.1"
 nifty = "1.4.3"
+spotbugs = "4.9.8"
 
 [libraries]
 
@@ -40,7 +41,7 @@ nifty-default-controls = { module = "com.github.nifty-gui:nifty-default-controls
 nifty-examples         = { module = "com.github.nifty-gui:nifty-examples",         version.ref = "nifty" }
 nifty-style-black      = { module = "com.github.nifty-gui:nifty-style-black",      version.ref = "nifty" }
 
-spotbugs-gradle-plugin = "com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.18"
+spotbugs-gradle-plugin = "com.github.spotbugs.snom:spotbugs-gradle-plugin:6.4.8"
 vecmath = "javax.vecmath:vecmath:1.5.2"
 
 [bundles]


### PR DESCRIPTION
1) Upgrade spotbugs and checkstyle
2) Run them both as part of CI, but make them non blocking. Upload the logs so we can take a look whenever.
3) Move versioning into the unified version file just like everything else.