### PR TITLE
Modify VS Code settings for Java configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,5 @@
     "editor.formatOnPaste": false,
     "editor.formatOnType": false,
     "editor.formatOnSave": false,
-    "editor.formatOnSaveMode": "modifications" ,
     "java.jdt.ls.vmargs": "-Xms512M -Xmx6G -XX:+UseG1GC -XX:+UseStringDeduplication  -XX:AdaptiveSizePolicyWeight=90"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,5 @@
     "editor.formatOnType": false,
     "editor.formatOnSave": false,
     "editor.formatOnSaveMode": "modifications" ,
-    "java.jdt.ls.vmargs": "-Xms1m -Xmx24G -XX:+UseG1GC -XX:+UseStringDeduplication  -XX:AdaptiveSizePolicyWeight=90"
+    "java.jdt.ls.vmargs": "-Xms512M -Xmx6G -XX:+UseG1GC -XX:+UseStringDeduplication  -XX:AdaptiveSizePolicyWeight=90"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,10 @@
 {
-    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.configuration.updateBuildConfiguration": "interactive",
     "java.compile.nullAnalysis.mode": "automatic",
-    "java.refactor.renameFromFileExplorer": "prompt",
     "java.format.settings.url": "./.vscode/JME_style.xml",
-    "editor.formatOnPaste": true,
+    "editor.formatOnPaste": false,
     "editor.formatOnType": false,
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
     "editor.formatOnSaveMode": "modifications" ,
-
-    "prettier.tabWidth": 4,
-    "prettier.printWidth": 110,
-    "prettier.enable": true,
-    "prettier.resolveGlobalModules": true
+    "java.jdt.ls.vmargs": "-Xms1m -Xmx24G -XX:+UseG1GC -XX:+UseStringDeduplication  -XX:AdaptiveSizePolicyWeight=90"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
     "editor.formatOnPaste": false,
     "editor.formatOnType": false,
     "editor.formatOnSave": false,
-    "java.jdt.ls.vmargs": "-Xms512M -Xmx6G -XX:+UseG1GC -XX:+UseStringDeduplication  -XX:AdaptiveSizePolicyWeight=90"
+    "java.jdt.ls.vmargs": "-Xms512M -Xmx2G -XX:+UseG1GC -XX:+UseStringDeduplication -XX:AdaptiveSizePolicyWeight=90"
 }


### PR DESCRIPTION
Some changes to vscode json:
- avoid unexpected formatting
- increase memory limits
- prevent build from being stuck in a loop due to updateBuildConfiguration:automatic in some versions of vscode's java ext