### PR TITLE
Fix scene processor resizing with highdpi/supersampling mode

### DIFF
--- a/jme3-android/src/main/java/com/jme3/app/AndroidHarnessFragment.java
+++ b/jme3-android/src/main/java/com/jme3/app/AndroidHarnessFragment.java
@@ -244,6 +244,7 @@ public abstract class AndroidHarnessFragment extends Fragment implements SystemL
     }
 
     @Override
+    @Deprecated
     public void rescale(float x, float y) {
         app.rescale(x, y);
     }

--- a/jme3-android/src/main/java/com/jme3/system/android/OGLESContext.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/OGLESContext.java
@@ -465,7 +465,6 @@ public class OGLESContext implements JmeContext, GLSurfaceView.Renderer, SoftTex
         if (renderable.get()) {
             logger.log(Level.FINE, "App already initialized, calling reshape");
             listener.reshape(logicalWidth, logicalHeight, getRenderFramebufferWidth(), getRenderFramebufferHeight());
-            listener.rescale(displayScale.x, displayScale.y);
         }
     }
 
@@ -512,7 +511,6 @@ public class OGLESContext implements JmeContext, GLSurfaceView.Renderer, SoftTex
         updateDisplayScaleMetrics();
         if (renderable.get()) {
             listener.reshape(logicalWidth, logicalHeight, getRenderFramebufferWidth(), getRenderFramebufferHeight());
-            listener.rescale(displayScale.x, displayScale.y);
         }
     }
 
@@ -531,7 +529,6 @@ public class OGLESContext implements JmeContext, GLSurfaceView.Renderer, SoftTex
                 listener.initialize();
                 if (framebufferWidth > 0 && framebufferHeight > 0) {
                     listener.reshape(logicalWidth, logicalHeight, getRenderFramebufferWidth(), getRenderFramebufferHeight());
-                    listener.rescale(displayScale.x, displayScale.y);
                 }
                 renderable.set(true);
             }

--- a/jme3-core/src/main/java/com/jme3/app/LegacyApplication.java
+++ b/jme3-core/src/main/java/com/jme3/app/LegacyApplication.java
@@ -603,7 +603,13 @@ public class LegacyApplication implements Application, SystemListener {
         }
     }
 
+    /**
+     * @deprecated Display scale changes are reported through
+     * {@link #reshape(int, int, int, int)}. Built-in contexts no longer call
+     * this method.
+     */
     @Override
