### PR TITLE
Improve Lightlist performance

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@
 
 checkstyle = "13.3.0"
 jacoco = "0.8.12"
+jmh = "1.37"
 lwjgl3 = "3.4.1"
 angle = "2026-05-09"
 libjglios = "0.4"
@@ -28,6 +29,8 @@ jbullet = "com.github.stephengold:jbullet:1.0.3"
 jinput = "net.java.jinput:jinput:2.0.9"
 jna = "net.java.dev.jna:jna:5.18.1"
 jnaerator-runtime = "com.nativelibs4java:jnaerator-runtime:0.12"
+jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
+jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }
 junit-bom = "org.junit:junit-bom:5.13.4"
 junit4 = "junit:junit:4.13.2"
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@
 
 checkstyle = "13.3.0"
 jacoco = "0.8.12"
+jmh = "1.37"
 lwjgl3 = "3.4.3"
 angle = "2026-05-09"
 libjglios = "0.9"
@@ -42,6 +43,8 @@ jbullet = "com.github.stephengold:jbullet:1.0.3"
 jinput = "net.java.jinput:jinput:2.0.9"
 jna = "net.java.dev.jna:jna:5.18.1"
 jnaerator-runtime = "com.nativelibs4java:jnaerator-runtime:0.12"
+jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
+jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }
 junit-bom = "org.junit:junit-bom:5.13.4"
 junit4 = "junit:junit:4.13.2"
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }

--- a/jme3-benchmark/build.gradle
+++ b/jme3-benchmark/build.gradle
@@ -1,0 +1,20 @@
+dependencies {
+    implementation project(':jme3-core')
+    implementation libs.jmh.core
+    annotationProcessor libs.jmh.generator.annprocess
+}
+
+tasks.register('jmh', JavaExec) {
+    dependsOn tasks.named('classes')
+    description = 'Run jME JMH benchmarks. Pass JMH options with -PjmhArgs="...".'
+    group = 'verification'
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'org.openjdk.jmh.Main'
+
+    def rawArgs = providers.gradleProperty('jmhArgs').orElse('').map { it.trim() }
+    doFirst {
+        if (rawArgs.get()) {
+            args rawArgs.get().split(/\s+/)
+        }
+    }
+}

--- a/jme3-benchmark/src/main/java/com/jme3/bounding/BoundingVolumeBenchmark.java
+++ b/jme3-benchmark/src/main/java/com/jme3/bounding/BoundingVolumeBenchmark.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2009-2026 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.bounding;
+
+import com.jme3.math.Vector3f;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(2)
+@State(Scope.Thread)
+public class BoundingVolumeBenchmark {
+
+    @Param({"inside", "outside"})
+    public String pointLocation;
+
+    private BoundingBox box;
+    private BoundingSphere sphere;
+    private Vector3f point;
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+        box = new BoundingBox(new Vector3f(3f, -2f, 7f), 5f, 9f, 13f);
+        sphere = new BoundingSphere(11f, new Vector3f(3f, -2f, 7f));
+        if ("inside".equals(pointLocation)) {
+            point = new Vector3f(4f, 0f, 9f);
+        } else {
+            point = new Vector3f(39f, -31f, 45f);
+        }
+    }
+
+    @Benchmark
+    public void boxDistanceToEdge(Blackhole blackhole) {
+        blackhole.consume(box.distanceToEdge(point));
+    }
+
+    @Benchmark
+    public void boxIntersectsPoint(Blackhole blackhole) {
+        blackhole.consume(box.intersects(point));
+    }
+
+    @Benchmark
+    public void sphereDistanceToEdge(Blackhole blackhole) {
+        blackhole.consume(sphere.distanceToEdge(point));
+    }
+
+    @Benchmark
+    public void sphereIntersectsPoint(Blackhole blackhole) {
+        blackhole.consume(sphere.intersects(point));
+    }
+}

