### PR TITLE
Close gaps in new renderers and use dedicated camera for framebuffer blit

### DIFF
--- a/jme3-android/src/main/java/com/jme3/renderer/android/AndroidGL.java
+++ b/jme3-android/src/main/java/com/jme3/renderer/android/AndroidGL.java
@@ -131,6 +131,12 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
         return builder.toString();
     }
 
+    private static void unmapBufferAfterRead(int target) {
+        if (!GLES30.glUnmapBuffer(target)) {
+            throw new RendererException("Mapped buffer data became corrupted while reading");
+        }
+    }
+
     private static void checkLimit(Buffer buffer) {
         if (buffer == null) {
             return;
@@ -229,7 +235,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
             source.limit(byteCount);
             data.duplicate().put(source);
         } finally {
-            GLES30.glUnmapBuffer(target);
+            unmapBufferAfterRead(target);
         }
     }
 
@@ -247,7 +253,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
             source.order(data.order());
             data.duplicate().put(source.asIntBuffer());
         } finally {
-            GLES30.glUnmapBuffer(target);
+            unmapBufferAfterRead(target);
         }
     }
 
@@ -355,7 +361,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public void glDrawRangeElements(int mode, int start, int end, int count, int type, long indices) {
-        GLES20.glDrawElements(mode, count, type, checkedLongToInt(indices, "indices offset"));
+        GLES30.glDrawRangeElements(mode, start, end, count, type, checkedLongToInt(indices, "indices offset"));
     }
 
     @Override
@@ -667,7 +673,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public void glGetMultisample(int pname, int index, FloatBuffer val) {
-        GLES31.glGetMultisamplefv(pname, index, val);
+        throw new UnsupportedOperationException("Multisample textures require OpenGL ES 3.1");
     }
 
     @Override
@@ -677,7 +683,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public void glTexImage2DMultisample(int target, int samples, int internalformat, int width, int height, boolean fixedSampleLocations) {
-        GLES31.glTexStorage2DMultisample(target, samples, internalformat, width, height, fixedSampleLocations);
+        throw new UnsupportedOperationException("Multisample textures require OpenGL ES 3.1");
     }
 
     @Override
@@ -702,15 +708,12 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public int glGetProgramResourceIndex(int program, int programInterface, String name) {
-        return GLES31.glGetProgramResourceIndex(program, programInterface, name);
+        throw new UnsupportedOperationException("Shader storage buffer objects require OpenGL ES 3.1");
     }
 
     @Override
     public void glShaderStorageBlockBinding(int program, int storageBlockIndex, int storageBlockBinding) {
-        /*
-         * GLES 3.1 exposes shader storage block binding through GLSL layout(binding = N).
-         * Android's GLES31 Java bindings do not expose glShaderStorageBlockBinding.
-         */
+        throw new UnsupportedOperationException("Shader storage buffer objects require OpenGL ES 3.1");
     }
 
     @Override

--- a/jme3-android/src/main/java/com/jme3/renderer/android/AndroidGL.java
+++ b/jme3-android/src/main/java/com/jme3/renderer/android/AndroidGL.java
@@ -81,6 +81,56 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
         return buffer.limit() / elementSize;
     }
 
