### PR TITLE
Fix wrong interpolation ratio in glTF TrackData.populateTransform()

### DIFF
--- a/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/TrackData.java
+++ b/jme3-plugins/src/gltf/java/com/jme3/scene/plugins/gltf/TrackData.java
@@ -221,7 +221,8 @@ public class TrackData {
             } else {
                 //interpolation between the previous transform and the next one.
                 KeyFrame lastKeyFrame = keyFrames.get(transformIndices.last);
-                float ratio = currentKeyFrame.time / (nextKeyFrame.time - lastKeyFrame.time);
+                float ratio = (currentKeyFrame.time - lastKeyFrame.time)
+                        / (nextKeyFrame.time - lastKeyFrame.time);
                 interpolate(type, ratio, lastKeyFrame, nextKeyFrame, index);
             }
 


### PR DESCRIPTION
When a node's translation/rotation/scale channels carry different keyframe timestamps, update() merges them onto one shared time grid and gap-fills missing samples via populateTransform()/interpolate(). The blend ratio for that interpolation was computed as
"currentKeyFrame.time / (nextKeyFrame.time - lastKeyFrame.time)", missing "- lastKeyFrame.time" in the numerator. Instead of the intended 0..1 blend position within [lastKeyFrame.time, nextKeyFrame.time], this passed the clip's absolute elapsed time into Quaternion.nlerp(), which doesn't clamp its blend parameter and so extrapolated wildly rather than interpolating.

Only triggers on the "channels don't share identical keyframe times" merge
path (`equalTimes(timeArrays)` false) — simple clips where every channel is
sampled at the same rate never hit it.

Verified against a real affected clip: a bone was rotating >100° from bind
mid-clip in a stretch where the source data is smooth; after the fix,
motion is normal throughout.

Forum discussion: https://hub.jmonkeyengine.org/t/wrong-interpolation-in-gltf-loader/49640

(Created with help from AI)