### PR TITLE
Default shader version selection to GLSL300 for GLES3

### DIFF
--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -1754,7 +1754,14 @@ public final class GLRenderer implements Renderer {
         if (language.startsWith("GLSL")) {
             if (version > 100) {
                 stringBuf.append("#version ");
-                stringBuf.append(language.substring(4));
+
+                if (version >= 150 && version < 300 && gles3) {
+                    // upgrade to 300, since it's the minimum version for GLES3.
+                    version = 300;
+                }
+
+                stringBuf.append(String.valueOf(version));
+                
                 if (version >= 150) {
                     if(gles3) {
                         stringBuf.append(" es");
@@ -1763,12 +1770,15 @@ public final class GLRenderer implements Renderer {
                         stringBuf.append(" core");
                     }
                 }
+
                 stringBuf.append("\n");
             } else {
-                if (gles2 || gles3) {
+                if (gles3) {
+                    // request GLSL ES (3.00) when compiling under GLES3.
+                    stringBuf.append("#version 300 es\n");
+                } else if (gles2) {
                     // request GLSL ES (1.00) when compiling under GLES2.
                     stringBuf.append("#version 100\n");
-
                 } else {
                     // version 100 does not exist in desktop GLSL.
                     // put version 110 in that case to enable strict checking

--- a/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/opengl/GLRenderer.java
@@ -1760,7 +1760,7 @@ public final class GLRenderer implements Renderer {
                     version = 300;
                 }
 
-                stringBuf.append(String.valueOf(version));
+                stringBuf.append(version);
                 
                 if (version >= 150) {
                     if(gles3) {


### PR DESCRIPTION
JME shader version default ( GLSL100 ) selects the minimum glsl version available in the platform.

The problem is that in GLES3 it defaults to `GLSL100` (GLES2) for every shader that is not specifically hinted to `GLSL300`, this means that `GLSL>=150 && GLSL < 300` shaders that would otherwise run fine in GLES3 are downgraded to GLES2 and break. 

GLES2 is not supported anymore and, after the recent updates to the engine, GLES3.0 is guaranteed in every platform, so having to deal with GLES2 and all its quirkiness just to support a lower default is not worth.

This PR move the default to `GLSL300` when using a GLES backend.


If a shader is written with the old syntax, after this PR it needs to import `GLSLCompat.glsllib`, but this technically already the case in jme, since without `GLSLCompat` the shader will not work properly anyway.