+    private static int getRemainingBytes(ByteBuffer buffer) {
+        checkLimit(buffer);
+        return buffer.remaining();
+    }
+
+    private static int getRemainingBytes(IntBuffer buffer) {
+        checkLimit(buffer);
+        return checkedLongToInt((long) buffer.remaining() * 4L, "buffer size");
+    }
+
+    private static int checkedLongToInt(long value, String name) {
+        if (value < 0 || value > Integer.MAX_VALUE) {
+            throw new RendererException(name + " exceeds the range supported by Android GLES bindings: " + value);
+        }
+        return (int) value;
+    }
+
+    private static long getSyncHandle(Object sync) {
+        if (!(sync instanceof Long)) {
+            throw new IllegalArgumentException("Expected a sync object returned by glFenceSync");
+        }
+        return (Long) sync;
+    }
+
+    private static int getBooleanValueCount(int pname) {
+        if (pname == GLES20.GL_COLOR_WRITEMASK) {
+            return 4;
+        }
+        return 1;
+    }
+
+    private static String joinShaderSource(String[] strings, IntBuffer lengths) {
+        StringBuilder builder = new StringBuilder();
+        int lengthPosition = lengths == null ? 0 : lengths.position();
+
+        for (int i = 0; i < strings.length; i++) {
+            String source = strings[i];
+            if (lengths != null) {
+                int length = lengths.get(lengthPosition + i);
+                if (length >= 0 && length < source.length()) {
+                    builder.append(source, 0, length);
+                    continue;
+                }
+            }
+            builder.append(source);
+        }
+
+        return builder.toString();
+    }
+
     private static void checkLimit(Buffer buffer) {
         if (buffer == null) {
             return;
@@ -148,32 +198,57 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public void glBufferData(int target, long dataSize, int usage) {
-        GLES20.glBufferData(target, (int) dataSize, null, usage);
+        GLES20.glBufferData(target, checkedLongToInt(dataSize, "data size"), null, usage);
     }
 
     @Override
     public void glBufferSubData(int target, long offset, FloatBuffer data) {
-        GLES20.glBufferSubData(target, (int) offset, getLimitBytes(data), data);
+        GLES20.glBufferSubData(target, checkedLongToInt(offset, "offset"), getLimitBytes(data), data);
     }
 
     @Override
     public void glBufferSubData(int target, long offset, ShortBuffer data) {
-        GLES20.glBufferSubData(target, (int) offset, getLimitBytes(data), data);
+        GLES20.glBufferSubData(target, checkedLongToInt(offset, "offset"), getLimitBytes(data), data);
     }
 
     @Override
     public void glBufferSubData(int target, long offset, ByteBuffer data) {
-        GLES20.glBufferSubData(target, (int) offset, getLimitBytes(data), data);
+        GLES20.glBufferSubData(target, checkedLongToInt(offset, "offset"), getLimitBytes(data), data);
     }
 
     @Override
     public void glGetBufferSubData(int target, long offset, ByteBuffer data) {
-        throw new UnsupportedOperationException("OpenGL ES 2 does not support glGetBufferSubData");
+        int byteCount = getRemainingBytes(data);
+        Buffer mapped = GLES30.glMapBufferRange(target, checkedLongToInt(offset, "offset"), byteCount, GLES30.GL_MAP_READ_BIT);
+        if (!(mapped instanceof ByteBuffer)) {
+            throw new RendererException("Unable to map buffer for reading");
+        }
+
+        try {
+            ByteBuffer source = (ByteBuffer) mapped;
+            source.limit(byteCount);
+            data.duplicate().put(source);
+        } finally {
+            GLES30.glUnmapBuffer(target);
+        }
     }
 
     @Override
     public void glGetBufferSubData(int target, long offset, IntBuffer data) {
-        throw new UnsupportedOperationException("OpenGL ES 2 does not support glGetBufferSubData");
+        int byteCount = getRemainingBytes(data);
+        Buffer mapped = GLES30.glMapBufferRange(target, checkedLongToInt(offset, "offset"), byteCount, GLES30.GL_MAP_READ_BIT);
+        if (!(mapped instanceof ByteBuffer)) {
+            throw new RendererException("Unable to map buffer for reading");
+        }
+
+        try {
+            ByteBuffer source = (ByteBuffer) mapped;
+            source.limit(byteCount);
+            source.order(data.order());
+            data.duplicate().put(source.asIntBuffer());
+        } finally {
+            GLES30.glUnmapBuffer(target);
+        }
     }
 
     @Override
@@ -280,7 +355,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public void glDrawRangeElements(int mode, int start, int end, int count, int type, long indices) {
-        GLES20.glDrawElements(mode, count, type, (int)indices);
+        GLES20.glDrawElements(mode, count, type, checkedLongToInt(indices, "indices offset"));
     }
 
     @Override
@@ -325,8 +400,18 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public void glGetBoolean(int pname, ByteBuffer params) {
-        // GLES20.glGetBoolean(pname, params);
-        throw new UnsupportedOperationException("Today is not a good day for this");
+        checkLimit(params);
+        int count = getBooleanValueCount(pname);
+        if (params.remaining() < count) {
+            throw new RendererException("Insufficient buffer space for boolean query result");
+        }
+        boolean[] values = new boolean[count];
+        GLES20.glGetBooleanv(pname, values, 0);
+
+        ByteBuffer destination = params.duplicate();
+        for (boolean value : values) {
+            destination.put((byte) (value ? GLES20.GL_TRUE : GLES20.GL_FALSE));
+        }
     }
 
     @Override
@@ -427,10 +512,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public void glShaderSource(int shader, String[] string, IntBuffer length) {
-        if (string.length != 1) {
-            throw new UnsupportedOperationException("Today is not a good day");
-        }
-        GLES20.glShaderSource(shader, string[0]);
+        GLES20.glShaderSource(shader, joinShaderSource(string, length));
     }
 
     @Override
@@ -545,7 +627,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public void glVertexAttribPointer(int index, int size, int type, boolean normalized, int stride, long pointer) {
-        GLES20.glVertexAttribPointer(index, size, type, normalized, stride, (int)pointer);
+        GLES20.glVertexAttribPointer(index, size, type, normalized, stride, checkedLongToInt(pointer, "pointer offset"));
     }
 
     @Override
@@ -565,7 +647,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public void glBufferSubData(int target, long offset, IntBuffer data) {
-        GLES20.glBufferSubData(target, (int)offset, getLimitBytes(data), data);
+        GLES20.glBufferSubData(target, checkedLongToInt(offset, "offset"), getLimitBytes(data), data);
     }
 
     @Override
@@ -580,7 +662,7 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public void glDrawElementsInstancedARB(int mode, int indicesCount, int type, long indicesBufferOffset, int primcount) {
-        GLES30.glDrawElementsInstanced(mode, indicesCount, type, (int)indicesBufferOffset, primcount);
+        GLES30.glDrawElementsInstanced(mode, indicesCount, type, checkedLongToInt(indicesBufferOffset, "indices offset"), primcount);
     }
 
     @Override
@@ -692,23 +774,22 @@ public class AndroidGL implements GL, GL2, GLES_30, GLExt, GLFbo {
 
     @Override
     public void glReadPixels(int x, int y, int width, int height, int format, int type, long offset) {
-        // TODO: no offset???
-        GLES20.glReadPixels(x, y, width, height, format, type, null);
+        GLES30.glReadPixels(x, y, width, height, format, type, checkedLongToInt(offset, "offset"));
     }
 
     @Override
     public int glClientWaitSync(Object sync, int flags, long timeout) {
-        throw new UnsupportedOperationException("OpenGL ES 2 does not support sync fences");
+        return GLES30.glClientWaitSync(getSyncHandle(sync), flags, timeout);
     }
 
     @Override
     public void glDeleteSync(Object sync) {
-        throw new UnsupportedOperationException("OpenGL ES 2 does not support sync fences");
+        GLES30.glDeleteSync(getSyncHandle(sync));
     }
 
     @Override
     public Object glFenceSync(int condition, int flags) {
-        throw new UnsupportedOperationException("OpenGL ES 2 does not support sync fences");
+        return GLES30.glFenceSync(condition, flags);
     }
 
     @Override

--- a/jme3-android/src/main/java/com/jme3/system/android/OGLESContext.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/OGLESContext.java
@@ -59,6 +59,7 @@ import com.jme3.input.controls.SoftTextDialogInputListener;
 import com.jme3.input.dummy.DummyKeyInput;
 import com.jme3.material.Material;
 import com.jme3.renderer.Caps;
+import com.jme3.renderer.Camera;
 import com.jme3.renderer.RenderManager;
 import com.jme3.renderer.android.AndroidGL;
 import com.jme3.renderer.opengl.*;
@@ -101,6 +102,7 @@ public class OGLESContext implements JmeContext, GLSurfaceView.Renderer, SoftTex
     private Application application;
     private Material blitMaterial;
     private Picture blitGeometry;
+    private final Camera blitCamera = new Camera(1, 1);
     private FrameBuffer linearFrameBuffer;
     private Texture2D linearFrameBufferColorTexture;
     private boolean linearFrameBufferDirty;
@@ -693,12 +695,27 @@ public class OGLESContext implements JmeContext, GLSurfaceView.Renderer, SoftTex
         }
 
         renderer.setMainFrameBufferOverride(null);
+        RenderManager renderManager = application.getRenderManager();
+        Camera previousCamera = renderManager.getCurrentCamera();
         try {
             renderer.setFrameBuffer(null);
+            int blitWidth = linearFrameBuffer.getWidth();
+            int blitHeight = linearFrameBuffer.getHeight();
+            if (blitCamera.getWidth() != blitWidth || blitCamera.getHeight() != blitHeight) {
+                blitCamera.resize(blitWidth, blitHeight, true);
+            }
+            renderManager.setCamera(blitCamera, true);
+            if (blitGeometry.getWidth() != blitWidth || blitGeometry.getHeight() != blitHeight) {
+                blitGeometry.setWidth(blitWidth);
+                blitGeometry.setHeight(blitHeight);
+            }            
             blitGeometry.updateGeometricState();
-            application.getRenderManager().renderGeometry(blitGeometry);
+            renderManager.renderGeometry(blitGeometry);
         } finally {
             renderer.setMainFrameBufferOverride(restoreMainFramebuffer);
+            if (previousCamera != null) {
+                renderManager.setCamera(previousCamera, false);
+            }
         }
         return true;
     }

--- a/jme3-lwjgl3/src/main/java/com/jme3/renderer/lwjgl/LwjglGLES.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/renderer/lwjgl/LwjglGLES.java
@@ -19,6 +19,7 @@ import org.lwjgl.opengles.GLES20;
 import org.lwjgl.opengles.GLES30;
 import org.lwjgl.opengles.GLES31;
 import org.lwjgl.opengles.EXTDisjointTimerQuery;
+import org.lwjgl.system.MemoryUtil;
 
 
 /**
@@ -45,31 +46,37 @@ public class LwjglGLES extends LwjglRender implements GL, GL2, GLES_30, GLExt, G
         }
     }
 
-    private static int getLimitBytes(ByteBuffer buffer) {
+    private static long getRemainingBytes(IntBuffer buffer) {
+        checkLimit(buffer);
+        return (long) buffer.remaining() * Integer.BYTES;
+    }
+
+    private static long getRemainingBytes(ByteBuffer buffer) {
         checkLimit(buffer);
         return buffer.remaining();
     }
 
-    private static int getLimitBytes(ShortBuffer buffer) {
-        checkLimit(buffer);
-        return buffer.remaining() * 2;
+    private static long getSyncHandle(Object sync) {
+        if (!(sync instanceof Long)) {
+            throw new IllegalArgumentException("Expected a sync object returned by glFenceSync");
+        }
+        return (Long) sync;
     }
 
-    private static int getLimitBytes(IntBuffer buffer) {
-        checkLimit(buffer);
-        return buffer.remaining() * 4;
-    }
+    private static void readMappedBuffer(int target, long offset, long byteCount, Buffer destination) {
+        long mappedAddress = GLES30.nglMapBufferRange(target, offset, byteCount, GLES30.GL_MAP_READ_BIT);
+        if (mappedAddress == MemoryUtil.NULL) {
+            throw new RendererException("Unable to map buffer for reading");
+        }
 
-    private static int getLimitBytes(FloatBuffer buffer) {
-        checkLimit(buffer);
-        return buffer.remaining() * 4;
+        try {
+            MemoryUtil.memCopy(mappedAddress, MemoryUtil.memAddress(destination), byteCount);
+        } finally {
+            if (!GLES30.glUnmapBuffer(target)) {
+                throw new RendererException("Mapped buffer data became corrupted while reading");
+            }
+        }
     }
-
-    private static int getLimitCount(Buffer buffer, int elementSize) {
-        checkLimit(buffer);
-        return buffer.remaining() / elementSize;
-    }
-
 
     @Override
     public void glActiveTexture(int texture) {
@@ -156,7 +163,7 @@ public class LwjglGLES extends LwjglRender implements GL, GL2, GLES_30, GLExt, G
 
     @Override
     public void glGetBufferSubData(int target, long offset, ByteBuffer data) {
-        throw new UnsupportedOperationException("OpenGL ES does not support glGetBufferSubData");
+        readMappedBuffer(target, offset, getRemainingBytes(data), data);
     }
 
     @Override
@@ -394,10 +401,7 @@ public class LwjglGLES extends LwjglRender implements GL, GL2, GLES_30, GLExt, G
 
     @Override
     public void glShaderSource(int shader, String[] string, IntBuffer length) {
-        if (string == null || string.length != 1) {
-            throw new UnsupportedOperationException("Expected exactly one shader source string");
-        }
-        GLES20.glShaderSource(shader, string[0]);
+        GLES20.glShaderSource(shader, string);
     }
 
     @Override
@@ -610,6 +614,34 @@ public class LwjglGLES extends LwjglRender implements GL, GL2, GLES_30, GLExt, G
     }
 
     @Override
+    public int glGetUniformBlockIndex(int program, String uniformBlockName) {
+        return GLES30.glGetUniformBlockIndex(program, uniformBlockName);
+    }
+
+    @Override
+    public void glBindBufferBase(int target, int index, int buffer) {
+        GLES30.glBindBufferBase(target, index, buffer);
+    }
+
+    @Override
+    public void glUniformBlockBinding(int program, int uniformBlockIndex, int uniformBlockBinding) {
+        GLES30.glUniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
+    }
+
+    @Override
+    public int glGetProgramResourceIndex(int program, int programInterface, String name) {
+        return GLES31.glGetProgramResourceIndex(program, programInterface, name);
+    }
+
+    @Override
+    public void glShaderStorageBlockBinding(int program, int storageBlockIndex, int storageBlockBinding) {
+        /*
+         * GLES 3.1 exposes shader storage block binding through GLSL layout(binding = N),
+         * but not as a GL entry point.
+         */
+    }
+
+    @Override
     public void glDrawBuffers(IntBuffer bufs) {
         checkLimit(bufs);
         GLES30.glDrawBuffers(bufs);
@@ -805,17 +837,17 @@ public class LwjglGLES extends LwjglRender implements GL, GL2, GLES_30, GLExt, G
 
     @Override
     public int glClientWaitSync(Object sync, int flags, long timeout) {
-        throw new UnsupportedOperationException("Sync fences not wired in this GLES wrapper yet");
+        return GLES30.glClientWaitSync(getSyncHandle(sync), flags, timeout);
     }
 
     @Override
     public void glDeleteSync(Object sync) {
-        throw new UnsupportedOperationException("Sync fences not wired in this GLES wrapper yet");
+        GLES30.glDeleteSync(getSyncHandle(sync));
     }
 
     @Override
     public Object glFenceSync(int condition, int flags) {
-        throw new UnsupportedOperationException("Sync fences not wired in this GLES wrapper yet");
+        return GLES30.glFenceSync(condition, flags);
     }
 
 
@@ -827,7 +859,6 @@ public class LwjglGLES extends LwjglRender implements GL, GL2, GLES_30, GLExt, G
 
     @Override
     public void glGetBufferSubData(int target, long offset, IntBuffer data) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'glGetBufferSubData'");
+        readMappedBuffer(target, offset, getRemainingBytes(data), data);
     }
 }

