### PR TITLE
fix lwjgl3 dependencies: add windows-arm64 and remove 32bit

### DIFF
--- a/jme3-lwjgl3/build.gradle
+++ b/jme3-lwjgl3/build.gradle
@@ -19,24 +19,28 @@ dependencies {
 
     runtimeOnly libs.angle
     runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-windows') })
+    runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-windows-arm64') })
     runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-linux') })
     runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-linux-arm64') })
     runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-macos') })
     runtimeOnly(variantOf(libs.lwjgl3.base){ classifier('natives-macos-arm64') })
 
     runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-windows') })
+    runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-windows-arm64') })
     runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-linux') })
     runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-linux-arm64') })
     runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-macos') })
     runtimeOnly(variantOf(libs.lwjgl3.jemalloc){ classifier('natives-macos-arm64') })
 
     runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-windows') })
+    runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-windows-arm64') })
     runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-linux') })
     runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-linux-arm64') })
     runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-macos') })
     runtimeOnly(variantOf(libs.lwjgl3.opengl){ classifier('natives-macos-arm64') })
 
     runtimeOnly(variantOf(libs.lwjgl3.openal){ classifier('natives-windows') })
+    runtimeOnly(variantOf(libs.lwjgl3.openal){ classifier('natives-windows-arm64') })
     runtimeOnly(variantOf(libs.lwjgl3.openal){ classifier('natives-linux') })
     runtimeOnly(variantOf(libs.lwjgl3.openal){ classifier('natives-linux-arm64') })
     runtimeOnly(variantOf(libs.lwjgl3.openal){ classifier('natives-macos') })
@@ -44,14 +48,14 @@ dependencies {
 
 
     runtimeOnly(variantOf(libs.lwjgl3.opengles){ classifier('natives-windows') })
-    runtimeOnly(variantOf(libs.lwjgl3.opengles){ classifier('natives-windows-x86') })
+    runtimeOnly(variantOf(libs.lwjgl3.opengles){ classifier('natives-windows-arm64') })
     runtimeOnly(variantOf(libs.lwjgl3.opengles){ classifier('natives-linux') })
-    runtimeOnly(variantOf(libs.lwjgl3.opengles){ classifier('natives-linux-arm32') })
     runtimeOnly(variantOf(libs.lwjgl3.opengles){ classifier('natives-linux-arm64') })
     runtimeOnly(variantOf(libs.lwjgl3.opengles){ classifier('natives-macos') })
     runtimeOnly(variantOf(libs.lwjgl3.opengles){ classifier('natives-macos-arm64') })
  
     runtimeOnly(variantOf(libs.lwjgl3.sdl){ classifier('natives-windows') })
+    runtimeOnly(variantOf(libs.lwjgl3.sdl){ classifier('natives-windows-arm64') })
     runtimeOnly(variantOf(libs.lwjgl3.sdl){ classifier('natives-linux') })
     runtimeOnly(variantOf(libs.lwjgl3.sdl){ classifier('natives-linux-arm64') })
     runtimeOnly(variantOf(libs.lwjgl3.sdl){ classifier('natives-macos') })


### PR DESCRIPTION
partially fixes https://github.com/jMonkeyEngine/jmonkeyengine/issues/1853
tests are still missing, but out of scope of this pr, since we test only on linux and android, doing tests elsewhere needs a specialized harness and dedicated PR