### PR TITLE
Only display the screenshots failed message for runs that create a report (not full compile failures)

### DIFF
--- a/.github/workflows/screenshot-test-comment.yml
+++ b/.github/workflows/screenshot-test-comment.yml
@@ -49,8 +49,10 @@ jobs:
 
             // Find the ScreenshotTests job
             let screenshotTestRun = null;
+            let workflowRunId = null;
             for (const run of runs.data.workflow_runs) {
               if (run.name === 'Build jMonkeyEngine') {
+                workflowRunId = run.id;
                 const jobs = await github.rest.actions.listJobsForWorkflowRun({
                   owner,
                   repo,
@@ -75,7 +77,20 @@ jobs:
 
             // Check if the job failed
             if (screenshotTestRun.conclusion === 'failure') {
-              core.setOutput('failed', 'true');
+              // Now check if the changed images artifact exists
+              const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                owner,
+                repo,
+                run_id: workflowRunId
+              });
+
+              const hasChangedImages = artifacts.data.artifacts.some(a => a.name === 'screenshot-test-report');
+              if (hasChangedImages) {
+                core.setOutput('failed', 'true');
+              } else {
+                console.log('Job failed but no changed images were generated.');
+                core.setOutput('failed', 'false');
+              }
             } else {
               core.setOutput('failed', 'false');
             }

--- a/.github/workflows/screenshot-test-comment.yml
+++ b/.github/workflows/screenshot-test-comment.yml
@@ -75,6 +75,8 @@ jobs:
               return;
             }
 
+            core.setOutput('run_url', `https://github.com/${owner}/${repo}/actions/runs/${workflowRunId}`);
+
             // Check if the job failed
             if (screenshotTestRun.conclusion === 'failure') {
               // Now check if the changed images artifact exists
@@ -84,9 +86,10 @@ jobs:
                 run_id: workflowRunId
               });
 
-              const hasChangedImages = artifacts.data.artifacts.some(a => a.name === 'screenshot-test-report');
-              if (hasChangedImages) {
+              const artifact = artifacts.data.artifacts.find(a => a.name === 'screenshot-test-report');
+              if (artifact) {
                 core.setOutput('failed', 'true');
+                core.setOutput('artifact_url', `https://github.com/${owner}/${repo}/actions/runs/${workflowRunId}/artifacts/${artifact.id}`);
               } else {
                 console.log('Job failed but no changed images were generated.');
                 core.setOutput('failed', 'false');
@@ -113,7 +116,8 @@ jobs:
             The purpose of these tests is to ensure that changes introduced in this PR don't break visual features. They are visual unit tests.
 
             📄 **Where to find the report:**
-            - Go to the (failed run) > Summary > Artifacts > screenshot-test-report
+            - **[Direct Download: screenshot-test-report](${{ steps.check-status.outputs.artifact_url }})**
+            - Alternatively, go to the [failed run summary](${{ steps.check-status.outputs.run_url }}) > Artifacts > screenshot-test-report
             - Download the zip and open jme3-screenshot-tests/build/reports/ScreenshotDiffReport.html
 
             ⚠️ **If you didn't expect to change anything visual:** 


### PR DESCRIPTION
### Changes

- The "Screenshot tests have failed" message will only be shown if a report is generated. Not (for example) if a compile failure means all steps fail
- The "Screenshot tests have failed" message now includes a direct link to the screenshot report
- The "Screenshot tests have failed" message updates itself (so new failing run will update the links, so they always point to the most recent failing screenshot run

### Example message
<img width="879" height="700" alt="image" src="https://github.com/user-attachments/assets/fdbe8b3d-d46a-478d-8de0-c3ce02ba11d7" />
