### PR TITLE
Tolerate gated screenshot test checks

### DIFF
--- a/.github/workflows/screenshot-test-comment.yml
+++ b/.github/workflows/screenshot-test-comment.yml
@@ -24,6 +24,8 @@ jobs:
         run: sleep 120
 
       - name: Wait for Screenshot Tests to complete
+        id: wait-for-screenshot-tests
+        continue-on-error: true
         uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -72,6 +74,8 @@ jobs:
 
             if (!screenshotTestRun) {
               console.log('Screenshot test job not found');
+              core.notice('Run Screenshot Tests check was not found. The build workflow may be waiting for maintainer approval.');
+              core.setOutput('failed', 'false');
               return;
             }
 


### PR DESCRIPTION
## Summary

- keep the screenshot comment workflow from failing when the screenshot check was never created
- report the missing check as a notice, which can happen when the pull request build workflow is waiting for maintainer approval

## Reasoning

Fork pull requests can leave the `Build jMonkeyEngine` workflow in `action_required` before any jobs are created. In that case the `Run Screenshot Tests` check never exists, but the `pull_request_target` comment workflow still runs and currently fails while waiting for that check.

This keeps real screenshot failures working the same way, while avoiding a misleading failed check when there was no screenshot test run to inspect.

