### PR TITLE
Fix assetLoader cfgs

### DIFF
--- a/jme3-android/src/main/resources/com/jme3/asset/Android.cfg
+++ b/jme3-android/src/main/resources/com/jme3/asset/Android.cfg
@@ -6,4 +6,3 @@ LOCATOR / com.jme3.asset.plugins.AndroidLocator
 # Android specific loaders
 LOADER com.jme3.texture.plugins.AndroidNativeImageLoader : jpg, bmp, gif, png, jpeg
 LOADER com.jme3.texture.plugins.AndroidBufferImageLoader : webp, heic, heif
-LOADER com.jme3.audio.plugins.OGGLoader : ogg

--- a/jme3-core/src/main/resources/com/jme3/asset/Desktop.cfg
+++ b/jme3-core/src/main/resources/com/jme3/asset/Desktop.cfg
@@ -2,4 +2,4 @@ INCLUDE com/jme3/asset/General.cfg
 
 # Desktop-specific loaders
 LOADER com.jme3.texture.plugins.AWTLoader : jpg, bmp, gif, png, jpeg
-LOADER com.jme3.audio.plugins.OGGLoader : ogg
+LOADER com.jme3.cursors.plugins.CursorLoader : ani, cur, ico

--- a/jme3-core/src/main/resources/com/jme3/asset/General.cfg
+++ b/jme3-core/src/main/resources/com/jme3/asset/General.cfg
@@ -3,7 +3,6 @@ LOCATOR / com.jme3.asset.plugins.ClasspathLocator
 
 # Generic loaders that should be supported on all platforms.
 LOADER com.jme3.audio.plugins.WAVLoader : wav
-LOADER com.jme3.cursors.plugins.CursorLoader : ani, cur, ico
 LOADER com.jme3.material.plugins.J3MLoader : j3m
 LOADER com.jme3.material.plugins.J3MLoader : j3md
 LOADER com.jme3.material.plugins.ShaderNodeDefinitionLoader : j3sn
@@ -24,3 +23,4 @@ LOADER com.jme3.shader.plugins.GLSLLoader : vert, frag, geom, tsctrl, tseval, gl
 LOADER com.jme3.scene.plugins.gltf.GltfLoader : gltf
 LOADER com.jme3.scene.plugins.gltf.BinLoader : bin
 LOADER com.jme3.scene.plugins.gltf.GlbLoader : glb
+LOADER com.jme3.audio.plugins.OGGLoader : ogg


### PR DESCRIPTION
OGGLoader is crossplatform, CursorLoader is not.
This PR changes the asset loader's .cfg files to reflect that.