### PR TITLE
Optimize BoundingBox distanceToEdge math

### DIFF
--- a/jme3-core/src/main/java/com/jme3/bounding/BoundingBox.java
+++ b/jme3-core/src/main/java/com/jme3/bounding/BoundingBox.java
@@ -960,47 +960,36 @@ public class BoundingBox extends BoundingVolume {
 
     @Override
     public float distanceToEdge(Vector3f point) {
-        // compute coordinates of point in box coordinate system
-        TempVars vars = TempVars.get();
-        Vector3f closest = vars.vect1;
-
-        point.subtract(center, closest);
-
-        // project test point onto box
         float sqrDistance = 0.0f;
         float delta;
+        float closestX = point.x - center.x;
 
-        if (closest.x < -xExtent) {
-            delta = closest.x + xExtent;
+        if (closestX < -xExtent) {
+            delta = closestX + xExtent;
             sqrDistance += delta * delta;
-            closest.x = -xExtent;
-        } else if (closest.x > xExtent) {
-            delta = closest.x - xExtent;
+        } else if (closestX > xExtent) {
+            delta = closestX - xExtent;
             sqrDistance += delta * delta;
-            closest.x = xExtent;
         }
 
-        if (closest.y < -yExtent) {
-            delta = closest.y + yExtent;
+        float closestY = point.y - center.y;
+        if (closestY < -yExtent) {
+            delta = closestY + yExtent;
             sqrDistance += delta * delta;
-            closest.y = -yExtent;
-        } else if (closest.y > yExtent) {
-            delta = closest.y - yExtent;
+        } else if (closestY > yExtent) {
+            delta = closestY - yExtent;
             sqrDistance += delta * delta;
-            closest.y = yExtent;
         }
 
-        if (closest.z < -zExtent) {
-            delta = closest.z + zExtent;
+        float closestZ = point.z - center.z;
+        if (closestZ < -zExtent) {
+            delta = closestZ + zExtent;
             sqrDistance += delta * delta;
-            closest.z = -zExtent;
-        } else if (closest.z > zExtent) {
-            delta = closest.z - zExtent;
+        } else if (closestZ > zExtent) {
+            delta = closestZ - zExtent;
             sqrDistance += delta * delta;
-            closest.z = zExtent;
         }
 
-        vars.release();
         return FastMath.sqrt(sqrDistance);
     }
 

--- a/jme3-core/src/test/java/com/jme3/bounding/TestBoundingBox.java
+++ b/jme3-core/src/test/java/com/jme3/bounding/TestBoundingBox.java
@@ -31,6 +31,7 @@
  */
 package com.jme3.bounding;
 
+import com.jme3.math.FastMath;
 import com.jme3.math.Vector3f;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,19 @@ import org.junit.jupiter.api.Test;
  * @author Stephen Gold
  */
 public class TestBoundingBox {
+    /**
+     * Verify distanceToEdge() for points inside and outside a non-origin box.
+     */
+    @Test
+    public void testDistanceToEdge() {
+        BoundingBox box = new BoundingBox(new Vector3f(3f, -2f, 7f), 5f, 9f, 13f);
+
+        Assertions.assertEquals(0f, box.distanceToEdge(new Vector3f(4f, 0f, 9f)), 0f);
+        Assertions.assertEquals(0f, box.distanceToEdge(new Vector3f(8f, -2f, 7f)), 0f);
+        Assertions.assertEquals(3f, box.distanceToEdge(new Vector3f(11f, -2f, 7f)), 0f);
+        Assertions.assertEquals(6f, box.distanceToEdge(new Vector3f(10f, -15f, 24f)), FastMath.ZERO_TOLERANCE);
+    }
+
     /**
      * Verify that equals() behaves as expected.
      */


### PR DESCRIPTION
Avoid TempVars and temporary Vector3f mutation in the point distance path by computing axis deltas directly.

Adds direct edge-case coverage for inside, surface, single-axis outside, and multi-axis outside points.

Measured a perf improvement with a jmh microbenchmark. See BoundingVolumeBenchmark.java on my branch that adds some jmh benchmarks to jmonkey: https://github.com/8Keep/jmonkeyengine/commit/195e3769fa27ac07e032740d7514379d8123d1bf#diff-cff928ca242470aac884e59988007461fc7415aa1c16d5484a249485b38c0d46

 - before: about 23 ns/op
  - optimized inside point: 2.090 ns/op
  - optimized outside point: 2.524 ns/op

~10x speedup for this

Whether we want to try to actually land some jmh benchmarks into the repo is a good question, and if anyone would like my jme benchmarks I'm working on to be included, I can, but I figured it's best to split out the result of that into commits like this one.

Also add some tests for this function.