--- a/jme3-benchmark/src/main/java/com/jme3/light/LightListMutationBenchmark.java
+++ b/jme3-benchmark/src/main/java/com/jme3/light/LightListMutationBenchmark.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2009-2026 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.light;
+
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Mesh;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(2)
+@State(Scope.Thread)
+public class LightListMutationBenchmark {
+
+    @Param({"8", "64", "256"})
+    public int lightCount;
+
+    private Geometry owner;
+    private Light[] lights;
+    private LightList list;
+    private LightList local;
+    private LightList parent;
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+        owner = new Geometry("owner", new Mesh());
+        lights = new Light[lightCount * 2];
+        for (int i = 0; i < lights.length; i++) {
+            lights[i] = new PointLight(new Vector3f(i, i * 0.5f, -i));
+        }
+        list = new LightList(owner);
+        local = new LightList(owner);
+        parent = new LightList(owner);
+        for (int i = 0; i < lightCount; i++) {
+            local.add(lights[i]);
+            parent.add(lights[lightCount + i]);
+        }
+    }
+
+    @Setup(Level.Invocation)
+    public void setupInvocation() {
+        list.clear();
+        for (int i = 0; i < lightCount; i++) {
+            list.add(lights[i]);
+        }
+    }
+
+    @Benchmark
+    public void removeFromFront(Blackhole blackhole) {
+        list.remove(0);
+        blackhole.consume(list.size());
+    }
+
+    @Benchmark
+    public void removeFromMiddle(Blackhole blackhole) {
+        list.remove(lightCount >>> 1);
+        blackhole.consume(list.size());
+    }
+
+    @Benchmark
+    public void removeFromEnd(Blackhole blackhole) {
+        list.remove(lightCount - 1);
+        blackhole.consume(list.size());
+    }
+
+    @Benchmark
+    public void updateFromLocalAndParent(Blackhole blackhole) {
+        list.update(local, parent);
+        blackhole.consume(list.size());
+    }
+}

--- a/jme3-benchmark/src/main/java/com/jme3/light/LightListMutationBenchmark.java
+++ b/jme3-benchmark/src/main/java/com/jme3/light/LightListMutationBenchmark.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2009-2026 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.light;
+
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Mesh;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(2)
+@State(Scope.Thread)
+public class LightListMutationBenchmark {
+
+    private static final Predicate<Light> NON_GLOBAL_LIGHT = light -> !light.isGlobal();
+
+    @Param({"8", "64", "256"})
+    public int lightCount;
+
+    private Geometry owner;
+    private Light[] lights;
+    private LightList list;
+    private LightList local;
+    private LightList parent;
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+        owner = new Geometry("owner", new Mesh());
+        lights = new Light[lightCount * 2];
+        for (int i = 0; i < lights.length; i++) {
+            lights[i] = i % 4 == 0
+                    ? new DirectionalLight(new Vector3f(i, i * 0.5f, -i))
+                    : new PointLight(new Vector3f(i, i * 0.5f, -i));
+        }
+        list = new LightList(owner);
+        local = new LightList(owner);
+        parent = new LightList(owner);
+        for (int i = 0; i < lightCount; i++) {
+            local.add(lights[i]);
+            parent.add(lights[lightCount + i]);
+        }
+    }
+
+    @Setup(Level.Invocation)
+    public void setupInvocation() {
+        list.clear();
+        for (int i = 0; i < lightCount; i++) {
+            list.add(lights[i]);
+        }
+    }
+
+    @Benchmark
+    public void removeFromFront(Blackhole blackhole) {
+        list.remove(0);
+        blackhole.consume(list.size());
+    }
+
+    @Benchmark
+    public void removeFromMiddle(Blackhole blackhole) {
+        list.remove(lightCount >>> 1);
+        blackhole.consume(list.size());
+    }
+
+    @Benchmark
+    public void removeFromEnd(Blackhole blackhole) {
+        list.remove(lightCount - 1);
+        blackhole.consume(list.size());
+    }
+
+    @Benchmark
+    public void updateFromLocalAndParent(Blackhole blackhole) {
+        list.update(local, parent);
+        blackhole.consume(list.size());
+    }
+
+    /**
+     * Matches {@code Spatial.updateWorldLightList()}, which filters global
+     * lights from the local list before appending the parent world list.
+     */
+    @Benchmark
+    public void updateWithGlobalLightFilter(Blackhole blackhole) {
+        list.update(local, parent, NON_GLOBAL_LIGHT);
+        blackhole.consume(list.size());
+    }
+}

