### PR TITLE
Include all runtime dependencies in examples dist

### DIFF
--- a/jme3-examples/build.gradle
+++ b/jme3-examples/build.gradle
@@ -69,7 +69,7 @@ jar.doFirst{
 //                'Implementation-Vendor'  : vendor,
                 'Main-Class'             : getProperty('mainClassName'),
                 // Add dependencies to manifest, remove version
-                'Class-Path'             : configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+                'Class-Path'             : configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
                                                         'lib/' +
                                                         it.name +
                                                         (it.classifier != null ? '-' + it.classifier : '') +
@@ -81,7 +81,7 @@ jar.doFirst{
 task dist (dependsOn: ['build', ':jme3-android:jar', ':jme3-android-native:jar']) {
     doLast {
         // Copy all dependencies to ../dist/lib, remove versions from jar files
-        configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+        configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from artifact.file
                 into '../dist/lib'


### PR DESCRIPTION
Fix https://hub.jmonkeyengine.org/t/jme-3-10-0-alpha4/49585/3

The dist didn't include all the dependencies