### PR TITLE
build only on java 25 and download it if needed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -240,8 +240,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest,windows-latest,macOS-latest]
-        jdk: [17, 21, 25]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        jdk: [25]
         include:
           - os: ubuntu-latest
             osName: linux
@@ -252,22 +252,12 @@ jobs:
           - os: macOS-latest
             osName: mac
             deploy: false
-          - jdk: 17
-            deploy: false
-          - jdk: 21
-            deploy: false
 
     steps:
       - name: Clone the repo
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
-
-      - name: Setup the java environment
-        uses: actions/setup-java@v5.2.0
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.jdk }}
 
       - name: Download natives for android
         uses: actions/download-artifact@v8.0.1

--- a/common.gradle
+++ b/common.gradle
@@ -18,15 +18,17 @@ version = jmeFullVersion
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+        vendor = JvmVendorSpec.ADOPTIUM
+    }
 }
 
 tasks.withType(JavaCompile) { // compile-time options:
     //options.compilerArgs << '-Xlint:deprecation' // to show deprecation warnings
     options.compilerArgs << '-Xlint:unchecked'
     options.encoding = 'UTF-8'
-    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_10)) {
-        options.release = 8
-    }
+    options.release = 8
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,9 @@ includeBranchInVersion = false
 # specify if JavaDoc should be built
 buildJavaDoc = true
 
+# Let Gradle fetch missing JDKs for toolchains automatically.
+org.gradle.java.installations.auto-download=true
+
 # specify if SDK and Native libraries get built
 buildNativeProjects = false
 buildAndroidExamples = false

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,10 @@
 /**
  * This is the global settings file used by all subprojects.
  **/
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
 rootProject.name = 'jmonkeyengine'
 
 // Core classes, should work on all java platforms


### PR DESCRIPTION
`options.release = 8` should guarantee that we use java 8 standard lib.
With this in place it should be fine to compile only with java 25 in CI, making the build faster.

This PR also makes sure java 25 is automatically downloaded with foojay toolchains.