+    @Deprecated
     public void rescale(float x, float y) {
         if (renderManager != null) {
             renderManager.notifyRescale(x, y);

--- a/jme3-core/src/main/java/com/jme3/post/Filter.java
+++ b/jme3-core/src/main/java/com/jme3/post/Filter.java
@@ -203,11 +203,18 @@ public abstract class Filter implements Savable {
         }
 
         public void cleanup(Renderer r) {
-            renderFrameBuffer.dispose();
-            renderedTexture.getImage().dispose();
-            if(depthTexture!=null){
+            if (renderFrameBuffer != null) {
+                renderFrameBuffer.dispose();
+                renderFrameBuffer = null;
+            }
+            if (renderedTexture != null && renderedTexture.getImage() != null) {
+                renderedTexture.getImage().dispose();
+                renderedTexture = null;
+            }
+            if (depthTexture != null && depthTexture.getImage() != null) {
                 depthTexture.getImage().dispose();
-            }  
+                depthTexture = null;
+            }
         }
 
         @Override

--- a/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/FilterPostProcessor.java
@@ -102,6 +102,7 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
     private float top;
     private int originalWidth;
     private int originalHeight;
+    private boolean resizeWithDefaultFramebuffer;
     private int lastFilterIndex = -1;
     private boolean cameraInit = false;
     private boolean multiView = false;
@@ -217,11 +218,11 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
         right = cam.getViewPortRight();
         top = cam.getViewPortTop();
         bottom = cam.getViewPortBottom();
-        originalWidth = cam.getWidth();
-        originalHeight = cam.getHeight();
+        originalWidth = vp.getRenderTargetWidth();
+        originalHeight = vp.getRenderTargetHeight();
 
         // First call to reshape to set up internal framebuffers and textures
-        reshape(vp, cam.getWidth(), cam.getHeight());
+        reshape(vp, originalWidth, originalHeight);
     }
 
     /**
@@ -534,20 +535,8 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
             viewPort.setOutputFrameBuffer(outputBuffer);
             viewPort = null;
 
-            // Dispose of internal framebuffers and textures
-            if (renderFrameBuffer != null) {
-                renderFrameBuffer.dispose();
-            }
-            if (depthTexture != null) {
-                depthTexture.getImage().dispose();
-            }
-            filterTexture.getImage().dispose();
-            if (renderFrameBufferMS != null) {
-                renderFrameBufferMS.dispose();
-            }
-            for (Filter filter : filters.getArray()) {
-                filter.cleanup(renderer);
-            }
+            cleanupFilterResources();
+            cleanupFrameBuffers();
         }
     }
 
@@ -602,8 +591,14 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
         cameraInit = true;
         computeDepth = false;
 
-        if (renderFrameBuffer == null && renderFrameBufferMS == null) {
+        boolean initialized = renderFrameBuffer != null || renderFrameBufferMS != null;
+        if (!initialized) {
             outputBuffer = viewPort.getOutputFrameBuffer();
+            resizeWithDefaultFramebuffer = outputBuffer == null;
+        } else {
+            viewPort.setOutputFrameBuffer(outputBuffer);
+            cleanupFilterResources();
+            cleanupFrameBuffers();
         }
 
         Collection<Caps> caps = renderer.getCaps();
@@ -650,6 +645,31 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
             initFilter(filter, vp);
         }
         setupViewPortFrameBuffer();
+    }
+
+    private void cleanupFilterResources() {
+        for (Filter filter : filters.getArray()) {
+            filter.cleanup(renderer);
+        }
+    }
+
+    private void cleanupFrameBuffers() {
+        if (renderFrameBuffer != null) {
+            renderFrameBuffer.dispose();
+            renderFrameBuffer = null;
+        }
+        if (renderFrameBufferMS != null) {
+            renderFrameBufferMS.dispose();
+            renderFrameBufferMS = null;
+        }
+        if (filterTexture != null && filterTexture.getImage() != null) {
+            filterTexture.getImage().dispose();
+        }
+        filterTexture = null;
+        if (depthTexture != null && depthTexture.getImage() != null) {
+            depthTexture.getImage().dispose();
+        }
+        depthTexture = null;
     }
 
     /**
@@ -804,5 +824,6 @@ public class FilterPostProcessor implements SceneProcessor, Savable {
         } else {
             viewPort.setOutputFrameBuffer(renderFrameBuffer);
         }
+        viewPort.setResizeWithDefaultFramebuffer(resizeWithDefaultFramebuffer);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/post/HDRRenderer.java
+++ b/jme3-core/src/main/java/com/jme3/post/HDRRenderer.java
@@ -61,6 +61,7 @@ public class HDRRenderer implements SceneProcessor {
     private Renderer renderer;
     private RenderManager renderManager;
     private ViewPort viewPort;
+    private boolean resizeWithDefaultFramebuffer;
     private static final Logger logger = Logger.getLogger(HDRRenderer.class.getName());
     private Camera fbCam = new Camera(1, 1);
 
@@ -282,11 +283,13 @@ public class HDRRenderer implements SceneProcessor {
             msFB.setDepthBuffer(Format.Depth);
             msFB.setColorBuffer(bufFormat);
             vp.setOutputFrameBuffer(msFB);
+            vp.setResizeWithDefaultFramebuffer(resizeWithDefaultFramebuffer);
         } else {
             if (numSamples > 1)
                 logger.warning("FBO multisampling not supported on this GPU, request ignored.");
 
             vp.setOutputFrameBuffer(mainSceneFB);
+            vp.setResizeWithDefaultFramebuffer(resizeWithDefaultFramebuffer);
         }
 
         createLumShaders();
@@ -331,8 +334,10 @@ public class HDRRenderer implements SceneProcessor {
         tone.setFloat("White", 100);
 
         // load();
-        int w = vp.getCamera().getWidth();
-        int h = vp.getCamera().getHeight();
+        FrameBuffer outputBuffer = vp.getOutputFrameBuffer();
+        resizeWithDefaultFramebuffer = outputBuffer == null;
+        int w = vp.getRenderTargetWidth();
+        int h = vp.getRenderTargetHeight();
         reshape(vp, w, h);
     }
 

--- a/jme3-core/src/main/java/com/jme3/post/SceneProcessor.java
+++ b/jme3-core/src/main/java/com/jme3/post/SceneProcessor.java
@@ -65,10 +65,15 @@ public interface SceneProcessor {
     /**
      * Called when the scale of the viewport has been changed.
      *
+     * @deprecated Display scale changes are reported through
+     * {@link #reshape(ViewPort, int, int)} using the viewport render target size.
+     * Built-in contexts no longer call this method.
+     *
      * @param vp the affected ViewPort
      * @param x the new horizontal scale 
      * @param y the new vertical scale 
      */
+    @Deprecated
     public default void rescale(ViewPort vp, float x, float y) {
 
     }

--- a/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
@@ -486,6 +486,7 @@ public class RenderManager {
         }
     }
 
