### PR TITLE
Improve gamepads rumble and add device rumble

### DIFF
--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidInputHandler.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidInputHandler.java
@@ -111,6 +111,7 @@ public class AndroidInputHandler implements View.OnTouchListener,
 
     public void loadSettings(AppSettings settings) {
         touchInput.loadSettings(settings);
+        joyInput.loadSettings(settings);
     }
 
     public TouchInput getTouchInput() {

--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidJoyInput.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidJoyInput.java
@@ -108,7 +108,7 @@ public class AndroidJoyInput implements JoyInput {
         onDeviceJoystickRumble = settings.isOnDeviceJoystickRumble();
     }
 
-    protected boolean isOnDeviceJoystickRumble() {
+    boolean isOnDeviceJoystickRumble() {
         return onDeviceJoystickRumble;
     }
 

--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidJoyInput.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidJoyInput.java
@@ -31,9 +31,7 @@
  */
 package com.jme3.input.android;
 
-import android.content.Context;
 import android.opengl.GLSurfaceView;
-import android.os.Vibrator;
 import com.jme3.input.InputManager;
 import com.jme3.input.JoyInput;
 import com.jme3.input.Joystick;
@@ -42,6 +40,7 @@ import com.jme3.input.event.InputEvent;
 import com.jme3.input.event.JoyAxisEvent;
 import com.jme3.input.event.JoyButtonEvent;
 import com.jme3.system.AppSettings;
+import com.jme3.system.JmeSystem;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -55,9 +54,9 @@ import java.util.logging.Logger;
  * This class manages all the joysticks and feeds the inputs from each back
  * to jME's InputManager.
  *
- * This handler also supports the joystick.rumble(rumbleAmount) method.  In this
- * case, when joystick.rumble(rumbleAmount) is called, the Android device will vibrate
- * if the device has a built-in vibrate motor.
+ * This handler also supports redirecting joystick.rumble(rumbleAmount) to the
+ * Android device vibrator if AppSettings#setOnDeviceJoystickRumble(boolean) is
+ * enabled and the device has a built-in vibrate motor.
  *
  * Because Android does not allow for the user to define the intensity of the
  * vibration, the rumble amount (ie strength) is converted into vibration pulses
@@ -92,9 +91,7 @@ public class AndroidJoyInput implements JoyInput {
     private RawInputListener listener = null;
     private ConcurrentLinkedQueue<InputEvent> eventQueue = new ConcurrentLinkedQueue<>();
     private AndroidSensorJoyInput sensorJoyInput;
-    private Vibrator vibrator = null;
-    private boolean vibratorActive = false;
-    private long maxRumbleTime = 250;  // 250ms
+    private boolean onDeviceJoystickRumble = false;
 
     public AndroidJoyInput(AndroidInputHandler inputHandler) {
         this.inputHandler = inputHandler;
@@ -102,23 +99,17 @@ public class AndroidJoyInput implements JoyInput {
     }
 
     public void setView(GLSurfaceView view) {
-        if (view == null) {
-            vibrator = null;
-        } else {
-            // Get instance of Vibrator from current Context
-            vibrator = (Vibrator) view.getContext().getSystemService(Context.VIBRATOR_SERVICE);
-            if (vibrator == null) {
-                logger.log(Level.FINE, "Vibrator Service not found.");
-            }
-        }
-
         if (sensorJoyInput != null) {
             sensorJoyInput.setView(view);
         }
     }
 
     public void loadSettings(AppSettings settings) {
+        onDeviceJoystickRumble = settings.isOnDeviceJoystickRumble();
+    }
 
+    protected boolean isOnDeviceJoystickRumble() {
+        return onDeviceJoystickRumble;
     }
 
     public void addEvent(InputEvent event) {
@@ -133,8 +124,8 @@ public class AndroidJoyInput implements JoyInput {
         if (sensorJoyInput != null) {
             sensorJoyInput.pauseSensors();
         }
-        if (vibrator != null && vibratorActive) {
-            vibrator.cancel();
+        if (onDeviceJoystickRumble) {
+            JmeSystem.rumble(0f);
         }
 
     }
@@ -183,27 +174,22 @@ public class AndroidJoyInput implements JoyInput {
 
     @Override
     public void setJoyRumble(int joyId, float amount) {
-        // convert amount to pulses since Android doesn't allow intensity
-        if (vibrator != null) {
-            final long rumbleOnDur = (long)(amount * maxRumbleTime); // ms to pulse vibration on
-            final long rumbleOffDur = maxRumbleTime - rumbleOnDur; // ms to delay between pulses
-            final long[] rumblePattern = {
-                0, // start immediately
-                rumbleOnDur, // time to leave vibration on
-                rumbleOffDur // time to delay between vibrations
-            };
-            final int rumbleRepeatFrom = 0; // index into rumble pattern to repeat from
+        if (onDeviceJoystickRumble && JmeSystem.isDeviceRumbleSupported()) {
+            JmeSystem.rumble(amount);
+        }
+    }
 
-//            logger.log(Level.FINE, "Rumble amount: {0}, rumbleOnDur: {1}, rumbleOffDur: {2}",
-//                    new Object[]{amount, rumbleOnDur, rumbleOffDur});
+    @Override
+    public void setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
+        if (onDeviceJoystickRumble && JmeSystem.isDeviceRumbleSupported()) {
+            JmeSystem.rumble(amountHigh, amountLow, duration);
+        }
+    }
 
-            if (rumbleOnDur > 0) {
-                vibrator.vibrate(rumblePattern, rumbleRepeatFrom);
-                vibratorActive = true;
-            } else {
-                vibrator.cancel();
-                vibratorActive = false;
-            }
+    @Override
+    public void stopJoyRumble(int joyId) {
+        if (onDeviceJoystickRumble && JmeSystem.isDeviceRumbleSupported()) {
+            JmeSystem.stopRumble();
         }
     }
 

--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidJoyInput.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidJoyInput.java
@@ -125,7 +125,7 @@ public class AndroidJoyInput implements JoyInput {
             sensorJoyInput.pauseSensors();
         }
         if (onDeviceJoystickRumble) {
-            JmeSystem.rumble(0f);
+            JmeSystem.stopRumble();
         }
 
     }

--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidJoyInput.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidJoyInput.java
@@ -173,13 +173,6 @@ public class AndroidJoyInput implements JoyInput {
     }
 
     @Override
-    public void setJoyRumble(int joyId, float amount) {
-        if (onDeviceJoystickRumble && JmeSystem.isDeviceRumbleSupported()) {
-            JmeSystem.rumble(amount);
-        }
-    }
-
-    @Override
     public void setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
         if (onDeviceJoystickRumble && JmeSystem.isDeviceRumbleSupported()) {
             JmeSystem.rumble(amountHigh, amountLow, duration);

--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidJoyInput14.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidJoyInput14.java
@@ -99,15 +99,6 @@ public class AndroidJoyInput14 extends AndroidJoyInput {
     }
 
     @Override
-    public void setJoyRumble(int joyId, float amount) {
-        if (isOnDeviceJoystickRumble() && JmeSystem.isDeviceRumbleSupported()) {
-            super.setJoyRumble(joyId, amount);
-        } else {
-            joystickJoyInput.setJoyRumble(joyId, amount);
-        }
-    }
-
-    @Override
     public void setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
         if (isOnDeviceJoystickRumble() && JmeSystem.isDeviceRumbleSupported()) {
             super.setJoyRumble(joyId, amountHigh, amountLow, duration);

--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidJoyInput14.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidJoyInput14.java
@@ -35,6 +35,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import com.jme3.input.InputManager;
 import com.jme3.input.Joystick;
+import com.jme3.system.JmeSystem;
 import java.util.logging.Logger;
 
 /**
@@ -95,6 +96,33 @@ public class AndroidJoyInput14 extends AndroidJoyInput {
         joystickList.addAll(joystickJoyInput.loadJoysticks(joystickList.size(), inputManager));
         // return the list of joysticks back to InputManager
         return joystickList.toArray( new Joystick[joystickList.size()] );
+    }
+
+    @Override
+    public void setJoyRumble(int joyId, float amount) {
+        if (isOnDeviceJoystickRumble() && JmeSystem.isDeviceRumbleSupported()) {
+            super.setJoyRumble(joyId, amount);
+        } else {
+            joystickJoyInput.setJoyRumble(joyId, amount);
+        }
+    }
+
+    @Override
+    public void setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
+        if (isOnDeviceJoystickRumble() && JmeSystem.isDeviceRumbleSupported()) {
+            super.setJoyRumble(joyId, amountHigh, amountLow, duration);
+        } else {
+            joystickJoyInput.setJoyRumble(joyId, amountHigh, amountLow, duration);
+        }
+    }
+
+    @Override
+    public void stopJoyRumble(int joyId) {
+        if (isOnDeviceJoystickRumble() && JmeSystem.isDeviceRumbleSupported()) {
+            super.stopJoyRumble(joyId);
+        } else {
+            joystickJoyInput.stopJoyRumble(joyId);
+        }
     }
 
     public boolean onGenericMotion(MotionEvent event) {

--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidJoystickJoyInput14.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidJoystickJoyInput14.java
@@ -246,7 +246,7 @@ public class AndroidJoystickJoyInput14 {
         return consumed;
     }
 
-    public boolean setJoyRumble(int joyId, float amount) {
+    boolean setJoyRumble(int joyId, float amount) {
         AndroidJoystick joystick = getJoystick(joyId);
         if (joystick == null || !joystick.isHapticFeedbackSupported()) {
             return false;
@@ -255,7 +255,7 @@ public class AndroidJoystickJoyInput14 {
         return true;
     }
 
-    public boolean setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
+    boolean setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
         AndroidJoystick joystick = getJoystick(joyId);
         if (joystick == null || !joystick.isHapticFeedbackSupported()) {
             return false;
@@ -264,7 +264,7 @@ public class AndroidJoystickJoyInput14 {
         return true;
     }
 
-    public boolean stopJoyRumble(int joyId) {
+    boolean stopJoyRumble(int joyId) {
         AndroidJoystick joystick = getJoystick(joyId);
         if (joystick == null || !joystick.isHapticFeedbackSupported()) {
             return false;
@@ -326,7 +326,7 @@ public class AndroidJoystickJoyInput14 {
             return device.getVibrator();
         }
 
-        protected boolean isHapticFeedbackSupported() {
+        private boolean isHapticFeedbackSupported() {
             return AndroidHapticFeedback.isSupported(getVibrator());
         }
 

--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidJoystickJoyInput14.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidJoystickJoyInput14.java
@@ -47,6 +47,7 @@ import com.jme3.input.JoystickButton;
 import com.jme3.input.JoystickCompatibilityMappings;
 import com.jme3.input.event.JoyAxisEvent;
 import com.jme3.input.event.JoyButtonEvent;
+import com.jme3.system.android.AndroidHapticFeedback;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -96,7 +97,7 @@ public class AndroidJoystickJoyInput14 {
 
 
     public void pauseJoysticks() {
-
+        stopAllRumble();
     }
 
     public void resumeJoysticks() {
@@ -104,7 +105,7 @@ public class AndroidJoystickJoyInput14 {
     }
 
     public void destroy() {
-
+        stopAllRumble();
     }
 
     public List<Joystick> loadJoysticks(int joyId, InputManager inputManager) {
@@ -245,6 +246,48 @@ public class AndroidJoystickJoyInput14 {
         return consumed;
     }
 
+    public boolean setJoyRumble(int joyId, float amount) {
+        AndroidJoystick joystick = getJoystick(joyId);
+        if (joystick == null || !joystick.isHapticFeedbackSupported()) {
+            return false;
+        }
+        joystick.rumble(amount);
+        return true;
+    }
+
+    public boolean setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
+        AndroidJoystick joystick = getJoystick(joyId);
+        if (joystick == null || !joystick.isHapticFeedbackSupported()) {
+            return false;
+        }
+        joystick.rumble(amountHigh, amountLow, duration);
+        return true;
+    }
+
+    public boolean stopJoyRumble(int joyId) {
+        AndroidJoystick joystick = getJoystick(joyId);
+        if (joystick == null || !joystick.isHapticFeedbackSupported()) {
+            return false;
+        }
+        joystick.stopRumble();
+        return true;
+    }
+
+    private AndroidJoystick getJoystick(int joyId) {
+        for (AndroidJoystick joystick : joystickIndex.values()) {
+            if (joystick.getJoyId() == joyId) {
+                return joystick;
+            }
+        }
+        return null;
+    }
+
+    private void stopAllRumble() {
+        for (AndroidJoystick joystick : joystickIndex.values()) {
+            joystick.stopRumble();
+        }
+    }
+
     protected class AndroidJoystick extends AbstractJoystick {
 
         private JoystickAxis nullAxis;
@@ -276,6 +319,30 @@ public class AndroidJoystickJoyInput14 {
 
         protected Set<Integer> getAndroidAxes() {
             return axisIndex.keySet();
+        }
+
+        @SuppressWarnings("deprecation")
+        private android.os.Vibrator getVibrator() {
+            return device.getVibrator();
+        }
+
+        protected boolean isHapticFeedbackSupported() {
+            return AndroidHapticFeedback.isSupported(getVibrator());
+        }
+
+        @Override
+        public void rumble(float amount) {
+            AndroidHapticFeedback.rumble(getVibrator(), amount, amount, Float.POSITIVE_INFINITY);
+        }
+
+        @Override
+        public void rumble(float amountHigh, float amountLow, float duration) {
+            AndroidHapticFeedback.rumble(getVibrator(), amountHigh, amountLow, duration);
+        }
+
+        @Override
+        public void stopRumble() {
+            AndroidHapticFeedback.stop(getVibrator());
         }
 
         protected JoystickButton getButton(int keyCode) {

--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidJoystickJoyInput14.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidJoystickJoyInput14.java
@@ -331,11 +331,6 @@ public class AndroidJoystickJoyInput14 {
         }
 
         @Override
-        public void rumble(float amount) {
-            AndroidHapticFeedback.rumble(getVibrator(), amount, amount, Float.POSITIVE_INFINITY);
-        }
-
-        @Override
         public void rumble(float amountHigh, float amountLow, float duration) {
             AndroidHapticFeedback.rumble(getVibrator(), amountHigh, amountLow, duration);
         }

--- a/jme3-android/src/main/java/com/jme3/system/android/AndroidHapticFeedback.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/AndroidHapticFeedback.java
@@ -34,8 +34,12 @@ package com.jme3.system.android;
 import com.jme3.math.FastMath;
 
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
+import java.util.IdentityHashMap;
+import java.util.Map;
 
 /**
  * Android haptic helpers shared by device and input-device vibrators.
@@ -43,6 +47,8 @@ import android.os.Vibrator;
 public final class AndroidHapticFeedback {
 
     private static final long PULSE_CYCLE_MS = 250L;
+    private static final Handler MAIN_HANDLER = new Handler(Looper.getMainLooper());
+    private static final Map<Vibrator, Runnable> pendingStops = new IdentityHashMap<>();
 
     private AndroidHapticFeedback() {
     }
@@ -57,12 +63,13 @@ public final class AndroidHapticFeedback {
             return;
         }
         float amount = Math.max(FastMath.clamp(amountHigh, 0f, 1f), FastMath.clamp(amountLow, 0f, 1f));
-        if (amount <= 0f || duration <= 0f) {
+        if (amount <= 0f || !(duration > 0f)) {
             stop(vibrator);
             return;
         }
 
         try {
+            cancelPendingStop(vibrator);
             if (duration == Float.POSITIVE_INFINITY) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && vibrator.hasAmplitudeControl()) {
                     int amplitude = Math.max(1, Math.round(amount * 255f));
@@ -81,9 +88,9 @@ public final class AndroidHapticFeedback {
                     int amplitude = Math.max(1, Math.round(amount * 255f));
                     vibrator.vibrate(VibrationEffect.createOneShot(durationMs, amplitude));
                 } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    vibrator.vibrate(VibrationEffect.createWaveform(createPulsePattern(amount, durationMs), -1));
+                    vibrateWithoutAmplitudeControl(vibrator, amount, durationMs);
                 } else {
-                    vibrator.vibrate(createPulsePattern(amount, durationMs), -1);
+                    vibrateWithoutAmplitudeControl(vibrator, amount, durationMs);
                 }
             }
         } catch (SecurityException ignored) {
@@ -91,33 +98,62 @@ public final class AndroidHapticFeedback {
         }
     }
 
-    private static long[] createPulsePattern(float amount, long durationMs) {
+    @SuppressWarnings("deprecation")
+    private static void vibrateWithoutAmplitudeControl(Vibrator vibrator, float amount, long durationMs) {
+        if (amount >= 1f) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                vibrator.vibrate(VibrationEffect.createOneShot(durationMs, VibrationEffect.DEFAULT_AMPLITUDE));
+            } else {
+                vibrator.vibrate(durationMs);
+            }
+            return;
+        }
+
+        long[] rumblePattern = createRepeatingPulsePattern(amount);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            vibrator.vibrate(VibrationEffect.createWaveform(rumblePattern, 0));
+        } else {
+            vibrator.vibrate(rumblePattern, 0);
+        }
+        scheduleStop(vibrator, durationMs);
+    }
+
+    private static long[] createRepeatingPulsePattern(float amount) {
         long rumbleOnDur = Math.max(1L, Math.round(amount * PULSE_CYCLE_MS));
         long rumbleOffDur = Math.max(0L, PULSE_CYCLE_MS - rumbleOnDur);
-        long[] rumblePattern = new long[(int) Math.ceil((double) durationMs / PULSE_CYCLE_MS) * 2 + 1];
+        return new long[]{0L, rumbleOnDur, rumbleOffDur};
+    }
 
-        rumblePattern[0] = 0L;
-        long remainingMs = durationMs;
-        int patternIndex = 1;
-        while (remainingMs > 0L) {
-            long onDur = Math.min(rumbleOnDur, remainingMs);
-            rumblePattern[patternIndex++] = onDur;
-            remainingMs -= onDur;
+    private static void scheduleStop(final Vibrator vibrator, long durationMs) {
+        Runnable stopTask = new Runnable() {
+            @Override
+            public void run() {
+                synchronized (pendingStops) {
+                    if (pendingStops.get(vibrator) != this) {
+                        return;
+                    }
+                    pendingStops.remove(vibrator);
+                }
+                stop(vibrator);
+            }
+        };
 
-            if (remainingMs > 0L) {
-                long offDur = Math.min(rumbleOffDur, remainingMs);
-                rumblePattern[patternIndex++] = offDur;
-                remainingMs -= offDur;
+        synchronized (pendingStops) {
+            Runnable previousStop = pendingStops.put(vibrator, stopTask);
+            if (previousStop != null) {
+                MAIN_HANDLER.removeCallbacks(previousStop);
             }
         }
+        MAIN_HANDLER.postDelayed(stopTask, durationMs);
+    }
 
-        if (patternIndex == rumblePattern.length) {
-            return rumblePattern;
+    private static void cancelPendingStop(Vibrator vibrator) {
+        synchronized (pendingStops) {
+            Runnable pendingStop = pendingStops.remove(vibrator);
+            if (pendingStop != null) {
+                MAIN_HANDLER.removeCallbacks(pendingStop);
+            }
         }
-
-        long[] trimmedPattern = new long[patternIndex];
-        System.arraycopy(rumblePattern, 0, trimmedPattern, 0, patternIndex);
-        return trimmedPattern;
     }
 
     public static void stop(Vibrator vibrator) {
@@ -125,6 +161,7 @@ public final class AndroidHapticFeedback {
             return;
         }
         try {
+            cancelPendingStop(vibrator);
             vibrator.cancel();
         } catch (SecurityException ignored) {
             // Applications without VIBRATE permission should degrade to no-op.

--- a/jme3-android/src/main/java/com/jme3/system/android/AndroidHapticFeedback.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/AndroidHapticFeedback.java
@@ -87,8 +87,6 @@ public final class AndroidHapticFeedback {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && vibrator.hasAmplitudeControl()) {
                     int amplitude = Math.max(1, Math.round(amount * 255f));
                     vibrator.vibrate(VibrationEffect.createOneShot(durationMs, amplitude));
-                } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    vibrateWithoutAmplitudeControl(vibrator, amount, durationMs);
                 } else {
                     vibrateWithoutAmplitudeControl(vibrator, amount, durationMs);
                 }

--- a/jme3-android/src/main/java/com/jme3/system/android/AndroidHapticFeedback.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/AndroidHapticFeedback.java
@@ -75,7 +75,7 @@ public final class AndroidHapticFeedback {
                     vibrator.vibrate(new long[]{0, rumbleOnDur, rumbleOffDur}, 0);
                 }
             } else {
-               long durationMs = duration <= 0f ? 0L : Math.max(1L, Math.round(duration * 1000f));
+                long durationMs = Math.max(1L, Math.round(duration * 1000f));
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && vibrator.hasAmplitudeControl()) {
                     int amplitude = Math.max(1, Math.round(amount * 255f));
                     vibrator.vibrate(VibrationEffect.createOneShot(durationMs, amplitude));

--- a/jme3-android/src/main/java/com/jme3/system/android/AndroidHapticFeedback.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/AndroidHapticFeedback.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2009-2026 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.system.android;
+
+import com.jme3.math.FastMath;
+
+import android.os.Build;
+import android.os.VibrationEffect;
+import android.os.Vibrator;
+
+/**
+ * Android haptic helpers shared by device and input-device vibrators.
+ */
+public final class AndroidHapticFeedback {
+
+
+    private AndroidHapticFeedback() {
+    }
+
+    public static boolean isSupported(Vibrator vibrator) {
+        return vibrator != null && vibrator.hasVibrator();
+    }
+
+    @SuppressWarnings("deprecation")
+    public static void rumble(Vibrator vibrator, float amountHigh, float amountLow, float duration) {
+        if (!isSupported(vibrator)) {
+            return;
+        }
+        float amount = Math.max(FastMath.clamp(amountHigh, 0f, 1f), FastMath.clamp(amountLow, 0f, 1f));
+        if (amount <= 0f || duration <= 0f) {
+            stop(vibrator);
+            return;
+        }
+
+        try {
+            if (duration == Float.POSITIVE_INFINITY) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && vibrator.hasAmplitudeControl()) {
+                    int amplitude = Math.max(1, Math.round(amount * 255f));
+                    vibrator.vibrate(VibrationEffect.createWaveform(
+                            new long[]{0, 1000},
+                            new int[]{0, amplitude},
+                            0));
+                } else {
+                    long rumbleOnDur = Math.max(1L, Math.round(amount * 1000));
+                    long rumbleOffDur = Math.max(0L, 1000 - rumbleOnDur);
+                    vibrator.vibrate(new long[]{0, rumbleOnDur, rumbleOffDur}, 0);
+                }
+            } else {
+               long durationMs = duration <= 0f ? 0L : Math.max(1L, Math.round(duration * 1000f));
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && vibrator.hasAmplitudeControl()) {
+                    int amplitude = Math.max(1, Math.round(amount * 255f));
+                    vibrator.vibrate(VibrationEffect.createOneShot(durationMs, amplitude));
+                } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    vibrator.vibrate(VibrationEffect.createOneShot(durationMs, VibrationEffect.DEFAULT_AMPLITUDE));
+                } else {
+                    vibrator.vibrate(durationMs);
+                }
+            }
+        } catch (SecurityException ignored) {
+            // Applications without VIBRATE permission should degrade to no-op.
+        }
+    }
+
+    public static void stop(Vibrator vibrator) {
+        if (!isSupported(vibrator)) {
+            return;
+        }
+        try {
+            vibrator.cancel();
+        } catch (SecurityException ignored) {
+            // Applications without VIBRATE permission should degrade to no-op.
+        }
+    } 
+}

--- a/jme3-android/src/main/java/com/jme3/system/android/AndroidHapticFeedback.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/AndroidHapticFeedback.java
@@ -42,6 +42,7 @@ import android.os.Vibrator;
  */
 public final class AndroidHapticFeedback {
 
+    private static final long PULSE_CYCLE_MS = 250L;
 
     private AndroidHapticFeedback() {
     }
@@ -80,14 +81,43 @@ public final class AndroidHapticFeedback {
                     int amplitude = Math.max(1, Math.round(amount * 255f));
                     vibrator.vibrate(VibrationEffect.createOneShot(durationMs, amplitude));
                 } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    vibrator.vibrate(VibrationEffect.createOneShot(durationMs, VibrationEffect.DEFAULT_AMPLITUDE));
+                    vibrator.vibrate(VibrationEffect.createWaveform(createPulsePattern(amount, durationMs), -1));
                 } else {
-                    vibrator.vibrate(durationMs);
+                    vibrator.vibrate(createPulsePattern(amount, durationMs), -1);
                 }
             }
         } catch (SecurityException ignored) {
             // Applications without VIBRATE permission should degrade to no-op.
         }
+    }
+
+    private static long[] createPulsePattern(float amount, long durationMs) {
+        long rumbleOnDur = Math.max(1L, Math.round(amount * PULSE_CYCLE_MS));
+        long rumbleOffDur = Math.max(0L, PULSE_CYCLE_MS - rumbleOnDur);
+        long[] rumblePattern = new long[(int) Math.ceil((double) durationMs / PULSE_CYCLE_MS) * 2 + 1];
+
+        rumblePattern[0] = 0L;
+        long remainingMs = durationMs;
+        int patternIndex = 1;
+        while (remainingMs > 0L) {
+            long onDur = Math.min(rumbleOnDur, remainingMs);
+            rumblePattern[patternIndex++] = onDur;
+            remainingMs -= onDur;
+
+            if (remainingMs > 0L) {
+                long offDur = Math.min(rumbleOffDur, remainingMs);
+                rumblePattern[patternIndex++] = offDur;
+                remainingMs -= offDur;
+            }
+        }
+
+        if (patternIndex == rumblePattern.length) {
+            return rumblePattern;
+        }
+
+        long[] trimmedPattern = new long[patternIndex];
+        System.arraycopy(rumblePattern, 0, trimmedPattern, 0, patternIndex);
+        return trimmedPattern;
     }
 
     public static void stop(Vibrator vibrator) {

--- a/jme3-android/src/main/java/com/jme3/system/android/JmeAndroidSystem.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/JmeAndroidSystem.java
@@ -33,6 +33,7 @@ import java.util.logging.Level;
 public class JmeAndroidSystem extends JmeSystemDelegate {
 
     private static View view;
+    private static Vibrator vibrator;
 
     static {
         try {
@@ -203,6 +204,7 @@ public class JmeAndroidSystem extends JmeSystemDelegate {
 
     public static void setView(View view) {
         JmeAndroidSystem.view = view;
+        vibrator = null;
     }
 
     public static View getView() {
@@ -225,11 +227,16 @@ public class JmeAndroidSystem extends JmeSystemDelegate {
     }
 
     private static Vibrator getVibrator() {
+        if (vibrator != null) {
+            return vibrator;
+        }
+
         View currentView = view;
         if (currentView == null || currentView.getContext() == null) {
             return null;
         }
-        return (Vibrator) currentView.getContext().getSystemService(Context.VIBRATOR_SERVICE);
+        vibrator = (Vibrator) currentView.getContext().getSystemService(Context.VIBRATOR_SERVICE);
+        return vibrator;
     }
 
     @Override

--- a/jme3-android/src/main/java/com/jme3/system/android/JmeAndroidSystem.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/JmeAndroidSystem.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.Environment;
+import android.os.Vibrator;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import com.jme3.audio.AudioRenderer;
@@ -206,6 +207,34 @@ public class JmeAndroidSystem extends JmeSystemDelegate {
 
     public static View getView() {
         return view;
+    }
+
+    @Override
+    public boolean isDeviceRumbleSupported() {
+        return AndroidHapticFeedback.isSupported(getVibrator());
+    }
+
+    @Override
+    public void rumble(float amount) {
+        AndroidHapticFeedback.rumble(getVibrator(), amount, amount, Float.POSITIVE_INFINITY);
+    }
+
+    @Override
+    public void rumble(float amountHigh, float amountLow, float duration) {
+        AndroidHapticFeedback.rumble(getVibrator(), amountHigh, amountLow, duration);
+    }
+
+    @Override
+    public void stopRumble() {
+        AndroidHapticFeedback.stop(getVibrator());
+    }
+
+    private static Vibrator getVibrator() {
+        View currentView = view;
+        if (currentView == null || currentView.getContext() == null) {
+            return null;
+        }
+        return (Vibrator) currentView.getContext().getSystemService(Context.VIBRATOR_SERVICE);
     }
 
     @Override

--- a/jme3-android/src/main/java/com/jme3/system/android/JmeAndroidSystem.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/JmeAndroidSystem.java
@@ -215,11 +215,6 @@ public class JmeAndroidSystem extends JmeSystemDelegate {
     }
 
     @Override
-    public void rumble(float amount) {
-        AndroidHapticFeedback.rumble(getVibrator(), amount, amount, Float.POSITIVE_INFINITY);
-    }
-
-    @Override
     public void rumble(float amountHigh, float amountLow, float duration) {
         AndroidHapticFeedback.rumble(getVibrator(), amountHigh, amountLow, duration);
     }

--- a/jme3-core/src/main/java/com/jme3/input/AbstractJoystick.java
+++ b/jme3-core/src/main/java/com/jme3/input/AbstractJoystick.java
@@ -82,16 +82,6 @@ public abstract class AbstractJoystick implements Joystick {
         buttons.add(button);
     }
 
-    /**
-     * Rumbles the joystick for the given amount/magnitude.
-     *
-     * @param amount The amount to rumble. Should be between 0 and 1.
-     */
-    @Override
-    public void rumble(float amount) {
-        joyInput.setJoyRumble(joyId, amount);
-    }
-
     @Override
     public void rumble(float amountHigh, float amountLow, float duration) {
         joyInput.setJoyRumble(joyId, amountHigh, amountLow, duration);

--- a/jme3-core/src/main/java/com/jme3/input/AbstractJoystick.java
+++ b/jme3-core/src/main/java/com/jme3/input/AbstractJoystick.java
@@ -92,6 +92,16 @@ public abstract class AbstractJoystick implements Joystick {
         joyInput.setJoyRumble(joyId, amount);
     }
 
+    @Override
+    public void rumble(float amountHigh, float amountLow, float duration) {
+        joyInput.setJoyRumble(joyId, amountHigh, amountLow, duration);
+    }
+
+    @Override
+    public void stopRumble() {
+        joyInput.stopJoyRumble(joyId);
+    }
+
     /**
      * Assign the mapping name to receive events from the given button index
      * on the joystick.

--- a/jme3-core/src/main/java/com/jme3/input/HapticDevice.java
+++ b/jme3-core/src/main/java/com/jme3/input/HapticDevice.java
@@ -44,7 +44,9 @@ public interface HapticDevice {
      *
      * @param amount the amount to rumble, between 0 and 1
      */
-    void rumble(float amount);
+    default void rumble(float amount) {
+        rumble(amount, amount, Float.POSITIVE_INFINITY);
+    }
 
     /**
      * Rumbles the device with separate high and low frequency amounts for the

--- a/jme3-core/src/main/java/com/jme3/input/HapticDevice.java
+++ b/jme3-core/src/main/java/com/jme3/input/HapticDevice.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2009-2026 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.input;
+
+/**
+ * A device that can produce haptic feedback.
+ */
+public interface HapticDevice {
+
+    /**
+     * Rumbles the device with the given amount.
+     * <p>
+     * This starts a continuous rumble that keeps playing until
+     * {@code rumble(0)} or {@link #stopRumble()} is called.
+     *
+     * @param amount the amount to rumble, between 0 and 1
+     */
+    void rumble(float amount);
+
+    /**
+     * Rumbles the device with separate high and low frequency amounts for the
+     * given duration.
+     *
+     * @param amountHigh the high frequency amount, between 0 and 1
+     * @param amountLow the low frequency amount, between 0 and 1
+     * @param duration the duration in seconds
+     */
+    void rumble(float amountHigh, float amountLow, float duration);
+
+    /**
+     * Stops any rumble currently playing on the device.
+     */
+    default void stopRumble() {
+        rumble(0f);
+    }
+}

--- a/jme3-core/src/main/java/com/jme3/input/JoyInput.java
+++ b/jme3-core/src/main/java/com/jme3/input/JoyInput.java
@@ -56,7 +56,9 @@ public interface JoyInput extends Input {
      * @param joyId The joystick index
      * @param amount Rumble amount. Should be between 0 and 1.
      */
-    public void setJoyRumble(int joyId, float amount);
+    public default void setJoyRumble(int joyId, float amount) {
+        setJoyRumble(joyId, amount, amount, Float.POSITIVE_INFINITY);
+    }
 
     /**
      * Causes the joystick at <code>joyId</code> index to rumble with
@@ -67,9 +69,7 @@ public interface JoyInput extends Input {
      * @param amountLow Low frequency rumble amount. Should be between 0 and 1.
      * @param duration Rumble duration in seconds.
      */
-    public default void setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
-        setJoyRumble(joyId, Math.max(amountHigh, amountLow));
-    }
+    public void setJoyRumble(int joyId, float amountHigh, float amountLow, float duration);
 
     /**
      * Stops any rumble currently playing on the joystick at <code>joyId</code>.

--- a/jme3-core/src/main/java/com/jme3/input/JoyInput.java
+++ b/jme3-core/src/main/java/com/jme3/input/JoyInput.java
@@ -49,11 +49,36 @@ public interface JoyInput extends Input {
     /**
      * Causes the joystick at <code>joyId</code> index to rumble with
      * the given amount.
+     * <p>
+     * The rumble continues until this method is called with 0 or
+     * {@link #stopJoyRumble(int)} is called.
      * 
      * @param joyId The joystick index
      * @param amount Rumble amount. Should be between 0 and 1.
      */
     public void setJoyRumble(int joyId, float amount);
+
+    /**
+     * Causes the joystick at <code>joyId</code> index to rumble with
+     * separate high and low frequency amounts for the given duration.
+     *
+     * @param joyId The joystick index
+     * @param amountHigh High frequency rumble amount. Should be between 0 and 1.
+     * @param amountLow Low frequency rumble amount. Should be between 0 and 1.
+     * @param duration Rumble duration in seconds.
+     */
+    public default void setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
+        setJoyRumble(joyId, Math.max(amountHigh, amountLow));
+    }
+
+    /**
+     * Stops any rumble currently playing on the joystick at <code>joyId</code>.
+     *
+     * @param joyId the joystick index
+     */
+    public default void stopJoyRumble(int joyId) {
+        setJoyRumble(joyId, 0f);
+    }
     
     /**
      * Loads a list of joysticks from the system.

--- a/jme3-core/src/main/java/com/jme3/input/Joystick.java
+++ b/jme3-core/src/main/java/com/jme3/input/Joystick.java
@@ -38,14 +38,8 @@ import java.util.List;
  *
  * @author Paul Speed, Kirill Vainer
  */
-public interface Joystick {
+public interface Joystick extends HapticDevice {
 
-    /**
-     * Rumbles the joystick for the given amount/magnitude.
-     *
-     * @param amount The amount to rumble. Should be between 0 and 1.
-     */
-    public void rumble(float amount);
 
     /**
      * Assign the mapping name to receive events from the given button index

--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -346,6 +346,7 @@ public final class AppSettings extends HashMap<String, Object> {
         defaults.put("JoysticksTriggerToButtonThreshold", 0.5f);
         defaults.put("JoysticksAxisJitterThreshold", 0.0001f);
         defaults.put("SDLGameControllerDBResourcePath", "");
+        defaults.put("OnDeviceJoystickRumble", false);
         //  defaults.put("Icons", null);
     }
 
@@ -796,6 +797,15 @@ public final class AppSettings extends HashMap<String, Object> {
      */
     public void setUseJoysticks(boolean use) {
         putBoolean("DisableJoysticks", !use);
+    }
+
+    /**
+     * @param enabled If true, joystick rumble requests may be redirected to
+     * the device rumble motor on supported platforms.
+     * (Default: false)
+     */
+    public void setOnDeviceJoystickRumble(boolean enabled) {
+        putBoolean("OnDeviceJoystickRumble", enabled);
     }
 
     /**
@@ -1266,6 +1276,16 @@ public final class AppSettings extends HashMap<String, Object> {
      */
     public boolean useJoysticks() {
         return !getBoolean("DisableJoysticks");
+    }
+
+    /**
+     * Get whether joystick rumble may be redirected to device rumble.
+     *
+     * @return true to redirect joystick rumble to device rumble when supported
+     * @see #setOnDeviceJoystickRumble(boolean)
+     */
+    public boolean isOnDeviceJoystickRumble() {
+        return getBoolean("OnDeviceJoystickRumble");
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/system/JmeSystem.java
+++ b/jme3-core/src/main/java/com/jme3/system/JmeSystem.java
@@ -125,6 +125,26 @@ public class JmeSystem {
         systemDelegate.showSoftKeyboard(show);
     }
 
+    public static boolean isDeviceRumbleSupported() {
+        checkDelegate();
+        return systemDelegate.isDeviceRumbleSupported();
+    }
+
+    public static void rumble(float amount) {
+        checkDelegate();
+        systemDelegate.rumble(amount);
+    }
+
+    public static void rumble(float amountHigh, float amountLow, float duration) {
+        checkDelegate();
+        systemDelegate.rumble(amountHigh, amountLow, duration);
+    }
+
+    public static void stopRumble() {
+        checkDelegate();
+        systemDelegate.stopRumble();
+    }
+
     public static SoftTextDialogInput getSoftTextDialogInput() {
         checkDelegate();
         return systemDelegate.getSoftTextDialogInput();

--- a/jme3-core/src/main/java/com/jme3/system/JmeSystemDelegate.java
+++ b/jme3-core/src/main/java/com/jme3/system/JmeSystemDelegate.java
@@ -163,11 +163,6 @@ public abstract class JmeSystemDelegate implements HapticDevice {
     public void rumble(float amountHigh, float amountLow, float duration) {
     }
 
-
-    @Override
-    public void rumble(float amount) {
-    }
-
     public final AssetManager newAssetManager(URL configFile) {
         return new DesktopAssetManager(configFile);
     }

--- a/jme3-core/src/main/java/com/jme3/system/JmeSystemDelegate.java
+++ b/jme3-core/src/main/java/com/jme3/system/JmeSystemDelegate.java
@@ -34,6 +34,7 @@ package com.jme3.system;
 import com.jme3.asset.AssetManager;
 import com.jme3.asset.DesktopAssetManager;
 import com.jme3.audio.AudioRenderer;
+import com.jme3.input.HapticDevice;
 import com.jme3.input.SoftTextDialogInput;
 import com.jme3.util.res.Resources;
 
@@ -55,7 +56,7 @@ import java.util.logging.Logger;
  *
  * @author Kirill Vainer, normenhansen
  */
-public abstract class JmeSystemDelegate {
+public abstract class JmeSystemDelegate implements HapticDevice {
 
     protected final Logger logger = Logger.getLogger(JmeSystem.class.getName());
     protected boolean initialized = false;
@@ -152,6 +153,19 @@ public abstract class JmeSystemDelegate {
     
     public SoftTextDialogInput getSoftTextDialogInput() {
         return softTextDialogInput;
+    }
+
+    public boolean isDeviceRumbleSupported() {
+        return false;
+    }
+
+    @Override
+    public void rumble(float amountHigh, float amountLow, float duration) {
+    }
+
+
+    @Override
+    public void rumble(float amount) {
     }
 
     public final AssetManager newAssetManager(URL configFile) {

--- a/jme3-examples/src/main/java/jme3test/input/TestDeviceRumble.java
+++ b/jme3-examples/src/main/java/jme3test/input/TestDeviceRumble.java
@@ -1,0 +1,120 @@
+package jme3test.input;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.collision.CollisionResults;
+import com.jme3.font.BitmapText;
+import com.jme3.input.MouseInput;
+import com.jme3.input.RawInputListenerAdapter;
+import com.jme3.input.controls.ActionListener;
+import com.jme3.input.controls.MouseButtonTrigger;
+import com.jme3.input.event.TouchEvent;
+import com.jme3.light.DirectionalLight;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.Ray;
+import com.jme3.math.Vector2f;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.shape.Box;
+import com.jme3.system.AppSettings;
+import com.jme3.system.JmeSystem;
+
+public class TestDeviceRumble extends SimpleApplication {
+
+    private static final String CLICK_MAPPING = "ClickCube";
+
+    private Geometry cube;
+    private Material cubeMaterial;
+    private BitmapText statusText;
+    private boolean rumbling;
+
+    public static void main(String[] args) {
+        TestDeviceRumble app = new TestDeviceRumble();
+        AppSettings settings = new AppSettings(true);
+        settings.setUseJoysticks(false);
+        app.setSettings(settings);
+        app.start();
+    }
+
+    @Override
+    public void simpleInitApp() {
+        flyCam.setEnabled(false);
+        inputManager.setCursorVisible(true);
+
+        cubeMaterial = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+        cubeMaterial.setColor("Color", ColorRGBA.Blue);
+
+        cube = new Geometry("Device rumble cube", new Box(1.25f, 1.25f, 1.25f));
+        cube.setMaterial(cubeMaterial);
+        rootNode.attachChild(cube);
+
+        DirectionalLight light = new DirectionalLight();
+        light.setDirection(new Vector3f(-1f, -1f, -1f).normalizeLocal());
+        rootNode.addLight(light);
+
+        cam.setLocation(new Vector3f(0f, 0f, 6f));
+        cam.lookAt(Vector3f.ZERO, Vector3f.UNIT_Y);
+
+        statusText = new BitmapText(guiFont);
+        statusText.setLocalTranslation(12f, cam.getHeight() - 12f, 0f);
+        guiNode.attachChild(statusText);
+        updateStatusText();
+
+        inputManager.addMapping(CLICK_MAPPING, new MouseButtonTrigger(MouseInput.BUTTON_LEFT));
+        inputManager.addListener((ActionListener) (name, isPressed, tpf) -> {
+            if (isPressed) {
+                startRumble(inputManager.getCursorPosition());
+            } else {
+                stopRumble();
+            }
+        }, CLICK_MAPPING);
+
+        inputManager.addRawInputListener(new RawInputListenerAdapter() {
+            @Override
+            public void onTouchEvent(TouchEvent evt) {
+                if (evt.getType() == TouchEvent.Type.DOWN) {
+                    startRumble(new Vector2f(evt.getX(), evt.getY()));
+                } else if (evt.getType() == TouchEvent.Type.UP) {
+                    stopRumble();
+                }
+            }
+        });
+    }
+
+    private void startRumble(Vector2f screenPosition) {
+        if (!isCubeHit(screenPosition)) {
+            return;
+        }
+
+        rumbling = true;
+        cubeMaterial.setColor("Color", ColorRGBA.Red);
+        if (JmeSystem.isDeviceRumbleSupported()) {
+            JmeSystem.rumble(1f, 1f, Float.POSITIVE_INFINITY);
+        }
+        updateStatusText();
+    }
+
+    private void stopRumble() {
+        if (!rumbling) {
+            return;
+        }
+        rumbling = false;
+        JmeSystem.stopRumble();
+        cubeMaterial.setColor("Color", ColorRGBA.Blue);
+        updateStatusText();
+    }
+
+    private boolean isCubeHit(Vector2f screenPosition) {
+        Vector3f origin = cam.getWorldCoordinates(screenPosition, 0f);
+        Vector3f direction = cam.getWorldCoordinates(screenPosition, 1f).subtractLocal(origin).normalizeLocal();
+        CollisionResults results = new CollisionResults();
+        cube.collideWith(new Ray(origin, direction), results);
+        return results.size() > 0;
+    }
+
+    private void updateStatusText() {
+        String state = rumbling ? "rumbling" : "idle";
+        String supported = JmeSystem.isDeviceRumbleSupported() ? "supported" : "not supported";
+        statusText.setText("Device rumble: " + supported + "\nHold the cube to test\nState: " + state);
+    }
+}

--- a/jme3-examples/src/main/java/jme3test/input/TestJoystick.java
+++ b/jme3-examples/src/main/java/jme3test/input/TestJoystick.java
@@ -29,6 +29,8 @@ import com.jme3.scene.Geometry;
 import com.jme3.scene.Node;
 import com.jme3.scene.shape.Quad;
 import com.jme3.system.AppSettings;
+import com.jme3.system.JmeSystem;
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -42,6 +44,7 @@ public class TestJoystick extends SimpleApplication {
     private Node joystickInfo;
     private float yInfo = 0;
     private JoystickButton lastButton;
+    private static final float SHORT_RUMBLE_TIME = 0.4f;
 
     public static void main(String[] args){
         TestJoystick app = new TestJoystick();
@@ -62,11 +65,16 @@ public class TestJoystick extends SimpleApplication {
             throw new IllegalStateException("Cannot find any joysticks!");
 
         try {
-            PrintWriter out = new PrintWriter( new FileWriter( "joysticks-" + System.currentTimeMillis() + ".txt" ) );
-            dumpJoysticks( joysticks, out );
-            out.close();
+            File storageFolder = JmeSystem.getStorageFolder();
+            if (storageFolder != null) {
+                storageFolder.mkdirs();
+            }
+            File dumpFile = new File(storageFolder, "joysticks-" + System.currentTimeMillis() + ".txt");
+            try (PrintWriter out = new PrintWriter(new FileWriter(dumpFile))) {
+                dumpJoysticks(joysticks, out);
+            }
         } catch( IOException e ) {
-            throw new RuntimeException( "Error writing joystick dump", e );
+            System.err.println( "Error writing joystick dump: " + e );
         }   
 
 
@@ -137,6 +145,7 @@ public class TestJoystick extends SimpleApplication {
             yInfo = 0;
  
             addInfo(  "Joystick:\"" + stick.getName() + "\"  id:" + stick.getJoyId(), 0 );
+            addInfo(  "Rumble: buttons=joystick, dpad=device", 0 );
  
             yInfo -= 5;
                        
@@ -156,6 +165,118 @@ public class TestJoystick extends SimpleApplication {
             }
             
         } 
+    }
+
+    protected void handleRumbleButton(JoystickButton button, boolean pressed) {
+        String logicalId = button.getLogicalId();
+        if (isDpadButton(logicalId)) {
+            handleDeviceRumbleButton(logicalId, pressed);
+            return;
+        }
+
+        Joystick joystick = button.getJoystick();
+        if (JoystickButton.BUTTON_XBOX_B.equals(logicalId)) {
+            if (pressed) {
+                joystick.rumble(1f, 0.35f, SHORT_RUMBLE_TIME);
+            }
+            return;
+        }
+
+        if (!pressed) {
+            joystick.stopRumble();
+            return;
+        }
+
+        float[] pattern = getJoystickRumblePattern(button);
+        joystick.rumble(pattern[0], pattern[1], Float.POSITIVE_INFINITY);
+    }
+
+    protected void handleTriggerRumble(JoystickAxis axis, float value) {
+        String logicalId = axis.getLogicalId();
+        if (!JoystickAxis.AXIS_XBOX_LEFT_TRIGGER.equals(logicalId)
+                && !JoystickAxis.AXIS_XBOX_RIGHT_TRIGGER.equals(logicalId)) {
+            return;
+        }
+
+        Joystick joystick = axis.getJoystick();
+        if (value <= 0f) {
+            joystick.stopRumble();
+            return;
+        }
+
+        float amount = FastMath.clamp(value, 0f, 1f);
+        if (JoystickAxis.AXIS_XBOX_LEFT_TRIGGER.equals(logicalId)) {
+            joystick.rumble(0.25f + amount * 0.35f, amount, Float.POSITIVE_INFINITY);
+        } else {
+            joystick.rumble(amount, 0.25f + amount * 0.35f, Float.POSITIVE_INFINITY);
+        }
+    }
+
+    protected boolean isDpadButton(String logicalId) {
+        return JoystickButton.BUTTON_XBOX_DPAD_UP.equals(logicalId)
+                || JoystickButton.BUTTON_XBOX_DPAD_RIGHT.equals(logicalId)
+                || JoystickButton.BUTTON_XBOX_DPAD_DOWN.equals(logicalId)
+                || JoystickButton.BUTTON_XBOX_DPAD_LEFT.equals(logicalId);
+    }
+
+    protected void handleDeviceRumbleButton(String logicalId, boolean pressed) {
+        if (!JmeSystem.isDeviceRumbleSupported()) {
+            return;
+        }
+        if (!pressed) {
+            JmeSystem.stopRumble();
+            return;
+        }
+
+        float high = 0.5f;
+        float low = 0.5f;
+        if (JoystickButton.BUTTON_XBOX_DPAD_UP.equals(logicalId)) {
+            high = 1f;
+            low = 0.2f;
+        } else if (JoystickButton.BUTTON_XBOX_DPAD_RIGHT.equals(logicalId)) {
+            high = 0.2f;
+            low = 1f;
+        } else if (JoystickButton.BUTTON_XBOX_DPAD_DOWN.equals(logicalId)) {
+            high = 0.35f;
+            low = 0.35f;
+        } else if (JoystickButton.BUTTON_XBOX_DPAD_LEFT.equals(logicalId)) {
+            high = 0.75f;
+            low = 0.75f;
+        }
+
+        JmeSystem.rumble(high, low, Float.POSITIVE_INFINITY);
+    }
+
+    protected float[] getJoystickRumblePattern(JoystickButton button) {
+        String logicalId = button.getLogicalId();
+        if (JoystickButton.BUTTON_XBOX_A.equals(logicalId)) {
+            return new float[]{1f, 1f};
+        } else if (JoystickButton.BUTTON_XBOX_X.equals(logicalId)) {
+            return new float[]{0.25f, 1f};
+        } else if (JoystickButton.BUTTON_XBOX_Y.equals(logicalId)) {
+            return new float[]{1f, 0.25f};
+        } else if (JoystickButton.BUTTON_XBOX_LB.equals(logicalId)) {
+            return new float[]{0.15f, 0.7f};
+        } else if (JoystickButton.BUTTON_XBOX_RB.equals(logicalId)) {
+            return new float[]{0.7f, 0.15f};
+        } else if (JoystickButton.BUTTON_XBOX_LT.equals(logicalId)) {
+            return new float[]{0.45f, 0.9f};
+        } else if (JoystickButton.BUTTON_XBOX_RT.equals(logicalId)) {
+            return new float[]{0.9f, 0.45f};
+        } else if (JoystickButton.BUTTON_XBOX_BACK.equals(logicalId)) {
+            return new float[]{0.3f, 0.3f};
+        } else if (JoystickButton.BUTTON_XBOX_START.equals(logicalId)) {
+            return new float[]{0.6f, 0.6f};
+        } else if (JoystickButton.BUTTON_XBOX_L3.equals(logicalId)) {
+            return new float[]{0.2f, 0.5f};
+        } else if (JoystickButton.BUTTON_XBOX_R3.equals(logicalId)) {
+            return new float[]{0.5f, 0.2f};
+        }
+
+        int index = Math.abs(button.getButtonId());
+        float high = 0.2f + (index % 5) * 0.16f;
+        float low = 1f - (index % 4) * 0.18f;
+        return new float[]{high, low};
     }
 
     /**
@@ -184,9 +305,9 @@ public class TestJoystick extends SimpleApplication {
             }         
             setViewedJoystick( evt.getAxis().getJoystick() );            
             gamepad.setAxisValue( evt.getAxis(), value );
+            handleTriggerRumble(evt.getAxis(), value);
             if( value != 0 ) {
                 lastValues.put(evt.getAxis(), value);
-                evt.getAxis().getJoystick().rumble(0.5f);
             } 
         }
 
@@ -194,7 +315,7 @@ public class TestJoystick extends SimpleApplication {
         public void onJoyButtonEvent(JoyButtonEvent evt) {
             setViewedJoystick( evt.getButton().getJoystick() );
             gamepad.setButtonValue( evt.getButton(), evt.isPressed() ); 
-            evt.getButton().getJoystick().rumble(1f);
+            handleRumbleButton(evt.getButton(), evt.isPressed());
         }
 
         @Override

--- a/jme3-examples/src/main/java/jme3test/input/TestJoystick.java
+++ b/jme3-examples/src/main/java/jme3test/input/TestJoystick.java
@@ -167,7 +167,7 @@ public class TestJoystick extends SimpleApplication {
         } 
     }
 
-    protected void handleRumbleButton(JoystickButton button, boolean pressed) {
+    private void handleRumbleButton(JoystickButton button, boolean pressed) {
         String logicalId = button.getLogicalId();
         if (isDpadButton(logicalId)) {
             handleDeviceRumbleButton(logicalId, pressed);
@@ -191,7 +191,7 @@ public class TestJoystick extends SimpleApplication {
         joystick.rumble(pattern[0], pattern[1], Float.POSITIVE_INFINITY);
     }
 
-    protected void handleTriggerRumble(JoystickAxis axis, float value) {
+    private void handleTriggerRumble(JoystickAxis axis, float value) {
         String logicalId = axis.getLogicalId();
         if (!JoystickAxis.AXIS_XBOX_LEFT_TRIGGER.equals(logicalId)
                 && !JoystickAxis.AXIS_XBOX_RIGHT_TRIGGER.equals(logicalId)) {
@@ -212,14 +212,14 @@ public class TestJoystick extends SimpleApplication {
         }
     }
 
-    protected boolean isDpadButton(String logicalId) {
+    private boolean isDpadButton(String logicalId) {
         return JoystickButton.BUTTON_XBOX_DPAD_UP.equals(logicalId)
                 || JoystickButton.BUTTON_XBOX_DPAD_RIGHT.equals(logicalId)
                 || JoystickButton.BUTTON_XBOX_DPAD_DOWN.equals(logicalId)
                 || JoystickButton.BUTTON_XBOX_DPAD_LEFT.equals(logicalId);
     }
 
-    protected void handleDeviceRumbleButton(String logicalId, boolean pressed) {
+    private void handleDeviceRumbleButton(String logicalId, boolean pressed) {
         if (!JmeSystem.isDeviceRumbleSupported()) {
             return;
         }
@@ -247,7 +247,7 @@ public class TestJoystick extends SimpleApplication {
         JmeSystem.rumble(high, low, Float.POSITIVE_INFINITY);
     }
 
-    protected float[] getJoystickRumblePattern(JoystickButton button) {
+    private float[] getJoystickRumblePattern(JoystickButton button) {
         String logicalId = button.getLogicalId();
         if (JoystickButton.BUTTON_XBOX_A.equals(logicalId)) {
             return new float[]{1f, 1f};

--- a/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/JInputJoyInput.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/JInputJoyInput.java
@@ -69,12 +69,6 @@ public class JInputJoyInput implements JoyInput {
     private Map<Controller, JInputJoystick> joystickIndex = new HashMap<>();
     private Map<Integer, Long> rumbleStopTimes = new HashMap<>();
 
-    @Override
-    public void setJoyRumble(int joyId, float amount){
-        rumbleStopTimes.remove(joyId);
-        applyJoyRumble(joyId, amount);
-    }
-
     private void applyJoyRumble(int joyId, float amount) {
         if( joyId >= joysticks.length )
             throw new IllegalArgumentException();

--- a/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/JInputJoyInput.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/JInputJoyInput.java
@@ -82,7 +82,7 @@ public class JInputJoyInput implements JoyInput {
 
     @Override
     public void setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
-        float amount = Math.max(amountHigh, amountLow);
+        float amount = Math.max(FastMath.clamp(amountHigh, 0f, 1f), FastMath.clamp(amountLow, 0f, 1f));
         if (amount <= 0f || !(duration > 0f)) {
             stopJoyRumble(joyId);
             return;

--- a/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/JInputJoyInput.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/JInputJoyInput.java
@@ -47,6 +47,7 @@ import com.jme3.input.event.JoyButtonEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import com.jme3.math.FastMath;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/JInputJoyInput.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/JInputJoyInput.java
@@ -44,10 +44,10 @@ import com.jme3.input.JoystickCompatibilityMappings;
 import com.jme3.input.RawInputListener;
 import com.jme3.input.event.JoyAxisEvent;
 import com.jme3.input.event.JoyButtonEvent;
+import com.jme3.math.FastMath;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import com.jme3.math.FastMath;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -223,6 +223,9 @@ public class JInputJoyInput implements JoyInput {
     }
 
     private void updateTimedRumbles() {
+        if (rumbleStopTimes.isEmpty()) {
+            return;
+        }
         long now = System.nanoTime();
         Iterator<Map.Entry<Integer, Long>> iterator = rumbleStopTimes.entrySet().iterator();
         while (iterator.hasNext()) {

--- a/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/JInputJoyInput.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/JInputJoyInput.java
@@ -92,7 +92,7 @@ public class JInputJoyInput implements JoyInput {
         if (duration == Float.POSITIVE_INFINITY) {
             rumbleStopTimes.remove(joyId);
         } else {
-            long durationNanos = Math.max(1L, (long) (duration * 1_000_000_000L));
+            long durationNanos = Math.max(1L, Math.round(duration * 1_000_000_000.0));
             rumbleStopTimes.put(joyId, System.nanoTime() + durationNanos);
         }
     }

--- a/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/JInputJoyInput.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/input/lwjgl/JInputJoyInput.java
@@ -46,6 +46,7 @@ import com.jme3.input.event.JoyAxisEvent;
 import com.jme3.input.event.JoyButtonEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -66,10 +67,15 @@ public class JInputJoyInput implements JoyInput {
     private RawInputListener listener;
 
     private Map<Controller, JInputJoystick> joystickIndex = new HashMap<>();
+    private Map<Integer, Long> rumbleStopTimes = new HashMap<>();
 
     @Override
     public void setJoyRumble(int joyId, float amount){
+        rumbleStopTimes.remove(joyId);
+        applyJoyRumble(joyId, amount);
+    }
 
+    private void applyJoyRumble(int joyId, float amount) {
         if( joyId >= joysticks.length )
             throw new IllegalArgumentException();
 
@@ -80,7 +86,37 @@ public class JInputJoyInput implements JoyInput {
     }
 
     @Override
+    public void setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
+        float amount = Math.max(amountHigh, amountLow);
+        if (amount <= 0f || !(duration > 0f)) {
+            stopJoyRumble(joyId);
+            return;
+        }
+
+        applyJoyRumble(joyId, amount);
+        if (duration == Float.POSITIVE_INFINITY) {
+            rumbleStopTimes.remove(joyId);
+        } else {
+            long durationNanos = Math.max(1L, (long) (duration * 1_000_000_000L));
+            rumbleStopTimes.put(joyId, System.nanoTime() + durationNanos);
+        }
+    }
+
+    @Override
+    public void stopJoyRumble(int joyId) {
+        rumbleStopTimes.remove(joyId);
+        applyJoyRumble(joyId, 0f);
+    }
+
+    @Override
     public Joystick[] loadJoysticks(InputManager inputManager){
+        if (joysticks != null) {
+            for (JInputJoystick joystick : joysticks) {
+                applyJoyRumble(joystick.getJoyId(), 0f);
+            }
+        }
+        rumbleStopTimes.clear();
+
         ControllerEnvironment ce =
             ControllerEnvironment.getDefaultEnvironment();
 
@@ -122,6 +158,8 @@ public class JInputJoyInput implements JoyInput {
 
     @Override
     public void update() {
+        updateTimedRumbles();
+
         ControllerEnvironment ce =
             ControllerEnvironment.getDefaultEnvironment();
 
@@ -189,8 +227,26 @@ public class JInputJoyInput implements JoyInput {
         }
     }
 
+    private void updateTimedRumbles() {
+        long now = System.nanoTime();
+        Iterator<Map.Entry<Integer, Long>> iterator = rumbleStopTimes.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<Integer, Long> entry = iterator.next();
+            if (now >= entry.getValue()) {
+                applyJoyRumble(entry.getKey(), 0f);
+                iterator.remove();
+            }
+        }
+    }
+
     @Override
     public void destroy() {
+        if (joysticks != null) {
+            for (JInputJoystick joystick : joysticks) {
+                applyJoyRumble(joystick.getJoyId(), 0f);
+            }
+        }
+        rumbleStopTimes.clear();
         initialized = false;
     }
 
@@ -357,6 +413,3 @@ public class JInputJoyInput implements JoyInput {
         }
     }
 }
-
-
-

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/SdlJoystickInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/SdlJoystickInput.java
@@ -201,6 +201,7 @@ public class SdlJoystickInput implements JoyInput {
         // clear all states associated with this joystick
         joyButtonPressed.entrySet().removeIf(e -> e.getKey().getJoystick() == joystick);
         joyAxisValues.entrySet().removeIf(e -> e.getKey().getJoystick() == joystick);
+        stopJoyRumble(joystick.getJoyId());
         joysticks.remove(deviceIndex);
 
         // free resources
@@ -214,7 +215,10 @@ public class SdlJoystickInput implements JoyInput {
     @Override
     public Joystick[] loadJoysticks(InputManager inputManager) {
 
-        for (SdlJoystick js : joysticks.values()) destroyJoystick(js);
+        for (SdlJoystick js : joysticks.values()) {
+            stopJoyRumble(js.getJoyId());
+            destroyJoystick(js);
+        }
         joysticks.clear();
 
         joyButtonPressed.clear();
@@ -225,8 +229,9 @@ public class SdlJoystickInput implements JoyInput {
             IntBuffer gamepads = SDL_GetGamepads();
             if (gamepads != null) {
                 try {
-                    while (gamepads.hasRemaining()) {
-                        int deviceId = gamepads.get();
+                    IntBuffer gamepadIds = gamepads.duplicate();
+                    while (gamepadIds.hasRemaining()) {
+                        int deviceId = gamepadIds.get();
                         onDeviceConnected(inputManager, deviceId, true);
                     }
                 } finally {
@@ -240,8 +245,9 @@ public class SdlJoystickInput implements JoyInput {
             IntBuffer joys = SDL_GetJoysticks();
             if (joys != null) {
                 try {
-                    while (joys.hasRemaining()) {
-                        int deviceId = joys.get();
+                    IntBuffer joystickIds = joys.duplicate();
+                    while (joystickIds.hasRemaining()) {
+                        int deviceId = joystickIds.get();
                         onDeviceConnected(inputManager, deviceId, false);
                     }
                 } finally {
@@ -378,21 +384,43 @@ public class SdlJoystickInput implements JoyInput {
 
     @Override
     public void setJoyRumble(int joyId, float amount) {
-        setJoyRumble(joyId, amount, amount, 100f / 1000f);
+        setJoyRumble(joyId, amount, amount, Float.POSITIVE_INFINITY);
     }
 
-    public void setJoyRumble(int joyId, float highFrequency, float lowFrequency, float duration) {
+    @Override
+    public void setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
         SdlJoystick js = joysticks.get(joyId);
         if (js == null) return;
 
-        highFrequency = FastMath.clamp(highFrequency, 0f, 1f);
-        lowFrequency = FastMath.clamp(lowFrequency, 0f, 1f);
+        amountHigh = FastMath.clamp(amountHigh, 0f, 1f);
+        amountLow = FastMath.clamp(amountLow, 0f, 1f);
 
+        int durationMs = 0;
+        if (duration == Float.POSITIVE_INFINITY) {
+            durationMs = 21 * 24 * 60 * 60 * 1000; 
+        }else if (duration <= 0f) {
+            durationMs = 0;
+        } else{
+            durationMs = Math.max(1, (int) (duration * 1000f));
+        }
+
+        int ampLow = (int) (amountLow * 0xFFFF);
+        int ampHigh = (int) (amountHigh * 0xFFFF);
         if (js.isGamepad() && js.gamepad != 0L) {
-            int ampHigh = (int) (highFrequency * 0xFFFF);
-            int ampLow = (int) (lowFrequency * 0xFFFF);
-            int durationMs = (int) (duration * 1000f);
-            SDL_RumbleGamepad(js.gamepad, (short) ampHigh, (short) ampLow, durationMs);
+            SDL_RumbleGamepad(js.gamepad, (short) ampLow, (short) ampHigh, durationMs);
+        } else if (js.joystick != 0L) {
+            SDL_RumbleJoystick(js.joystick, (short) ampLow, (short) ampHigh, durationMs);
+        }
+    }
+
+    @Override
+    public void stopJoyRumble(int joyId) {
+        SdlJoystick js = joysticks.get(joyId);
+        if (js == null) return;
+        if (js.isGamepad() && js.gamepad != 0L) {
+            SDL_RumbleGamepad(js.gamepad, (short) 0, (short) 0, 0);
+        } else if (js.joystick != 0L) {
+            SDL_RumbleJoystick(js.joystick, (short) 0, (short) 0, 0);
         }
     }
 
@@ -539,6 +567,7 @@ public class SdlJoystickInput implements JoyInput {
     public void destroy() {
         // Close devices
         for (SdlJoystick js : joysticks.values()) {
+            stopJoyRumble(js.getJoyId());
             if (js.gamepad != 0L) SDL_CloseGamepad(js.gamepad);
             if (js.joystick != 0L) SDL_CloseJoystick(js.joystick);
         }

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/SdlJoystickInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/SdlJoystickInput.java
@@ -392,10 +392,10 @@ public class SdlJoystickInput implements JoyInput {
 
         int durationMs = 0;
         if (duration == Float.POSITIVE_INFINITY) {
-            durationMs = 21 * 24 * 60 * 60 * 1000; 
-        }else if (duration <= 0f) {
+            durationMs = 21 * 24 * 60 * 60 * 1000;
+        } else if (duration <= 0f) {
             durationMs = 0;
-        } else{
+        } else {
             durationMs = Math.max(1, (int) (duration * 1000f));
         }
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/SdlJoystickInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/SdlJoystickInput.java
@@ -392,7 +392,7 @@ public class SdlJoystickInput implements JoyInput {
 
         int durationMs = 0;
         if (duration == Float.POSITIVE_INFINITY) {
-            durationMs = 21 * 24 * 60 * 60 * 1000;
+            durationMs = -1;
         } else if (duration <= 0f) {
             durationMs = 0;
         } else {

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/SdlJoystickInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/SdlJoystickInput.java
@@ -383,11 +383,6 @@ public class SdlJoystickInput implements JoyInput {
     }
 
     @Override
-    public void setJoyRumble(int joyId, float amount) {
-        setJoyRumble(joyId, amount, amount, Float.POSITIVE_INFINITY);
-    }
-
-    @Override
     public void setJoyRumble(int joyId, float amountHigh, float amountLow, float duration) {
         SdlJoystick js = joysticks.get(joyId);
         if (js == null) return;


### PR DESCRIPTION
Improves gamepads rumble support by making it consistent across backends, and implement device rumble on supported devices (ie. android).

Rumble methods are now abstracted with the `HapticDevice` interface that is implemented by JmeSystemDelegate and Joystick.