### PR TITLE
Pin actions and restrict permissions for DeployJavaSnapshot job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -443,29 +443,31 @@ jobs:
     name: Deploy Java Snapshot
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref_name == 'master'
+    permissions:
+      contents: read
     steps:
 
       # We need to clone everything again for uploadToMaven.sh ...
       - name: Clone the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       # Setup jdk 21 used for building Maven-style artifacts
       - name: Setup the java environment
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Download natives for android
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: android-natives
           path: build/native
 
       - name: Download natives for iOS
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ios-natives
           path: jme3-ios-native/template/META-INF/robovm/ios/libs/jme3-ios-native.xcframework


### PR DESCRIPTION
### Motivation
- The `DeployJavaSnapshot` job ran mutable GitHub Action refs before invoking Gradle with OSSRH and signing secrets, creating a CI/CD supply-chain exposure risk.
- Reduce the risk by pinning upstream action references to immutable commit SHAs and by limiting job permissions to the minimum required.

### Description
- Added `permissions: contents: read` to the `DeployJavaSnapshot` job in `.github/workflows/main.yml` to restrict repository access.
- Replaced the mutable refs used inside the `DeployJavaSnapshot` job with full 40-character commit SHAs for `actions/checkout`, `actions/setup-java`, and both `actions/download-artifact` steps, while retaining version comments for readability.
- Preserved the existing snapshot publication behavior and the Gradle publish invocation including its secret inputs to avoid changing runtime behavior.

### Testing
- Parsed the modified workflow with Ruby using `YAML.load_file('.github/workflows/main.yml')` which succeeded.
- Executed a Python inspection that verifies all `uses: actions/...@` refs in the `DeployJavaSnapshot` block are pinned to full 40-hex SHAs, and the check passed.
- Ran `git diff --check` to ensure no whitespace or diff-check issues were introduced and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff4c3bb728832eb3b6649bf76f6b51)