### PR TITLE
Deprecate FBX loader

### DIFF
--- a/jme3-core/src/main/resources/com/jme3/asset/General.cfg
+++ b/jme3-core/src/main/resources/com/jme3/asset/General.cfg
@@ -21,7 +21,6 @@ LOADER com.jme3.scene.plugins.ogre.SkeletonLoader : skeletonxml, skeleton.xml
 LOADER com.jme3.scene.plugins.ogre.MaterialLoader : material
 LOADER com.jme3.scene.plugins.ogre.SceneLoader : scene
 LOADER com.jme3.shader.plugins.GLSLLoader : vert, frag, geom, tsctrl, tseval, glsl, glsllib, comp
-LOADER com.jme3.scene.plugins.fbx.FbxLoader : fbx
 LOADER com.jme3.scene.plugins.gltf.GltfLoader : gltf
 LOADER com.jme3.scene.plugins.gltf.BinLoader : bin
 LOADER com.jme3.scene.plugins.gltf.GlbLoader : glb

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/AnimationList.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/AnimationList.java
@@ -41,7 +41,11 @@ import java.util.Objects;
  * <code>firstFrame</code> and <code>lastFrame</code> defines animation time interval.<br>
  * Use <code>layerName</code> also to define source animation layer in the case of multiple layers in the scene.<br>
  * Skeletal animations will be created if only scene contain skeletal bones</p>
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
  */
+@Deprecated
 public class AnimationList {
 
     List<AnimInverval> list = new ArrayList<>();

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/ContentTextureKey.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/ContentTextureKey.java
@@ -41,9 +41,13 @@ import com.jme3.export.OutputCapsule;
 import java.io.IOException;
 
 /**
- * Used to load textures from image binary content.
+ * Texture key used by the FBX loader for embedded textures.
  * <p>Filename is required to acquire proper type asset loader according to extension.</p>
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
  */
+@Deprecated
 public class ContentTextureKey extends TextureKey {
 
     private byte[] content;

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/ContentTextureLocator.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/ContentTextureLocator.java
@@ -43,7 +43,11 @@ import java.util.logging.Logger;
 
 /**
  * Used to locate a resource based on a {@link ContentTextureKey}.
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
  */
+@Deprecated
 public class ContentTextureLocator implements AssetLocator {
 
     private static final Logger logger = Logger.getLogger(ContentTextureLocator.class.getName());

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/FbxDeprecationWarnings.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/FbxDeprecationWarnings.java
@@ -1,0 +1,25 @@
+package com.jme3.scene.plugins.fbx;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+final class FbxDeprecationWarnings {
+
+    private static volatile boolean logged;
+
+    private FbxDeprecationWarnings() {
+    }
+
+    static void log(Logger logger) {
+        if (!logged) {
+            synchronized (FbxDeprecationWarnings.class) {
+                if (!logged) {
+                    logger.log(Level.WARNING,
+                            "FBX support is deprecated and will be removed in a future release. "
+                            + "Prefer glTF assets instead.");
+                    logged = true;
+                }
+            }
+        }
+    }
+}

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/FbxLoader.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/FbxLoader.java
@@ -70,6 +70,13 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Loads FBX scene assets.
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
+ */
+@Deprecated
 public class FbxLoader implements AssetLoader {
     
     private static final Logger logger = Logger.getLogger(FbxLoader.class.getName());
@@ -87,6 +94,7 @@ public class FbxLoader implements AssetLoader {
     
     @Override
     public Object load(AssetInfo assetInfo) throws IOException {
+        FbxDeprecationWarnings.log(logger);
         this.assetManager = assetInfo.getManager();
         AssetKey<?> assetKey = assetInfo.getKey();
         if (!(assetKey instanceof ModelKey)) {
@@ -138,7 +146,7 @@ public class FbxLoader implements AssetLoader {
     private void reset() {
         globalSettings = new FbxGlobalSettings();
     }
-    
+
     private void releaseObjects() {
         globalSettings = null;
         objectMap.clear();

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneKey.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneKey.java
@@ -34,6 +34,13 @@ package com.jme3.scene.plugins.fbx;
 import com.jme3.asset.ModelKey;
 import java.util.Objects;
 
+/**
+ * Asset key for FBX scene loading.
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
+ */
+@Deprecated
 public class SceneKey extends ModelKey {
 
     private final AnimationList animList;

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneLoader.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneLoader.java
@@ -46,7 +46,11 @@ import com.jme3.scene.plugins.fbx.objects.FbxTexture;
  * <p> Loads scene meshes, materials, textures, skeleton and skeletal animation.
  * Multiple animations can be defined with {@link AnimationList} passing into {@link SceneKey}
  * or loaded from different animation layer.</p>
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
  */
+@Deprecated
 public class SceneLoader implements AssetLoader {
 
     private static final Logger logger = Logger.getLogger(SceneLoader.class.getName());
@@ -87,6 +91,7 @@ public class SceneLoader implements AssetLoader {
 
     @Override
     public Object load(AssetInfo assetInfo) throws IOException {
+        FbxDeprecationWarnings.log(logger);
         this.currentAssetInfo = assetInfo;
         this.assetManager = assetInfo.getManager();
         AssetKey<?> assetKey = assetInfo.getKey();

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneWithAnimationLoader.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/SceneWithAnimationLoader.java
@@ -14,6 +14,13 @@ import com.jme3.asset.AssetLoadException;
 import com.jme3.asset.AssetLoader;
 import com.jme3.asset.ModelKey;
 
+/**
+ * Loads FBX scenes using an auxiliary animation-list descriptor.
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
+ */
+@Deprecated
 public class SceneWithAnimationLoader implements AssetLoader {
 
     private Pattern splitStrings = Pattern.compile("([^\"]\\S*|\".+?\")\\s*");

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/package-info.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/anim/package-info.java
@@ -30,6 +30,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * import animations from an FBX asset
+ * Import animations from an FBX asset.
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
  */
+@Deprecated
 package com.jme3.scene.plugins.fbx.anim;

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/file/package-info.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/file/package-info.java
@@ -30,6 +30,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * read and parse FBX files
+ * Read and parse FBX files.
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
  */
+@Deprecated
 package com.jme3.scene.plugins.fbx.file;

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/material/package-info.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/material/package-info.java
@@ -30,6 +30,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * import materials from an FBX asset
+ * Import materials from an FBX asset.
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
  */
+@Deprecated
 package com.jme3.scene.plugins.fbx.material;

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/mesh/package-info.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/mesh/package-info.java
@@ -30,6 +30,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * import meshes from an FBX asset
+ * Import meshes from an FBX asset.
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
  */
+@Deprecated
 package com.jme3.scene.plugins.fbx.mesh;

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/node/package-info.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/node/package-info.java
@@ -30,6 +30,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * import nodes from an FBX asset
+ * Import nodes from an FBX asset.
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
  */
+@Deprecated
 package com.jme3.scene.plugins.fbx.node;

--- a/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/package-info.java
+++ b/jme3-plugins/src/fbx/java/com/jme3/scene/plugins/fbx/package-info.java
@@ -30,6 +30,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * import models in the FBX file format
+ * Import models in the FBX file format.
+ *
+ * @deprecated FBX support is deprecated and will be removed in a future release.
+ * Prefer glTF assets instead.
  */
+@Deprecated
 package com.jme3.scene.plugins.fbx;


### PR DESCRIPTION
https://github.com/jMonkeyEngine/jmonkeyengine/issues/2666

* Also remove it from general.cfg, so that assetmanager does not know how to load fbx files by default. If users want fbx support, they should add it to assetmanager manually for their app.