### PR TITLE
Target Java 11 bytecode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Note: The master branch on GitHub is a development version of the engine and is 
  - libraries for GUI, networking, physics, SFX, terrain, importing assets, etc.
  - platform-neutral core library for scene graph, animation, rendering, math, etc.
  - LWJGL v2/v3 (to access GLFW, OpenAL, OpenGL, and OpenVR) or Android or iOS
- - Java Virtual Machine (v8 or higher)
+ - Java Virtual Machine (v11 or higher)
 
 ### Documentation
 

--- a/common.gradle
+++ b/common.gradle
@@ -16,8 +16,8 @@ group = 'org.jmonkeyengine'
 version = jmeFullVersion
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
         vendor = JvmVendorSpec.ADOPTIUM
@@ -30,7 +30,7 @@ tasks.withType(JavaCompile) { // compile-time options:
     //options.compilerArgs << '-Xlint:deprecation' // to show deprecation warnings
     options.compilerArgs.addAll(['-Xlint:unchecked', '-Xlint:-options', '-Werror'])
     options.encoding = 'UTF-8'
-    options.release = 8
+    options.release = 11
 }
 
 repositories {


### PR DESCRIPTION
Android gradle plugin has support for desugaring based on which min sdk you target. Is it time to bump this up to 11, along with other modernization we are doing with jme 3.10?