--- a/jme3-lwjgl3/src/main/java/com/jme3/renderer/lwjgl/LwjglGLES.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/renderer/lwjgl/LwjglGLES.java
@@ -17,7 +17,6 @@ import java.nio.ShortBuffer;
 import org.lwjgl.opengles.GLES;
 import org.lwjgl.opengles.GLES20;
 import org.lwjgl.opengles.GLES30;
-import org.lwjgl.opengles.GLES31;
 import org.lwjgl.opengles.EXTDisjointTimerQuery;
 import org.lwjgl.system.MemoryUtil;
 
@@ -630,15 +629,12 @@ public class LwjglGLES extends LwjglRender implements GL, GL2, GLES_30, GLExt, G
 
     @Override
     public int glGetProgramResourceIndex(int program, int programInterface, String name) {
-        return GLES31.glGetProgramResourceIndex(program, programInterface, name);
+        throw new UnsupportedOperationException("Shader storage buffer objects require OpenGL ES 3.1");
     }
 
     @Override
     public void glShaderStorageBlockBinding(int program, int storageBlockIndex, int storageBlockBinding) {
-        /*
-         * GLES 3.1 exposes shader storage block binding through GLSL layout(binding = N),
-         * but not as a GL entry point.
-         */
+        throw new UnsupportedOperationException("Shader storage buffer objects require OpenGL ES 3.1");
     }
 
     @Override
