### PR TITLE
Fix snapshot deploy version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -482,7 +482,6 @@ jobs:
             -PcentralUsername=${{ secrets.CENTRAL_USERNAME }} \
             -PsigningKey='${{ secrets.SIGNING_KEY }}' \
             -PsigningPassword='${{ secrets.SIGNING_PASSWORD }}' \
-            -PuseCommitHashAsVersionName=true \
             --console=plain --stacktrace
           fi
 


### PR DESCRIPTION
https://github.com/jMonkeyEngine/jmonkeyengine/commit/4e18b18a3e791f4618052ff37ecd3a1c57ce8e33 broke the deployment of the -SNAPSHOT versions.

see: https://github.com/jMonkeyEngine/jmonkeyengine/actions/runs/25610910664/job/75181417729

```
* What went wrong:
Execution failed for task ':jme3-android:publishMavenPublicationToSNAPSHOTRepository'.
> Failed to publish publication 'maven' to repository 'SNAPSHOT'
   > Could not PUT 'https://central.sonatype.com/repository/maven-snapshots/org/jmonkeyengine/jme3-android/4e18b18a3e791f4618052ff37ecd3a1c57ce8e33/jme3-android-4e18b18a3e791f4618052ff37ecd3a1c57ce8e33.jar'. Received status code 400 from server: Repository version policy: SNAPSHOT does not allow version: 4e18b18a3e791f4618052ff37ecd3a1c57ce8e33
```

So for deployment of snapshots, we want 3.10.0-SNAPSHOT usually so consumers can depend on that consistently.