### PR TITLE
Deprecate legacy reshape() and improve backward compatibility

### DIFF
--- a/jme3-android/src/main/java/com/jme3/system/android/OGLESContext.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/OGLESContext.java
@@ -465,6 +465,7 @@ public class OGLESContext implements JmeContext, GLSurfaceView.Renderer, SoftTex
         if (renderable.get()) {
             logger.log(Level.FINE, "App already initialized, calling reshape");
             listener.reshape(logicalWidth, logicalHeight, getRenderFramebufferWidth(), getRenderFramebufferHeight());
+            listener.reshape(logicalWidth, logicalHeight);
         }
     }
 
@@ -511,6 +512,7 @@ public class OGLESContext implements JmeContext, GLSurfaceView.Renderer, SoftTex
         updateDisplayScaleMetrics();
         if (renderable.get()) {
             listener.reshape(logicalWidth, logicalHeight, getRenderFramebufferWidth(), getRenderFramebufferHeight());
+            listener.reshape(logicalWidth, logicalHeight);
         }
     }
 
@@ -529,6 +531,7 @@ public class OGLESContext implements JmeContext, GLSurfaceView.Renderer, SoftTex
                 listener.initialize();
                 if (framebufferWidth > 0 && framebufferHeight > 0) {
                     listener.reshape(logicalWidth, logicalHeight, getRenderFramebufferWidth(), getRenderFramebufferHeight());
+                    listener.reshape(logicalWidth, logicalHeight);
                 }
                 renderable.set(true);
             }

