### PR TITLE
Remove very old deprecated code from com.jme3.input package

### DIFF
--- a/jme3-core/src/main/java/com/jme3/input/AbstractJoystick.java
+++ b/jme3-core/src/main/java/com/jme3/input/AbstractJoystick.java
@@ -92,50 +92,6 @@ public abstract class AbstractJoystick implements Joystick {
         joyInput.stopJoyRumble(joyId);
     }
 
-    /**
-     * Assign the mapping name to receive events from the given button index
-     * on the joystick.
-     *
-     * @param mappingName The mapping to receive joystick button events.
-     * @param buttonId The button index.
-     *
-     * @see Joystick#getButtonCount()
-     * @deprecated Use JoystickButton.assignButton() instead.
-     */
-    @Override
-    @Deprecated
-    public void assignButton(String mappingName, int buttonId) {
-        if (buttonId < 0 || buttonId >= getButtonCount())
-            throw new IllegalArgumentException();
-
-        inputManager.addMapping(mappingName, new JoyButtonTrigger(joyId, buttonId));
-    }
-
-    /**
-     * Assign the mappings to receive events from the given joystick axis.
-     *
-     * @param positiveMapping The mapping to receive events when the axis is negative
-     * @param negativeMapping The mapping to receive events when the axis is positive
-     * @param axisId The axis index.
-     *
-     * @see Joystick#getAxisCount()
-     * @deprecated Use JoystickAxis.assignAxis() instead.
-     */
-    @Override
-    @Deprecated
-    public void assignAxis(String positiveMapping, String negativeMapping, int axisId) {
-
-        // For backwards compatibility
-        if (axisId == JoyInput.AXIS_POV_X) {
-            axisId = getPovXAxis().getAxisId();
-        } else if (axisId == JoyInput.AXIS_POV_Y) {
-            axisId = getPovYAxis().getAxisId();
-        }
-
-        inputManager.addMapping(positiveMapping, new JoyAxisTrigger(joyId, axisId, false));
-        inputManager.addMapping(negativeMapping, new JoyAxisTrigger(joyId, axisId, true));
-    }
-
     @Override
     public JoystickAxis getAxis(String logicalId) {
         for (JoystickAxis axis : axes) {

--- a/jme3-core/src/main/java/com/jme3/input/ChaseCamera.java
+++ b/jme3-core/src/main/java/com/jme3/input/ChaseCamera.java
@@ -100,43 +100,6 @@ public class ChaseCamera implements ActionListener, AnalogListener, Control, Jme
     protected Vector3f temp = new Vector3f(0, 0, 0);
     protected boolean invertYaxis = false;
     protected boolean invertXaxis = false;
-
-    /**
-     * @deprecated use {@link CameraInput#CHASECAM_DOWN}
-     */
-    @Deprecated
-    public static final String ChaseCamDown = "ChaseCamDown";
-    /**
-     * @deprecated use {@link CameraInput#CHASECAM_UP}
-     */
-    @Deprecated
-    public static final String ChaseCamUp = "ChaseCamUp";
-    /**
-     * @deprecated use {@link CameraInput#CHASECAM_ZOOMIN}
-     */
-    @Deprecated
-    public static final String ChaseCamZoomIn = "ChaseCamZoomIn";
-    /**
-     * @deprecated use {@link CameraInput#CHASECAM_ZOOMOUT}
-     */
-    @Deprecated
-    public static final String ChaseCamZoomOut = "ChaseCamZoomOut";
-    /**
-     * @deprecated use {@link CameraInput#CHASECAM_MOVELEFT}
-     */
-    @Deprecated
-    public static final String ChaseCamMoveLeft = "ChaseCamMoveLeft";
-    /**
-     * @deprecated use {@link CameraInput#CHASECAM_MOVERIGHT}
-     */
-    @Deprecated
-    public static final String ChaseCamMoveRight = "ChaseCamMoveRight";
-    /**
-     * @deprecated use {@link CameraInput#CHASECAM_TOGGLEROTATE}
-     */
-    @Deprecated
-    public static final String ChaseCamToggleRotate = "ChaseCamToggleRotate";
-
     protected boolean zoomin;
     protected boolean hideCursorOnRotate = true;
 

--- a/jme3-core/src/main/java/com/jme3/input/InputManager.java
+++ b/jme3-core/src/main/java/com/jme3/input/InputManager.java
@@ -774,20 +774,6 @@ public class InputManager implements RawInputListener {
             touch.setSimulateMouse(value);
         }
     }
-    /**
-     * @deprecated Use isSimulateMouse
-     * Returns state of simulation of mouse events. Used for touchscreen input only.
-     *
-     * @return true if a mouse is simulated, otherwise false
-     */
-    @Deprecated
-    public boolean getSimulateMouse() {
-        if (touch != null) {
-            return touch.isSimulateMouse();
-        } else {
-            return false;
-        }
-    }
 
     /**
      * Returns state of simulation of mouse events. Used for touchscreen input only.

--- a/jme3-core/src/main/java/com/jme3/input/Joystick.java
+++ b/jme3-core/src/main/java/com/jme3/input/Joystick.java
@@ -42,32 +42,6 @@ public interface Joystick extends HapticDevice {
 
 
     /**
-     * Assign the mapping name to receive events from the given button index
-     * on the joystick.
-     *
-     * @param mappingName The mapping to receive joystick button events.
-     * @param buttonId The button index.
-     *
-     * @see Joystick#getButtonCount()
-     * @deprecated Use JoystickButton.assignButton() instead.
-     */
-    @Deprecated
-    public void assignButton(String mappingName, int buttonId);
-
-    /**
-     * Assign the mappings to receive events from the given joystick axis.
-     *
-     * @param positiveMapping The mapping to receive events when the axis is negative
-     * @param negativeMapping The mapping to receive events when the axis is positive
-     * @param axisId The axis index.
-     *
-     * @see Joystick#getAxisCount()
-     * @deprecated Use JoystickAxis.assignAxis() instead.
-     */
-    @Deprecated
-    public void assignAxis(String positiveMapping, String negativeMapping, int axisId); 
-
-    /**
      * Returns the JoystickAxis with the specified logical ID.
      *
      * @param logicalId The id of the axis to search for as returned by JoystickAxis.getLogicalId().


### PR DESCRIPTION
This stuff has been deprecated for a very long time. I think we should remove it now.