--- a/jme3-benchmark/src/main/java/com/jme3/light/LightListSortBenchmark.java
+++ b/jme3-benchmark/src/main/java/com/jme3/light/LightListSortBenchmark.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2009-2026 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.light;
+
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Mesh;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(2)
+@State(Scope.Thread)
+public class LightListSortBenchmark {
+
+    @Param({"8", "64", "256"})
+    public int lightCount;
+
+    @Param({"1", "8", "1024"})
+    public int retainedCapacityMultiplier;
+
+    private Geometry owner;
+    private Light[] lights;
+    private LightList list;
+    private int invocation;
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+        owner = new Geometry("owner", new Mesh());
+        owner.setLocalTranslation(3f, -7f, 11f);
+        owner.updateGeometricState();
+
+        lights = new Light[lightCount];
+        Random random = new Random(0x51A7E5L + lightCount);
+        for (int i = 0; i < lightCount; i++) {
+            switch (i & 3) {
+                case 0:
+                    lights[i] = new AmbientLight();
+                    break;
+                case 1:
+                    lights[i] = new DirectionalLight(new Vector3f(1f, -1f, 0.25f).normalizeLocal());
+                    break;
+                default:
+                    lights[i] = new PointLight(new Vector3f(
+                            random.nextFloat() * 200f - 100f,
+                            random.nextFloat() * 200f - 100f,
+                            random.nextFloat() * 200f - 100f));
+                    break;
+            }
+        }
+
+        list = new LightList(owner);
+        int retainedCapacity = Math.max(lightCount, lightCount * retainedCapacityMultiplier);
+        for (int i = 0; i < retainedCapacity; i++) {
+            list.add(lights[i % lightCount]);
+        }
+        list.clear();
+    }
+
+    @Setup(Level.Invocation)
+    public void setupInvocation() {
+        list.clear();
+        int offset = (invocation++ & Integer.MAX_VALUE) % lightCount;
+        for (int i = 0; i < lightCount; i++) {
+            list.add(lights[(i + offset) % lightCount]);
+        }
+    }
+
+    @Benchmark
+    public void sortTransformChanged(Blackhole blackhole) {
+        list.sort(true);
+        blackhole.consume(list.get(lightCount - 1));
+    }
+}

--- a/jme3-benchmark/src/main/java/com/jme3/renderer/queue/GeometryListBenchmark.java
+++ b/jme3-benchmark/src/main/java/com/jme3/renderer/queue/GeometryListBenchmark.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2009-2026 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.renderer.queue;
+
+import com.jme3.scene.Geometry;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(2)
+@State(Scope.Thread)
+public class GeometryListBenchmark {
+
+    @Param({"8", "64", "256", "1024"})
+    public int geometryCount;
+
+    private Geometry[] geometries;
+    private GeometryList list;
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+        geometries = new Geometry[geometryCount];
+        for (int i = 0; i < geometryCount; i++) {
+            geometries[i] = new Geometry("geom-" + i);
+        }
+        list = new GeometryList(new NullComparator());
+    }
+
+    @Setup(Level.Invocation)
+    public void setupInvocation() {
+        list.clear();
+        for (Geometry geometry : geometries) {
+            list.add(geometry);
+        }
+    }
+
+    @Benchmark
+    public void clear(Blackhole blackhole) {
+        list.clear();
+        blackhole.consume(list.size());
+    }
+}

