### PR TITLE
Add tester methods to JSON abstraction

### DIFF
--- a/jme3-plugins-json-gson/src/main/java/com/jme3/plugins/gson/GsonElement.java
+++ b/jme3-plugins-json-gson/src/main/java/com/jme3/plugins/gson/GsonElement.java
@@ -119,5 +119,25 @@ class GsonElement implements JsonElement {
         if (element.isJsonPrimitive()) return (T) new GsonPrimitive(element.getAsJsonPrimitive());
         return (T) new GsonElement(element);
     }
+
+    @Override
+    public boolean isJsonObject() {
+        return element != null && element.isJsonObject();
+    }
+
+    @Override
+    public boolean isJsonArray() {
+        return element != null && element.isJsonArray();
+    }
+
+    @Override
+    public boolean isJsonPrimitive() {
+        return element != null && element.isJsonPrimitive();
+    }
+
+    @Override
+    public boolean isJsonNull() {
+        return isNull(element);
+    }
     
 }

--- a/jme3-plugins-json/src/main/java/com/jme3/plugins/json/JsonElement.java
+++ b/jme3-plugins-json/src/main/java/com/jme3/plugins/json/JsonElement.java
@@ -98,4 +98,36 @@ public interface JsonElement {
      * @return the casted JsonElement
      */
     public <T extends JsonElement> T autoCast();
+
+    /**
+     * Check if this element is a JsonObject
+     * @return true if this element is a JsonObject, false otherwise
+     */
+    default boolean isJsonObject() {
+        return this instanceof JsonObject;
+    }
+
+    /**
+     * Check if this element is a JsonArray
+     * @return true if this element is a JsonArray, false otherwise
+     */
+    default boolean isJsonArray() {
+        return this instanceof JsonArray;
+    }
+
+    /**
+     * Check if this element is a JsonPrimitive
+     * @return true if this element is a JsonPrimitive, false otherwise
+     */
+    default boolean isJsonPrimitive() {
+        return this instanceof JsonPrimitive;
+    }
+
+    /**
+     * Check if this element is a JSON null
+     * @return true if this element represents a null value, false otherwise
+     */
+    default boolean isJsonNull() {
+        return false;
+    }
 }


### PR DESCRIPTION
Added default methods to JsonElement interface:
- isJsonObject()
- isJsonArray()
- isJsonPrimitive()
- isJsonNull()

Also added overriding implementations in GsonElement that delegate to the underlying com.google.gson.JsonElement methods.

Closes jMonkeyEngine#2316