### PR TITLE
Add Spatial#getUserData(String, T defaultValue) convenience overload

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Spatial.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Spatial.java
@@ -1630,6 +1630,20 @@ public abstract class Spatial implements Savable, Cloneable, Collidable,
         }
     }
 
+    /**
+     * Retrieves user-defined data stored with this spatial.
+     *
+     * @param <T> The expected type of the user data.
+     * @param key The key under which the data is stored (not null).
+     * @param defaultValue the value to return if no data is associated with the key.
+     * @return the stored value, or {@code defaultValue} if the key is not present.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getUserData(String key, T defaultValue) {
+        T value = getUserData(key);
+        return value != null ? value : defaultValue;
+    }
+
     @SuppressWarnings("unchecked")
     public Collection<String> getUserDataKeys() {
         if (userData != null) {

--- a/jme3-core/src/main/java/com/jme3/scene/Spatial.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Spatial.java
@@ -1638,7 +1638,6 @@ public abstract class Spatial implements Savable, Cloneable, Collidable,
      * @param defaultValue the value to return if no data is associated with the key.
      * @return the stored value, or {@code defaultValue} if the key is not present.
      */
-    @SuppressWarnings("unchecked")
     public <T> T getUserData(String key, T defaultValue) {
         T value = getUserData(key);
         return value != null ? value : defaultValue;


### PR DESCRIPTION
## Summary

This PR adds a convenience overload to `Spatial#getUserData()` that allows callers to specify a default value when no user data is associated with the given key. The implementation delegates to the existing method `getUserData(String)`:

```java
public <T> T getUserData(String key, T defaultValue) {
    T value = getUserData(key);
    return value != null ? value : defaultValue;
}
```

## Motivation

Retrieving user data currently requires explicit null checks:

```java
Integer team = spatial.getUserData("team");
if (team == null) {
    team = -1;
}
```

With this overload, the same code becomes:

```java
Integer team = spatial.getUserData("team", -1);
```

This improves readability and makes the API more convenient to use, following the same idea as `Map.getOrDefault()`.

## Benefits

* Improves API usability.
* Eliminates repetitive null-check boilerplate.
* Fully backward compatible.
* No additional allocations.
* Negligible runtime overhead (the implementation simply delegates to the existing `getUserData(String)` method).

No existing behavior is changed; this is purely an additive convenience API.
