### PR TITLE
Fix native deploy matrix on Java 25 workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -256,8 +256,6 @@ jobs:
             deploy: false
           - jdk: 21
             deploy: false
-          - jdk: 25
-            deploy: false
 
     steps:
       - name: Clone the repo


### PR DESCRIPTION
The github actions deploy step has been failing since https://github.com/jMonkeyEngine/jmonkeyengine/pull/2694

It's a pretty obvious reason why. Fix this