@@ -738,15 +734,13 @@ public class LwjglGLES extends LwjglRender implements GL, GL2, GLES_30, GLExt, G
 
     @Override
     public void glGetMultisample(int pname, int index, FloatBuffer val) {
-        checkLimit(val);
-        GLES31.glGetMultisamplefv(pname, index, val);
+        throw new UnsupportedOperationException("Multisample textures require OpenGL ES 3.1");
     }
 
     @Override
     public void glTexImage2DMultisample(int target, int samples, int internalformat, int width, int height,
             boolean fixedSampleLocations) {
-        GLES31.glTexStorage2DMultisample(target, samples, internalformat, width, height,
-                fixedSampleLocations);
+        throw new UnsupportedOperationException("Multisample textures require OpenGL ES 3.1");
     }
 
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -57,6 +57,7 @@ import com.jme3.input.lwjgl.SdlMouseInput;
 import com.jme3.material.Material;
 import com.jme3.math.Vector2f;
 import com.jme3.renderer.Caps;
+import com.jme3.renderer.Camera;
 import com.jme3.renderer.RenderManager;
 import com.jme3.system.AppSettings;
 import com.jme3.system.Displays;
@@ -216,6 +217,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
     private final Vector2f oldScale = new Vector2f(1, 1);
     private Material auxFramebufferBlitMaterial;
     private Picture auxFramebufferBlitGeometry;