+    @Deprecated
     private void notifyRescale(ViewPort vp, float x, float y) {
         List<SceneProcessor> processors = vp.getProcessors();
         for (SceneProcessor proc : processors) {
@@ -555,9 +556,14 @@ public class RenderManager {
      * Internal use only.
      * Updates the scale of all on-screen ViewPorts
      *
+     * @deprecated Display scale changes are handled by {@link #notifyReshape(int, int, int, int)}
+     * using logical and framebuffer sizes. Built-in contexts no longer call
+     * this method.
+     *
      * @param x the new horizontal scale
      * @param y the new vertical scale
      */
+    @Deprecated
     public void notifyRescale(float x, float y) {
         for (ViewPort vp : preViewPorts) {
             notifyRescale(vp, x, y);

--- a/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/RenderManager.java
@@ -532,7 +532,7 @@ public class RenderManager {
                                   int surfaceWidth, int surfaceHeight) {
         for (ViewPort vp : viewPorts) {
             FrameBuffer frameBuffer = vp.getOutputFrameBuffer();
-            if (frameBuffer == null) {
+            if (vp.isResizeWithDefaultFramebuffer() || frameBuffer == null) {
                 Camera cam = vp.getCamera();
                 cam.resize(logicalWidth, logicalHeight, true);
                 notifyReshape(vp, surfaceWidth, surfaceHeight);

--- a/jme3-core/src/main/java/com/jme3/renderer/ViewPort.java
+++ b/jme3-core/src/main/java/com/jme3/renderer/ViewPort.java
@@ -94,6 +94,7 @@ public class ViewPort {
      * FrameBuffer for output.
      */
     protected FrameBuffer out = null;
+    private boolean resizeWithDefaultFramebuffer;
     protected int renderTargetWidth;
     protected int renderTargetHeight;
 
@@ -310,6 +311,29 @@ public class ViewPort {
      */
     public void setOutputFrameBuffer(FrameBuffer out) {
         this.out = out;
+        resizeWithDefaultFramebuffer = false;
+    }
+
+    /**
+     * Determines whether reshape notifications for this viewport should follow
+     * the default framebuffer size.
+     *
+     * @return true if reshape should use the default framebuffer size, otherwise
+     *     false
+     */
+    public boolean isResizeWithDefaultFramebuffer() {
+        return resizeWithDefaultFramebuffer;
+    }
+
+    /**
+     * Sets whether reshape notifications for this viewport should follow the
+     * default framebuffer size.
+     *
+     * @param resizeWithDefaultFramebuffer true to use the default framebuffer size, false to
+     *     use the explicit output framebuffer size
+     */
+    public void setResizeWithDefaultFramebuffer(boolean resizeWithDefaultFramebuffer) {
+        this.resizeWithDefaultFramebuffer = resizeWithDefaultFramebuffer;
     }
 
     void setRenderTargetSize(int width, int height) {

--- a/jme3-core/src/main/java/com/jme3/system/SystemListener.java
+++ b/jme3-core/src/main/java/com/jme3/system/SystemListener.java
@@ -66,9 +66,15 @@ public interface SystemListener {
 
     /**
      * Called to notify the application that the scale has changed.
+     *
+     * @deprecated Display scale changes are reported through
+     * {@link #reshape(int, int, int, int)}. Built-in contexts no longer call
+     * this method.
+     *
      * @param x the new horizontal scale of the display 
      * @param y the new vertical scale of the display
      */
+    @Deprecated
     public default void rescale(float x, float y){
 
     }

--- a/jme3-core/src/test/java/com/jme3/post/FilterPostProcessorTest.java
+++ b/jme3-core/src/test/java/com/jme3/post/FilterPostProcessorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+package com.jme3.post;
+
+import com.jme3.asset.AssetManager;
+import com.jme3.material.Material;
+import com.jme3.renderer.Camera;
+import com.jme3.renderer.RenderManager;
+import com.jme3.renderer.Renderer;
+import com.jme3.renderer.ViewPort;
+import com.jme3.system.NullRenderer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FilterPostProcessorTest {
+
+    @Test
+    void initializesFromViewportRenderTargetSize() {
+        RenderManager renderManager = new RenderManager(new NullRenderer());
+        Camera camera = new Camera(320, 240);
+        ViewPort viewPort = renderManager.createMainView("main", camera);
+        renderManager.notifyReshape(320, 240, 640, 480);
+
+        RecordingFilter filter = new RecordingFilter();
+        FilterPostProcessor processor = new FilterPostProcessor(null);
+        processor.addFilter(filter);
+        viewPort.addProcessor(processor);
+
+        renderManager.notifyReshape(320, 240, 640, 480);
+
+        assertEquals(640, filter.width);
+        assertEquals(480, filter.height);
+
+        renderManager.notifyReshape(320, 240, 800, 600);
+
+        assertEquals(800, filter.width);
+        assertEquals(600, filter.height);
+        assertEquals(1, filter.cleanupCount);
+    }
+
+    private static class RecordingFilter extends Filter {
+        private int width;
+        private int height;
+        private int cleanupCount;
+
+        @Override
+        protected void initFilter(AssetManager manager, RenderManager renderManager, ViewPort vp, int w, int h) {
+            width = w;
+            height = h;
+        }
+
+        @Override
+        protected Material getMaterial() {
+            return null;
+        }
+
+        @Override
+        protected void cleanUpFilter(Renderer r) {
+            cleanupCount++;
+        }
+    }
+}

--- a/jme3-desktop/src/main/java/com/jme3/system/awt/AwtPanelsContext.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/awt/AwtPanelsContext.java
@@ -70,6 +70,7 @@ public class AwtPanelsContext implements JmeContext {
         }
 
         @Override
+        @Deprecated
         public void rescale(float x, float y) {
             logger.severe("rescale is not supported.");
         }

--- a/jme3-ios/src/main/java/com/jme3/system/ios/IGLESContext.java
+++ b/jme3-ios/src/main/java/com/jme3/system/ios/IGLESContext.java
@@ -319,7 +319,6 @@ public class IGLESContext implements JmeContext {
                 logger.log(Level.FINE, "iOS framebuffer resized, width: {0} height: {1}",
                         new Object[]{framebufferWidth, framebufferHeight});
                 listener.reshape(logicalWidth, logicalHeight, getRenderFramebufferWidth(), getRenderFramebufferHeight());
-                listener.rescale(displayScale.x, displayScale.y);
             }
         }
     }
@@ -365,7 +364,6 @@ public class IGLESContext implements JmeContext {
         linearFrameBufferDirty = true;
         if (renderable.get() && listener != null) {
             listener.reshape(logicalWidth, logicalHeight, getRenderFramebufferWidth(), getRenderFramebufferHeight());
-            listener.rescale(displayScale.x, displayScale.y);
         }
     }
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -238,6 +238,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
     private Texture2D blitColorTexture;
     private boolean blitFramebufferDirty;
     private boolean blitFramebufferTextureMultisampleWarningIssued;
+    private boolean windowStateChangedSinceLastSwap;
+    private boolean windowSizeUpdatePending;
 
     public LwjglWindow(final JmeContext.Type type) {
         if (!SUPPORTED_TYPES.contains(type)) {
@@ -982,6 +984,11 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             throw new IllegalStateException();
         }
 
+        pollEvents(true);
+        if (needClose.get() || windowCloseRequested.get()) {
+            return;
+        }
+
         if (!renderFrameWithBlitFramebuffer()) {
             listener.update();
         }
@@ -990,7 +997,14 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             try {
                 if ((type != Type.Canvas) && allowSwapBuffers && autoFlush) {
                     if (!SDL_GL_SwapWindow(window)) {
-                        throw new IllegalStateException("SDL_GL_SwapWindow failed: " + SDL_GetError());
+                        String error = SDL_GetError();
+                        pollEvents(true);
+                        if (!isTransientSwapFailure()) {
+                            throw new IllegalStateException("SDL_GL_SwapWindow failed: " + error);
+                        }
+                        LOGGER.log(Level.FINE, "Skipping transient SDL_GL_SwapWindow failure: {0}", error);
+                    } else {
+                        windowStateChangedSinceLastSwap = false;
                     }
                 }
             } catch (Throwable ex) {
@@ -1017,6 +1031,14 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         pollEvents(true);
     }
 
+    private boolean isTransientSwapFailure() {
+        if (needClose.get() || windowCloseRequested.get() || windowStateChangedSinceLastSwap) {
+            return true;
+        }
+        long flags = window == NULL ? 0 : SDL_GetWindowFlags(window);
+        return (flags & (SDL_WINDOW_HIDDEN | SDL_WINDOW_MINIMIZED | SDL_WINDOW_OCCLUDED)) != 0;
+    }
+
     private void pollEvents(boolean dispatchToInputs) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
             SDL_Event event = SDL_Event.malloc(stack);
@@ -1026,6 +1048,10 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
                     dispatchSDLEvent(event);
                 }
             }
+        }
+        if (windowSizeUpdatePending) {
+            windowSizeUpdatePending = false;
+            updateSizes(created.get() && dispatchToInputs);
         }
     }
 
@@ -1071,11 +1097,19 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             case SDL_EVENT_WINDOW_RESIZED:
             case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
             case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
-                if (created.get()) {
-                    updateSizes();
-                } else {
-                    updateSizes(false);
-                }
+                windowStateChangedSinceLastSwap = true;
+                windowSizeUpdatePending = true;
+                break;
+            case SDL_EVENT_WINDOW_SHOWN:
+            case SDL_EVENT_WINDOW_HIDDEN:
+            case SDL_EVENT_WINDOW_EXPOSED:
+            case SDL_EVENT_WINDOW_MINIMIZED:
+            case SDL_EVENT_WINDOW_RESTORED:
+            case SDL_EVENT_WINDOW_DISPLAY_CHANGED:
+            case SDL_EVENT_WINDOW_OCCLUDED:
+            case SDL_EVENT_WINDOW_ENTER_FULLSCREEN:
+            case SDL_EVENT_WINDOW_LEAVE_FULLSCREEN:
+                windowStateChangedSinceLastSwap = true;
                 break;
             default:
                 break;

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -229,7 +229,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
     private int oldFramebufferHeight;
     private int oldLogicalWidth;
     private int oldLogicalHeight;
-    private final Vector2f oldScale = new Vector2f(1, 1);
     private final Vector2f displayScale = new Vector2f(1, 1);
     private Material blitMaterial;
     private Picture blitGeometry;
@@ -586,10 +585,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
                 oldFramebufferHeight = framebufferHeight;
             }
 
-            if (oldScale.x != displayScale.x || oldScale.y != displayScale.y) {
-                listener.rescale(displayScale.x, displayScale.y);
-                oldScale.set(displayScale);
-            }
         }
     }
 
@@ -681,7 +676,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             oldFramebufferHeight = 0;
             oldLogicalWidth = 0;
             oldLogicalHeight = 0;
-            oldScale.set(1, 1);
         } catch (Exception ex) {
             if (failure == null) {
                 failure = ex;


### PR DESCRIPTION
Fixes https://github.com/jMonkeyEngine/jmonkeyengine/issues/2838

This pr:

1. deprecates the unused `rescale` hook, likely a left over from a previous attempt at implementing high dpi support. Currently unused by the engine and a defacto no-op.

2. handle resource and swap failures that can happen during fast window rescaling operations

3. add a `resizeWithDefaultFramebuffer` flag in ViewPort. When true the viewport will receive with and height values from 
the highdpi/supersampled framebuffer.

SceneProcessors, like FilterPostProcessor, rely on a sort of "hack" where they replace the viewport output framebuffer with their internal one, and then blit it back to the default framebuffer. 
The problem is that the scene processors are resized to their own viewport and  FilterPostProcessor resizes the viewport (and framebuffer) from its resize hook, so they resize each other recursively.

 The only reason this currently working is that FilterPostProcessor used the camera sizes to do the scaling, instead of the viewport output size. This used to work fine before because camera sizes used to be equivalent to the render target size, but this is not true anymore now that we have proper highdpi/scaling support, since camera sizes will be the logical size of the viewport while the underlying render target can be much bigger. Point 3 solves this by making the engine aware of when a viewport wants to track the default framebuffer.