### PR TITLE
Fix misuse of constants

### DIFF
--- a/jme3-core/src/main/java/com/jme3/cinematic/events/MotionEvent.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/events/MotionEvent.java
@@ -50,6 +50,7 @@ import com.jme3.scene.control.Control;
 import com.jme3.util.clone.Cloner;
 import com.jme3.util.clone.JmeCloneable;
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * A MotionEvent is a control over the spatial that manages
@@ -65,7 +66,7 @@ public class MotionEvent extends AbstractCinematicEvent implements Control, JmeC
     protected float currentValue;
     protected Vector3f direction = new Vector3f();
     protected Vector3f lookAt = null;
-    protected Vector3f upVector = Vector3f.UNIT_Y;
+    protected Vector3f upVector = Vector3f.UNIT_Y.clone();
     protected Quaternion rotation = null;
     protected Direction directionType = Direction.None;
     protected MotionPath path;
@@ -231,7 +232,7 @@ public class MotionEvent extends AbstractCinematicEvent implements Control, JmeC
         super.read(im);
         InputCapsule ic = im.getCapsule(this);
         lookAt = (Vector3f) ic.readSavable("lookAt", null);
-        upVector = (Vector3f) ic.readSavable("upVector", Vector3f.UNIT_Y);
+        upVector = (Vector3f) ic.readSavable("upVector", Vector3f.UNIT_Y.clone());
         rotation = (Quaternion) ic.readSavable("rotation", null);
         directionType = ic.readEnum("directionType", Direction.class, Direction.None);
         path = (MotionPath) ic.readSavable("path", null);