+    private final Camera auxFramebufferBlitCamera = new Camera(1, 1);
     private FrameBuffer auxFramebuffer;
     private Texture2D auxFramebufferColorTexture;
     private boolean auxFramebufferDirty;
@@ -872,12 +874,27 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         }
 
         glRenderer.setMainFrameBufferOverride(null);
+        Camera previousCamera = renderManager.getCurrentCamera();
         try {
             glRenderer.setFrameBuffer(null);
+            int blitWidth = auxFramebuffer.getWidth();
+            int blitHeight = auxFramebuffer.getHeight();
+            if (auxFramebufferBlitCamera.getWidth() != blitWidth
+                    || auxFramebufferBlitCamera.getHeight() != blitHeight) {
+                auxFramebufferBlitCamera.resize(blitWidth, blitHeight, true);
+            }
+            renderManager.setCamera(auxFramebufferBlitCamera, true);
+            if (auxFramebufferBlitGeometry.getWidth() != blitWidth || auxFramebufferBlitGeometry.getHeight() != blitHeight) {
+                auxFramebufferBlitGeometry.setWidth(blitWidth);
+                auxFramebufferBlitGeometry.setHeight(blitHeight);
+            }
             auxFramebufferBlitGeometry.updateGeometricState();
             renderManager.renderGeometry(auxFramebufferBlitGeometry);
         } finally {
             glRenderer.setMainFrameBufferOverride(restoreMainFramebuffer);
+            if (previousCamera != null) {
+                renderManager.setCamera(previousCamera, false);
+            }
         }
         return true;
     }


### PR DESCRIPTION
This PR improves GLES3 renderers by implementing some missing apis.
It also changes the software sRGB correction logic to use a dedicated camera, fixing potential issues that could arise in apps using special camera settings for their default camera.