### PR TITLE
remove spammy log message in SkinningControl.java

### DIFF
--- a/jme3-core/src/main/java/com/jme3/anim/SkinningControl.java
+++ b/jme3-core/src/main/java/com/jme3/anim/SkinningControl.java
@@ -207,7 +207,6 @@ public class SkinningControl extends AbstractControl implements JmeCloneable {
 
         try {
             renderManager.preloadScene(spatial);
-            logger.log(Level.INFO, "Hardware skinning engaged for {0}", spatial);
             hwSkinningEngaged = true;
 
         } catch (RendererException ex) {


### PR DESCRIPTION
can be very spammy if you load/unload spatials. and the catch block logs failures (haven't checked all).