### PR TITLE
Support exclusive fullscreen

### DIFF
--- a/jme3-core/src/main/java/com/jme3/system/AppSettings.java
+++ b/jme3-core/src/main/java/com/jme3/system/AppSettings.java
@@ -81,6 +81,20 @@ public final class AppSettings extends HashMap<String, Object> {
     public static final float DISPLAY_SCALE_DPI_AWARE = 1f;
 
     /**
+     * Use borderless fullscreen desktop mode when fullscreen is enabled.
+     *
+     * @see #setFullscreenMode(java.lang.String)
+     */
+    public static final String FULLSCREEN_MODE_BORDERLESS_WINDOW = "BorderlessWindow";
+
+    /**
+     * Use an exclusive fullscreen display mode when fullscreen is enabled.
+     *
+     * @see #setFullscreenMode(java.lang.String)
+     */
+    public static final String FULLSCREEN_MODE_EXCLUSIVE_FULLSCREEN = "ExclusiveFullscreen";
+
+    /**
      * Use LWJGL as the display system and force using the OpenGL2.0 renderer.
      * <p>
      * If the underlying system does not support OpenGL2.0, then the context
@@ -380,6 +394,7 @@ public final class AppSettings extends HashMap<String, Object> {
         defaults.put("StencilBits", 0);
         defaults.put("Samples", 0);
         defaults.put("Fullscreen", false);
+        defaults.put("FullscreenMode", FULLSCREEN_MODE_BORDERLESS_WINDOW);
         defaults.put("Title", JmeVersion.FULL_NAME);
         defaults.put("Renderer", ANGLE_GLES3);
         defaults.put("AudioRenderer", OPENAL);
@@ -1131,6 +1146,30 @@ public final class AppSettings extends HashMap<String, Object> {
     }
 
     /**
+     * Sets how supporting backends enter fullscreen when
+     * {@link #setFullscreen(boolean)} is enabled.
+     * <p>
+     * <ul>
+     * <li>{@link #FULLSCREEN_MODE_BORDERLESS_WINDOW}: borderless fullscreen
+     * desktop mode.</li>
+     * <li>{@link #FULLSCREEN_MODE_EXCLUSIVE_FULLSCREEN}: exclusive fullscreen
+     * using the closest display mode to the configured resolution and refresh
+     * rate.</li>
+     * </ul>
+     * Some backends may ignore this setting.
+     * (Default: {@link #FULLSCREEN_MODE_BORDERLESS_WINDOW})
+     *
+     * @param mode fullscreen mode
+     */
+    public void setFullscreenMode(String mode) {
+        if (!FULLSCREEN_MODE_BORDERLESS_WINDOW.equals(mode)
+                && !FULLSCREEN_MODE_EXCLUSIVE_FULLSCREEN.equals(mode)) {
+            throw new IllegalArgumentException("Unsupported fullscreen mode: " + mode);
+        }
+        putString("FullscreenMode", mode);
+    }
+
+    /**
      * Enable or disable vertical synchronization. If enabled, rendering will be
      * synchronized with the display's refresh interval.
      *
@@ -1380,6 +1419,21 @@ public final class AppSettings extends HashMap<String, Object> {
      */
     public boolean isFullscreen() {
         return getBoolean("Fullscreen");
+    }
+
+    /**
+     * Gets how supporting backends enter fullscreen.
+     *
+     * @return one of {@link #FULLSCREEN_MODE_BORDERLESS_WINDOW} or
+     * {@link #FULLSCREEN_MODE_EXCLUSIVE_FULLSCREEN}
+     * @see #setFullscreenMode(java.lang.String)
+     */
+    public String getFullscreenMode() {
+        String mode = getString("FullscreenMode", FULLSCREEN_MODE_BORDERLESS_WINDOW);
+        if (!FULLSCREEN_MODE_EXCLUSIVE_FULLSCREEN.equals(mode)) {
+            return FULLSCREEN_MODE_BORDERLESS_WINDOW;
+        }
+        return mode;
     }
 
     /**

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -78,8 +78,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.lwjgl.Version;
+import org.lwjgl.sdl.SDL;
 import org.lwjgl.sdl.SDL_DisplayMode;
 import org.lwjgl.sdl.SDL_Event;
+import org.lwjgl.sdl.SDL_Rect;
 import org.lwjgl.sdl.SDL_Surface;
 import org.lwjgl.sdl.SDLStdinc;
 import org.lwjgl.system.Configuration;
@@ -95,6 +97,8 @@ import static org.lwjgl.sdl.SDLPixels.*;
 import static org.lwjgl.sdl.SDLSurface.*;
 import static org.lwjgl.sdl.SDLStdinc.SDL_setenv_unsafe;
 import static org.lwjgl.sdl.SDLVideo.*;
+import static org.lwjgl.system.APIUtil.apiGetFunctionAddress;
+import static org.lwjgl.system.JNI.invokePPZ;
 import static org.lwjgl.system.MemoryUtil.NULL;
 
 /**
@@ -105,6 +109,8 @@ import static org.lwjgl.system.MemoryUtil.NULL;
  */
 public abstract class LwjglWindow extends LwjglContext implements Runnable {
     private static final String BLIT_MATERIAL = "Common/MatDefs/Blit/Blit.j3md";
+    private static final long SDL_SET_WINDOW_FULLSCREEN_MODE = apiGetFunctionAddress(
+            SDL.getLibrary(), "SDL_SetWindowFullscreenMode");
     private static final LibraryInfo angleEGL = new LibraryInfo("angleEGL")
             .addNativeVariant(Platform.Windows64, "native/angle/windows/x86_64/libEGL.dll", "libEGL.dll")
             .addNativeVariant(Platform.Windows_ARM64, "native/angle/windows/arm64/libEGL.dll", "libEGL.dll")
@@ -310,9 +316,13 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             }
         }
 
