### PR TITLE
Fix NPE in Geometry's morph state (#2919)

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Geometry.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Geometry.java
@@ -629,7 +629,7 @@ public class Geometry extends Spatial {
     public void setMorphState(String morphTarget, float state) {
         int index = mesh.getMorphIndex(morphTarget);
         if (index >= 0) {
-            morphState[index] = state;
+            getMorphState()[index] = state;
             this.dirtyMorph = true;
         }
     }
@@ -677,7 +677,7 @@ public class Geometry extends Spatial {
         if (index < 0) {
             return -1;
         } else {
-            return morphState[index];
+            return getMorphState()[index];
         }
     }
 

--- a/jme3-core/src/test/java/com/jme3/scene/GeometryMorphStateTest.java
+++ b/jme3-core/src/test/java/com/jme3/scene/GeometryMorphStateTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2009-2025 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.scene;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.jme3.scene.mesh.MorphTarget;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the name-based morph state accessors work on a geometry whose
+ * morph state array has not been allocated yet.
+ *
+ * <p>The array is allocated lazily, and before this was fixed only
+ * {@link Geometry#setMorphState(float[])} and {@link Geometry#getMorphState()}
+ * did so. The name-based overloads indexed it directly, so calling either of
+ * them first threw a {@link NullPointerException} -- which is exactly what
+ * happens when morph targets are driven from application code rather than by a
+ * morph animation, since nothing else has touched the array by then.
+ *
+ * @author jMonkeyEngine
+ */
+public class GeometryMorphStateTest {
+
+    private static final String FIRST = "first";
+    private static final String SECOND = "second";
+
+    /**
+     * A geometry with two named morph targets and no morph state array yet.
+     * Geometries start out dirty, so the flag is cleared to let the tests below
+     * observe whether a call actually sets it.
+     */
+    private static Geometry geometryWithMorphTargets() {
+        Mesh mesh = new Mesh();
+        mesh.addMorphTarget(new MorphTarget(FIRST));
+        mesh.addMorphTarget(new MorphTarget(SECOND));
+        Geometry geometry = new Geometry("test", mesh);
+        geometry.setDirtyMorph(false);
+        return geometry;
+    }
+
+    /**
+     * Sets a morph state by name on an otherwise untouched geometry.
+     */
+    @Test
+    public void setMorphStateByNameAllocatesTheStateArray() {
+        Geometry geometry = geometryWithMorphTargets();
+
+        geometry.setMorphState(SECOND, 0.75f);
+
+        assertEquals(0.75f, geometry.getMorphState(SECOND), 0f);
+        assertEquals(0f, geometry.getMorphState(FIRST), 0f);
+        assertTrue(geometry.isDirtyMorph());
+    }
+
+    /**
+     * Reads a morph state by name on an otherwise untouched geometry.
+     */
+    @Test
+    public void getMorphStateByNameAllocatesTheStateArray() {
+        Geometry geometry = geometryWithMorphTargets();
+
+        assertEquals(0f, geometry.getMorphState(FIRST), 0f);
+        assertEquals(2, geometry.getMorphState().length);
+    }
+
+    /**
+     * An unknown morph name is ignored on write and reports -1 on read, and must
+     * not disturb the states that do exist.
+     */
+    @Test
+    public void unknownMorphNameIsIgnored() {
+        Geometry geometry = geometryWithMorphTargets();
+
+        geometry.setMorphState("nonexistent", 1f);
+
+        assertFalse(geometry.isDirtyMorph());
+        assertEquals(-1f, geometry.getMorphState("nonexistent"), 0f);
+        assertEquals(0f, geometry.getMorphState(FIRST), 0f);
+        assertEquals(0f, geometry.getMorphState(SECOND), 0f);
+    }
+}


### PR DESCRIPTION
Geometry allocates its morphState array lazily. setMorphState(float[]) and getMorphState() both create it on demand, but the name-based overloads setMorphState(String, float) and getMorphState(String) indexed the field directly, so calling either one first threw NullPointerException:

    java.lang.NullPointerException: Cannot store to float array because
    "this.morphState" is null

Nothing else populates the array. MorphControl only reads it, and the control itself is attached by GltfLoader only when the asset carries an animation channel targeting "weights". An application driving morph targets from its own code -- expression blending, a slider, anything procedural -- therefore has an unallocated array precisely when it reaches for the name-based setter, which is the natural one to use since it is the only API that resolves a morph by name.

Route both overloads through getMorphState(), which already allocates on demand, so the by-name and by-array paths behave alike. The lookup guard is unchanged: an unknown name still writes nothing and reads -1.