### PR TITLE
make ios backend check AppSettings.isEmulateMouse before enabling mouse event emulation

### DIFF
--- a/jme3-ios/src/main/java/com/jme3/input/ios/IosInputHandler.java
+++ b/jme3-ios/src/main/java/com/jme3/input/ios/IosInputHandler.java
@@ -21,7 +21,7 @@ public class IosInputHandler implements TouchInput {
     private final static int MAX_TOUCH_EVENTS = 1024;
 
     // Custom settings
-    private boolean mouseEventsEnabled = true;
+    private boolean mouseEventsEnabled = false;
     private boolean mouseEventsInvertX = false;
     private boolean mouseEventsInvertY = false;
     private boolean keyboardEventsEnabled = false;
@@ -143,7 +143,7 @@ public class IosInputHandler implements TouchInput {
     public void loadSettings(AppSettings settings) {
         // TODO: add simulate keyboard to settings
 //        keyboardEventsEnabled = true;
-        mouseEventsEnabled = true;//settings.isEmulateMouse();
+        mouseEventsEnabled = settings.isEmulateMouse();
         mouseEventsInvertX = settings.isEmulateMouseFlipX();
         mouseEventsInvertY = settings.isEmulateMouseFlipY();
 


### PR DESCRIPTION
make ios backend check AppSettings.isEmulateMouse before enabling mouse event emulation