@@ -392,8 +393,8 @@ public class MotionEvent extends AbstractCinematicEvent implements Control, JmeC
      * @param upVector the up vector to consider for this direction.
      */
     public void setDirection(Vector3f direction, Vector3f upVector) {
-        this.direction.set(direction);
-        this.upVector.set(upVector);
+        this.direction.set(Objects.requireNonNull(direction, "direction cannot be null"));
+        this.upVector.set(Objects.requireNonNull(upVector, "upVector cannot be null"));
     }
 
     /**
@@ -422,7 +423,7 @@ public class MotionEvent extends AbstractCinematicEvent implements Control, JmeC
      */
     public void setLookAt(Vector3f lookAt, Vector3f upVector) {
         this.lookAt = lookAt;
-        this.upVector = upVector;
+        this.upVector.set(upVector);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -77,7 +77,7 @@ import com.jme3.util.clone.JmeCloneable;
 public class ParticleEmitter extends Geometry {
 
     private boolean enabled = true;
-    private static final EmitterShape DEFAULT_SHAPE = new EmitterPointShape(Vector3f.ZERO);
+    private static final EmitterShape DEFAULT_SHAPE = new EmitterPointShape(Vector3f.ZERO.clone());
     private static final ParticleInfluencer DEFAULT_INFLUENCER = new DefaultParticleInfluencer();
     private ParticleEmitterControl control;
     private EmitterShape shape = DEFAULT_SHAPE;
@@ -476,8 +476,10 @@ public class ParticleEmitter extends Geometry {
     public void setFaceNormal(Vector3f faceNormal) {
         if (faceNormal == null || !Vector3f.isValidVector(faceNormal)) {
             this.faceNormal.set(Vector3f.NAN);
+        } else if (this.faceNormal == null) {
+            this.faceNormal = faceNormal.clone();
         } else {
-            this.faceNormal = faceNormal;
+            this.faceNormal.set(faceNormal);
         }
     }
 

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterBoxShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterBoxShape.java
@@ -39,6 +39,7 @@ import com.jme3.math.FastMath;
 import com.jme3.math.Vector3f;
 import com.jme3.util.clone.Cloner;
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * An {@link EmitterShape} that emits particles randomly within the bounds of an axis-aligned box.
@@ -74,7 +75,7 @@ public class EmitterBoxShape implements EmitterShape {
             throw new IllegalArgumentException("min or max cannot be null");
         }
 
-        this.min = min;
+        this.min = min.clone();
         this.len = new Vector3f();
         this.len.set(max).subtractLocal(min);
     }
@@ -151,7 +152,7 @@ public class EmitterBoxShape implements EmitterShape {
      * @param min The new minimum corner.
      */
     public void setMin(Vector3f min) {
-        this.min = min;
+        this.min = Objects.requireNonNull(min, "min cannot be null").clone();
     }
 
     /**
@@ -171,7 +172,7 @@ public class EmitterBoxShape implements EmitterShape {
      * @param len The new length vector.
      */
     public void setLen(Vector3f len) {
-        this.len = len;
+        this.len = Objects.requireNonNull(len, "len cannot be null").clone();
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
+++ b/jme3-core/src/main/java/com/jme3/effect/shapes/EmitterSphereShape.java
@@ -39,6 +39,7 @@ import com.jme3.math.FastMath;
 import com.jme3.math.Vector3f;
 import com.jme3.util.clone.Cloner;
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * An {@link EmitterShape} that emits particles randomly from within the volume of a sphere.
@@ -155,7 +156,7 @@ public class EmitterSphereShape implements EmitterShape {
      * @param center The new center point.
      */
     public void setCenter(Vector3f center) {
-        this.center = center;
+        this.center = Objects.requireNonNull(center, "center cannot be null");
     }
 
     /**
@@ -179,14 +180,14 @@ public class EmitterSphereShape implements EmitterShape {
     @Override
     public void write(JmeExporter ex) throws IOException {
         OutputCapsule oc = ex.getCapsule(this);
-        oc.write(center, "center", null);
+        oc.write(center, "center", Vector3f.ZERO);
         oc.write(radius, "radius", 0);
     }
 
     @Override
     public void read(JmeImporter im) throws IOException {
         InputCapsule ic = im.getCapsule(this);
-        center = (Vector3f) ic.readSavable("center", null);
+        center = (Vector3f) ic.readSavable("center", Vector3f.ZERO);
         radius = ic.readFloat("radius", 0);
     }
 }

--- a/jme3-core/src/main/java/com/jme3/scene/Spatial.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Spatial.java
@@ -1714,7 +1714,7 @@ public abstract class Spatial implements Savable, Cloneable, Collidable,
         shadowMode = ic.readEnum("shadow_mode", ShadowMode.class,
                 ShadowMode.Inherit);
 
-        localTransform = (Transform) ic.readSavable("transform", Transform.IDENTITY);
+        localTransform = (Transform) ic.readSavable("transform", Transform.IDENTITY.clone());
 
         localLights = (LightList) ic.readSavable("lights", null);
         localLights.setOwner(this);

--- a/jme3-examples/src/main/java/jme3test/model/anim/TestGltfMorph.java
+++ b/jme3-examples/src/main/java/jme3test/model/anim/TestGltfMorph.java
@@ -83,7 +83,7 @@ public class TestGltfMorph extends SimpleApplication {
 
         // Add ambient light
         AmbientLight al = new AmbientLight();
-        al.setColor(ColorRGBA.White.multLocal(0.4f));
+        al.setColor(ColorRGBA.White.mult(0.4f));
         rootNode.addLight(al);
 
         final int SHADOWMAP_SIZE = 1024;

--- a/jme3-jbullet/src/main/java/com/jme3/bullet/joints/SixDofJoint.java
+++ b/jme3-jbullet/src/main/java/com/jme3/bullet/joints/SixDofJoint.java
@@ -198,12 +198,12 @@ public class SixDofJoint extends PhysicsJoint {
             rotationalLimitMotor.setTargetVelocity(capsule.readFloat("rotMotor" + i + "_TargetVelocity", 0));
             rotationalLimitMotor.setEnableMotor(capsule.readBoolean("rotMotor" + i + "_EnableMotor", false));
         }
-        getTranslationalLimitMotor().setAccumulatedImpulse((Vector3f) capsule.readSavable("transMotor_AccumulatedImpulse", Vector3f.ZERO));
+        getTranslationalLimitMotor().setAccumulatedImpulse((Vector3f) capsule.readSavable("transMotor_AccumulatedImpulse", Vector3f.ZERO.clone()));
         getTranslationalLimitMotor().setDamping(capsule.readFloat("transMotor_Damping", 1.0f));
         getTranslationalLimitMotor().setLimitSoftness(capsule.readFloat("transMotor_LimitSoftness", 0.7f));
-        getTranslationalLimitMotor().setLowerLimit((Vector3f) capsule.readSavable("transMotor_LowerLimit", Vector3f.ZERO));
+        getTranslationalLimitMotor().setLowerLimit((Vector3f) capsule.readSavable("transMotor_LowerLimit", Vector3f.ZERO.clone()));
         getTranslationalLimitMotor().setRestitution(capsule.readFloat("transMotor_Restitution", 0.5f));
-        getTranslationalLimitMotor().setUpperLimit((Vector3f) capsule.readSavable("transMotor_UpperLimit", Vector3f.ZERO));
+        getTranslationalLimitMotor().setUpperLimit((Vector3f) capsule.readSavable("transMotor_UpperLimit", Vector3f.ZERO.clone()));
     }
 
     @Override

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainPatch.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainPatch.java
@@ -902,7 +902,7 @@ public class TerrainPatch extends Geometry {
         oc.write(totalSize, "totalSize", 16);
         oc.write(quadrant, "quadrant", (short)0);
         oc.write(stepScale, "stepScale", Vector3f.UNIT_XYZ);
-        oc.write(offset, "offset", Vector3f.UNIT_XYZ);
+        oc.write(offset, "offset", Vector2f.ZERO);
         oc.write(offsetAmount, "offsetAmount", 0);
         //oc.write(lodCalculator, "lodCalculator", null);
         //oc.write(lodCalculatorFactory, "lodCalculatorFactory", null);
@@ -920,7 +920,7 @@ public class TerrainPatch extends Geometry {
         totalSize = ic.readInt("totalSize", 16);
         quadrant = ic.readShort("quadrant", (short)0);
         stepScale = (Vector3f) ic.readSavable("stepScale", Vector3f.UNIT_XYZ);
-        offset = (Vector2f) ic.readSavable("offset", Vector3f.UNIT_XYZ);
+        offset = (Vector2f) ic.readSavable("offset", Vector2f.ZERO);
         offsetAmount = ic.readFloat("offsetAmount", 0);
         //lodCalculator = (LodCalculator) ic.readSavable("lodCalculator", new DistanceLodCalculator());
         //lodCalculator.setTerrainPatch(this);

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -126,7 +126,7 @@ public class TerrainQuad extends Node implements Terrain {
     private BoundingBox affectedAreaBBox; // only set in the root quad
 
     private TerrainPicker picker = new BresenhamTerrainPicker(this);
-    private Vector3f lastScale = Vector3f.UNIT_XYZ;
+    private Vector3f lastScale = Vector3f.UNIT_XYZ.clone();
 
     protected NeighbourFinder neighbourFinder;
 
@@ -885,7 +885,7 @@ public class TerrainQuad extends Node implements Terrain {
             return true;
         if (!lastScale.equals(getWorldScale())) {
             affectedAreaBBox = new BoundingBox(getWorldTranslation(), Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE);
-            lastScale = getWorldScale();
+            lastScale.set(getWorldScale());
             return true;
         }
         return false;


### PR DESCRIPTION
This PR fixes several cases of constants misuse that could end up being mutated, and one case where the code used the wrong constant.

Since passing references is often intentional in jme, I made sure to clone objects only when passing a reference was already causing the internal state to break.

