### PR TITLE
Fix Android prebuilt native extraction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,6 @@ buildscript {
     }
 }
 
-import org.gradle.api.file.RelativePath
-
 // Set the license for IDEs that understand this
 ext.license = file("$rootDir/source-file-header-template.txt")
 
@@ -280,10 +278,8 @@ if (skipPrebuildLibraries != "true" && buildNativeProjects != "true") {
             }) {
                 eachFile { details ->
                     def segments = details.relativePath.segments
-                    if (segments.length <= 1) {
-                        details.exclude()
-                    } else {
-                        details.relativePath = new RelativePath(details.isDirectory(), segments[1..-1] as String[])
+                    if (segments.length > 1) {
+                        details.path = segments[1..-1].join('/')
                     }
                 }
                 includeEmptyDirs = false


### PR DESCRIPTION
I messed up PR #2700 which caused the android examples to fail finding the native openal lib.

The native snapshot zip stores files under an `android/` top-level directory. The extraction task tried to strip that first path segment with `RelativePath`, but the task produced only empty ABI directories. As a result, Android example APKs had no packaged `.so` files and crashed at runtime when audio initialized.

Before the fix, `:jme3-android-examples:installAndroidExamples` built an APK with `mergeDebugNativeLibs NO-SOURCE`, and launching `jme3test.helloworld.HelloLoop` on an emulator failed with `UnsatisfiedLinkError: library "libopenalsoftjme.so" not found`.


before:
<img width="2424" height="1080" alt="before-native-missing" src="https://github.com/user-attachments/assets/8c17e2b8-701f-493b-a32e-22ee7f525b64" />

after:
<img width="2424" height="1080" alt="after-native-packaged" src="https://github.com/user-attachments/assets/64b472f1-2e06-4127-a388-156cb4412721" />