--- a/jme3-core/src/main/java/com/jme3/app/LegacyApplication.java
+++ b/jme3-core/src/main/java/com/jme3/app/LegacyApplication.java
@@ -590,10 +590,14 @@ public class LegacyApplication implements Application, SystemListener {
 
     /**
      * Internal use only.
+     *
+     * @deprecated Display size changes are reported through
+     * {@link #reshape(int, int, int, int)}. Use this new method instead.
+     * This one is kept only for backward compatibility.
      */
     @Override
+    @Deprecated
     public void reshape(int w, int h) {
-        reshape(w, h, w, h);
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/system/SystemListener.java
+++ b/jme3-core/src/main/java/com/jme3/system/SystemListener.java
@@ -48,8 +48,13 @@ public interface SystemListener {
      * Called to notify the application that the resolution has changed.
      * @param width the new logical width of the display (&ge;0)
      * @param height the new logical height of the display (&ge;0)
+     *
+     * @deprecated Implement {@link #reshape(int, int, int, int)} instead.
+     * This one is kept only for backward compatibility.
      */
-    public void reshape(int width, int height);
+    @Deprecated
+    public default void reshape(int width, int height) {
+    }
 
     /**
      * Called to notify the application that logical application size and
@@ -61,7 +66,6 @@ public interface SystemListener {
      * @param framebufferHeight the physical framebuffer height in pixels
      */
     public default void reshape(int logicalWidth, int logicalHeight, int framebufferWidth, int framebufferHeight) {
-        reshape(logicalWidth, logicalHeight);
     }
 
     /**

--- a/jme3-core/src/test/java/com/jme3/app/LegacyApplicationReshapeTest.java
+++ b/jme3-core/src/test/java/com/jme3/app/LegacyApplicationReshapeTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2009-2022 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+package com.jme3.app;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LegacyApplicationReshapeTest {
+
+    @Test
+    void fourArgumentReshapeDoesNotCallLegacyOverride() {
+        LegacyReshapeApplication application = new LegacyReshapeApplication();
+
+        application.reshape(320, 240, 640, 480);
+
+        assertEquals(0, application.legacyReshapeCalls);
+    }
+
+    @Test
+    void directLegacyReshapeCallInvokesLegacyOverrideOnly() {
+        LegacyReshapeApplication application = new LegacyReshapeApplication();
+
+        application.reshape(320, 240);
+
+        assertEquals(1, application.legacyReshapeCalls);
+        assertEquals(320, application.width);
+        assertEquals(240, application.height);
+    }
+
+    @Test
+    void fourArgumentReshapeWithModernOverrideDoesNotCallLegacyOverride() {
+        ModernReshapeApplication application = new ModernReshapeApplication();
+
+        application.reshape(320, 240, 640, 480);
+
+        assertEquals(1, application.modernReshapeCalls);
+        assertEquals(0, application.legacyReshapeCalls);
+    }
+
+    @Test
+    void directLegacyReshapeCallDoesNotReachModernOverride() {
+        ModernOnlyReshapeApplication application = new ModernOnlyReshapeApplication();
+
+        application.reshape(320, 240);
+
+        assertEquals(0, application.modernReshapeCalls);
+    }
+
+    private static class LegacyReshapeApplication extends LegacyApplication {
+
+        protected int legacyReshapeCalls;
+        private int width;
+        private int height;
+
+        @Override
+        public void reshape(int width, int height) {
+            legacyReshapeCalls++;
+            this.width = width;
+            this.height = height;
+            super.reshape(width, height);
+        }
+    }
+
+    private static final class ModernReshapeApplication extends LegacyReshapeApplication {
+
+        private int modernReshapeCalls;
+
+        @Override
+        public void reshape(int logicalWidth, int logicalHeight, int framebufferWidth, int framebufferHeight) {
+            modernReshapeCalls++;
+            super.reshape(logicalWidth, logicalHeight, framebufferWidth, framebufferHeight);
+        }
+    }
+
+    private static final class ModernOnlyReshapeApplication extends LegacyApplication {
+
+        private int modernReshapeCalls;
+        private int logicalWidth;
+        private int logicalHeight;
+        private int framebufferWidth;
+        private int framebufferHeight;
+
+        @Override
+        public void reshape(int logicalWidth, int logicalHeight, int framebufferWidth, int framebufferHeight) {
+            modernReshapeCalls++;
+            this.logicalWidth = logicalWidth;
+            this.logicalHeight = logicalHeight;
+            this.framebufferWidth = framebufferWidth;
+            this.framebufferHeight = framebufferHeight;
+            super.reshape(logicalWidth, logicalHeight, framebufferWidth, framebufferHeight);
+        }
+    }
+}

--- a/jme3-ios/src/main/java/com/jme3/system/ios/IGLESContext.java
+++ b/jme3-ios/src/main/java/com/jme3/system/ios/IGLESContext.java
@@ -260,6 +260,7 @@ public class IGLESContext implements JmeContext {
         renderable.set(true);
         if (framebufferWidth > 0 && framebufferHeight > 0) {
             listener.reshape(logicalWidth, logicalHeight, getRenderFramebufferWidth(), getRenderFramebufferHeight());
+            listener.reshape(logicalWidth, logicalHeight);
         }
 
         if (waitFor) {
@@ -319,6 +320,7 @@ public class IGLESContext implements JmeContext {
                 logger.log(Level.FINE, "iOS framebuffer resized, width: {0} height: {1}",
                         new Object[]{framebufferWidth, framebufferHeight});
                 listener.reshape(logicalWidth, logicalHeight, getRenderFramebufferWidth(), getRenderFramebufferHeight());
+                listener.reshape(logicalWidth, logicalHeight);
             }
         }
     }
@@ -364,6 +366,7 @@ public class IGLESContext implements JmeContext {
         linearFrameBufferDirty = true;
         if (renderable.get() && listener != null) {
             listener.reshape(logicalWidth, logicalHeight, getRenderFramebufferWidth(), getRenderFramebufferHeight());
+            listener.reshape(logicalWidth, logicalHeight);
         }
     }
 

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
@@ -210,6 +210,7 @@ public class LwjglCanvas extends LwjglAbstractDisplay implements JmeCanvasContex
                 width = newWidth;
                 height = newHeight;
                 if (listener != null) {
+                    listener.reshape(width, height, width, height);
                     listener.reshape(width, height);
                 }
             }

--- a/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/system/lwjgl/LwjglDisplay.java
@@ -226,6 +226,7 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
             } catch (LWJGLException ex) {
                 logger.log(Level.SEVERE, "Failed to set display settings!", ex);
             }
+            listener.reshape(settings.getWidth(), settings.getHeight(), settings.getWidth(), settings.getHeight());
             listener.reshape(settings.getWidth(), settings.getHeight());
             if (renderable.get()) {
                 reinitContext();
@@ -237,6 +238,7 @@ public class LwjglDisplay extends LwjglAbstractDisplay {
             int newWidth = Display.getWidth();
             int newHeight = Display.getHeight();
             settings.setResolution(newWidth, newHeight);
+            listener.reshape(newWidth, newHeight, newWidth, newHeight);
             listener.reshape(newWidth, newHeight);
         }
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglCanvas.java
@@ -525,6 +525,7 @@ public class LwjglCanvas extends LwjglWindow implements JmeCanvasContext, Runnab
             if (needResize.getAndSet(false)) {
                 settings.setResolution(framebufferWidth, framebufferHeight);
                 listener.reshape(framebufferWidth, framebufferHeight, framebufferWidth, framebufferHeight);
+                listener.reshape(framebufferWidth, framebufferHeight);
             }
 
             synchronized (lock) {

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -579,6 +579,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
                     || framebufferWidth != oldFramebufferWidth || framebufferHeight != oldFramebufferHeight) {
                 settings.setResolution(logicalWidth, logicalHeight);
                 listener.reshape(logicalWidth, logicalHeight, getRenderFramebufferWidth(), getRenderFramebufferHeight());
+                listener.reshape(logicalWidth, logicalHeight);
                 oldLogicalWidth = logicalWidth;
                 oldLogicalHeight = logicalHeight;
                 oldFramebufferWidth = framebufferWidth;


### PR DESCRIPTION
This marks the 2 params reshape as deprecated in favor of the new 4  params (logic+framebuffer) dpi aware hook.
It also changes the way backward compatibility is implemented, previously I made the old method redirect to the new, but this overlooked the possibility of user code overriding the reshape hook inside SimpleApplication (see [here](https://hub.jmonkeyengine.org/t/jme-3-10-0-beta1/49603/52?u=riccardoblb)).
To properly support backward compatibility, even in this case, the engine now calls both the new and old hooks from every backend.