### PR TITLE
Workaround vscode issue with jme3-examples

### DIFF
--- a/jme3-examples/build.gradle
+++ b/jme3-examples/build.gradle
@@ -368,7 +368,7 @@ dependencies {
     implementation project(':jme3-plugins-json-gson')
     implementation project(':jme3-terrain')
     implementation project(':jme3-awt-dialogs')
-    runtimeOnly project(':jme3-testdata')
+    implementation project(':jme3-testdata')
     runtimeOnly libs.nifty.examples // for the "all/intro.xml" example GUI
 }
 


### PR DESCRIPTION
vscode java test runner does not like that jme3-examples has a runtimeOnly dependency to testdata and reports build errors.

This PR switches it to `implementation`. This change should not matter for us, since this module contains only examples anyway.
