### PR TITLE
Clear stale input states when triggers are removed and fix virtual LT/RT buttons in sdl backend

### DIFF
--- a/jme3-core/src/main/java/com/jme3/input/InputManager.java
+++ b/jme3-core/src/main/java/com/jme3/input/InputManager.java
@@ -673,11 +673,13 @@ public class InputManager implements RawInputListener {
 
         int hash = trigger.triggerHashCode();
         ArrayList<Mapping> maps = bindings.get(hash);
-        maps.remove(mapping);
-        if (maps.isEmpty()) {
-            bindings.remove(hash);
-            pressedButtons.remove(hash);
-            axisValues.remove(hash);
+        if (maps != null) {
+            maps.remove(mapping);
+            if (maps.isEmpty()) {
+                bindings.remove(hash);
+                pressedButtons.remove(hash);
+                axisValues.remove(hash);
+            }
         }
         mapping.triggers.remove((Integer) hash);
 

--- a/jme3-core/src/main/java/com/jme3/input/InputManager.java
+++ b/jme3-core/src/main/java/com/jme3/input/InputManager.java
@@ -643,11 +643,13 @@ public class InputManager implements RawInputListener {
         for (int i = triggers.size() - 1; i >= 0; i--) {
             int hash = triggers.get(i);
             ArrayList<Mapping> maps = bindings.get(hash);
-            maps.remove(mapping);
-            if (maps.isEmpty()) {
-                bindings.remove(hash);
-                pressedButtons.remove(hash);
-                axisValues.remove(hash);
+            if (maps != null) {
+                maps.remove(mapping);
+                if (maps.isEmpty()) {
+                    bindings.remove(hash);
+                    pressedButtons.remove(hash);
+                    axisValues.remove(hash);
+                }
             }
         }
         mapping.triggers.clear();

--- a/jme3-core/src/main/java/com/jme3/input/InputManager.java
+++ b/jme3-core/src/main/java/com/jme3/input/InputManager.java
@@ -644,7 +644,14 @@ public class InputManager implements RawInputListener {
             int hash = triggers.get(i);
             ArrayList<Mapping> maps = bindings.get(hash);
             maps.remove(mapping);
+            if (maps.isEmpty()) {
+                bindings.remove(hash);
+                pressedButtons.remove(hash);
+                axisValues.remove(hash);
+            }
         }
+        mapping.triggers.clear();
+        mapping.listeners.clear();
     }
 
     /**
@@ -664,8 +671,15 @@ public class InputManager implements RawInputListener {
             throw new IllegalArgumentException("Cannot find mapping: " + mappingName);
         }
 
-        ArrayList<Mapping> maps = bindings.get(trigger.triggerHashCode());
+        int hash = trigger.triggerHashCode();
+        ArrayList<Mapping> maps = bindings.get(hash);
         maps.remove(mapping);
+        if (maps.isEmpty()) {
+            bindings.remove(hash);
+            pressedButtons.remove(hash);
+            axisValues.remove(hash);
+        }
+        mapping.triggers.remove((Integer) hash);
 
     }
 

--- a/jme3-core/src/test/java/com/jme3/test/PreventCoreIssueRegressions.java
+++ b/jme3-core/src/test/java/com/jme3/test/PreventCoreIssueRegressions.java
@@ -41,8 +41,13 @@ import com.jme3.app.state.ScreenshotAppState;
 import com.jme3.asset.AssetManager;
 import com.jme3.asset.DesktopAssetManager;
 import com.jme3.input.InputManager;
+import com.jme3.input.KeyInput;
+import com.jme3.input.RawInputListener;
+import com.jme3.input.controls.AnalogListener;
+import com.jme3.input.controls.KeyTrigger;
 import com.jme3.input.dummy.DummyKeyInput;
 import com.jme3.input.dummy.DummyMouseInput;
+import com.jme3.input.event.KeyInputEvent;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.Camera;
 import com.jme3.renderer.RenderManager;
@@ -53,7 +58,10 @@ import com.jme3.system.NullRenderer;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -131,6 +139,87 @@ public class PreventCoreIssueRegressions {
         for (Joint joint : sControl.getArmature().getJointList()) {
             assertTrue(Vector3f.isValidVector(joint.getLocalTranslation()),
                     "Invalid translation for joint " + joint.getName());
+        }
+    }
+
+    @Test
+    public void testDeletedMappingClearsPressedKeyState() {
+        TestKeyInput keys = new TestKeyInput();
+        keys.initialize();
+        DummyMouseInput mouse = new DummyMouseInput();
+        mouse.initialize();
+        InputManager inputManager = new InputManager(mouse, keys, null, null);
+        List<String> calls = new ArrayList<>();
+        KeyTrigger trigger = new KeyTrigger(KeyInput.KEY_D);
+
+        inputManager.addMapping("walk", trigger);
+        inputManager.addListener((AnalogListener) (name, value, tpf) -> calls.add("old"), "walk");
+        keys.queue(key(KeyInput.KEY_D, true, keys.getInputTimeNanos()));
+        inputManager.update(0.016f);
+
+        inputManager.deleteMapping("walk");
+        inputManager.addMapping("walk", trigger);
+        inputManager.addListener((AnalogListener) (name, value, tpf) -> calls.add("new"), "walk");
+        inputManager.update(0.016f);
+
+        assertFalse(calls.contains("new"));
+    }
+
+    @Test
+    public void testDeletedTriggerClearsPressedKeyState() {
+        TestKeyInput keys = new TestKeyInput();
+        keys.initialize();
+        DummyMouseInput mouse = new DummyMouseInput();
+        mouse.initialize();
+        InputManager inputManager = new InputManager(mouse, keys, null, null);
+        List<String> calls = new ArrayList<>();
+        KeyTrigger trigger = new KeyTrigger(KeyInput.KEY_D);
+
+        inputManager.addMapping("walk", trigger);
+        inputManager.addListener((AnalogListener) (name, value, tpf) -> calls.add("old"), "walk");
+        keys.queue(key(KeyInput.KEY_D, true, keys.getInputTimeNanos()));
+        inputManager.update(0.016f);
+
+        inputManager.deleteTrigger("walk", trigger);
+        inputManager.addMapping("newWalk", trigger);
+        inputManager.addListener((AnalogListener) (name, value, tpf) -> calls.add("new"), "newWalk");
+        inputManager.update(0.016f);
+
+        assertFalse(calls.contains("new"));
+    }
+
+    private static KeyInputEvent key(int keyCode, boolean pressed, long time) {
+        KeyInputEvent event = new KeyInputEvent(keyCode, '\0', pressed, false);
+        event.setTime(time);
+        return event;
+    }
+
+    private static final class TestKeyInput extends DummyKeyInput {
+        private final Queue<KeyInputEvent> events = new ArrayDeque<>();
+        private RawInputListener listener;
+        private long timeNanos = 1_000_000L;
+
+        private void queue(KeyInputEvent event) {
+            events.add(event);
+        }
+
+        @Override
+        public void setInputListener(RawInputListener listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        public void update() {
+            super.update();
+            while (!events.isEmpty()) {
+                listener.onKeyEvent(events.remove());
+            }
+        }
+
+        @Override
+        public long getInputTimeNanos() {
+            timeNanos += 16_000_000L;
+            return timeNanos;
         }
     }
 }

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/SdlJoystickInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/SdlJoystickInput.java
@@ -357,6 +357,11 @@ public class SdlJoystickInput implements JoyInput {
                     int buttonId = button.getButtonId();
                     String jmeButtonId = button.getLogicalId();
 
+                    if (JoystickButton.BUTTON_XBOX_LT.equals(jmeButtonId)
+                            || JoystickButton.BUTTON_XBOX_RT.equals(jmeButtonId)) {
+                        continue;
+                    }
+
                     boolean pressed = SDL_GetGamepadButton(gp, buttonId);
                     updateButton(button, pressed);
 


### PR DESCRIPTION
This PR solves two input related issues:
1. when all triggers for a mapping are removed, the state of the button/axis is cleared: before it was possible to remove all triggers while a button was pressed, leaving it permanently pressed.
2. Skip polling of virtual LT/RT buttons in SDL backend: for compatibility reasons the SDL backend creates two "virtual buttons" for RT/LT axis, but since they are not real button seen by SDL,  the normal polling was overwriting the values computed by the backend.

