### PR TITLE
Remove isJava8Compatible() checks from Gradle files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,9 +174,7 @@ tasks.register('mergedJavadoc', Javadoc) {
     destinationDir = file("dist/javadoc")
 
     options.encoding = 'UTF-8'
-    if (JavaVersion.current().isJava8Compatible()) {
-        options.addStringOption('Xdoclint:none', '-quiet')
-    }
+    options.addStringOption('Xdoclint:none', '-quiet')
 
     options.overview = file("javadoc-overview.html")
     source = mergedJavadocSubprojects.collect { project(it).sourceSets.main.allJava }

--- a/common.gradle
+++ b/common.gradle
@@ -79,9 +79,7 @@ javadoc {
     options.use = "true"
     options.charSet = "UTF-8"
     options.encoding = "UTF-8"
-    if (JavaVersion.current().isJava8Compatible()) {
-        options.addStringOption('Xdoclint:none', '-quiet')
-    }
+    options.addStringOption('Xdoclint:none', '-quiet')
     source = sourceSets.main.allJava // main only, exclude tests
 }
 

--- a/jme3-lwjgl3/build.gradle
+++ b/jme3-lwjgl3/build.gradle
@@ -58,10 +58,3 @@ dependencies {
     runtimeOnly(variantOf(libs.lwjgl3.sdl){ classifier('natives-macos-arm64') })
  
 }
-
-javadoc {
-    // Disable doclint for JDK8+.
-    if (JavaVersion.current().isJava8Compatible()){
-        options.addStringOption('Xdoclint:none', '-quiet')
-    }
-}

--- a/jme3-saferallocator/build.gradle
+++ b/jme3-saferallocator/build.gradle
@@ -3,10 +3,3 @@ dependencies {
 
     implementation libs.bundles.saferalloc
 }
-
-javadoc {
-    // Disable doclint for JDK8+.
-    if (JavaVersion.current().isJava8Compatible()){
-        options.addStringOption('Xdoclint:none', '-quiet')
-    }
-}

--- a/jme3-terrain/build.gradle
+++ b/jme3-terrain/build.gradle
@@ -5,10 +5,3 @@ dependencies {
     testRuntimeOnly project(':jme3-desktop')
     testRuntimeOnly project(':jme3-testdata')
 }
-
-javadoc {
-    // Disable doclint for JDK8+.
-    if (JavaVersion.current().isJava8Compatible()){
-        options.addStringOption('Xdoclint:none', '-quiet')
-    }
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,10 +29,8 @@ include 'jme3-terrain'
 // Desktop dependent java classes
 include 'jme3-desktop'
 include 'jme3-lwjgl'
-if (JavaVersion.current().isJava8Compatible()) {
-    include 'jme3-lwjgl3'
-    include 'jme3-saferallocator'
-}
+include 'jme3-lwjgl3'
+include 'jme3-saferallocator'
 
 // Other external dependencies
 include 'jme3-jbullet'


### PR DESCRIPTION
Since the project now requires JDK 8+, the JavaVersion.current().isJava8Compatible() checks are no longer needed.