### PR TITLE
Fix glTF CUBICSPLINE animation sampling

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -61,6 +61,7 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -1135,6 +1136,7 @@ public class GltfLoader implements AssetLoader {
             assertNotNull(dataIndex, "No output accessor Provided for animation sampler");
 
             String interpolation = getAsString(sampler, "interpolation");
+            boolean cubicSpline = "CUBICSPLINE".equals(interpolation);
             if (interpolation == null || !interpolation.equals("LINEAR")) {
                 // JME anim system only supports Linear interpolation (will be possible with monkanim though)
                 // TODO rework this once monkanim is core,
@@ -1153,18 +1155,30 @@ public class GltfLoader implements AssetLoader {
             if (targetPath.equals("translation")) {
                 trackData.timeArrays.add(new TrackData.TimeData(times, TrackData.Type.Translation));
                 Vector3f[] translations = readAccessorData(dataIndex, vector3fArrayPopulator);
+                if (cubicSpline) {
+                    translations = getCubicSplineValues(translations);
+                }
                 trackData.translations = translations;
             } else if (targetPath.equals("scale")) {
                 trackData.timeArrays.add(new TrackData.TimeData(times, TrackData.Type.Scale));
                 Vector3f[] scales = readAccessorData(dataIndex, vector3fArrayPopulator);
+                if (cubicSpline) {
+                    scales = getCubicSplineValues(scales);
+                }
                 trackData.scales = scales;
             } else if (targetPath.equals("rotation")) {
                 trackData.timeArrays.add(new TrackData.TimeData(times, TrackData.Type.Rotation));
                 Quaternion[] rotations = readAccessorData(dataIndex, quaternionArrayPopulator);
+                if (cubicSpline) {
+                    rotations = getCubicSplineValues(rotations);
+                }
                 trackData.rotations = rotations;
             } else {
                 trackData.timeArrays.add(new TrackData.TimeData(times, TrackData.Type.Morph));
                 float[] weights = readAccessorData(dataIndex, floatArrayPopulator);
+                if (cubicSpline) {
+                    weights = getCubicSplineValues(weights, times.length);
+                }
                 trackData.weights = weights;
                 hasMorphTrack = true;
             }
@@ -1493,6 +1507,23 @@ public class GltfLoader implements AssetLoader {
         Geometry g = (Geometry) spatial;
         int nbMorph = g.getMesh().getMorphTargets().length;
         return new MorphTrack(g, data.times, data.weights, nbMorph);
+    }
+
+    private <T> T[] getCubicSplineValues(T[] data) {
+        T[] values = Arrays.copyOf(data, data.length / 3);
+        for (int i = 0; i < values.length; i++) {
+            values[i] = data[i * 3 + 1];
+        }
+        return values;
+    }
+
+    private float[] getCubicSplineValues(float[] data, int timesLength) {
+        int valuesPerTime = data.length / timesLength / 3;
+        float[] values = new float[timesLength * valuesPerTime];
+        for (int i = 0; i < timesLength; i++) {
+            System.arraycopy(data, (i * 3 + 1) * valuesPerTime, values, i * valuesPerTime, valuesPerTime);
+        }
+        return values;
     }
 
     public <T> T fetchFromCache(String name, int index, Class<T> type) {

--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/GltfLoader.java
@@ -1510,6 +1510,12 @@ public class GltfLoader implements AssetLoader {
     }
 
     private <T> T[] getCubicSplineValues(T[] data) {
+        if (data == null) {
+            throw new AssetLoadException("No output data defined for cubic spline animation sampler");
+        }
+        if (data.length % 3 != 0) {
+            throw new AssetLoadException("Cubic spline animation sampler output does not contain tangent/value triplets");
+        }
         T[] values = Arrays.copyOf(data, data.length / 3);
         for (int i = 0; i < values.length; i++) {
             values[i] = data[i * 3 + 1];
@@ -1518,6 +1524,12 @@ public class GltfLoader implements AssetLoader {
     }
 
     private float[] getCubicSplineValues(float[] data, int timesLength) {
+        if (data == null) {
+            throw new AssetLoadException("No output data defined for cubic spline animation sampler");
+        }
+        if (timesLength <= 0 || data.length % timesLength != 0 || (data.length / timesLength) % 3 != 0) {
+            throw new AssetLoadException("Cubic spline animation sampler output does not match input times");
+        }
         int valuesPerTime = data.length / timesLength / 3;
         float[] values = new float[timesLength * valuesPerTime];
         for (int i = 0; i < timesLength; i++) {

--- a/jme3-plugins/src/test/java/com/jme3/scene/plugins/gltf/GltfLoaderTest.java
+++ b/jme3-plugins/src/test/java/com/jme3/scene/plugins/gltf/GltfLoaderTest.java
@@ -92,6 +92,17 @@ public class GltfLoaderTest {
     }
 
     @Test
+    public void testLoadCubicSplineScaleAnimation() {
+        try {
+            Spatial scene = assetManager.loadModel("gltf/cubicSplineScale.gltf");
+            dumpScene(scene, 0);
+        } catch (AssetLoadException ex) {
+            ex.printStackTrace();
+            Assertions.fail("Failed to import gltf model with cubic spline scale animation");
+        }
+    }
+
+    @Test
     public void testLightsPunctualExtension() {
         try {
             Spatial scene = assetManager.loadModel("gltf/lights/lights.gltf");

--- a/jme3-plugins/src/test/resources/gltf/cubicSplineScale.gltf
+++ b/jme3-plugins/src/test/resources/gltf/cubicSplineScale.gltf
@@ -1,0 +1,77 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "AnimatedNode"
+    }
+  ],
+  "animations": [
+    {
+      "name": "CubicSplineScale",
+      "channels": [
+        {
+          "sampler": 0,
+          "target": {
+            "node": 0,
+            "path": "scale"
+          }
+        }
+      ],
+      "samplers": [
+        {
+          "input": 0,
+          "interpolation": "CUBICSPLINE",
+          "output": 1
+        }
+      ]
+    }
+  ],
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAAAAAAAgD8AAABAAABAQAAAgEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAACAPwAAgD8AAAAAAACAPwAAgD8AAAAAAAAAQAAAAEAAAAAAAAAAQAAAAEAAAAAAAAAAQAAAAEAAAAAAAABAQAAAQEAAAAAAAABAQAAAQEAAAAAAAABAQAAAQEAAAAAAAACAQAAAgEAAAAAAAACAQAAAgEAAAAAAAACAQAAAgEA=",
+      "byteLength": 200
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 20
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 20,
+      "byteLength": 180
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 5,
+      "type": "SCALAR",
+      "min": [
+        0
+      ],
+      "max": [
+        4
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 15,
+      "type": "VEC3"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes glTF animation loading for CUBICSPLINE samplers by normalizing sampler output data before it is passed to TrackData.

glTF stores cubic spline animation output as triplets per keyframe:

`	ext
in tangent, value, out tangent
`

jME currently warns that only linear animation interpolation is supported, but then continues to read the full cubic spline output array as if it contained one value per timestamp. For a sampler with 5 input times, this produces 15 output values, which later fails in TrackData.checkTimesConsistency() with:

`	ext
AssetLoadException: Inconsistent animation sampling
`

This affects assets such as Khronos' InterpolationTest.gltf.

## Fix

When a sampler uses CUBICSPLINE, this change keeps the actual keyframe value from each triplet and discards the in/out tangents before assigning animation data to TrackData.

This does not add full cubic spline interpolation support. It preserves the existing behavior of warning that only linear interpolation is supported, while allowing the asset to load using the actual keyframe values instead of crashing.

Covered paths:

- translation
- scale
- rotation
- morph weights

## Test

Added a small regression glTF asset with a cubic spline scale animation.

Before this fix, the new test failed with:

`	ext
AssetLoadException: Inconsistent animation sampling
`

After this fix:

`	ext
./gradlew :jme3-plugins:test --tests com.jme3.scene.plugins.gltf.GltfLoaderTest.testLoadCubicSplineScaleAnimation --no-daemon
`

passes.

Also ran the full plugin test suite:

`	ext
./gradlew :jme3-plugins:test --no-daemon
`

Result:

`	ext
BUILD SUCCESSFUL
`

Fixes #2384