### PR TITLE
Fix/lwjglx crash angle (canvas | AWT)

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/system/awt/AwtPanelsContext.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/awt/AwtPanelsContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023 jMonkeyEngine
+ * Copyright (c) 2009-2026 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -239,7 +239,7 @@ public class AwtPanelsContext implements JmeContext {
     @Override
     public void setSettings(AppSettings settings) {
         this.settings.copyFrom(settings);
-        this.settings.setRenderer(AppSettings.LWJGL_OPENGL2);
+        this.settings.setRenderer(AppSettings.LWJGL_OPENGL32);
         if (actualContext != null) {
             actualContext.setSettings(settings);
         }

--- a/jme3-examples/src/main/java/jme3test/awt/TestCanvas.java
+++ b/jme3-examples/src/main/java/jme3test/awt/TestCanvas.java
@@ -210,6 +210,7 @@ public class TestCanvas {
         // Note: Only for Linux and Wayland platforms, forces you to
         // use XWayland (x11) with awt.
         settings.setX11PlatformPreferred(true);
+        settings.setRenderer(AppSettings.LWJGL_OPENGL32);
         settings.setWidth(640);
         settings.setHeight(480);
 

--- a/jme3-examples/src/main/java/jme3test/awt/TestCanvas.java
+++ b/jme3-examples/src/main/java/jme3test/awt/TestCanvas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 jMonkeyEngine
+ * Copyright (c) 2009-2026 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jme3-examples/src/main/java/jme3test/awt/TestSafeCanvas.java
+++ b/jme3-examples/src/main/java/jme3test/awt/TestSafeCanvas.java
@@ -15,6 +15,8 @@ public class TestSafeCanvas extends SimpleApplication {
 
     public static void main(String[] args) throws InterruptedException{
         AppSettings settings = new AppSettings(true);
+        settings.setX11PlatformPreferred(true);
+        settings.setRenderer(AppSettings.LWJGL_OPENGL32);
         settings.setWidth(640);
         settings.setHeight(480);
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
@@ -77,6 +77,7 @@ import org.lwjgl.system.Configuration;
 
 import static org.lwjgl.system.MemoryUtil.*;
 import static com.jme3.system.lwjglx.LwjglxDefaultGLPlatform.*;
+import org.lwjgl.system.Platform;
 
 /**
  * Class <code>LwjglCanvas</code> that integrates <a href="https://github.com/LWJGLX/lwjgl3-awt">LWJGLX</a>
@@ -116,47 +117,53 @@ public class LwjglCanvas extends LwjglWindow implements JmeCanvasContext, Runnab
 
     /*
         Register the different versions.
+
+        The 'COMPATIBILITY' profile is used for operational reasons on different
+        platforms.
+    
+        see the discussion:
+        https://github.com/jMonkeyEngine/jmonkeyengine/pull/2153#issuecomment-1860913192
     */
     static {
         RENDER_CONFIGS.put(AppSettings.LWJGL_OPENGL32, (data) -> {
             data.majorVersion = 3;
             data.minorVersion = 2;
-            data.profile = GLData.Profile.CORE;
+            data.profile = GLData.Profile.COMPATIBILITY;
         });
         RENDER_CONFIGS.put(AppSettings.LWJGL_OPENGL33, (data) -> {
             data.majorVersion = 3;
             data.minorVersion = 3;
-            data.profile = GLData.Profile.CORE;
+            data.profile = GLData.Profile.COMPATIBILITY;
         });
         RENDER_CONFIGS.put(AppSettings.LWJGL_OPENGL40, (data) -> {
             data.majorVersion = 4;
             data.minorVersion = 0;
-            data.profile = GLData.Profile.CORE;
+            data.profile = GLData.Profile.COMPATIBILITY;
         });
         RENDER_CONFIGS.put(AppSettings.LWJGL_OPENGL41, (data) -> {
             data.majorVersion = 4;
             data.minorVersion = 1;
-            data.profile = GLData.Profile.CORE;
+            data.profile = GLData.Profile.COMPATIBILITY;
         });
         RENDER_CONFIGS.put(AppSettings.LWJGL_OPENGL42, (data) -> {
             data.majorVersion = 4;
             data.minorVersion = 2;
-            data.profile = GLData.Profile.CORE;
+            data.profile = GLData.Profile.COMPATIBILITY;
         });
         RENDER_CONFIGS.put(AppSettings.LWJGL_OPENGL43, (data) -> {
             data.majorVersion = 4;
             data.minorVersion = 3;
-            data.profile = GLData.Profile.CORE;
+            data.profile = GLData.Profile.COMPATIBILITY;
         });
         RENDER_CONFIGS.put(AppSettings.LWJGL_OPENGL44, (data) -> {
             data.majorVersion = 4;
             data.minorVersion = 4;
-            data.profile = GLData.Profile.CORE;
+            data.profile = GLData.Profile.COMPATIBILITY;
         });
         RENDER_CONFIGS.put(AppSettings.LWJGL_OPENGL45, (data) -> {
             data.majorVersion = 4;
             data.minorVersion = 5;
-            data.profile = GLData.Profile.CORE;
+            data.profile = GLData.Profile.COMPATIBILITY;
         });
     }
 
@@ -453,6 +460,47 @@ public class LwjglCanvas extends LwjglWindow implements JmeCanvasContext, Runnab
     }
 
     /**
+     * Returns the GL context handler.
+     *
+     * @return String
+     */
+    @Override
+    protected String getCurrentVideoDriver() {
+        StringBuilder buffer = new StringBuilder();
+        buffer.append("AWT|Swing (LWJGLX) GLv")
+                .append(canvas.data.majorVersion)
+                .append('.')
+                .append(canvas.data.minorVersion);
+
+        String driver = isWayland() ? "(XWayland|X11) GLX" : "X11 GLX";
+
+        Platform platform = Platform.get();
+        if (null == platform) {
+            buffer.append(" Unknown NULL");
+        } else {
+            switch (platform) {
+                case FREEBSD:
+                    buffer.append(" FreeBSD ")
+                          .append(driver);
+                    break;
+                case LINUX:
+                    buffer.append(" Linux ")
+                           .append(driver);
+                    break;
+                case MACOSX:
+                    buffer.append(" MacOSX Cocoa NSGL");
+                    break;
+                case WINDOWS:
+                    buffer.append(" Win32 WGL");
+                    break;
+                default:
+                    break;
+            }
+        }
+        return String.valueOf(buffer);
+    }
+
+    /**
      * Check if the canvas is displayed, that is, if it has a parent that has set it up.
      * <p>
      * It is very important that this verification be done so that LWJGL3-AWT works correctly.
@@ -688,7 +736,7 @@ public class LwjglCanvas extends LwjglWindow implements JmeCanvasContext, Runnab
         }
 
         glData.alphaSize = settings.getAlphaBits();
-        glData.sRGB = settings.isGammaCorrection() && !useAuxFramebufferSrgb();
+        glData.sRGB = settings.isGammaCorrection(); // Not compatible with very old devices
 
         glData.depthSize = settings.getDepthBits();
         glData.stencilSize = settings.getStencilBits();
@@ -697,7 +745,11 @@ public class LwjglCanvas extends LwjglWindow implements JmeCanvasContext, Runnab
 
         glData.debug = settings.isGraphicsDebug();
         glData.api = GLData.API.GL;
-        glData.forwardCompatible = true;
+
+        /* This is done to prevent the context from breaking in Windows,
+         * since the 'CORE' profile causes rendering failures (black screen).
+         */
+        glData.forwardCompatible = false;
 
         allowSwapBuffers = settings.isSwapBuffers();
 
@@ -766,7 +818,7 @@ public class LwjglCanvas extends LwjglWindow implements JmeCanvasContext, Runnab
     /** (non-Javadoc) */
     @Override protected void showWindow() { }
     /** (non-Javadoc) */
-    @Override  protected void setWindowIcon(final AppSettings settings) { }
+    @Override protected void setWindowIcon(final AppSettings settings) { }
     /**(non-Javadoc) */
     @Override public Vector2f getWindowContentScale(Vector2f store) {
         return store == null ? new Vector2f() : store;
@@ -1004,5 +1056,27 @@ public class LwjglCanvas extends LwjglWindow implements JmeCanvasContext, Runnab
     @Override
     public Canvas getCanvas() {
         return canvas;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @param settings AppSettings
+     */
+    @Override
+    public void setSettings(AppSettings settings) {
+        if (settings.getRenderer().equals(AppSettings.ANGLE_GLES3)) {
+            StringBuilder buffer = new StringBuilder();
+            buffer.append("LWJGX is not compatible with ANGLE/SDL or GLES, as it only supports the following:")
+                    .append('\n').append(" * WGL | Windows")
+                    .append('\n').append(" * GLX | Linux (X11/XWayland)")
+                    .append('\n').append(" * CGL | MacOsX")
+                    .append('\n').append(" * Therefore, version ")
+                    .append(AppSettings.LWJGL_OPENGL32)
+                    .append("(3.2) will be used for the GL context.");
+            
+            LOGGER.log(Level.WARNING, String.valueOf(buffer));
+            settings.setRenderer(AppSettings.LWJGL_OPENGL32);
+        }
+        super.setSettings(settings);
     }
 }

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
@@ -74,10 +74,10 @@ import org.lwjgl.awthacks.NonClearGraphics2D;
 import org.lwjgl.opengl.awt.GLData;
 
 import org.lwjgl.system.Configuration;
+import org.lwjgl.system.Platform;
 
 import static org.lwjgl.system.MemoryUtil.*;
 import static com.jme3.system.lwjglx.LwjglxDefaultGLPlatform.*;
-import org.lwjgl.system.Platform;
 
 /**
  * Class <code>LwjglCanvas</code> that integrates <a href="https://github.com/LWJGLX/lwjgl3-awt">LWJGLX</a>

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
@@ -1067,7 +1067,7 @@ public class LwjglCanvas extends LwjglWindow implements JmeCanvasContext, Runnab
     public void setSettings(AppSettings settings) {
         if (settings.getRenderer().equals(AppSettings.ANGLE_GLES3)) {
             StringBuilder buffer = new StringBuilder();
-            buffer.append("LWJGX is not compatible with ANGLE/SDL or GLES, as it only supports the following:")
+            buffer.append("LWJGLX is not compatible with ANGLE/SDL or GLES, as it only supports the following:")
                     .append('\n').append(" * WGL | Windows")
                     .append('\n').append(" * GLX | Linux (X11/XWayland)")
                     .append('\n').append(" * CGL | MacOsX")

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
@@ -81,7 +81,10 @@ import static com.jme3.system.lwjglx.LwjglxDefaultGLPlatform.*;
 
 /**
  * Class <code>LwjglCanvas</code> that integrates <a href="https://github.com/LWJGLX/lwjgl3-awt">LWJGLX</a>
- * which allows using AWT-Swing components.
+ * which allows using AWT-Swing components, make sure you use an OpenGL renderer:
+ * <pre><code>
+ * settings.setRenderer(AppSettings.LWJGL_OPENGL32);
+ * </code></pre>
  *
  * <p>
  * If <b>LwjglCanvas</b> throws an exception due to configuration problems, we can debug as follows:
@@ -101,8 +104,7 @@ import static com.jme3.system.lwjglx.LwjglxDefaultGLPlatform.*;
  * <pre><code>
  * ....
  *  AppSettings settings = new AppSettings(true);
- *  settings.setGammaCorrection(true);
- *  settings.setRenderer(AppSettings.LWJGL_OPENGL32);
+ *  settings.setGammaCorrection(false);
  * ...
  * </code></pre>
  *

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
@@ -101,7 +101,8 @@ import org.lwjgl.system.Platform;
  * <pre><code>
  * ....
  *  AppSettings settings = new AppSettings(true);
- *  settings.setGammaCorrection(false);
+ *  settings.setGammaCorrection(true);
+ *  settings.setRenderer(AppSettings.LWJGL_OPENGL32);
  * ...
  * </code></pre>
  *

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023 jMonkeyEngine
+ * Copyright (c) 2009-2026 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,6 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package com.jme3.system.lwjgl;
 
 import com.jme3.input.JoyInput;
@@ -55,28 +54,27 @@ import com.jme3.util.LWJGLBufferAllocator;
 import com.jme3.util.LWJGLBufferAllocator.ConcurrentLWJGLBufferAllocator;
 import com.jme3.util.LWJGLSaferAllocMemoryAllocator;
 
-import static com.jme3.util.LWJGLBufferAllocator.PROPERTY_CONCURRENT_BUFFER_ALLOCATOR;
 import java.nio.IntBuffer;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.lwjgl.Version;
 import org.lwjgl.opengl.ARBDebugOutput;
 import org.lwjgl.opengl.ARBFramebufferObject;
 import org.lwjgl.opengl.EXTFramebufferMultisample;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL30;
-
-import static org.lwjgl.opengl.GL.createCapabilities;
-import static org.lwjgl.opengl.GL11.glGetInteger;
 import org.lwjgl.opengl.GLCapabilities;
 import org.lwjgl.opengles.GLES;
 import org.lwjgl.opengles.GLES30;
 import org.lwjgl.opengles.GLESCapabilities;
-import static org.lwjgl.sdl.SDLVideo.*;
 import org.lwjgl.system.Configuration;
-import org.lwjgl.system.MemoryStack;
+
+import static org.lwjgl.opengl.GL.createCapabilities;
+import static org.lwjgl.opengl.GL11.glGetInteger;
+import static com.jme3.util.LWJGLBufferAllocator.PROPERTY_CONCURRENT_BUFFER_ALLOCATOR;
 
 /**
  * A LWJGL implementation of a graphics context.
@@ -149,11 +147,13 @@ public abstract class LwjglContext implements JmeContext {
 
     protected void printContextInitInfo() {
         if (logger.isLoggable(Level.INFO)) {
-            logger.log(Level.INFO, "LWJGL {0} context running on thread {1}\n * Video backend: SDL {2}",
-                    APIUtil.toArray(Version.getVersion(), Thread.currentThread().getName(), SDL_GetCurrentVideoDriver()));
+            logger.log(Level.INFO, "LWJGL {0} context running on thread {1}\n * Video backend: {2}",
+                    APIUtil.toArray(Version.getVersion(), Thread.currentThread().getName(), getCurrentVideoDriver()));
         }
     }
 
+    protected abstract String getCurrentVideoDriver();
+    
     protected int determineMaxSamples() {
         final GLCapabilities capabilities = org.lwjgl.opengl.GL.getCapabilities();
         if (capabilities.GL_ARB_framebuffer_object) {

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -31,20 +31,6 @@
  */
 package com.jme3.system.lwjgl;
 
-import static org.lwjgl.egl.EXTPlatformWayland.EGL_PLATFORM_WAYLAND_EXT;
-import static org.lwjgl.egl.EXTPlatformX11.EGL_PLATFORM_X11_EXT;
-import static org.lwjgl.sdl.SDLError.*;
-import static org.lwjgl.sdl.SDLEvents.*;
-import static org.lwjgl.sdl.SDLHints.*;
-import static org.lwjgl.sdl.SDLInit.*;
-import static org.lwjgl.sdl.SDLKeyboard.*;
-import static org.lwjgl.sdl.SDLMouse.*;
-import static org.lwjgl.sdl.SDLPixels.*;
-import static org.lwjgl.sdl.SDLSurface.*;
-import static org.lwjgl.sdl.SDLStdinc.SDL_setenv_unsafe;
-import static org.lwjgl.sdl.SDLVideo.*;
-import static org.lwjgl.system.MemoryUtil.NULL;
-
 import com.jme3.app.Application;
 import com.jme3.asset.AssetManager;
 import com.jme3.input.JoyInput;
@@ -75,6 +61,8 @@ import com.jme3.texture.image.ColorSpace;
 import com.jme3.ui.Picture;
 import com.jme3.util.BufferUtils;
 import com.jme3.util.SafeArrayList;
+import com.jme3.renderer.opengl.GLRenderer;
+
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.nio.ByteBuffer;
@@ -85,6 +73,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.lwjgl.Version;
 import org.lwjgl.sdl.SDL_DisplayMode;
 import org.lwjgl.sdl.SDL_Event;
@@ -92,7 +81,18 @@ import org.lwjgl.sdl.SDL_Surface;
 import org.lwjgl.sdl.SDLStdinc;
 import org.lwjgl.system.Configuration;
 import org.lwjgl.system.MemoryStack;
-import com.jme3.renderer.opengl.GLRenderer;
+
+import static org.lwjgl.egl.EXTPlatformWayland.EGL_PLATFORM_WAYLAND_EXT;
+import static org.lwjgl.egl.EXTPlatformX11.EGL_PLATFORM_X11_EXT;
+import static org.lwjgl.sdl.SDLError.*;
+import static org.lwjgl.sdl.SDLEvents.*;
+import static org.lwjgl.sdl.SDLHints.*;
+import static org.lwjgl.sdl.SDLInit.*;
+import static org.lwjgl.sdl.SDLPixels.*;
+import static org.lwjgl.sdl.SDLSurface.*;
+import static org.lwjgl.sdl.SDLStdinc.SDL_setenv_unsafe;
+import static org.lwjgl.sdl.SDLVideo.*;
+import static org.lwjgl.system.MemoryUtil.NULL;
 
 /**
  * SDL3-backed window/context implementation for LWJGL 3.4+.
@@ -241,6 +241,11 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             throw new IllegalStateException("Unable to disable NVIDIA OpenGL threaded optimizations: "
                     + SDL_GetError());
         }
+    }
+
+    @Override
+    protected String getCurrentVideoDriver() {
+        return "SDL " + SDL_GetCurrentVideoDriver();
     }
 
     @Override


### PR DESCRIPTION
This PR reverts some changes that were introduced in the integration of the new SLD backend (see [here](https://github.com/jMonkeyEngine/jmonkeyengine/pull/2585)), which resolves the broken canvas issue on Windows (and thus resolves this [problem](https://github.com/jMonkeyEngine/jmonkeyengine/issues/2766) (#2766)).

It is important to note that the AWT backend works exclusively with OpenGL and is not compatible with GLES.