### PR TITLE
Add missing dependency in ios module and test iOS build in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ on:
       - v3.5
       - v3.4
       - v3.3
-      - ios-2024_2
+      - ios
   pull_request:
   release:
     types: [published]
@@ -174,6 +174,29 @@ jobs:
             **/build/changed-images/**
             **/build/test-results/**
 
+  BuildIOS:
+    name: Build for iOS
+    runs-on: macos-latest
+    steps:
+      - name: Clone the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup the java environment
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.jdk }}
+          
+      - name: Validate the Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v6.1.0
+    
+      - name: Build iOS examples
+        shell: bash
+        run: |
+         ./gradlew buildIosSimulatorApp
+         
   # Build the engine, we only deploy from ubuntu-latest jdk25
   BuildJMonkey:
     name: Build on ${{ matrix.osName }} jdk${{ matrix.jdk }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,7 +174,7 @@ jobs:
             **/build/changed-images/**
             **/build/test-results/**
 
-  BuildIOS:
+  TestIOSBuild:
     name: Build for iOS
     runs-on: macos-latest
     steps:
@@ -195,7 +195,7 @@ jobs:
       - name: Build iOS examples
         shell: bash
         run: |
-         ./gradlew buildIosSimulatorApp
+         ./gradlew :jme3-ios-examples:buildIosSimulatorApp
          
   # Build the engine, we only deploy from ubuntu-latest jdk25
   BuildJMonkey:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,7 +187,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: ${{ matrix.jdk }}
+          java-version: 25
           
       - name: Validate the Gradle wrapper
         uses: gradle/actions/wrapper-validation@v6.1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,7 +175,7 @@ jobs:
             **/build/test-results/**
 
   TestIOSBuild:
-    name: Build for iOS
+    name: Test iOS build
     runs-on: macos-latest
     steps:
       - name: Clone the repo
@@ -196,6 +196,7 @@ jobs:
         shell: bash
         run: |
          ./gradlew :jme3-ios-examples:buildIosSimulatorApp
+         ./gradlew :jme3-ios-examples:buildIosDebugApp
          
   # Build the engine, we only deploy from ubuntu-latest jdk25
   BuildJMonkey:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,7 +196,6 @@ jobs:
         shell: bash
         run: |
          ./gradlew :jme3-ios-examples:buildIosSimulatorApp
-         ./gradlew :jme3-ios-examples:buildIosDebugApp
          
   # Build the engine, we only deploy from ubuntu-latest jdk25
   BuildJMonkey:

--- a/jme3-ios-examples/build.gradle
+++ b/jme3-ios-examples/build.gradle
@@ -304,11 +304,6 @@ dependencies {
     implementation project(':jme3-core')
     implementation project(':jme3-ios')
     implementation project(':jme3-saferallocator')
-    implementation libs.libjglios.core.ios
-    implementation libs.libjglios.gles.ios
-    implementation libs.libjglios.sdl3.ios
-    implementation libs.libjglios.openal.ios
-    implementation libs.libjglios.angle.ios
     implementation project(':jme3-effects')
     implementation project(':jme3-jbullet')
     implementation project(':jme3-jogg')

--- a/jme3-ios/build.gradle
+++ b/jme3-ios/build.gradle
@@ -4,4 +4,5 @@ dependencies {
     api libs.libjglios.gles.ios
     api libs.libjglios.sdl3.ios
     api libs.libjglios.openal.ios
+    api libs.libjglios.angle.ios
 }


### PR DESCRIPTION
This PR adds the missing angle-ios dependency to jme3-ios and removes all explicit libjglios dependencies from jme3-ios-example, to test the build with transitive dependencies inherited from jme3-ios, as  normal user project would do.