### PR TITLE
Add Matrix4f affine inverse round-trip test

### DIFF
--- a/jme3-core/src/test/java/com/jme3/math/Matrix4fTest.java
+++ b/jme3-core/src/test/java/com/jme3/math/Matrix4fTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2009-2021 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.math;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Matrix4fTest {
+
+    /**
+     * Builds an affine transform with translation, scale, and rotation via
+     * setTransform, inverts it, multiplies transform by inverse, and asserts
+     * the product is the identity matrix.
+     */
+    @Test
+    public void testInvert_roundTripWithTranslationScaleAndRotation() {
+        final Matrix3f rotation = new Matrix3f();
+        rotation.fromAngleAxis(FastMath.HALF_PI, Vector3f.UNIT_Y);
+
+        final Matrix4f transform = new Matrix4f();
+        transform.setTransform(
+                new Vector3f(3.0f, -2.0f, 5.0f),
+                new Vector3f(2.0f, 1.0f, 4.0f),
+                rotation);
+
+        final Matrix4f inverse = transform.invert();
+        final Matrix4f product = transform.mult(inverse);
+
+        assertTrue(product.isSimilar(Matrix4f.IDENTITY, 1e-4f));
+    }
+}

--- a/jme3-core/src/test/java/com/jme3/math/Matrix4fTest.java
+++ b/jme3-core/src/test/java/com/jme3/math/Matrix4fTest.java
@@ -39,8 +39,8 @@ public class Matrix4fTest {
 
     /**
      * Builds an affine transform with translation, scale, and rotation via
-     * setTransform, inverts it, multiplies transform by inverse, and asserts
-     * the product is the identity matrix.
+     * setTransform, inverts it, and asserts transform * inverse and
+     * inverse * transform are both the identity matrix.
      */
     @Test
     public void testInvert_roundTripWithTranslationScaleAndRotation() {
@@ -54,8 +54,13 @@ public class Matrix4fTest {
                 rotation);
 
         final Matrix4f inverse = transform.invert();
-        final Matrix4f product = transform.mult(inverse);
 
-        assertTrue(product.isSimilar(Matrix4f.IDENTITY, 1e-4f));
+        final Matrix4f product = transform.mult(inverse);
+        assertTrue(product.isSimilar(Matrix4f.IDENTITY, 1e-4f),
+                () -> "transform * inverse should be identity, but was:\n" + product);
+
+        final Matrix4f inverseProduct = inverse.mult(transform);
+        assertTrue(inverseProduct.isSimilar(Matrix4f.IDENTITY, 1e-4f),
+                () -> "inverse * transform should be identity, but was:\n" + inverseProduct);
     }
 }


### PR DESCRIPTION
## Summary

Adds an initial `Matrix4fTest` for `com.jme3.math.Matrix4f`, which previously had no dedicated test suite.

The test builds a typical affine transform using translation, scale, and rotation via `setTransform`, inverts it with `invert()`, multiplies the transform by its inverse with `mult()`, and verifies the result is approximately `Matrix4f.IDENTITY`.

## Motivation

`Matrix4f` is used throughout jMonkeyEngine for world/view/projection matrices, camera math, skinning, shadows, and collision transforms. However, it currently has limited direct test coverage. This test introduces a basic mathematical property of affine transforms to exercise several important methods together, and provides a starting point for future, more comprehensive `Matrix4f` tests.