--- a/jme3-core/src/main/java/com/jme3/light/LightList.java
+++ b/jme3-core/src/main/java/com/jme3/light/LightList.java
@@ -49,8 +49,8 @@ import java.util.function.Predicate;
 public final class LightList implements Iterable<Light>, Savable, Cloneable, JmeCloneable {
 
     private Light[] list, tlist;
-    private float[] distToOwner;
     private int listSize;
+    private int tlistSize;
     private Spatial owner;
 
     private static final int DEFAULT_SIZE = 1;
@@ -84,8 +84,6 @@ public final class LightList implements Iterable<Light>, Savable, Cloneable, Jme
     public LightList(Spatial owner) {
         listSize = 0;
         list = new Light[DEFAULT_SIZE];
-        distToOwner = new float[DEFAULT_SIZE];
-        Arrays.fill(distToOwner, Float.NEGATIVE_INFINITY);
         this.owner = owner;
     }
 
@@ -100,11 +98,8 @@ public final class LightList implements Iterable<Light>, Savable, Cloneable, Jme
 
     private void doubleSize() {
         Light[] temp = new Light[list.length * 2];
-        float[] temp2 = new float[list.length * 2];
         System.arraycopy(list, 0, temp, 0, list.length);
-        System.arraycopy(distToOwner, 0, temp2, 0, list.length);
         list = temp;
-        distToOwner = temp2;
     }
 
     /**
@@ -117,8 +112,7 @@ public final class LightList implements Iterable<Light>, Savable, Cloneable, Jme
         if (listSize == list.length) {
             doubleSize();
         }
-        list[listSize] = l;
-        distToOwner[listSize++] = Float.NEGATIVE_INFINITY;
+        list[listSize++] = l;
     }
 
     /**
@@ -136,8 +130,9 @@ public final class LightList implements Iterable<Light>, Savable, Cloneable, Jme
             return;
         }
 
-        for (int i = index; i < listSize; i++) {
-            list[i] = list[i+1];
+        int copyLength = listSize - index;
+        if (copyLength > 0) {
+            System.arraycopy(list, index + 1, list, index, copyLength);
         }
         list[listSize] = null;
     }
@@ -182,11 +177,11 @@ public final class LightList implements Iterable<Light>, Savable, Cloneable, Jme
         if (listSize == 0)
             return;
 
-        for (int i = 0; i < listSize; i++)
-            list[i] = null;
+        Arrays.fill(list, 0, listSize, null);
 
         if (tlist != null)
-            Arrays.fill(tlist, null);
+            Arrays.fill(tlist, 0, tlistSize, null);
+        tlistSize = 0;
 
         listSize = 0;
     }
@@ -205,11 +200,15 @@ public final class LightList implements Iterable<Light>, Savable, Cloneable, Jme
     public void sort(boolean transformChanged) {
         if (listSize > 1) {
             // resize or populate our temporary array as necessary
-            if (tlist == null || tlist.length != list.length) {
-                tlist = list.clone();
+            if (tlist == null || tlist.length < listSize) {
+                tlist = new Light[listSize];
             } else {
-                System.arraycopy(list, 0, tlist, 0, list.length);
+                if (tlistSize > listSize) {
+                    Arrays.fill(tlist, listSize, tlistSize, null);
+                }
             }
+            System.arraycopy(list, 0, tlist, 0, listSize);
+            tlistSize = listSize;
 
             if (transformChanged) {
                 // check distance of each light
@@ -249,31 +248,33 @@ public final class LightList implements Iterable<Light>, Savable, Cloneable, Jme
         // using the arguments
         clear();
 
-        while (list.length <= local.listSize) {
+        int requiredSize = local.listSize + (parent == null ? 0 : parent.listSize);
+        while (list.length < requiredSize) {
             doubleSize();
         }
         
-        int localListSize = 0;
-        for(int i=0;i<local.listSize;i++){
-            Light l = local.list[i];
-            if (filter != null && !filter.test(l))  continue; 
-            list[localListSize] = l;
-            distToOwner[localListSize] = Float.NEGATIVE_INFINITY;
-            localListSize++;
+        int localListSize;
+        if (filter == null) {
+            localListSize = local.listSize;
+            System.arraycopy(local.list, 0, list, 0, localListSize);
+        } else {
+            localListSize = 0;
+            for(int i=0;i<local.listSize;i++){
+                Light l = local.list[i];
+                if (!filter.test(l))  continue;
+                list[localListSize] = l;
+                localListSize++;
+            }
         }
 
         // if the spatial has a parent node, add the lights
         // from the parent list as well
         if (parent != null) {
             int sz = localListSize + parent.listSize;
-            while (list.length <= sz)
+            while (list.length < sz)
                 doubleSize();
 
-            for (int i = 0; i < parent.listSize; i++) {
-                int p = i + localListSize;
-                list[p] = parent.list[i];
-                distToOwner[p] = Float.NEGATIVE_INFINITY;
-            }
+            System.arraycopy(parent.list, 0, list, localListSize, parent.listSize);
 
             listSize = localListSize + parent.listSize;
         } else {
@@ -319,7 +320,6 @@ public final class LightList implements Iterable<Light>, Savable, Cloneable, Jme
 
             clone.owner = null;
             clone.list = list.clone();
-            clone.distToOwner = distToOwner.clone();
             clone.tlist = null; // list used for sorting only
 
             return clone;
@@ -343,7 +343,6 @@ public final class LightList implements Iterable<Light>, Savable, Cloneable, Jme
     public void cloneFields(Cloner cloner, Object original) {
         this.owner = cloner.clone(owner);
         this.list = cloner.clone(list);
-        this.distToOwner = cloner.clone(distToOwner);
     }
 
     @Override
@@ -370,13 +369,10 @@ public final class LightList implements Iterable<Light>, Savable, Cloneable, Jme
         // NOTE: make sure the array has a length of at least 1
         int arraySize = Math.max(DEFAULT_SIZE, listSize);
         list = new Light[arraySize];
-        distToOwner = new float[arraySize];
 
         for (int i = 0; i < listSize; i++) {
             list[i] = lights.get(i);
         }
-
-        Arrays.fill(distToOwner, Float.NEGATIVE_INFINITY);
     }
 
     @Override

--- a/jme3-core/src/test/java/com/jme3/light/LightListTest.java
+++ b/jme3-core/src/test/java/com/jme3/light/LightListTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.light;
+
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Mesh;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for LightList.
+ */
+public class LightListTest {
+
+    /**
+     * Verify sort() remains correct after the list previously held more lights.
+     */
+    @Test
+    public void testSortAfterRetainedCapacity() {
+        Geometry owner = new Geometry("owner", new Mesh());
+        LightList list = new LightList(owner);
+
+        for (int i = 0; i < 32; i++) {
+            list.add(new PointLight(new Vector3f(100f + i, 0f, 0f)));
+        }
+        list.sort(true);
+        list.clear();
+
+        PointLight far = new PointLight(new Vector3f(10f, 0f, 0f));
+        PointLight near = new PointLight(new Vector3f(1f, 0f, 0f));
+        PointLight middle = new PointLight(new Vector3f(5f, 0f, 0f));
+
+        list.add(far);
+        list.add(near);
+        list.add(middle);
+        list.sort(true);
+
+        Assertions.assertSame(near, list.get(0));
+        Assertions.assertSame(middle, list.get(1));
+        Assertions.assertSame(far, list.get(2));
+    }
+
+    /**
+     * Verify indexed removal preserves order for front, middle, and tail removals.
+     */
+    @Test
+    public void testRemovePreservesOrder() {
+        LightList list = new LightList(new Geometry("owner", new Mesh()));
+        AmbientLight first = new AmbientLight();
+        AmbientLight second = new AmbientLight();
+        AmbientLight third = new AmbientLight();
+        AmbientLight fourth = new AmbientLight();
+
+        list.add(first);
+        list.add(second);
+        list.add(third);
+        list.add(fourth);
+
+        list.remove(0);
+        Assertions.assertEquals(3, list.size());
+        Assertions.assertSame(second, list.get(0));
+        Assertions.assertSame(third, list.get(1));
+        Assertions.assertSame(fourth, list.get(2));
+
+        list.remove(1);
+        Assertions.assertEquals(2, list.size());
+        Assertions.assertSame(second, list.get(0));
+        Assertions.assertSame(fourth, list.get(1));
+
+        list.remove(1);
+        Assertions.assertEquals(1, list.size());
+        Assertions.assertSame(second, list.get(0));
+    }
+
+    /**
+     * Verify unfiltered world-list updates preserve local-then-parent ordering.
+     */
+    @Test
+    public void testUpdateCopiesLocalAndParentLights() {
+        LightList local = new LightList(new Geometry("local", new Mesh()));
+        LightList parent = new LightList(new Geometry("parent", new Mesh()));
+        LightList world = new LightList(new Geometry("world", new Mesh()));
+
+        AmbientLight localFirst = new AmbientLight();
+        AmbientLight localSecond = new AmbientLight();
+        AmbientLight parentFirst = new AmbientLight();
+        AmbientLight parentSecond = new AmbientLight();
+
+        local.add(localFirst);
+        local.add(localSecond);
+        parent.add(parentFirst);
+        parent.add(parentSecond);
+
+        world.update(local, parent);
+
+        Assertions.assertEquals(4, world.size());
+        Assertions.assertSame(localFirst, world.get(0));
+        Assertions.assertSame(localSecond, world.get(1));
+        Assertions.assertSame(parentFirst, world.get(2));
+        Assertions.assertSame(parentSecond, world.get(3));
+    }
+
+    /**
+     * Verify filtered world-list updates keep only accepted local lights.
+     */
+    @Test
+    public void testUpdateFiltersLocalLights() {
+        LightList local = new LightList(new Geometry("local", new Mesh()));
+        LightList parent = new LightList(new Geometry("parent", new Mesh()));
+        LightList world = new LightList(new Geometry("world", new Mesh()));
+
+        AmbientLight keep = new AmbientLight();
+        AmbientLight discard = new AmbientLight();
+        AmbientLight parentLight = new AmbientLight();
+
+        local.add(keep);
+        local.add(discard);
+        parent.add(parentLight);
+
+        world.update(local, parent, light -> light != discard);
+
+        Assertions.assertEquals(2, world.size());
+        Assertions.assertSame(keep, world.get(0));
+        Assertions.assertSame(parentLight, world.get(1));
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -83,6 +83,7 @@ def findAndroidSdk = {
 
 // Core classes, should work on all java platforms
 include 'jme3-core'
+include 'jme3-benchmark'
 include 'jme3-effects'
 include 'jme3-networking'
 include 'jme3-plugins'

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,6 +35,15 @@ def isIosExamplesTaskRequested = {
             || taskName.startsWith('jme3-ios-examples:')
     }
 }
+def isJmhTaskRequested = {
+    gradle.startParameter.taskNames.any { taskName ->
+        taskName == 'jmh'
+            || taskName == ':jmh'
+            || taskName == 'jme3-benchmark'
+            || taskName.startsWith(':jme3-benchmark:')
+            || taskName.startsWith('jme3-benchmark:')
+    }
+}
 
 def findAndroidSdk = {
     def sdkDirs = []
@@ -83,6 +92,9 @@ def findAndroidSdk = {
 
 // Core classes, should work on all java platforms
 include 'jme3-core'
+if (isJmhTaskRequested()) {
+    include 'jme3-benchmark'
+}
 include 'jme3-effects'
 include 'jme3-networking'
 include 'jme3-plugins'


### PR DESCRIPTION
Stacked on #2778; the first commit is the JMH harness.

## Summary

- avoid copying and clearing unused retained `LightList` backing capacity
- use bulk copy paths where `LightList.update()` has no filter
- keep the retained sort buffer sized to active lights rather than backing-array capacity
- remove unused `distToOwner` state
- add focused tests for removal ordering, update ordering/filtering, and sorting after retained capacity

## Benchmarking

The harness includes mutation and retained-capacity sort benchmarks. The original unfiltered `updateFromLocalAndParent` number is not presented as a production claim: `Spatial.updateWorldLightList()` uses a global-light filter. `updateWithGlobalLightFilter` covers that representative path; compact local measurements were promising at medium/large list sizes but need longer controlled runs before a PR performance claim.

## Testing

```sh
./gradlew :jme3-core:test --tests com.jme3.light.LightListTest --tests com.jme3.light.LightSortTest :jme3-benchmark:jmh -PjmhArgs='-l'
```
