### PR TITLE
Fix iOS and graalvm build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ def nativeImagePluginPublishTasks = [
         publish                                      : ':publish',
         publishToMavenLocal                         : ':publishToMavenLocal',
         install                                      : ':install',
+        publishMavenPublicationToCentralRepository  : ':publishAllPublicationsToCentralRepository',
+        publishMavenPublicationToSNAPSHOTRepository : ':publishAllPublicationsToSNAPSHOTRepository',
+        publishMavenPublicationToDistRepository     : ':publishAllPublicationsToDistRepository',
         publishAllPublicationsToCentralRepository   : ':publishAllPublicationsToCentralRepository',
         publishAllPublicationsToSNAPSHOTRepository  : ':publishAllPublicationsToSNAPSHOTRepository',
         publishAllPublicationsToDistRepository      : ':publishAllPublicationsToDistRepository'

--- a/jme3-nativeimage-plugin/build.gradle
+++ b/jme3-nativeimage-plugin/build.gradle
@@ -33,7 +33,7 @@ java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -41,8 +41,8 @@ java {
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    compileOnly 'org.graalvm.sdk:nativeimage:25.0.3'
-    compileOnly 'org.graalvm.nativeimage:svm:25.0.3'
+    compileOnly 'org.graalvm.sdk:nativeimage:23.1.3'
+    compileOnly 'org.graalvm.nativeimage:svm:23.1.3'
 }
 
 gradlePlugin {

--- a/jme3-nativeimage-plugin/src/main/resources/org/jmonkeyengine/gradle/nativeimage/native-image-metadata.gradle
+++ b/jme3-nativeimage-plugin/src/main/resources/org/jmonkeyengine/gradle/nativeimage/native-image-metadata.gradle
@@ -63,7 +63,8 @@ def defaultTargetTypes = [
         'com.jme3.opencl.PlatformChooser',
         'com.jme3.network.Message',
         'com.jme3.network.serializing.Serializer',
-        'com.jme3.app.Application'
+        'com.jme3.app.Application',
+        'com.jme3.app.IosApplicationLauncher'
 ]
 
 def defaultTargetAnnotations = [


### PR DESCRIPTION
This PR applies the following fixes to the graalvm and iOS build:
- the native image plugin is now published in maven central
- graalvm metadata are automatically built for ios launchers
- the native image plugin can be used in java 21