-        int requestX = SDL_WINDOWPOS_UNDEFINED_DISPLAY((int) display);
-        int requestY = SDL_WINDOWPOS_UNDEFINED_DISPLAY((int) display);
-        if (!settings.isFullscreen()) {
+        int requestX;
+        int requestY;
+        if (settings.isFullscreen()) {
+            int[] displayOrigin = getDisplayOrigin();
+            requestX = displayOrigin[0];
+            requestY = displayOrigin[1];
+        } else {
             if (settings.getCenterWindow()) {
                 requestX = SDL_WINDOWPOS_CENTERED_DISPLAY((int) display);
                 requestY = SDL_WINDOWPOS_CENTERED_DISPLAY((int) display);
@@ -329,10 +339,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         if (DisplayScaleUtils.requestsHighDensityFramebuffer(settings.getDisplayScaleMode())) {
             windowFlags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
         }
-        if (settings.isFullscreen()) {
-            windowFlags |= SDL_WINDOW_FULLSCREEN;
-        }
-
         window = createWindow(settings, requestWidth, requestHeight, windowFlags, srgbFramebufferRequested);
         if (window == NULL) {
             throw new RuntimeException("Failed to create SDL window: " + SDL_GetError());
@@ -340,10 +346,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
 
         windowId = SDL_GetWindowID(window);
         windowCloseRequested.set(false);
-
-        if (!settings.isFullscreen()) {
-            SDL_SetWindowPosition(window, requestX, requestY);
-        }
+        SDL_SetWindowPosition(window, requestX, requestY);
+        applyFullscreenMode(settings, requestWidth, requestHeight);
 
         glContext = SDL_GL_CreateContext(window);
         if (glContext == NULL) {
@@ -369,6 +373,66 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         allowSwapBuffers = settings.isSwapBuffers();
 
         updateSizes(false);
+    }
+
+    private void applyFullscreenMode(AppSettings settings, int width, int height) {
+        if (!settings.isFullscreen()) {
+            return;
+        }
+
+        if (AppSettings.FULLSCREEN_MODE_EXCLUSIVE_FULLSCREEN.equals(settings.getFullscreenMode())) {
+            try (MemoryStack stack = MemoryStack.stackPush()) {
+                SDL_DisplayMode fullscreenMode = SDL_DisplayMode.malloc(stack);
+                float refreshRate = settings.getFrequency() > 0 ? settings.getFrequency() : 0f;
+                boolean includeHighDensityModes = DisplayScaleUtils.requestsHighDensityFramebuffer(
+                        settings.getDisplayScaleMode());
+                if (!SDL_GetClosestFullscreenDisplayMode((int) display, width, height, refreshRate,
+                        includeHighDensityModes, fullscreenMode)) {
+                    throw new RuntimeException("Unable to find an SDL exclusive fullscreen mode for "
+                            + width + "x" + height + "@" + refreshRate + "Hz: " + SDL_GetError());
+                }
+                if (!setWindowFullscreenMode(window, fullscreenMode.address())) {
+                    throw new RuntimeException("Unable to set SDL exclusive fullscreen mode "
+                            + fullscreenMode.w() + "x" + fullscreenMode.h() + "@"
+                            + fullscreenMode.refresh_rate() + "Hz: " + SDL_GetError());
+                }
+            }
+        } else if (!setWindowFullscreenMode(window, NULL)) {
+            throw new RuntimeException("Unable to set SDL borderless fullscreen mode: " + SDL_GetError());
+        }
+
+        if (!SDL_SetWindowFullscreen(window, true)) {
+            throw new RuntimeException("Unable to enter SDL fullscreen mode: " + SDL_GetError());
+        }
+
+        int actualDisplay = SDL_GetDisplayForWindow(window);
+        LOGGER.log(Level.INFO, "Entered SDL {0} fullscreen on display {1} (requested display {2})",
+                new Object[] {
+                        AppSettings.FULLSCREEN_MODE_EXCLUSIVE_FULLSCREEN.equals(settings.getFullscreenMode())
+                                ? "exclusive" : "borderless",
+                        actualDisplay,
+                        display
+                });
+    }
+
+    private boolean setWindowFullscreenMode(long window, long mode) {
+        return invokePPZ(window, mode, SDL_SET_WINDOW_FULLSCREEN_MODE);
+    }
+
+    private int[] getDisplayOrigin() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            SDL_Rect bounds = SDL_Rect.malloc(stack);
+            if (SDL_GetDisplayBounds((int) display, bounds)) {
+                return new int[] { bounds.x(), bounds.y() };
+            }
+        }
+
+        LOGGER.log(Level.WARNING, "Unable to query SDL display bounds for display {0}: {1}",
+                new Object[] { display, SDL_GetError() });
+        return new int[] {
+                SDL_WINDOWPOS_UNDEFINED_DISPLAY((int) display),
+                SDL_WINDOWPOS_UNDEFINED_DISPLAY((int) display)
+        };
     }
 
     private void configureVideoDriverHints(AppSettings settings) {


### PR DESCRIPTION
This PR adds exclusive fullscreen to the SDL3 backend, and a `FullscreenMode`  AppSetting to toggle between borderless window and exclusive fullscreen